### PR TITLE
chore(CodeBlock): remove duplicate fullscreen icon import

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -412,9 +412,7 @@ function LiveCode(props: LiveCodeProps) {
           : 'Show preview padding'
       }
       aria-pressed={showFocusModePadding}
-      icon={
-        showFocusModePadding ? focusModeIcon : focusModeCompactIcon
-      }
+      icon={showFocusModePadding ? focusModeIcon : focusModeCompactIcon}
     />
   )
 

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -27,7 +27,6 @@ import {
   check as checkIcon,
   fullscreen as focusModeIcon,
   close as focusModeCloseIcon,
-  fullscreen as focusModePaddingIcon,
   layout_grid as focusModeCompactIcon,
   launch as launchIcon,
 } from '@dnb/eufemia/src/icons'
@@ -414,7 +413,7 @@ function LiveCode(props: LiveCodeProps) {
       }
       aria-pressed={showFocusModePadding}
       icon={
-        showFocusModePadding ? focusModePaddingIcon : focusModeCompactIcon
+        showFocusModePadding ? focusModeIcon : focusModeCompactIcon
       }
     />
   )


### PR DESCRIPTION
The fullscreen icon was imported twice under different aliases (focusModeIcon and focusModePaddingIcon). Both resolved to the same icon. Reuse focusModeIcon for both purposes.

