### PR TITLE
chore(Field.Date): derive props from single source of truth

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -72,47 +72,7 @@ export type DateProps = Omit<
    */
   showResetButton?: DatePickerProps['showResetButton']
   onBlurValidator?: DateValidator | false
-} & Pick<
-    DatePickerProps,
-    | 'month'
-    | 'startMonth'
-    | 'endMonth'
-    | 'minDate'
-    | 'maxDate'
-    | 'maskOrder'
-    | 'maskPlaceholder'
-    | 'dateFormat'
-    | 'returnFormat'
-    | 'hideNavigation'
-    | 'hideDays'
-    | 'onlyMonth'
-    | 'hideLastWeek'
-    | 'disableAutofocus'
-    | 'showSubmitButton'
-    | 'submitButtonText'
-    | 'cancelButtonText'
-    | 'resetButtonText'
-    | 'firstDay'
-    | 'link'
-    | 'size'
-    | 'sync'
-    | 'addonElement'
-    | 'shortcuts'
-    | 'open'
-    | 'direction'
-    | 'alignPicker'
-    | 'onDaysRender'
-    | 'onType'
-    | 'onOpen'
-    | 'onClose'
-    | 'onSubmit'
-    | 'onCancel'
-    | 'onReset'
-    | 'skipPortal'
-    | 'yearNavigation'
-    | 'tooltip'
-    | 'triggerProps'
-  >
+} & PickedDatePickerProps
 
 function DateComponent(props: DateProps): ReactElement {
   const { errorRequired, label: defaultLabel } = useTranslation().Date
@@ -701,8 +661,10 @@ function isEmptyOrPlaceholder(date: string): boolean {
 }
 
 // Used to filter out DatePickerProps from the FieldProps.
-// Includes DatePickerProps that are not destructured in useFieldProps
-const datePickerPropKeys = [
+// Includes DatePickerProps that are not destructured in useFieldProps.
+// Single source of truth for both the type and the runtime key list.
+// Also used by DateDocs.ts to keep documentation in sync.
+export const datePickerPropKeys = [
   'month',
   'startMonth',
   'endMonth',
@@ -731,8 +693,6 @@ const datePickerPropKeys = [
   'direction',
   'alignPicker',
   'onDaysRender',
-  'showInput',
-  'onDaysRender',
   'onType',
   'onOpen',
   'onClose',
@@ -743,12 +703,67 @@ const datePickerPropKeys = [
   'yearNavigation',
   'tooltip',
   'triggerProps',
-]
+] as const satisfies ReadonlyArray<keyof DatePickerProps>
+
+type PickedDatePickerProps = Pick<
+  DatePickerProps,
+  (typeof datePickerPropKeys)[number]
+>
+
+// DatePickerProps that are intentionally not forwarded to DatePicker.
+// When a new prop is added to DatePickerProps, add it to either
+// datePickerPropKeys (forwarded) or this type (excluded).
+type ExcludedDatePickerProps =
+  // Value props handled by Field.Date
+  | 'date'
+  | 'startDate'
+  | 'endDate'
+  // Props with different defaults, handled separately
+  | 'range'
+  | 'showInput'
+  | 'showCancelButton'
+  | 'showResetButton'
+  // Props handled by useFieldProps
+  | 'label'
+  | 'labelDirection'
+  | 'labelSrOnly'
+  | 'labelAlignment'
+  | 'inputElement'
+  | 'disabled'
+  | 'stretch'
+  | 'skeleton'
+  | 'suffix'
+  | 'onChange'
+  | 'onFocus'
+  | 'onBlur'
+  // Not supported by Field.Date
+  | 'inline'
+  | 'resetDate'
+  | 'preventClose'
+  | 'noAnimation'
+  | 'enableKeyboardNav'
+  | 'tabIndex'
+  | 'className'
+  | '_omitInputShellClass'
+
+// Compile-time check: every DatePickerProps key must be either
+// forwarded (datePickerPropKeys) or explicitly excluded.
+// If this errors, a new DatePickerProps key needs to be added
+// to one of the two lists above.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type AssertNever<T extends never> = T
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type _AssertAllPropsHandled = AssertNever<
+  Exclude<
+    keyof DatePickerProps,
+    (typeof datePickerPropKeys)[number] | ExcludedDatePickerProps
+  >
+>
 
 function pickDatePickerProps(props: DateProps): Partial<DatePickerProps> {
   const datePickerProps = Object.keys(props).reduce(
     (datePickerProps, key) => {
-      if (datePickerPropKeys.includes(key)) {
+      if ((datePickerPropKeys as ReadonlyArray<string>).includes(key)) {
         datePickerProps[key] = props[key]
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
@@ -3,58 +3,44 @@ import {
   DatePickerEvents,
 } from '../../../../components/date-picker/DatePickerDocs'
 import type { PropertiesTableProps } from '../../../../shared/types'
+import { datePickerPropKeys } from './Date'
 
-// Filter out properties that are handled by `useFieldProps` or has a different default value
-const {
-  showCancelButton,
-  showResetButton,
-  showInput,
-  range,
-  skeleton,
-  globalStatus,
-  statusProps,
-  statusState,
-  status,
-  inputElement,
-  label,
-  labelDirection,
-  labelSrOnly,
-  labelAlignment,
-  suffix,
-  stretch,
-  size,
-  date,
-  startDate,
-  endDate,
-  '[Space](/uilib/layout/space/properties)': space,
-  ...datePickerProperties
-} = DatePickerProperties
+// Build the subset of DatePickerProperties that Field.Date forwards,
+// using datePickerPropKeys as the source of truth.
+// Event props (on*) are documented in DateEvents, not here.
+const datePickerProperties = datePickerPropKeys.reduce((acc, key) => {
+  if (DatePickerProperties[key]) {
+    acc[key] = DatePickerProperties[key]
+  }
+
+  return acc
+}, {} as PropertiesTableProps)
 
 // `range`, `showInput`, `showCancelButton` and `showResetButton` inherit from `DatePickerProperties`
 // Since they require `Field.Date` specific documentation, due to them having different default values
 export const DateProperties: PropertiesTableProps = {
   range: {
-    ...range,
+    ...DatePickerProperties.range,
     doc:
       'Defines if the Date field should support a value of two dates (starting and ending date). ' +
       'The `value` needs to be a string containing two dates, separated by a pipe character (`|`) (`01-09-2024|30-09-2024`) when this is set to `true`. ' +
       'Defaults to `false`.',
   },
   showInput: {
-    ...showInput,
+    ...DatePickerProperties.showInput,
     doc: 'If the input fields with the mask should be visible. Defaults to `true`.',
   },
   showCancelButton: {
-    ...showCancelButton,
+    ...DatePickerProperties.showCancelButton,
     doc: 'If set to `true`, a cancel button will be shown. You can change the default text by using `cancelButtonText="Avbryt"`. Defaults to `true`. If the `range` property is `true`, then the cancel button is shown.',
   },
   showResetButton: {
-    ...showResetButton,
+    ...DatePickerProperties.showResetButton,
     doc: 'If set to `true`, a reset button will be shown. You can change the default text by using `resetButtonText="Tilbakestill"`. When clicked, the field resets to the initial `value` or `defaultValue`. If no initial value was provided, the field is cleared. Defaults to `true`.',
   },
   size: {
-    ...size,
-    doc: `${size.doc} Consider rather setting field sizes with [Form.Appearance](/uilib/extensions/forms/Form/Appearance/).`,
+    ...DatePickerProperties.size,
+    doc: `${DatePickerProperties.size.doc} Consider rather setting field sizes with [Form.Appearance](/uilib/extensions/forms/Form/Appearance/).`,
   },
   ...datePickerProperties,
   onType: {


### PR DESCRIPTION
Replace the duplicated `Pick` type and runtime `datePickerPropKeys` array in `Field.Date` with a single `as const satisfies` array. The `PickedDatePickerProps` type is now derived from the array, so adding a new `DatePicker` prop to forward only requires one change.

Also removes stale duplicate `onDaysRender` and `showInput` entries from the runtime array.