### PR TITLE
fix(MCP): stamp Eufemia version in serverInfo and docs_entry

### DIFF
--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -871,7 +871,41 @@ export function createDocsTools(
   }
 }
 
-export const SERVER_INFO = { name: 'eufemia', version: '2.2.0' }
+export const SERVER_NAME = 'eufemia'
+
+export type DocsMeta = {
+  eufemiaVersion: string
+  generatedAt: string
+  commit: string
+}
+
+export function createServerInfo(eufemiaVersion?: string): {
+  name: string
+  version: string
+} {
+  return {
+    name: SERVER_NAME,
+    version: eufemiaVersion || '0.0.0-development',
+  }
+}
+
+export async function readDocsMeta(source: DocsSource): Promise<DocsMeta> {
+  const raw = await source.read('_meta.json')
+
+  if (raw) {
+    try {
+      return JSON.parse(raw) as DocsMeta
+    } catch {
+      // fall through
+    }
+  }
+
+  return {
+    eufemiaVersion: '0.0.0-development',
+    generatedAt: '',
+    commit: '',
+  }
+}
 
 export function registerDocsTools(
   server: McpServer,
@@ -977,12 +1011,15 @@ export function registerDocsTools(
   )
 }
 
-export function createDocsServer(options: { docsRoot?: string } = {}): {
+export async function createDocsServer(
+  options: { docsRoot?: string } = {}
+): Promise<{
   server: McpServer
   tools: DocsToolHandlers
-} {
+}> {
   const tools = createDocsTools(options)
-  const server = new McpServer(SERVER_INFO)
+  const meta = await readDocsMeta(tools.source)
+  const server = new McpServer(createServerInfo(meta.eufemiaVersion))
   registerDocsTools(server, tools)
   return { server, tools }
 }

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -871,7 +871,7 @@ export function createDocsTools(
   }
 }
 
-export const SERVER_NAME = 'eufemia'
+const SERVER_NAME = 'eufemia'
 
 export type DocsMeta = {
   eufemiaVersion: string

--- a/packages/dnb-eufemia/src/mcp/mcp-http-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-http-server.ts
@@ -35,8 +35,9 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
 
 import {
-  SERVER_INFO,
+  createServerInfo,
   createDocsTools,
+  readDocsMeta,
   registerDocsTools,
   validateDocsRoot,
 } from './mcp-docs-server'
@@ -83,12 +84,16 @@ function parseAllowedHosts(): string[] | undefined {
     .filter(Boolean)
 }
 
-function buildMcpServer(options: DocsToolsOptions = {}): {
+function buildMcpServer(
+  options: DocsToolsOptions & {
+    serverInfo: { name: string; version: string }
+  }
+): {
   server: McpServer
   docsRoot: string
 } {
   const tools = createDocsTools(options)
-  const server = new McpServer(SERVER_INFO)
+  const server = new McpServer(options.serverInfo)
   registerDocsTools(server, tools)
   return { server, docsRoot: tools.docsRoot }
 }
@@ -176,6 +181,12 @@ export async function startHttpServer(
   const authToken = options.authToken ?? process.env.MCP_AUTH_TOKEN
   const logErr = createLogger(options.silent ?? false)
 
+  // Read version metadata once at startup so the healthz endpoint can
+  // report the Eufemia version without an extra async call per request.
+  const startupTools = createDocsTools({ docsRoot: options.docsRoot })
+  const meta = await readDocsMeta(startupTools.source)
+  const serverInfo = createServerInfo(meta.eufemiaVersion)
+
   const app = express()
   app.disable('x-powered-by')
   app.use(express.json({ limit: '4mb' }))
@@ -184,8 +195,8 @@ export async function startHttpServer(
   app.get('/healthz', (_req: ExpressRequest, res: ExpressResponse) => {
     res.json({
       ok: true,
-      name: SERVER_INFO.name,
-      version: SERVER_INFO.version,
+      name: serverInfo.name,
+      version: serverInfo.version,
       transports: ['streamable-http', 'sse'],
     })
   })
@@ -242,7 +253,10 @@ export async function startHttpServer(
           }
         }
 
-        const { server } = buildMcpServer({ docsRoot: options.docsRoot })
+        const { server } = buildMcpServer({
+          docsRoot: options.docsRoot,
+          serverInfo,
+        })
         await server.connect(transport)
       }
 
@@ -286,7 +300,10 @@ export async function startHttpServer(
           sseTransports.delete(transport.sessionId)
         }
 
-        const { server } = buildMcpServer({ docsRoot: options.docsRoot })
+        const { server } = buildMcpServer({
+          docsRoot: options.docsRoot,
+          serverInfo,
+        })
         await server.connect(transport)
 
         logErr(`[eufemia] sse connected: ${transport.sessionId}`)

--- a/packages/dnb-eufemia/src/mcp/mcp-stdio.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-stdio.ts
@@ -21,7 +21,7 @@ function logErr(...args: unknown[]) {
 }
 
 async function main() {
-  const { server, tools } = createDocsServer()
+  const { server, tools } = await createDocsServer()
   logErr(`[eufemia] docsRoot: ${tools.docsRoot}`)
 
   await validateDocsRoot(tools.docsRoot)

--- a/packages/dnb-eufemia/src/mcp/worker/index.ts
+++ b/packages/dnb-eufemia/src/mcp/worker/index.ts
@@ -21,7 +21,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 
 import {
-  SERVER_INFO,
+  createServerInfo,
   createDocsTools,
   registerDocsTools,
   validateDocsSource,
@@ -41,6 +41,20 @@ const docsSource = createBundledDocsSource(
   docsBundle as Record<string, string>,
   { label: 'worker:docs.bundle.json' }
 )
+
+// Derive server info from the _meta.json entry baked into the bundle.
+const bundleMeta = (() => {
+  const raw = (docsBundle as Record<string, string>)['_meta.json']
+  if (raw) {
+    try {
+      return JSON.parse(raw) as { eufemiaVersion?: string }
+    } catch {
+      // fall through
+    }
+  }
+  return {}
+})()
+const serverInfo = createServerInfo(bundleMeta.eufemiaVersion)
 
 let validatedOnce = false
 
@@ -112,7 +126,7 @@ async function handleMcp(request: Request, env: Env): Promise<Response> {
   }
 
   const tools = createDocsTools({ source: docsSource })
-  const server = new McpServer(SERVER_INFO)
+  const server = new McpServer(serverInfo)
   registerDocsTools(server, tools)
 
   const transport = new WebStandardStreamableHTTPServerTransport({
@@ -142,8 +156,8 @@ function handleHealth(): Response {
   return new Response(
     JSON.stringify({
       ok: true,
-      name: SERVER_INFO.name,
-      version: SERVER_INFO.version,
+      name: serverInfo.name,
+      version: serverInfo.version,
       transports: ['streamable-http'],
       runtime: 'cloudflare-worker',
     }),

--- a/tools/eufemia-llm-metadata/scripts/buildDocsBundle.ts
+++ b/tools/eufemia-llm-metadata/scripts/buildDocsBundle.ts
@@ -87,6 +87,13 @@ export async function buildDocsBundle(
     bundle[rel.replaceAll(path.sep, '/')] = content
   }
 
+  // Include _meta.json so the MCP server can read the Eufemia version,
+  // build timestamp, and commit hash from the bundle at runtime.
+  const metaPath = path.join(docsRoot, '_meta.json')
+  if (await fs.pathExists(metaPath)) {
+    bundle['_meta.json'] = await fs.readFile(metaPath, 'utf8')
+  }
+
   await fs.ensureDir(path.dirname(outFile))
   await fs.writeFile(
     outFile,

--- a/tools/eufemia-llm-metadata/scripts/generateDocs.ts
+++ b/tools/eufemia-llm-metadata/scripts/generateDocs.ts
@@ -155,21 +155,22 @@ export async function generateDocs() {
     metadataBySlug,
   })
 
-  await writeLlmsText({
-    siteDir: repoRoot,
-    results,
-    version,
-    commit,
-    outputRoot,
-    publicUrlBase: PUBLIC_URL_BASE,
-    llmsFilename: 'llm.md',
-  })
-
   await fs.writeJson(
     path.join(outputRoot, '_meta.json'),
     { eufemiaVersion: version, generatedAt, commit },
     { spaces: 2 }
   )
+
+  await writeLlmsText({
+    siteDir: repoRoot,
+    results,
+    version,
+    commit,
+    generatedAt,
+    outputRoot,
+    publicUrlBase: PUBLIC_URL_BASE,
+    llmsFilename: 'llm.md',
+  })
 
   const warningSummary = formatUnhandledStandaloneMdxWarnings()
 

--- a/tools/eufemia-llm-metadata/scripts/generateDocs.ts
+++ b/tools/eufemia-llm-metadata/scripts/generateDocs.ts
@@ -18,7 +18,10 @@ import {
   toSlugAndDir,
   writeLlmsText,
 } from '../src/convertHelpers.ts'
-import { getNextReleaseVersion } from '../src/getNextReleaseVersion.ts'
+import {
+  getNextReleaseVersion,
+  getCommitHash,
+} from '../src/getNextReleaseVersion.ts'
 
 const PUBLIC_URL_BASE = ''
 
@@ -65,6 +68,8 @@ export async function generateDocs() {
   await fs.emptyDir(outputRoot)
 
   const version = await getNextReleaseVersion()
+  const commit = await getCommitHash()
+  const generatedAt = new Date().toISOString()
   const robots = await loadRobots(robotsRoot)
   const entryFiles = await findEntryMdxFiles(docsRoot)
   const allowedEntryFiles: string[] = []
@@ -154,10 +159,17 @@ export async function generateDocs() {
     siteDir: repoRoot,
     results,
     version,
+    commit,
     outputRoot,
     publicUrlBase: PUBLIC_URL_BASE,
     llmsFilename: 'llm.md',
   })
+
+  await fs.writeJson(
+    path.join(outputRoot, '_meta.json'),
+    { eufemiaVersion: version, generatedAt, commit },
+    { spaces: 2 }
+  )
 
   const warningSummary = formatUnhandledStandaloneMdxWarnings()
 

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -462,6 +462,7 @@ export async function writeLlmsText({
   results,
   version,
   commit,
+  generatedAt,
   outputRoot,
   llmsFilename = 'llms.txt',
   publicUrlBase = DEFAULT_PUBLIC_URL,
@@ -470,6 +471,7 @@ export async function writeLlmsText({
   results: Array<any>
   version: string
   commit?: string
+  generatedAt?: string
   outputRoot?: string
   llmsFilename?: string
   publicUrlBase?: string
@@ -483,6 +485,7 @@ export async function writeLlmsText({
     buildLlmsText(hydrated, {
       version,
       commit,
+      generatedAt,
       publicUrlBase,
     }),
     siteDir
@@ -894,15 +897,26 @@ export function buildLlmsText(
   {
     version,
     commit,
+    generatedAt,
     publicUrlBase = DEFAULT_PUBLIC_URL,
-  }: { version: string; commit?: string; publicUrlBase?: string }
+  }: {
+    version: string
+    commit?: string
+    generatedAt?: string
+    publicUrlBase?: string
+  }
 ) {
   const normalizedResults = results.filter((entry) => entry && entry.meta)
   const lines: string[] = []
-  const generatedAt = new Date().toISOString()
+  const resolvedAt = generatedAt || new Date().toISOString()
   const base = normalizePublicUrlBase(publicUrlBase || '')
 
-  appendLlmsHeaderTemplate(lines, { base, version, generatedAt, commit })
+  appendLlmsHeaderTemplate(lines, {
+    base,
+    version,
+    generatedAt: resolvedAt,
+    commit,
+  })
 
   const filtered = normalizedResults.filter((e) => {
     try {
@@ -1000,7 +1014,7 @@ export function buildLlmsText(
 
   lines.push('')
   lines.push(`Version: ${version}`)
-  lines.push(`GeneratedAt: ${generatedAt}`)
+  lines.push(`GeneratedAt: ${resolvedAt}`)
 
   return lines.join('\n')
 }

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -461,6 +461,7 @@ export async function writeLlmsText({
   siteDir,
   results,
   version,
+  commit,
   outputRoot,
   llmsFilename = 'llms.txt',
   publicUrlBase = DEFAULT_PUBLIC_URL,
@@ -468,6 +469,7 @@ export async function writeLlmsText({
   siteDir: string
   results: Array<any>
   version: string
+  commit?: string
   outputRoot?: string
   llmsFilename?: string
   publicUrlBase?: string
@@ -480,6 +482,7 @@ export async function writeLlmsText({
   const llmsContent = await formatLlmsText(
     buildLlmsText(hydrated, {
       version,
+      commit,
       publicUrlBase,
     }),
     siteDir
@@ -890,15 +893,16 @@ export function buildLlmsText(
   results: Array<any>,
   {
     version,
+    commit,
     publicUrlBase = DEFAULT_PUBLIC_URL,
-  }: { version: string; publicUrlBase?: string }
+  }: { version: string; commit?: string; publicUrlBase?: string }
 ) {
   const normalizedResults = results.filter((entry) => entry && entry.meta)
   const lines: string[] = []
   const generatedAt = new Date().toISOString()
   const base = normalizePublicUrlBase(publicUrlBase || '')
 
-  appendLlmsHeaderTemplate(lines, base)
+  appendLlmsHeaderTemplate(lines, { base, version, generatedAt, commit })
 
   const filtered = normalizedResults.filter((e) => {
     try {
@@ -1001,12 +1005,30 @@ export function buildLlmsText(
   return lines.join('\n')
 }
 
-function appendLlmsHeaderTemplate(lines: string[], base: string) {
+function appendLlmsHeaderTemplate(
+  lines: string[],
+  {
+    base,
+    version,
+    generatedAt,
+    commit,
+  }: {
+    base: string
+    version: string
+    generatedAt: string
+    commit?: string
+  }
+) {
   const templatePath = path.join(__dirname, 'templates', 'llm-header.md')
+  const commitSuffix = commit ? `, from commit ${commit}` : ''
 
   try {
     const raw = fs.readFileSync(templatePath, 'utf-8')
-    const content = raw.replace(/{{BASE}}/g, base)
+    const content = raw
+      .replace(/{{BASE}}/g, base)
+      .replace(/{{VERSION}}/g, version)
+      .replace(/{{GENERATED_AT}}/g, generatedAt)
+      .replace(/{{COMMIT_SUFFIX}}/g, commitSuffix)
     const trimmed = content.trimEnd()
 
     if (trimmed) {

--- a/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
+++ b/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
@@ -16,6 +16,19 @@ async function getBranchName(cwd: string) {
   }
 }
 
+export async function getCommitHash() {
+  const repoRoot = findRepoRoot()
+
+  try {
+    const { stdout } = await execAsync('git rev-parse --short HEAD', {
+      cwd: repoRoot,
+    })
+    return stdout.trim()
+  } catch {
+    return ''
+  }
+}
+
 export async function getNextReleaseVersion() {
   const repoRoot = findRepoRoot()
   const branchName = await getBranchName(repoRoot)

--- a/tools/eufemia-llm-metadata/src/templates/llm-header.md
+++ b/tools/eufemia-llm-metadata/src/templates/llm-header.md
@@ -2,6 +2,10 @@
 
 > DNB's Eufemia design system. This file points LLMs to machine-readable docs and clean Markdown copies.
 
+## Version
+
+This documentation reflects Eufemia **v{{VERSION}}**, generated {{GENERATED_AT}}{{COMMIT_SUFFIX}}.
+
 - Use the documentation exactly as provided.
 - Gather all required information from the documentation before using it as a reference.
 - Do not make assumptions or infer missing details unless explicitly instructed to do so.


### PR DESCRIPTION
## Summary

Ensures every MCP consumer knows which Eufemia version the docs were built from — without a dedicated tool or extra roundtrip.

### Changes

**Build pipeline:**
- `generateDocs.ts` writes `_meta.json` (`{ eufemiaVersion, generatedAt, commit }`) to the docs output directory
- `buildDocsBundle.ts` includes `_meta.json` in the Worker bundle
- Added `getCommitHash()` helper to `getNextReleaseVersion.ts`

**`serverInfo.version` (initialize handshake):**
- Removed hardcoded `SERVER_INFO = { version: '2.2.0' }` constant
- Added `createServerInfo(eufemiaVersion?)` and `readDocsMeta(source)` — reads `_meta.json` from the docs source
- Worker, HTTP, and stdio entry points all derive the version from the same `_meta.json`

**`docs_entry` (llm.md context):**
- Added `## Version` section to `llm-header.md` template: "This documentation reflects Eufemia **vX.Y.Z**, generated YYYY-MM-DD, from commit abc123"
- Passes version, generatedAt, and commit through `appendLlmsHeaderTemplate`

### Motivation

- `serverInfo.version` is metadata every MCP client gets for free on initialize — no tool call needed
- `docs_entry` is already the canonical first call; a version section at the top puts the info in context where it's most useful
- Both now pull from the same source of truth (`_meta.json`), replacing the stale hardcoded `2.2.0`