### PR TITLE
feat(DatePicker): show only one calendar in `range` and add `sideBySide` option for two calendars

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
@@ -221,7 +221,13 @@ export const DatePickerErrorStatus = () => (
 
 export const DatePickerCalendarInline = () => (
   <ComponentBox background="plain">
-    <DatePicker inline range startDate="2019-05-05" endDate="2019-06-05" />
+    <DatePicker
+      inline
+      range
+      sideBySide
+      startDate="2019-05-05"
+      endDate="2019-06-05"
+    />
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/visual-tests.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/visual-tests.tsx
@@ -164,6 +164,7 @@ const DatePickerRangeMode = () => (
     <DatePicker
       inline
       range
+      sideBySide
       startDate="2019-05-05"
       endDate="2019-06-05"
       onDaysRender={(days) => {

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -289,6 +289,10 @@ export type DatePickerProps = {
    * Will enable year navigation in the calendar if set to `true`. Defaults to `false`.
    */
   yearNavigation?: boolean
+  /**
+   * If set to `true`, two calendar views are shown side by side when `range` is `true`. By default, range mode shows a single calendar view. Defaults to `false`.
+   */
+  sideBySide?: boolean
   className?: string
   /**
    * Will be called right before every new calendar view gets rendered. See the example above.

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -3,7 +3,14 @@
  *
  */
 
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import type {
   ElementRef,
   HTMLProps,
@@ -135,6 +142,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
   const props = { ...defaultProps, ...restOfProps }
 
   const {
+    views,
     updateDates,
     setHasClickedCalendarDay,
     startDate,
@@ -168,6 +176,19 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     hideNextMonthWeek,
     onlyMonth,
   } = props
+
+  const isSinglePaneRange = isRange && views.length === 1
+
+  // Tracks which date is being edited during keyboard navigation
+  // in single-pane range mode (start date first, then end date).
+  const [editingDateType, setEditingDateType] = useState<'start' | 'end'>(
+    'start'
+  )
+  const editingDateTypeRef = useRef(editingDateType)
+  const updateEditingDateType = useCallback((type: 'start' | 'end') => {
+    editingDateTypeRef.current = type
+    setEditingDateType(type)
+  }, [])
 
   const tableRef = useRef<ElementRef<'table'> | null>(null)
   const days = useRef<Record<string, Array<DatePickerCalendarDay>>>({})
@@ -312,6 +333,14 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     [minDate, maxDate]
   )
 
+  const focusCalendarTable = useCallback((index: number) => {
+    const viewsContainer = tableRef.current?.closest(
+      '.dnb-date-picker__views'
+    )
+    const tables = viewsContainer?.querySelectorAll('table')
+    tables?.[index]?.focus({ preventScroll: true })
+  }, [])
+
   const onKeyDownHandler = useCallback(
     (event: KeyboardEvent<HTMLTableElement>) => {
       const pressedKey = event.code
@@ -328,7 +357,11 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
       event.preventDefault()
 
       const currentDates = currentDatesRef.current
-      const dateType = !isRange || nr === 0 ? 'start' : 'end'
+      const dateType = isSinglePaneRange
+        ? editingDateTypeRef.current
+        : !isRange || nr === 0
+          ? 'start'
+          : 'end'
       const currentDate = currentDates[`${dateType}Date`]
 
       let newDate = currentDate
@@ -340,11 +373,64 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         newDate === currentDate &&
         (pressedKey === 'Enter' || pressedKey === 'Space')
       ) {
-        return callOnSelect({
-          event,
-          nr,
-          hidePicker: true,
-        })
+        // In single-pane range mode, first Enter confirms start date
+        // and switches to editing end date
+        if (isSinglePaneRange && editingDateTypeRef.current === 'start') {
+          updateEditingDateType('end')
+
+          // Initialize end date cursor to start date position
+          const endDateValue =
+            currentDates.endDate || currentDates.startDate
+          currentDatesRef.current = {
+            ...currentDates,
+            endDate: endDateValue,
+          }
+
+          // Navigate calendar to show the end date's month
+          if (
+            endDateValue &&
+            !isSameMonth(endDateValue, currentDates.startMonth)
+          ) {
+            updateDates({ startMonth: endDateValue })
+            currentDatesRef.current.startMonth = endDateValue
+          }
+
+          return // stop here
+        }
+
+        const confirmSelection = () => {
+          if (isSinglePaneRange) {
+            updateEditingDateType('start')
+          } else if (isRange) {
+            focusCalendarTable(nr === 0 ? 1 : 0)
+          }
+
+          callOnSelect({
+            event,
+            nr,
+            hidePicker: !isRange,
+          })
+        }
+
+        // Auto-swap reversed range before confirming
+        if (isRange && currentDates.startDate && currentDates.endDate) {
+          const range = toRange(
+            currentDates.startDate,
+            currentDates.endDate
+          )
+
+          if (!isSameDay(range.startDate, currentDates.startDate)) {
+            return updateDates(
+              {
+                startDate: startOfDay(range.startDate),
+                endDate: startOfDay(range.endDate),
+              },
+              confirmSelection
+            )
+          }
+        }
+
+        return confirmSelection()
       }
 
       const dates: {
@@ -354,7 +440,12 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         endMonth?: Date
       } = {}
 
-      const currentMonth = currentDates[`${dateType}Month`]
+      // In single-pane range mode, the single calendar always displays
+      // startMonth regardless of which date type is being edited
+      const monthKey = (
+        isSinglePaneRange ? 'startMonth' : `${dateType}Month`
+      ) as 'startMonth' | 'endMonth'
+      const currentMonth = currentDates[monthKey]
 
       if (
         // in case we don't have a start/end date, then we use the current month date
@@ -370,8 +461,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
             : lastDayOfMonth(currentMonth)
 
         // only to make sure we navigate the calendar to the new date
-      } else if (currentMonth && !isSameMonth(currentDate, currentMonth)) {
-        dates[`${dateType}Month`] = newDate
+      } else if (currentMonth && !isSameMonth(newDate, currentMonth)) {
+        dates[monthKey] = newDate
       }
 
       newDate = findValid(newDate, pressedKey)
@@ -429,11 +520,14 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     [
       callOnSelect,
       findValid,
+      focusCalendarTable,
       hasReachedEnd,
+      isSinglePaneRange,
       onKeyDown,
       startDate,
       endDate,
       updateDates,
+      updateEditingDateType,
       hideNavigation,
       isRange,
       keyNavCalc,
@@ -497,6 +591,15 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
   return (
     <div
       className={clsx('dnb-date-picker__calendar', rtl && 'rtl')}
+      data-editing={
+        isSinglePaneRange
+          ? editingDateType
+          : isRange
+            ? nr === 0
+              ? 'start'
+              : 'end'
+            : undefined
+      }
       lang={locale}
     >
       {!hideNavigation && !onlyMonth && (
@@ -641,7 +744,11 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                         onClick={
                           handleAsDisabled
                             ? undefined
-                            : ({ event }) =>
+                            : ({ event }) => {
+                                if (isSinglePaneRange) {
+                                  updateEditingDateType('start')
+                                }
+
                                 onSelectRange({
                                   day,
                                   isRange,
@@ -661,6 +768,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                                     )
                                   },
                                 })
+                              }
                         }
                         onMouseOver={
                           handleAsDisabled

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -183,6 +183,11 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  sideBySide: {
+    doc: 'If set to `true`, two calendar views are shown side by side when `range` is `true`. By default, range mode shows a single calendar view. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
   labelAlignment: {
     doc: 'Sets the alignment of the label. Defaults to `left`.',
     type: ['"left"', '"center"', '"right"'],

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerProvider.tsx
@@ -84,6 +84,7 @@ function DatePickerProvider(props: DatePickerProviderProps) {
     maxDate,
     dateFormat = defaultDateFormat,
     range,
+    sideBySide,
     attributes,
     returnFormat: returnFormatProp,
     children,
@@ -118,6 +119,7 @@ function DatePickerProvider(props: DatePickerProviderProps) {
     startMonth: dates.startMonth,
     endMonth: dates.endMonth,
     isRange: range,
+    sideBySide,
   })
 
   const [lastEventCallCache, setLastEventCallCache] =

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5906,4 +5906,239 @@ describe('DatePicker ARIA', () => {
       expect(button.textContent).toContain('Open')
     })
   })
+
+  describe('single-pane range keyboard navigation', () => {
+    it('should allow selecting both start and end date with keyboard in single-pane range mode', async () => {
+      const onChange = vi.fn()
+
+      render(
+        <DatePicker
+          range
+          startDate="2024-10-01"
+          endDate="2024-10-15"
+          onChange={onChange}
+        />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      expect(
+        document.querySelectorAll('.dnb-date-picker__calendar').length
+      ).toBe(1)
+
+      const table = document.querySelector(
+        '.dnb-date-picker__calendar table'
+      )
+
+      // Focus the table and navigate start date with arrow keys
+      fireEvent.focus(table)
+      fireEvent.keyDown(table, { code: 'ArrowRight' })
+
+      // The start date should have moved one day forward
+      const startDateCell = document.querySelector(
+        '.dnb-date-picker__day--start-date'
+      )
+      expect(startDateCell).toBeInTheDocument()
+
+      // Confirm start date with Enter → should switch to editing end date
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      // The calendar should still be visible (not closed)
+      expect(
+        document.querySelector('.dnb-date-picker__calendar')
+      ).toBeInTheDocument()
+
+      // data-editing should now be 'end'
+      const calendar = document.querySelector('.dnb-date-picker__calendar')
+      expect(calendar.getAttribute('data-editing')).toBe('end')
+
+      // Navigate end date with arrow keys
+      fireEvent.keyDown(table, { code: 'ArrowRight' })
+
+      // Confirm end date with Enter → should stay open (submit button handles closing)
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      expect(
+        document.querySelector('.dnb-date-picker__calendar')
+      ).toBeInTheDocument()
+
+      // data-editing should reset to 'start'
+      expect(calendar.getAttribute('data-editing')).toBe('start')
+
+      expect(onChange).toHaveBeenCalled()
+    })
+
+    it('should auto-swap reversed range when confirming with keyboard', async () => {
+      render(
+        <DatePicker range startDate="2024-10-10" endDate="2024-10-20" />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      const table = document.querySelector(
+        '.dnb-date-picker__calendar table'
+      )
+
+      // Focus and navigate: move start date forward past end date
+      fireEvent.focus(table)
+
+      // Navigate start date to after end date (move right 15 days)
+      for (let i = 0; i < 15; i++) {
+        fireEvent.keyDown(table, { code: 'ArrowRight' })
+      }
+
+      // Confirm start date → switch to editing end date
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      // Confirm end date (which is now before start date)
+      // → should auto-swap and stay open
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      // Picker should stay open
+      expect(
+        document.querySelector('.dnb-date-picker__calendar')
+      ).toBeInTheDocument()
+
+      // After auto-swap, start date should be before end date
+      const startDateButton = document.querySelector(
+        '.dnb-date-picker__day--start-date button'
+      )
+      const endDateButton = document.querySelector(
+        '.dnb-date-picker__day--end-date button'
+      )
+      expect(startDateButton).toBeInTheDocument()
+      expect(endDateButton).toBeInTheDocument()
+
+      const startDay = Number(startDateButton.textContent)
+      const endDay = Number(endDateButton.textContent)
+      expect(startDay).toBeLessThan(endDay)
+    })
+
+    it('should set data-editing attribute on calendar div', async () => {
+      render(
+        <DatePicker range startDate="2024-10-01" endDate="2024-10-15" />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      const calendar = document.querySelector('.dnb-date-picker__calendar')
+
+      // Should start with 'start'
+      expect(calendar.getAttribute('data-editing')).toBe('start')
+
+      const table = document.querySelector(
+        '.dnb-date-picker__calendar table'
+      )
+      fireEvent.focus(table)
+
+      // Confirm start date → should switch to 'end'
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      expect(calendar.getAttribute('data-editing')).toBe('end')
+    })
+
+    it('should reset editing state to start when clicking a day', async () => {
+      render(
+        <DatePicker range startDate="2024-10-01" endDate="2024-10-15" />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      const table = document.querySelector(
+        '.dnb-date-picker__calendar table'
+      )
+      fireEvent.focus(table)
+
+      // Switch to editing end
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      const calendar = document.querySelector('.dnb-date-picker__calendar')
+      expect(calendar.getAttribute('data-editing')).toBe('end')
+
+      // Click a day → should reset to 'start'
+      const selectableDay = document.querySelector(
+        'td.dnb-date-picker__day--selectable button'
+      ) as HTMLButtonElement
+      fireEvent.click(selectableDay)
+
+      expect(calendar.getAttribute('data-editing')).toBe('start')
+    })
+
+    it('should switch calendar month when end date is in a different month', async () => {
+      render(
+        <DatePicker range startDate="2024-10-01" endDate="2024-11-15" />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      // Calendar should initially show October
+      const header = document.querySelector(
+        '.dnb-date-picker__header__title'
+      )
+      expect(header.textContent).toContain('oktober')
+
+      const table = document.querySelector(
+        '.dnb-date-picker__calendar table'
+      )
+      fireEvent.focus(table)
+
+      // Confirm start date → switches to end date editing
+      // End date is in November, so calendar should jump to November
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      expect(header.textContent).toContain('november')
+    })
+
+    it('should switch calendar month when navigating end date across months', async () => {
+      render(
+        <DatePicker range startDate="2024-10-28" endDate="2024-10-31" />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      const header = document.querySelector(
+        '.dnb-date-picker__header__title'
+      )
+      expect(header.textContent).toContain('oktober')
+
+      const table = document.querySelector(
+        '.dnb-date-picker__calendar table'
+      )
+      fireEvent.focus(table)
+
+      // Confirm start date → switch to editing end date
+      fireEvent.keyDown(table, { code: 'Enter' })
+
+      // Navigate end date forward past month boundary (Oct 31 + 1 = Nov 1)
+      fireEvent.keyDown(table, { code: 'ArrowRight' })
+
+      // Calendar should now show November
+      expect(header.textContent).toContain('november')
+    })
+
+    it('should not use single-pane behavior when sideBySide is true', async () => {
+      render(
+        <DatePicker
+          range
+          sideBySide
+          startDate="2024-10-01"
+          endDate="2024-10-15"
+        />
+      )
+
+      await userEvent.click(getDatePickerTriggerButton())
+
+      // Should show two calendars
+      expect(
+        document.querySelectorAll('.dnb-date-picker__calendar').length
+      ).toBe(2)
+
+      // Each calendar should have its fixed data-editing attribute
+      const calendars = document.querySelectorAll(
+        '.dnb-date-picker__calendar'
+      )
+      expect(calendars[0].getAttribute('data-editing')).toBe('start')
+      expect(calendars[1].getAttribute('data-editing')).toBe('end')
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -306,7 +306,7 @@ describe('DatePicker component', () => {
   it('will close the picker after selection', () => {
     const onChange = vi.fn()
     const { rerender } = render(
-      <DatePicker {...defaultProps} onChange={onChange} />
+      <DatePicker {...defaultProps} sideBySide onChange={onChange} />
     )
 
     fireEvent.click(
@@ -1185,6 +1185,7 @@ describe('DatePicker component', () => {
       <DatePicker
         noAnimation
         range
+        sideBySide
         shortcuts={[
           {
             title: 'day',
@@ -1301,8 +1302,8 @@ describe('DatePicker component', () => {
     )
   })
 
-  it('has two calendar views', () => {
-    render(<DatePicker {...defaultProps} />)
+  it('has two calendar views when sideBySide is true', () => {
+    render(<DatePicker {...defaultProps} sideBySide />)
 
     fireEvent.click(
       document.querySelector('button.dnb-input__submit-button__button')
@@ -1315,9 +1316,84 @@ describe('DatePicker component', () => {
     ).toBe(2)
   })
 
+  it('has one calendar view by default when range is true', () => {
+    render(
+      <DatePicker
+        range
+        startDate="2024-10-01"
+        endDate="2024-10-24"
+        showInput
+      />
+    )
+
+    fireEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-date-picker__calendar').length
+    ).toBe(1)
+  })
+
+  it('has two calendar views when sideBySide is true and range is true', () => {
+    render(
+      <DatePicker
+        range
+        sideBySide
+        startDate="2024-10-01"
+        endDate="2024-10-24"
+        showInput
+      />
+    )
+
+    fireEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-date-picker__calendar').length
+    ).toBe(2)
+  })
+
+  it('supports range selection with single calendar view', () => {
+    const onChange = vi.fn()
+
+    render(<DatePicker range showInput onChange={onChange} />)
+
+    fireEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+
+    const calendar = document.querySelector('.dnb-date-picker__calendar')
+    const selectableDays = calendar.querySelectorAll(
+      'td.dnb-date-picker__day--selectable'
+    )
+
+    // Click start date
+    fireEvent.click(selectableDays[0].querySelector('button'))
+
+    expect(selectableDays[0].classList).toContain(
+      'dnb-date-picker__day--start-date'
+    )
+
+    // Click end date
+    fireEvent.click(selectableDays[4].querySelector('button'))
+
+    expect(selectableDays[4].classList).toContain(
+      'dnb-date-picker__day--end-date'
+    )
+
+    expect(onChange).toHaveBeenCalled()
+  })
+
   it('has correctly synced calendar views based on user navigation and date selection', async () => {
     render(
-      <DatePicker range startDate="2024-10-01" endDate="2024-10-24" />
+      <DatePicker
+        range
+        sideBySide
+        startDate="2024-10-01"
+        endDate="2024-10-24"
+      />
     )
 
     await userEvent.click(getDatePickerTriggerButton())
@@ -1388,7 +1464,12 @@ describe('DatePicker component', () => {
 
   it('should not set the month pickers to same month when `startDate` and `endDate` are set to same day in range mode', async () => {
     render(
-      <DatePicker range startDate="2024-10-24" endDate="2024-11-24" />
+      <DatePicker
+        range
+        sideBySide
+        startDate="2024-10-24"
+        endDate="2024-11-24"
+      />
     )
 
     await userEvent.click(getDatePickerTriggerButton())
@@ -1452,7 +1533,12 @@ describe('DatePicker component', () => {
 
   it('should not set the month pickers to same month when `startDate` and `endDate` are set to same month in range mode', async () => {
     render(
-      <DatePicker range startDate="2024-10-24" endDate="2024-11-24" />
+      <DatePicker
+        range
+        sideBySide
+        startDate="2024-10-24"
+        endDate="2024-11-24"
+      />
     )
 
     await userEvent.click(getDatePickerTriggerButton())
@@ -1564,7 +1650,12 @@ describe('DatePicker component', () => {
 
   it('should set correct month based date selected with keyboard navigation in range mode', async () => {
     render(
-      <DatePicker range startDate="2024-10-01" endDate="2024-10-02" />
+      <DatePicker
+        range
+        sideBySide
+        startDate="2024-10-01"
+        endDate="2024-10-02"
+      />
     )
 
     await userEvent.click(getDatePickerTriggerButton())
@@ -2330,7 +2421,14 @@ describe('DatePicker component', () => {
 
   it('has correct css classes on range selection', () => {
     render(
-      <DatePicker id="date-picker-id" noAnimation range open showInput />
+      <DatePicker
+        id="date-picker-id"
+        noAnimation
+        range
+        sideBySide
+        open
+        showInput
+      />
     )
 
     const FirstCalendar = document.querySelectorAll(
@@ -2690,6 +2788,7 @@ describe('DatePicker component', () => {
       <DatePicker
         showInput
         range
+        sideBySide
         startDate={defaultProps.startDate}
         endDate={defaultProps.endDate}
       />
@@ -2886,7 +2985,12 @@ describe('DatePicker component', () => {
 
   it('should display correct start and end month on opening the date picker', async () => {
     render(
-      <DatePicker startMonth="2024-01-01" endMonth="2024-12-31" range />
+      <DatePicker
+        startMonth="2024-01-01"
+        endMonth="2024-12-31"
+        range
+        sideBySide
+      />
     )
 
     await userEvent.click(screen.getByLabelText('Åpne datovelger'))
@@ -2922,7 +3026,12 @@ describe('DatePicker component', () => {
 
   it('should display correct months in calendar view based on input value when opening the picker in range mode', async () => {
     render(
-      <DatePicker startMonth="2024-01-01" endMonth="2024-12-31" range />
+      <DatePicker
+        startMonth="2024-01-01"
+        endMonth="2024-12-31"
+        range
+        sideBySide
+      />
     )
 
     const [startDayInput, endDayInput] = Array.from(
@@ -4173,7 +4282,13 @@ describe('DatePicker component', () => {
 
   it('should display a month ahead in right picker when range is linked', async () => {
     render(
-      <DatePicker startDate="2024-10-10" endDate="2024-11-21" range link />
+      <DatePicker
+        startDate="2024-10-10"
+        endDate="2024-11-21"
+        range
+        sideBySide
+        link
+      />
     )
 
     const [startDay, startMonth, startYear, endDay, endMonth, endYear] =
@@ -4489,6 +4604,7 @@ describe('DatePicker component', () => {
         yearNavigation
         showInput
         range
+        sideBySide
       />
     )
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2879,6 +2879,12 @@ html:not([data-whatintent=touch]) .dnb-date-picker__day--inactive .dnb-button[di
 .dnb-date-picker__header__nav .dnb-button:hover:not(:active):not(:focus-visible) {
   background-color: var(--token-color-background-neutral);
 }
+.dnb-date-picker__calendar[data-editing=start] table:focus .dnb-date-picker__day--start-date .dnb-button, .dnb-date-picker__calendar[data-editing=end] table:focus .dnb-date-picker__day--end-date .dnb-button {
+  --border-color: var(--token-color-stroke-action-focus);
+  --border-width: var(--focus-ring-width);
+  box-shadow: 0 0 0 var(--border-width) var(--border-color);
+  border-color: transparent;
+}
 .dnb-date-picker .rtl {
   direction: rtl;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useViews.ts
@@ -11,12 +11,17 @@ export type ViewDates = {
 
 export type UseViewsParams = ViewDates & {
   isRange?: boolean
+  sideBySide?: boolean
 }
 
-export default function useViews({ isRange, ...dates }: UseViewsParams) {
+export default function useViews({
+  isRange,
+  sideBySide,
+  ...dates
+}: UseViewsParams) {
   const [previousDates, setPreviousDates] = useState(dates)
   const [views, setViews] = useState<Array<DatePickerCalendarView>>(
-    getViews({ ...dates, isRange })
+    getViews({ ...dates, isRange, sideBySide })
   )
 
   const hasClickedCalendarDay = useRef<boolean>(false)
@@ -44,19 +49,23 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
       const updatedViews = getViews({
         ...dates,
         isRange,
+        sideBySide,
       })
 
       setViews(updatedViews)
     }
   }
 
-  function updateViews(
-    views: Array<DatePickerCalendarView>,
-    cb: (...args: unknown[]) => void = null
-  ) {
-    setViews(views)
-    cb?.()
-  }
+  const updateViews = useCallback(
+    (
+      views: Array<DatePickerCalendarView>,
+      cb: (...args: unknown[]) => void = null
+    ) => {
+      setViews(views)
+      cb?.()
+    },
+    []
+  )
 
   return {
     views,
@@ -67,9 +76,10 @@ export default function useViews({ isRange, ...dates }: UseViewsParams) {
 
 export function getViews({
   isRange,
+  sideBySide,
   ...dates
 }: ViewDates & UseViewsParams): Array<DatePickerCalendarView> {
-  return isRange
+  return isRange && sideBySide
     ? [
         { nr: 0, month: getMonthView({ months: dates, nr: 0 }) },
         { nr: 1, month: getMonthView({ months: dates, nr: 1 }) },

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -485,12 +485,24 @@
     }
   }
 
+  // Reset nav button styles to remove default box-shadow and set neutral hover background
   &__header__nav {
     .dnb-button:not(:hover):not(:focus-visible) {
       box-shadow: none;
     }
     .dnb-button:hover:not(:active):not(:focus-visible) {
       background-color: var(--token-color-background-neutral);
+    }
+  }
+
+  // Keyboard focus indicator for the date being edited
+  &__calendar[data-editing='start'] table:focus &__day--start-date,
+  &__calendar[data-editing='end'] table:focus &__day--end-date {
+    .dnb-button {
+      @include utilities.fakeBorder(
+        var(--token-color-stroke-action-focus),
+        var(--focus-ring-width)
+      );
     }
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -701,6 +701,7 @@ export const datePickerPropKeys = [
   'onReset',
   'skipPortal',
   'yearNavigation',
+  'sideBySide',
   'tooltip',
   'triggerProps',
 ] as const satisfies ReadonlyArray<keyof DatePickerProps>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -1245,6 +1245,7 @@ describe('Field.Date', () => {
           month="2024-06-01"
           value="2024-01-15|2024-02-20"
           range
+          sideBySide
         />
       )
 
@@ -2334,7 +2335,9 @@ describe('Field.Date', () => {
   })
 
   it('should support linked calendars', async () => {
-    render(<Field.Date value="2024-11-01|2024-12-01" range link />)
+    render(
+      <Field.Date value="2024-11-01|2024-12-01" range sideBySide link />
+    )
 
     await userEvent.click(
       document.querySelector('button.dnb-input__submit-button__button')
@@ -2846,6 +2849,7 @@ describe('Field.Date', () => {
         onChange={onChange}
         yearNavigation
         range
+        sideBySide
       />
     )
 
@@ -3054,6 +3058,30 @@ describe('Field.Date', () => {
     )
   })
 
+  it('should show one calendar in range mode by default', async () => {
+    render(<Field.Date value="2025-04-01|2025-04-30" range />)
+
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-date-picker__calendar').length
+    ).toBe(1)
+  })
+
+  it('should forward `sideBySide` to DatePicker and show two calendars in range mode', async () => {
+    render(<Field.Date value="2025-04-01|2025-04-30" range sideBySide />)
+
+    await userEvent.click(
+      document.querySelector('button.dnb-input__submit-button__button')
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-date-picker__calendar').length
+    ).toBe(2)
+  })
+
   it('should export `dateValidator`', async () => {
     const myOnBlurValidator = (value: string) => {
       if (value === '2025-01-01') {
@@ -3243,7 +3271,12 @@ describe('Field.Date', () => {
   describe('startMonth and endMonth', () => {
     it('should display correct start and end month on opening the date picker', async () => {
       render(
-        <Field.Date startMonth="2024-01-01" endMonth="2024-12-31" range />
+        <Field.Date
+          startMonth="2024-01-01"
+          endMonth="2024-12-31"
+          range
+          sideBySide
+        />
       )
 
       await userEvent.click(
@@ -3267,6 +3300,7 @@ describe('Field.Date', () => {
           minDate="2024-10-01"
           maxDate="2024-10-31"
           range
+          sideBySide
         />
       )
 


### PR DESCRIPTION
Motivation: Enhance UX
Preview: https://feat-date-picker-single-cale-rt8o.eufemia-e25.pages.dev/uilib/components/date-picker