### PR TITLE
chore(CodeBlock): remove double top border on toolbar in omit-wrapper mode

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -141,7 +141,9 @@
   :global(.omit-wrapper) & {
     border-start-start-radius: var(--border-radius);
     border-start-end-radius: var(--border-radius);
+  }
 
+  :global(.omit-wrapper:not(.hide-code)) & {
     box-shadow: inset 0 0 0 0.0625rem
       var(--token-color-stroke-neutral-subtle);
 

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -144,6 +144,10 @@
 
     box-shadow: inset 0 0 0 0.0625rem
       var(--token-color-stroke-neutral-subtle);
+
+    &::after {
+      border-top: none;
+    }
   }
 }
 


### PR DESCRIPTION
Deploy preview: https://fix-omit-wrapper-double-top.eufemia-e25.pages.dev/uilib/usage/best-practices/for-formatting

From:
<img width="1252" height="610" alt="Screenshot 2026-05-21 at 12 29 53" src="https://github.com/user-attachments/assets/e6933e96-06c7-431e-9269-987014f828d0" />


To:
<img width="1265" height="620" alt="Screenshot 2026-05-21 at 12 29 34" src="https://github.com/user-attachments/assets/14081f4e-e659-414f-be21-fdb5b831f22b" />
