### PR TITLE
chore(CodeBlock): add Blocks namespace import for StackBlitz examples

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -78,26 +78,6 @@ function getReactExportNames() {
 // Shared exports from @dnb/eufemia/shared
 const SHARED_EXPORTS = ['Provider', 'Theme']
 
-// Known date-fns functions used in examples
-const DATE_FNS_FUNCTIONS = [
-  'addDays',
-  'addMonths',
-  'addWeeks',
-  'addYears',
-  'format',
-  'formatDistance',
-  'isAfter',
-  'isBefore',
-  'isSameDay',
-  'isWeekend',
-  'lastDayOfMonth',
-  'lastDayOfWeek',
-  'startOfMonth',
-  'startOfWeek',
-  'subDays',
-  'subMonths',
-]
-
 // Known icon namespace imports
 const ICON_NAMESPACES: Record<string, string> = {
   PrimaryIconsMedium: '@dnb/eufemia/icons/dnb/primary_icons_medium',
@@ -115,6 +95,19 @@ async function getIconExportNames(): Promise<string[]> {
     iconExportNamesCache = Object.keys(icons)
   }
   return iconExportNamesCache
+}
+
+/**
+ * Lazily loads all date-fns export names.
+ * Only loaded when someone clicks the StackBlitz button.
+ */
+let dateFnsExportNamesCache: string[] | null = null
+async function getDateFnsExportNames(): Promise<string[]> {
+  if (!dateFnsExportNamesCache) {
+    const dateFns = await import('date-fns')
+    dateFnsExportNamesCache = Object.keys(dateFns)
+  }
+  return dateFnsExportNamesCache
 }
 
 /**
@@ -139,7 +132,6 @@ function analyzeCodeForImports(code: string) {
   const usedReactHooks: string[] = []
   const usedReactExports: string[] = []
   const usedSharedExports: string[] = []
-  const usedDateFnsFunctions: string[] = []
   const usedIconNamespaces: string[] = []
   let usesStyled = false
   let usesBlocks = false
@@ -222,13 +214,6 @@ function analyzeCodeForImports(code: string) {
     }
   }
 
-  // Detect date-fns function usage
-  for (const fn of DATE_FNS_FUNCTIONS) {
-    if (new RegExp(`\\b${fn}\\b`).test(code)) {
-      usedDateFnsFunctions.push(fn)
-    }
-  }
-
   // Detect if code defines a function component (including exports)
   const isFunctionComponent =
     /^(export\s+)?(function\s+\w+|const\s+\w+\s*=\s*(\([^)]*\)|[^=])\s*=>)/m.test(
@@ -255,7 +240,6 @@ function analyzeCodeForImports(code: string) {
     usesStyled,
     usesBlocks,
     usedIconNamespaces,
-    usedDateFnsFunctions,
     isFunctionComponent,
     hasDefaultExport,
     usesRenderPattern,
@@ -264,14 +248,17 @@ function analyzeCodeForImports(code: string) {
 }
 
 /**
- * Detects individual icon imports needed by the code.
- * Dynamically loads the icon module to avoid bundling all SVGs on initial page load.
- * Returns import statements like: import { bell as Bell } from '@dnb/eufemia/icons'
+ * Detects external imports (icons, date-fns, etc.) needed by the code.
+ * Uses dynamic imports to avoid bundling heavy modules on initial page load.
+ * Only loaded when someone clicks the StackBlitz button.
  */
-async function detectIndividualIconImports(
+async function detectExternalImports(
   code: string,
   analysis: ReturnType<typeof analyzeCodeForImports>
-): Promise<string[]> {
+): Promise<{ imports: string[]; dependencies: Record<string, string> }> {
+  const imports: string[] = []
+  const dependencies: Record<string, string> = {}
+
   // Collect all names already handled by other import detection
   const knownNames = new Set([
     ...analysis.usedComponents,
@@ -282,9 +269,8 @@ async function detectIndividualIconImports(
     ...analysis.usedReactExports,
     ...analysis.usedSharedExports,
     ...analysis.usedIconNamespaces,
-    ...analysis.usedDateFnsFunctions,
     ...SHARED_EXPORTS,
-    // Common names that aren't icons
+    // Common names that aren't icons or date-fns
     'App',
     'Provider',
     'render',
@@ -292,58 +278,68 @@ async function detectIndividualIconImports(
     'Blocks',
   ])
 
-  // Find PascalCase or snake_case identifiers in the code
-  // that could be icon references (used as prop values or JSX)
-  const potentialIconNames = new Set<string>()
+  // Extract all identifiers from code that aren't already known
+  const unknownNames = new Set<string>()
   const identifierPattern =
-    /\b([A-Z][a-zA-Z]*|[a-z][a-z_]*_(?:medium|small|large))\b/g
+    /\b([A-Z][a-zA-Z]*|[a-z][a-z_]*_(?:medium|small|large)|[a-z][a-zA-Z]+)\b/g
   let match: RegExpExecArray | null
 
   while ((match = identifierPattern.exec(code)) !== null) {
     const name = match[1]
     if (!knownNames.has(name)) {
-      potentialIconNames.add(name)
+      unknownNames.add(name)
     }
   }
 
-  if (potentialIconNames.size === 0) {
-    return []
+  if (unknownNames.size === 0) {
+    return { imports, dependencies }
   }
 
-  // Load icon names lazily
+  // Detect individual icon imports
   const iconNames = await getIconExportNames()
   const iconNameSet = new Set(iconNames)
-
   const iconImportPairs: Array<{ snakeName: string; usedName: string }> =
     []
 
-  for (const name of potentialIconNames) {
-    // Check if it's already a snake_case icon name (e.g. bell_medium)
+  for (const name of unknownNames) {
     if (iconNameSet.has(name)) {
       iconImportPairs.push({ snakeName: name, usedName: name })
-      continue
-    }
-
-    // Try converting PascalCase to snake_case (e.g. BellMedium -> bell_medium)
-    const snakeName = toSnakeCase(name)
-    if (iconNameSet.has(snakeName)) {
-      iconImportPairs.push({ snakeName, usedName: name })
+      knownNames.add(name)
+    } else {
+      const snakeName = toSnakeCase(name)
+      if (iconNameSet.has(snakeName)) {
+        iconImportPairs.push({ snakeName, usedName: name })
+        knownNames.add(name)
+      }
     }
   }
 
-  if (iconImportPairs.length === 0) {
-    return []
-  }
-
-  // Group imports: aliased (PascalCase) and direct (snake_case)
-  const importSpecifiers = iconImportPairs.map(
-    ({ snakeName, usedName }) =>
+  if (iconImportPairs.length > 0) {
+    const specifiers = iconImportPairs.map(({ snakeName, usedName }) =>
       snakeName === usedName ? snakeName : `${snakeName} as ${usedName}`
-  )
+    )
+    imports.push(
+      `import { ${specifiers.join(', ')} } from '@dnb/eufemia/icons'`
+    )
+  }
 
-  return [
-    `import { ${importSpecifiers.join(', ')} } from '@dnb/eufemia/icons'`,
-  ]
+  // Detect date-fns imports dynamically
+  const dateFnsNames = await getDateFnsExportNames()
+  const dateFnsSet = new Set(dateFnsNames)
+  const usedDateFns: string[] = []
+
+  for (const name of unknownNames) {
+    if (!knownNames.has(name) && dateFnsSet.has(name)) {
+      usedDateFns.push(name)
+    }
+  }
+
+  if (usedDateFns.length > 0) {
+    imports.push(`import { ${usedDateFns.join(', ')} } from 'date-fns'`)
+    dependencies['date-fns'] = '^4.1.0'
+  }
+
+  return { imports, dependencies }
 }
 
 /**
@@ -437,14 +433,7 @@ function generateAppComponent(code: string, extraImports: string[] = []) {
     imports.push(`import * as ${name} from '${ICON_NAMESPACES[name]}'`)
   }
 
-  // date-fns imports
-  if (analysis.usedDateFnsFunctions.length > 0) {
-    imports.push(
-      `import { ${analysis.usedDateFnsFunctions.join(', ')} } from 'date-fns'`
-    )
-  }
-
-  // Extra imports (e.g. individual icon imports detected asynchronously)
+  // Extra imports (e.g. icons, date-fns detected asynchronously)
   imports.push(...extraImports)
 
   const importsBlock = imports.join('\n')
@@ -528,9 +517,9 @@ export async function openInStackBlitz(code: string) {
   // Analyze code to determine needed dependencies
   const analysis = analyzeCodeForImports(code)
 
-  // Detect individual icon imports asynchronously
-  // Icons are loaded lazily to avoid bundling all SVGs on every page
-  const iconImports = await detectIndividualIconImports(code, analysis)
+  // Detect external imports (icons, date-fns, etc.) asynchronously
+  // These modules are loaded lazily to avoid bundling on every page
+  const external = await detectExternalImports(code, analysis)
 
   const appCode = `import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -545,7 +534,7 @@ createRoot(document.getElementById('root')!).render(
 `
 
   const appComponent = await formatCode(
-    generateAppComponent(code, iconImports)
+    generateAppComponent(code, external.imports)
   )
 
   const indexHtml = `<!doctype html>
@@ -573,9 +562,7 @@ createRoot(document.getElementById('root')!).render(
     dependencies['@emotion/styled'] = '^11.14.0'
   }
 
-  if (analysis.usedDateFnsFunctions.length > 0) {
-    dependencies['date-fns'] = '^4.1.0'
-  }
+  Object.assign(dependencies, external.dependencies)
 
   const packageJson = JSON.stringify(
     {

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -90,6 +90,7 @@ function analyzeCodeForImports(code: string) {
   const usedReactExports: string[] = []
   const usedSharedExports: string[] = []
   let usesStyled = false
+  let usesBlocks = false
 
   // Helper to check if a name is used in code
   const isUsed = (name: string) => {
@@ -157,6 +158,11 @@ function analyzeCodeForImports(code: string) {
     usesStyled = true
   }
 
+  // Detect Blocks namespace usage (from @dnb/eufemia/extensions/forms/blocks)
+  if (/\bBlocks\./.test(code)) {
+    usesBlocks = true
+  }
+
   // Detect if code defines a function component (including exports)
   const isFunctionComponent =
     /^(export\s+)?(function\s+\w+|const\s+\w+\s*=\s*(\([^)]*\)|[^=])\s*=>)/m.test(
@@ -181,6 +187,7 @@ function analyzeCodeForImports(code: string) {
     usedReactExports,
     usedSharedExports,
     usesStyled,
+    usesBlocks,
     isFunctionComponent,
     hasDefaultExport,
     usesRenderPattern,
@@ -263,6 +270,13 @@ function generateAppComponent(code: string) {
   if (analysis.usedFormsComponents.length > 0) {
     imports.push(
       `import { ${analysis.usedFormsComponents.join(', ')} } from '@dnb/eufemia/extensions/forms'`
+    )
+  }
+
+  // Blocks namespace import
+  if (analysis.usesBlocks) {
+    imports.push(
+      `import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'`
     )
   }
 

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -78,12 +78,6 @@ function getReactExportNames() {
 // Shared exports from @dnb/eufemia/shared
 const SHARED_EXPORTS = ['Provider', 'Theme']
 
-// Known icon namespace imports
-const ICON_NAMESPACES: Record<string, string> = {
-  PrimaryIconsMedium: '@dnb/eufemia/icons/dnb/primary_icons_medium',
-  SecondaryIconsMedium: '@dnb/eufemia/icons/dnb/secondary_icons_medium',
-}
-
 /**
  * Lazily loads all icon export names from @dnb/eufemia/src/icons.
  * Only loaded when someone clicks the StackBlitz button.
@@ -122,6 +116,45 @@ function toSnakeCase(name: string): string {
 }
 
 /**
+ * Resolves a namespace name to a published import path by trying known
+ * subpath patterns via dynamic import. Only runs when StackBlitz is opened.
+ *
+ * Patterns tried:
+ * 1. Forms subpath: Blocks -> @dnb/eufemia/extensions/forms/blocks
+ * 2. Icon barrel:   PrimaryIconsMedium -> @dnb/eufemia/icons/dnb/primary_icons_medium
+ */
+const namespacePathCache = new Map<string, string | null>()
+async function resolveNamespacePath(name: string): Promise<string | null> {
+  if (namespacePathCache.has(name)) {
+    return namespacePathCache.get(name)!
+  }
+
+  const candidates = [
+    {
+      devPath: `@dnb/eufemia/src/extensions/forms/${name.toLowerCase()}`,
+      publishedPath: `@dnb/eufemia/extensions/forms/${name.toLowerCase()}`,
+    },
+    {
+      devPath: `@dnb/eufemia/src/icons/dnb/${toSnakeCase(name)}`,
+      publishedPath: `@dnb/eufemia/icons/dnb/${toSnakeCase(name)}`,
+    },
+  ]
+
+  for (const { devPath, publishedPath } of candidates) {
+    try {
+      await import(/* @vite-ignore */ devPath)
+      namespacePathCache.set(name, publishedPath)
+      return publishedPath
+    } catch {
+      // Not found at this path, try next
+    }
+  }
+
+  namespacePathCache.set(name, null)
+  return null
+}
+
+/**
  * Analyzes code to detect what imports are needed.
  */
 function analyzeCodeForImports(code: string) {
@@ -132,9 +165,7 @@ function analyzeCodeForImports(code: string) {
   const usedReactHooks: string[] = []
   const usedReactExports: string[] = []
   const usedSharedExports: string[] = []
-  const usedIconNamespaces: string[] = []
   let usesStyled = false
-  let usesBlocks = false
 
   // Helper to check if a name is used in code
   const isUsed = (name: string) => {
@@ -202,18 +233,6 @@ function analyzeCodeForImports(code: string) {
     usesStyled = true
   }
 
-  // Detect Blocks namespace usage (from @dnb/eufemia/extensions/forms/blocks)
-  if (/\bBlocks\./.test(code)) {
-    usesBlocks = true
-  }
-
-  // Detect icon namespace usage (PrimaryIconsMedium, SecondaryIconsMedium)
-  for (const name of Object.keys(ICON_NAMESPACES)) {
-    if (new RegExp(`\\b${name}\\b`).test(code)) {
-      usedIconNamespaces.push(name)
-    }
-  }
-
   // Detect if code defines a function component (including exports)
   const isFunctionComponent =
     /^(export\s+)?(function\s+\w+|const\s+\w+\s*=\s*(\([^)]*\)|[^=])\s*=>)/m.test(
@@ -238,8 +257,6 @@ function analyzeCodeForImports(code: string) {
     usedReactExports,
     usedSharedExports,
     usesStyled,
-    usesBlocks,
-    usedIconNamespaces,
     isFunctionComponent,
     hasDefaultExport,
     usesRenderPattern,
@@ -268,15 +285,29 @@ async function detectExternalImports(
     ...analysis.usedReactHooks,
     ...analysis.usedReactExports,
     ...analysis.usedSharedExports,
-    ...analysis.usedIconNamespaces,
     ...SHARED_EXPORTS,
-    // Common names that aren't icons or date-fns
+    // Common names that aren't external imports
     'App',
     'Provider',
     'render',
     'styled',
-    'Blocks',
   ])
+
+  // Detect namespace imports (SomeName.something patterns)
+  // Try to resolve each against known subpath conventions
+  const namespacePattern = /\b([A-Z][a-zA-Z]+)\./g
+  let nsMatch: RegExpExecArray | null
+
+  while ((nsMatch = namespacePattern.exec(code)) !== null) {
+    const name = nsMatch[1]
+    if (!knownNames.has(name)) {
+      const resolvedPath = await resolveNamespacePath(name)
+      if (resolvedPath) {
+        imports.push(`import * as ${name} from '${resolvedPath}'`)
+        knownNames.add(name)
+      }
+    }
+  }
 
   // Extract all identifiers from code that aren't already known
   const unknownNames = new Set<string>()
@@ -421,19 +452,7 @@ function generateAppComponent(code: string, extraImports: string[] = []) {
     )
   }
 
-  // Blocks namespace import
-  if (analysis.usesBlocks) {
-    imports.push(
-      `import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'`
-    )
-  }
-
-  // Icon namespace imports (PrimaryIconsMedium, SecondaryIconsMedium)
-  for (const name of analysis.usedIconNamespaces) {
-    imports.push(`import * as ${name} from '${ICON_NAMESPACES[name]}'`)
-  }
-
-  // Extra imports (e.g. icons, date-fns detected asynchronously)
+  // Extra imports (e.g. namespaces, icons, date-fns detected asynchronously)
   imports.push(...extraImports)
 
   const importsBlock = imports.join('\n')

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -78,6 +78,56 @@ function getReactExportNames() {
 // Shared exports from @dnb/eufemia/shared
 const SHARED_EXPORTS = ['Provider', 'Theme']
 
+// Known date-fns functions used in examples
+const DATE_FNS_FUNCTIONS = [
+  'addDays',
+  'addMonths',
+  'addWeeks',
+  'addYears',
+  'format',
+  'formatDistance',
+  'isAfter',
+  'isBefore',
+  'isSameDay',
+  'isWeekend',
+  'lastDayOfMonth',
+  'lastDayOfWeek',
+  'startOfMonth',
+  'startOfWeek',
+  'subDays',
+  'subMonths',
+]
+
+// Known icon namespace imports
+const ICON_NAMESPACES: Record<string, string> = {
+  PrimaryIconsMedium: '@dnb/eufemia/icons/dnb/primary_icons_medium',
+  SecondaryIconsMedium: '@dnb/eufemia/icons/dnb/secondary_icons_medium',
+}
+
+/**
+ * Lazily loads all icon export names from @dnb/eufemia/src/icons.
+ * Only loaded when someone clicks the StackBlitz button.
+ */
+let iconExportNamesCache: string[] | null = null
+async function getIconExportNames(): Promise<string[]> {
+  if (!iconExportNamesCache) {
+    const icons = await import('@dnb/eufemia/src/icons')
+    iconExportNamesCache = Object.keys(icons)
+  }
+  return iconExportNamesCache
+}
+
+/**
+ * Converts a PascalCase name to snake_case.
+ * E.g. "BellMedium" -> "bell_medium", "AccountCard" -> "account_card"
+ */
+function toSnakeCase(name: string): string {
+  return name
+    .replace(/([A-Z])/g, '_$1')
+    .toLowerCase()
+    .replace(/^_/, '')
+}
+
 /**
  * Analyzes code to detect what imports are needed.
  */
@@ -89,6 +139,8 @@ function analyzeCodeForImports(code: string) {
   const usedReactHooks: string[] = []
   const usedReactExports: string[] = []
   const usedSharedExports: string[] = []
+  const usedDateFnsFunctions: string[] = []
+  const usedIconNamespaces: string[] = []
   let usesStyled = false
   let usesBlocks = false
 
@@ -163,6 +215,20 @@ function analyzeCodeForImports(code: string) {
     usesBlocks = true
   }
 
+  // Detect icon namespace usage (PrimaryIconsMedium, SecondaryIconsMedium)
+  for (const name of Object.keys(ICON_NAMESPACES)) {
+    if (new RegExp(`\\b${name}\\b`).test(code)) {
+      usedIconNamespaces.push(name)
+    }
+  }
+
+  // Detect date-fns function usage
+  for (const fn of DATE_FNS_FUNCTIONS) {
+    if (new RegExp(`\\b${fn}\\b`).test(code)) {
+      usedDateFnsFunctions.push(fn)
+    }
+  }
+
   // Detect if code defines a function component (including exports)
   const isFunctionComponent =
     /^(export\s+)?(function\s+\w+|const\s+\w+\s*=\s*(\([^)]*\)|[^=])\s*=>)/m.test(
@@ -188,11 +254,96 @@ function analyzeCodeForImports(code: string) {
     usedSharedExports,
     usesStyled,
     usesBlocks,
+    usedIconNamespaces,
+    usedDateFnsFunctions,
     isFunctionComponent,
     hasDefaultExport,
     usesRenderPattern,
     hasExistingImports,
   }
+}
+
+/**
+ * Detects individual icon imports needed by the code.
+ * Dynamically loads the icon module to avoid bundling all SVGs on initial page load.
+ * Returns import statements like: import { bell as Bell } from '@dnb/eufemia/icons'
+ */
+async function detectIndividualIconImports(
+  code: string,
+  analysis: ReturnType<typeof analyzeCodeForImports>
+): Promise<string[]> {
+  // Collect all names already handled by other import detection
+  const knownNames = new Set([
+    ...analysis.usedComponents,
+    ...analysis.usedFragments,
+    ...analysis.usedElements,
+    ...analysis.usedFormsComponents,
+    ...analysis.usedReactHooks,
+    ...analysis.usedReactExports,
+    ...analysis.usedSharedExports,
+    ...analysis.usedIconNamespaces,
+    ...analysis.usedDateFnsFunctions,
+    ...SHARED_EXPORTS,
+    // Common names that aren't icons
+    'App',
+    'Provider',
+    'render',
+    'styled',
+    'Blocks',
+  ])
+
+  // Find PascalCase or snake_case identifiers in the code
+  // that could be icon references (used as prop values or JSX)
+  const potentialIconNames = new Set<string>()
+  const identifierPattern =
+    /\b([A-Z][a-zA-Z]*|[a-z][a-z_]*_(?:medium|small|large))\b/g
+  let match: RegExpExecArray | null
+
+  while ((match = identifierPattern.exec(code)) !== null) {
+    const name = match[1]
+    if (!knownNames.has(name)) {
+      potentialIconNames.add(name)
+    }
+  }
+
+  if (potentialIconNames.size === 0) {
+    return []
+  }
+
+  // Load icon names lazily
+  const iconNames = await getIconExportNames()
+  const iconNameSet = new Set(iconNames)
+
+  const iconImportPairs: Array<{ snakeName: string; usedName: string }> =
+    []
+
+  for (const name of potentialIconNames) {
+    // Check if it's already a snake_case icon name (e.g. bell_medium)
+    if (iconNameSet.has(name)) {
+      iconImportPairs.push({ snakeName: name, usedName: name })
+      continue
+    }
+
+    // Try converting PascalCase to snake_case (e.g. BellMedium -> bell_medium)
+    const snakeName = toSnakeCase(name)
+    if (iconNameSet.has(snakeName)) {
+      iconImportPairs.push({ snakeName, usedName: name })
+    }
+  }
+
+  if (iconImportPairs.length === 0) {
+    return []
+  }
+
+  // Group imports: aliased (PascalCase) and direct (snake_case)
+  const importSpecifiers = iconImportPairs.map(
+    ({ snakeName, usedName }) =>
+      snakeName === usedName ? snakeName : `${snakeName} as ${usedName}`
+  )
+
+  return [
+    `import { ${importSpecifiers.join(', ')} } from '@dnb/eufemia/icons'`,
+  ]
 }
 
 /**
@@ -219,8 +370,9 @@ export async function formatCode(code: string): Promise<string> {
 
 /**
  * Generates the App.tsx content based on code analysis.
+ * @param extraImports - Additional import statements (e.g. for icons detected asynchronously)
  */
-function generateAppComponent(code: string) {
+function generateAppComponent(code: string, extraImports: string[] = []) {
   const analysis = analyzeCodeForImports(code)
 
   // If code already has imports, use it as-is with minimal wrapping
@@ -279,6 +431,21 @@ function generateAppComponent(code: string) {
       `import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'`
     )
   }
+
+  // Icon namespace imports (PrimaryIconsMedium, SecondaryIconsMedium)
+  for (const name of analysis.usedIconNamespaces) {
+    imports.push(`import * as ${name} from '${ICON_NAMESPACES[name]}'`)
+  }
+
+  // date-fns imports
+  if (analysis.usedDateFnsFunctions.length > 0) {
+    imports.push(
+      `import { ${analysis.usedDateFnsFunctions.join(', ')} } from 'date-fns'`
+    )
+  }
+
+  // Extra imports (e.g. individual icon imports detected asynchronously)
+  imports.push(...extraImports)
 
   const importsBlock = imports.join('\n')
 
@@ -361,6 +528,10 @@ export async function openInStackBlitz(code: string) {
   // Analyze code to determine needed dependencies
   const analysis = analyzeCodeForImports(code)
 
+  // Detect individual icon imports asynchronously
+  // Icons are loaded lazily to avoid bundling all SVGs on every page
+  const iconImports = await detectIndividualIconImports(code, analysis)
+
   const appCode = `import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import '@dnb/eufemia/style'
@@ -373,7 +544,9 @@ createRoot(document.getElementById('root')!).render(
 )
 `
 
-  const appComponent = await formatCode(generateAppComponent(code))
+  const appComponent = await formatCode(
+    generateAppComponent(code, iconImports)
+  )
 
   const indexHtml = `<!doctype html>
 <html lang="en">
@@ -398,6 +571,10 @@ createRoot(document.getElementById('root')!).render(
 
   if (analysis.usesStyled) {
     dependencies['@emotion/styled'] = '^11.14.0'
+  }
+
+  if (analysis.usedDateFnsFunctions.length > 0) {
+    dependencies['date-fns'] = '^4.1.0'
   }
 
   const packageJson = JSON.stringify(


### PR DESCRIPTION
Motivation: https://main.eufemia-e25.pages.dev/uilib/extensions/forms/blocks/ChildrenWithAge#in-wizard

The StackBlitz integration was not detecting the Blocks namespace import, causing 'Cannot find name Blocks' errors when opening code examples that use Blocks.ChildrenWithAge.

Add detection for Blocks. usage patterns and generate the appropriate namespace import statement:
import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'

