### PR TITLE
chore(CodeBlock): remove unused tabMode prop

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -81,7 +81,6 @@ export type CodeSectionProps = {
   background?: 'grid' | 'plain'
   omitWrapper?: boolean
   children: string | ReactNode | (() => ReactNode)
-  tabMode?: 'focus' | 'indentation'
   'data-visual-test'?: string
 
   /** Injected by the babel transform — enclosing export name, stable across HMR. */


### PR DESCRIPTION
The tabMode prop was declared in the type but never destructured or forwarded. LiveEditor hardcodes tabMode="focus" regardless of any prop value, and no callers pass tabMode.

