### PR TITLE
chore(Portal): refactor StackBlitz CodeBlock integration to use babel plugin for all imports

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -85,6 +85,9 @@ export type CodeSectionProps = {
 
   /** Injected by the babel transform — enclosing export name, stable across HMR. */
   stableName?: string
+
+  /** Injected by the babel transform — original import statements from the Examples file. */
+  sourceImports?: string[]
 }
 
 const CodeBlock = ({
@@ -267,6 +270,7 @@ function LiveCode(props: LiveCodeProps) {
     surface: surfaceProp,
     'data-visual-test': visualTest,
     stableName: _stableName,
+    sourceImports,
 
     ...restProps
   } = props
@@ -381,8 +385,8 @@ function LiveCode(props: LiveCodeProps) {
 
   const handleOpenInStackBlitz = useCallback(async () => {
     const codeToOpen = editedCode ?? codeToUse
-    await openInStackBlitz(codeToOpen)
-  }, [editedCode, codeToUse])
+    await openInStackBlitz(codeToOpen, sourceImports)
+  }, [editedCode, codeToUse, sourceImports])
 
   const openInStackBlitzButton = (
     <Button

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -767,7 +767,12 @@ describe('CodeBlock', () => {
       )
 
       const { container } = render(
-        <CodeBlock reactLive scope={{}} language="jsx">
+        <CodeBlock
+          reactLive
+          scope={{}}
+          language="jsx"
+          sourceImports={["import { Button } from '@dnb/eufemia'"]}
+        >
           {
             '<Button onClick={() => console.log("clicked")}>Click me</Button>'
           }
@@ -785,9 +790,6 @@ describe('CodeBlock', () => {
 
       const appCode = submittedFormData['project[files][src/App.tsx]']
       expect(appCode).toContain("import { Button } from '@dnb/eufemia'")
-      expect(appCode).toContain(
-        "import { Provider } from '@dnb/eufemia/shared'"
-      )
 
       vi.restoreAllMocks()
     })
@@ -820,7 +822,15 @@ describe('CodeBlock', () => {
 }`
 
       const { container } = render(
-        <CodeBlock reactLive scope={{}} language="jsx">
+        <CodeBlock
+          reactLive
+          scope={{}}
+          language="jsx"
+          sourceImports={[
+            "import { useEffect, useState } from 'react'",
+            "import { Button } from '@dnb/eufemia'",
+          ]}
+        >
           {codeWithHooks}
         </CodeBlock>
       )

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/openInStackBlitz.test.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/openInStackBlitz.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest'
+import {
+  filterImportsByUsage,
+  analyzeCodeStructure,
+  generateAppComponent,
+  formatCode,
+  openInStackBlitz,
+} from '../openInStackBlitz'
+
+describe('filterImportsByUsage', () => {
+  it('keeps imports for names used in code', () => {
+    const result = filterImportsByUsage(
+      ["import { Button } from '@dnb/eufemia'"],
+      '<Button>Click</Button>'
+    )
+
+    expect(result).toEqual(["import { Button } from '@dnb/eufemia'"])
+  })
+
+  it('removes imports for names not used in code', () => {
+    const result = filterImportsByUsage(
+      ["import { Card } from '@dnb/eufemia'"],
+      '<Button>Click</Button>'
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('filters individual specifiers from grouped imports', () => {
+    const result = filterImportsByUsage(
+      ["import { Button, Card, Table } from '@dnb/eufemia'"],
+      '<Button>Click</Button>'
+    )
+
+    expect(result).toEqual(["import { Button } from '@dnb/eufemia'"])
+  })
+
+  it('keeps default imports when name is used', () => {
+    const result = filterImportsByUsage(
+      ["import styled from '@emotion/styled'"],
+      'const Wrapper = styled.div`color: red`'
+    )
+
+    expect(result).toEqual(["import styled from '@emotion/styled'"])
+  })
+
+  it('removes default imports when name is not used', () => {
+    const result = filterImportsByUsage(
+      ["import styled from '@emotion/styled'"],
+      '<Button>Click</Button>'
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('handles renamed imports by checking local name', () => {
+    const result = filterImportsByUsage(
+      ["import { trash as trashIcon } from '@dnb/eufemia/icons'"],
+      '<Button icon={trashIcon}>Click</Button>'
+    )
+
+    expect(result).toEqual([
+      "import { trash as trashIcon } from '@dnb/eufemia/icons'",
+    ])
+  })
+
+  it('keeps multiple imports from different sources', () => {
+    const result = filterImportsByUsage(
+      [
+        "import { Button } from '@dnb/eufemia'",
+        "import { useState } from 'react'",
+        "import { format } from 'date-fns'",
+      ],
+      'const [v, setV] = useState(0)\n<Button>Click</Button>'
+    )
+
+    expect(result).toEqual([
+      "import { Button } from '@dnb/eufemia'",
+      "import { useState } from 'react'",
+    ])
+  })
+
+  it('handles mixed default and named imports', () => {
+    const result = filterImportsByUsage(
+      ["import React, { useState, useEffect } from 'react'"],
+      'const [v, setV] = useState(0)'
+    )
+
+    expect(result).toEqual(["import { useState } from 'react'"])
+  })
+})
+
+describe('analyzeCodeStructure', () => {
+  it('detects function component pattern', () => {
+    const result = analyzeCodeStructure(
+      'function MyComponent() { return <div /> }'
+    )
+
+    expect(result.isFunctionComponent).toBe(true)
+  })
+
+  it('detects arrow function component pattern', () => {
+    const result = analyzeCodeStructure(
+      'const MyComponent = () => <div />'
+    )
+
+    expect(result.isFunctionComponent).toBe(true)
+  })
+
+  it('detects default export', () => {
+    const result = analyzeCodeStructure(
+      'export default function App() { return <div /> }'
+    )
+
+    expect(result.hasDefaultExport).toBe(true)
+  })
+
+  it('detects render() pattern', () => {
+    const result = analyzeCodeStructure('render(<MyComponent />)')
+
+    expect(result.usesRenderPattern).toBe(true)
+  })
+
+  it('detects existing imports', () => {
+    const result = analyzeCodeStructure(
+      "import { Button } from '@dnb/eufemia'\n<Button>Click</Button>"
+    )
+
+    expect(result.hasExistingImports).toBe(true)
+  })
+})
+
+describe('generateAppComponent', () => {
+  it('wraps plain JSX in an App component', () => {
+    const result = generateAppComponent('<Button>Click</Button>', [
+      "import { Button } from '@dnb/eufemia'",
+    ])
+
+    expect(result).toContain('export default function App()')
+    expect(result).toContain('<Button>Click</Button>')
+    expect(result).toContain("import { Button } from '@dnb/eufemia'")
+  })
+
+  it('passes through code with existing imports unchanged', () => {
+    const code =
+      "import { Button } from '@dnb/eufemia'\n<Button>Click</Button>"
+
+    const result = generateAppComponent(code)
+
+    expect(result).toBe(code)
+  })
+
+  it('includes imports in the output', () => {
+    const result = generateAppComponent(
+      '<Button icon={trash}>Click</Button>',
+      [
+        "import { Button } from '@dnb/eufemia'",
+        "import { trash } from '@dnb/eufemia/icons'",
+      ]
+    )
+
+    expect(result).toContain("import { Button } from '@dnb/eufemia'")
+    expect(result).toContain("import { trash } from '@dnb/eufemia/icons'")
+  })
+
+  it('wraps function component with App export', () => {
+    const result = generateAppComponent(
+      'function MyComp() { return <Button>Click</Button> }',
+      ["import { Button } from '@dnb/eufemia'"]
+    )
+
+    expect(result).toContain('export default function App()')
+    expect(result).toContain('<MyComp />')
+  })
+
+  it('handles default export by renaming', () => {
+    const result = generateAppComponent(
+      'export default function MyComp() { return <Button>Click</Button> }',
+      ["import { Button } from '@dnb/eufemia'"]
+    )
+
+    expect(result).toContain('function MyComp()')
+    expect(result).toContain('export default function App()')
+    expect(result).toContain('<MyComp />')
+  })
+})
+
+describe('openInStackBlitz', () => {
+  it('adds external dependency from sourceImports', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz(
+      'const Wrapper = styled.div`color: red`\n<Wrapper>hi</Wrapper>',
+      ["import styled from '@emotion/styled'"]
+    )
+
+    const packageJson = JSON.parse(
+      form.fields['project[files][package.json]']
+    )
+
+    expect(packageJson.dependencies['@emotion/styled']).toBe('latest')
+
+    form.cleanup()
+  })
+
+  it('detects external dependencies from sourceImports', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('format(new Date())', [
+      "import { format } from 'date-fns'",
+    ])
+
+    const packageJson = JSON.parse(
+      form.fields['project[files][package.json]']
+    )
+
+    expect(packageJson.dependencies['date-fns']).toBe('latest')
+
+    form.cleanup()
+  })
+
+  it('does not add @dnb/eufemia as extra dependency from sourceImports', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('<Button icon={trash}>Click</Button>', [
+      "import { Button } from '@dnb/eufemia'",
+      "import { trash } from '@dnb/eufemia/icons'",
+    ])
+
+    const packageJson = JSON.parse(
+      form.fields['project[files][package.json]']
+    )
+
+    expect(packageJson.dependencies['@dnb/eufemia']).toBe('latest')
+    expect(
+      Object.keys(packageJson.dependencies).filter(
+        (k: string) => k === '@dnb/eufemia'
+      )
+    ).toHaveLength(1)
+
+    form.cleanup()
+  })
+
+  it('includes only used sourceImports in App.tsx', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('<Button icon={trash}>Click</Button>', [
+      "import { Button, Card } from '@dnb/eufemia'",
+      "import { trash } from '@dnb/eufemia/icons'",
+    ])
+
+    const appTsx = form.fields['project[files][src/App.tsx]']
+
+    expect(appTsx).toContain("from '@dnb/eufemia/icons'")
+    expect(appTsx).toContain('Button')
+    expect(appTsx).not.toContain('Card')
+
+    form.cleanup()
+  })
+
+  it('filters sourceImports to avoid unused imports', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('<Button>Click</Button>', [
+      "import { Button } from '@dnb/eufemia'",
+      "import { Field } from '@dnb/eufemia/extensions/forms'",
+    ])
+
+    const appTsx = form.fields['project[files][src/App.tsx]']
+
+    expect(appTsx).toContain("from '@dnb/eufemia'")
+    expect(appTsx).not.toContain('Field')
+
+    form.cleanup()
+  })
+
+  it('always includes base dependencies', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('<Button>Click</Button>', [
+      "import { Button } from '@dnb/eufemia'",
+    ])
+
+    const packageJson = JSON.parse(
+      form.fields['project[files][package.json]']
+    )
+
+    expect(packageJson.dependencies).toHaveProperty('@dnb/eufemia')
+    expect(packageJson.dependencies).toHaveProperty('react')
+    expect(packageJson.dependencies).toHaveProperty('react-dom')
+
+    form.cleanup()
+  })
+
+  it('generates valid main.tsx', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('<Button>Click</Button>', [
+      "import { Button } from '@dnb/eufemia'",
+    ])
+
+    const mainTsx = form.fields['project[files][src/main.tsx]']
+
+    expect(mainTsx).toContain("import '@dnb/eufemia/style'")
+    expect(mainTsx).toContain("import App from './App.tsx'")
+    expect(mainTsx).toContain('<StrictMode>')
+    expect(mainTsx).toContain('<App />')
+    // Should not contain Provider wrapper
+    expect(mainTsx).not.toContain('Provider')
+
+    form.cleanup()
+  })
+})
+
+describe('formatCode', () => {
+  it('formats code with prettier', async () => {
+    const result = await formatCode('const x=1;const y=2;')
+
+    expect(result).toContain('const x = 1')
+    expect(result).toContain('const y = 2')
+  })
+
+  it('returns original code on parse error', async () => {
+    const broken = '{{{'
+
+    const result = await formatCode(broken)
+
+    expect(result).toBe(broken)
+  })
+})
+
+/**
+ * Intercepts form submission by stubbing document.createElement
+ * and captures the submitted field values.
+ */
+function mockFormSubmission() {
+  const fields: Record<string, string> = {}
+
+  const originalSubmit = HTMLFormElement.prototype.submit
+  HTMLFormElement.prototype.submit = function (this: HTMLFormElement) {
+    this.querySelectorAll('input[type="hidden"]').forEach((input) => {
+      const el = input as HTMLInputElement
+      fields[el.name] = el.value
+    })
+  }
+
+  return {
+    fields,
+    cleanup() {
+      HTMLFormElement.prototype.submit = originalSubmit
+    },
+  }
+}

--- a/packages/dnb-design-system-portal/src/shared/tags/formsExports.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/formsExports.ts
@@ -1,8 +1,5 @@
 /**
- * Shared forms exports for code block scope and StackBlitz code generation.
- *
- * This file provides a centralized list of forms components to avoid duplication
- * between ComponentBox.tsx and openInStackBlitz.ts.
+ * Shared forms exports for ComponentBox code block scope.
  *
  * The exports are dynamically derived from @dnb/eufemia/src/extensions/forms
  * by filtering for capitalized exports (components/namespaces) and excluding
@@ -43,8 +40,3 @@ export const formsScope = Object.fromEntries(
     return isComponentExport(name) && value !== undefined
   })
 ) as Record<string, unknown>
-
-/**
- * Names of forms exports for import detection in StackBlitz code generation.
- */
-export const FORMS_EXPORT_NAMES = Object.keys(formsScope)

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -1,380 +1,103 @@
 /**
  * StackBlitz integration for opening code examples in a live playground.
+ *
+ * Import detection relies on the babel plugin (react-live-babel.ts) which
+ * passes all file-level imports from Examples.tsx as sourceImports.
+ * This module filters those to only include names actually used in each
+ * code snippet — no hardcoded component/hook/export name lists needed.
  */
 
-// eslint-disable-next-line no-restricted-imports
-import * as ReactExports from 'react'
-import { getComponents } from '@dnb/eufemia/src/components/lib'
-import { getFragments } from '@dnb/eufemia/src/fragments/lib'
-import { getElements } from '@dnb/eufemia/src/elements/lib'
-import { FORMS_EXPORT_NAMES } from './formsExports'
 import { format } from 'prettier/standalone'
 import * as prettierPluginBabel from 'prettier/plugins/babel'
 import * as prettierPluginEstree from 'prettier/plugins/estree'
-
-// Lazy initialization - only compute when needed
-let EUFEMIA_COMPONENT_NAMES: string[] | null = null
-let EUFEMIA_FRAGMENT_NAMES: string[] | null = null
-let EUFEMIA_ELEMENT_NAMES: string[] | null = null
-let REACT_HOOK_NAMES: string[] | null = null
-let REACT_EXPORT_NAMES: string[] | null = null
-
-function getEufemiaComponentNames() {
-  if (!EUFEMIA_COMPONENT_NAMES) {
-    EUFEMIA_COMPONENT_NAMES = Object.keys(getComponents())
-  }
-  return EUFEMIA_COMPONENT_NAMES
-}
-
-function getEufemiaFragmentNames() {
-  if (!EUFEMIA_FRAGMENT_NAMES) {
-    EUFEMIA_FRAGMENT_NAMES = Object.keys(getFragments())
-  }
-  return EUFEMIA_FRAGMENT_NAMES
-}
-
-function getEufemiaElementNames() {
-  if (!EUFEMIA_ELEMENT_NAMES) {
-    EUFEMIA_ELEMENT_NAMES = Object.keys(getElements())
-  }
-  return EUFEMIA_ELEMENT_NAMES
-}
+import starterPackageJson from 'eufemia-starter/package.json'
 
 /**
- * Dynamically extracts React hook names from the React module.
- * Hooks are identified by the "use" prefix (e.g., useState, useEffect).
+ * Filters sourceImports to only include names actually used in the code.
+ * Each sourceImport is a full import statement string from the babel plugin.
  */
-function getReactHookNames() {
-  if (!REACT_HOOK_NAMES) {
-    REACT_HOOK_NAMES = Object.keys(ReactExports).filter(
-      (name) =>
-        name.startsWith('use') && typeof ReactExports[name] === 'function'
+export function filterImportsByUsage(
+  sourceImports: string[],
+  code: string
+): string[] {
+  const result: string[] = []
+
+  for (const stmt of sourceImports) {
+    const fromMatch = stmt.match(/from\s+['"]([^'"]+)['"]/)
+    if (!fromMatch) {
+      continue
+    }
+
+    const source = fromMatch[1]
+
+    // Extract default import name (e.g. "styled" from "import styled from ...")
+    const defaultMatch = stmt.match(/^import\s+(\w+)[\s,]/)
+    const defaultName =
+      defaultMatch && defaultMatch[1] !== '{' ? defaultMatch[1] : null
+
+    // Extract named imports
+    const namedMatch = stmt.match(/\{([^}]+)\}/)
+    const namedSpecs: Array<{ full: string; local: string }> = []
+
+    if (namedMatch) {
+      for (const spec of namedMatch[1].split(',')) {
+        const trimmed = spec.trim()
+        if (!trimmed) {
+          continue
+        }
+
+        const parts = trimmed.split(/\s+as\s+/)
+        const local = parts.length > 1 ? parts[1] : parts[0]
+        namedSpecs.push({ full: trimmed, local })
+      }
+    }
+
+    // Filter by code usage
+    const defaultUsed =
+      defaultName && new RegExp(`\\b${defaultName}\\b`).test(code)
+
+    const usedNamed = namedSpecs.filter((s) =>
+      new RegExp(`\\b${s.local}\\b`).test(code)
     )
+
+    if (!defaultUsed && usedNamed.length === 0) {
+      continue
+    }
+
+    // Rebuild import statement with only used specifiers
+    const parts: string[] = []
+
+    if (defaultUsed) {
+      parts.push(defaultName)
+    }
+
+    if (usedNamed.length > 0) {
+      parts.push(`{ ${usedNamed.map((s) => s.full).join(', ')} }`)
+    }
+
+    result.push(`import ${parts.join(', ')} from '${source}'`)
   }
-  return REACT_HOOK_NAMES
+
+  return result
 }
 
 /**
- * Dynamically extracts React exports that are not hooks.
- * Filters out internal/unstable APIs and non-importable values.
+ * Analyzes code structure to determine how to wrap it for StackBlitz.
  */
-function getReactExportNames() {
-  if (!REACT_EXPORT_NAMES) {
-    REACT_EXPORT_NAMES = Object.keys(ReactExports).filter((name) => {
-      // Skip hooks (handled by getReactHookNames)
-      if (name.startsWith('use')) return false
-      // Skip internal React fields
-      if (name.startsWith('__') || name.startsWith('unstable_'))
-        return false
-      // Skip non-importable values like 'version'
-      if (typeof ReactExports[name] === 'string') return false
-
-      return ReactExports[name] !== undefined
-    })
-  }
-  return REACT_EXPORT_NAMES
-}
-
-// Shared exports from @dnb/eufemia/shared
-const SHARED_EXPORTS = ['Provider', 'Theme']
-
-/**
- * Lazily loads all icon export names from @dnb/eufemia/src/icons.
- * Only loaded when someone clicks the StackBlitz button.
- */
-let iconExportNamesCache: string[] | null = null
-async function getIconExportNames(): Promise<string[]> {
-  if (!iconExportNamesCache) {
-    const icons = await import('@dnb/eufemia/src/icons')
-    iconExportNamesCache = Object.keys(icons)
-  }
-  return iconExportNamesCache
-}
-
-/**
- * Lazily loads all date-fns export names.
- * Only loaded when someone clicks the StackBlitz button.
- */
-let dateFnsExportNamesCache: string[] | null = null
-async function getDateFnsExportNames(): Promise<string[]> {
-  if (!dateFnsExportNamesCache) {
-    const dateFns = await import('date-fns')
-    dateFnsExportNamesCache = Object.keys(dateFns)
-  }
-  return dateFnsExportNamesCache
-}
-
-/**
- * Converts a PascalCase name to snake_case.
- * E.g. "BellMedium" -> "bell_medium", "AccountCard" -> "account_card"
- */
-function toSnakeCase(name: string): string {
-  return name
-    .replace(/([A-Z])/g, '_$1')
-    .toLowerCase()
-    .replace(/^_/, '')
-}
-
-/**
- * Resolves a namespace name to a published import path by trying known
- * subpath patterns via dynamic import. Only runs when StackBlitz is opened.
- *
- * Patterns tried:
- * 1. Forms subpath: Blocks -> @dnb/eufemia/extensions/forms/blocks
- * 2. Icon barrel:   PrimaryIconsMedium -> @dnb/eufemia/icons/dnb/primary_icons_medium
- */
-const namespacePathCache = new Map<string, string | null>()
-async function resolveNamespacePath(name: string): Promise<string | null> {
-  const cached = namespacePathCache.get(name)
-  if (cached !== undefined) {
-    return cached
-  }
-
-  const candidates = [
-    {
-      devPath: `@dnb/eufemia/src/extensions/forms/${name.toLowerCase()}`,
-      publishedPath: `@dnb/eufemia/extensions/forms/${name.toLowerCase()}`,
-    },
-    {
-      devPath: `@dnb/eufemia/src/icons/dnb/${toSnakeCase(name)}`,
-      publishedPath: `@dnb/eufemia/icons/dnb/${toSnakeCase(name)}`,
-    },
-  ]
-
-  for (const { devPath, publishedPath } of candidates) {
-    try {
-      await import(/* @vite-ignore */ devPath)
-      namespacePathCache.set(name, publishedPath)
-      return publishedPath
-    } catch {
-      // Not found at this path, try next
-    }
-  }
-
-  namespacePathCache.set(name, null)
-  return null
-}
-
-/**
- * Analyzes code to detect what imports are needed.
- */
-function analyzeCodeForImports(code: string) {
-  const usedComponents: string[] = []
-  const usedFragments: string[] = []
-  const usedElements: string[] = []
-  const usedFormsComponents: string[] = []
-  const usedReactHooks: string[] = []
-  const usedReactExports: string[] = []
-  const usedSharedExports: string[] = []
-  let usesStyled = false
-
-  // Helper to check if a name is used in code
-  const isUsed = (name: string) => {
-    // Match <Component, Component., or {Component (but not in strings/comments)
-    const pattern = new RegExp(
-      `[<{\\s,]${name}[.>\\s,)}]|^${name}[.>\\s]`,
-      'm'
-    )
-    return pattern.test(code)
-  }
-
-  // Detect Eufemia components
-  for (const name of getEufemiaComponentNames()) {
-    if (isUsed(name)) {
-      usedComponents.push(name)
-    }
-  }
-
-  // Detect Eufemia fragments
-  for (const name of getEufemiaFragmentNames()) {
-    if (isUsed(name)) {
-      usedFragments.push(name)
-    }
-  }
-
-  // Detect Eufemia elements
-  for (const name of getEufemiaElementNames()) {
-    if (isUsed(name)) {
-      usedElements.push(name)
-    }
-  }
-
-  // Detect Forms components
-  for (const name of FORMS_EXPORT_NAMES) {
-    if (isUsed(name)) {
-      usedFormsComponents.push(name)
-    }
-  }
-
-  // Detect React hooks
-  for (const hook of getReactHookNames()) {
-    const pattern = new RegExp(`\\b${hook}\\s*\\(`)
-    if (pattern.test(code)) {
-      usedReactHooks.push(hook)
-    }
-  }
-
-  // Detect other React exports
-  for (const exp of getReactExportNames()) {
-    const pattern = new RegExp(`\\b${exp}\\b`)
-    if (pattern.test(code)) {
-      usedReactExports.push(exp)
-    }
-  }
-
-  // Detect shared exports (Provider, Theme)
-  for (const exp of SHARED_EXPORTS) {
-    if (isUsed(exp)) {
-      usedSharedExports.push(exp)
-    }
-  }
-
-  // Detect styled usage (from @emotion/styled)
-  if (/\bstyled[.(]/.test(code)) {
-    usesStyled = true
-  }
-
-  // Detect if code defines a function component (including exports)
+export function analyzeCodeStructure(code: string) {
   /* eslint-disable security/detect-unsafe-regex */
   const functionPattern = /^(?:export\s+)?function\s+\w+/m
   const arrowPattern =
     /^(?:export\s+)?const\s+\w+\s*=\s*(?:\([^)]*\)|\w+)\s*=>/m
   /* eslint-enable security/detect-unsafe-regex */
-  const isFunctionComponent =
-    functionPattern.test(code) || arrowPattern.test(code)
-
-  // Detect if code already has a default export
-  const hasDefaultExport = /^export\s+default\b/m.test(code)
-
-  // Detect if code uses render() pattern (noInline)
-  const usesRenderPattern = /\brender\s*\(/.test(code)
-
-  // Check if code already has imports (user edited it)
-  const hasExistingImports = /^import\s+/m.test(code)
 
   return {
-    usedComponents,
-    usedFragments,
-    usedElements,
-    usedFormsComponents,
-    usedReactHooks,
-    usedReactExports,
-    usedSharedExports,
-    usesStyled,
-    isFunctionComponent,
-    hasDefaultExport,
-    usesRenderPattern,
-    hasExistingImports,
+    isFunctionComponent:
+      functionPattern.test(code) || arrowPattern.test(code),
+    hasDefaultExport: /^export\s+default\b/m.test(code),
+    usesRenderPattern: /\brender\s*\(/.test(code),
+    hasExistingImports: /^import\s+/m.test(code),
   }
-}
-
-/**
- * Detects external imports (icons, date-fns, etc.) needed by the code.
- * Uses dynamic imports to avoid bundling heavy modules on initial page load.
- * Only loaded when someone clicks the StackBlitz button.
- */
-async function detectExternalImports(
-  code: string,
-  analysis: ReturnType<typeof analyzeCodeForImports>
-): Promise<{ imports: string[]; dependencies: Record<string, string> }> {
-  const imports: string[] = []
-  const dependencies: Record<string, string> = {}
-
-  // Collect all names already handled by other import detection
-  const knownNames = new Set([
-    ...analysis.usedComponents,
-    ...analysis.usedFragments,
-    ...analysis.usedElements,
-    ...analysis.usedFormsComponents,
-    ...analysis.usedReactHooks,
-    ...analysis.usedReactExports,
-    ...analysis.usedSharedExports,
-    ...SHARED_EXPORTS,
-    // Common names that aren't external imports
-    'App',
-    'Provider',
-    'render',
-    'styled',
-  ])
-
-  // Detect namespace imports (SomeName.something patterns)
-  // Try to resolve each against known subpath conventions
-  const namespacePattern = /\b([A-Z][a-zA-Z]+)\./g
-  let nsMatch: RegExpExecArray | null
-
-  while ((nsMatch = namespacePattern.exec(code)) !== null) {
-    const name = nsMatch[1]
-    if (!knownNames.has(name)) {
-      const resolvedPath = await resolveNamespacePath(name)
-      if (resolvedPath) {
-        imports.push(`import * as ${name} from '${resolvedPath}'`)
-        knownNames.add(name)
-      }
-    }
-  }
-
-  // Extract all identifiers from code that aren't already known
-  const unknownNames = new Set<string>()
-  const identifierPattern =
-    /\b([A-Z][a-zA-Z]*|[a-z][a-z_]*_(?:medium|small|large)|[a-z][a-zA-Z]+)\b/g
-  let match: RegExpExecArray | null
-
-  while ((match = identifierPattern.exec(code)) !== null) {
-    const name = match[1]
-    if (!knownNames.has(name)) {
-      unknownNames.add(name)
-    }
-  }
-
-  if (unknownNames.size === 0) {
-    return { imports, dependencies }
-  }
-
-  // Detect individual icon imports
-  const iconNames = await getIconExportNames()
-  const iconNameSet = new Set(iconNames)
-  const iconImportPairs: Array<{ snakeName: string; usedName: string }> =
-    []
-
-  for (const name of Array.from(unknownNames)) {
-    if (iconNameSet.has(name)) {
-      iconImportPairs.push({ snakeName: name, usedName: name })
-      knownNames.add(name)
-    } else {
-      const snakeName = toSnakeCase(name)
-      if (iconNameSet.has(snakeName)) {
-        iconImportPairs.push({ snakeName, usedName: name })
-        knownNames.add(name)
-      }
-    }
-  }
-
-  if (iconImportPairs.length > 0) {
-    const specifiers = iconImportPairs.map(({ snakeName, usedName }) =>
-      snakeName === usedName ? snakeName : `${snakeName} as ${usedName}`
-    )
-    imports.push(
-      `import { ${specifiers.join(', ')} } from '@dnb/eufemia/icons'`
-    )
-  }
-
-  // Detect date-fns imports dynamically
-  const dateFnsNames = await getDateFnsExportNames()
-  const dateFnsSet = new Set(dateFnsNames)
-  const usedDateFns: string[] = []
-
-  for (const name of Array.from(unknownNames)) {
-    if (!knownNames.has(name) && dateFnsSet.has(name)) {
-      usedDateFns.push(name)
-    }
-  }
-
-  if (usedDateFns.length > 0) {
-    imports.push(`import { ${usedDateFns.join(', ')} } from 'date-fns'`)
-    dependencies['date-fns'] = '^4.1.0'
-  }
-
-  return { imports, dependencies }
 }
 
 /**
@@ -400,69 +123,23 @@ export async function formatCode(code: string): Promise<string> {
 }
 
 /**
- * Generates the App.tsx content based on code analysis.
- * @param extraImports - Additional import statements (e.g. for icons detected asynchronously)
+ * Generates the App.tsx content with imports and code wrapping.
  */
-function generateAppComponent(code: string, extraImports: string[] = []) {
-  const analysis = analyzeCodeForImports(code)
+export function generateAppComponent(
+  code: string,
+  imports: string[] = []
+) {
+  const structure = analyzeCodeStructure(code)
 
   // If code already has imports, use it as-is with minimal wrapping
-  if (analysis.hasExistingImports) {
+  if (structure.hasExistingImports) {
     return code
   }
-
-  // Build imports
-  const imports: string[] = []
-
-  // React imports (sorted for consistency)
-  const reactImports = [
-    ...analysis.usedReactHooks,
-    ...analysis.usedReactExports,
-  ].sort()
-  if (reactImports.length > 0) {
-    imports.push(`import { ${reactImports.join(', ')} } from 'react'`)
-  }
-
-  // Combine all Eufemia imports (components, fragments, elements)
-  const allEufemiaImports = [
-    ...analysis.usedComponents,
-    ...analysis.usedFragments,
-    ...analysis.usedElements,
-  ]
-  if (allEufemiaImports.length > 0) {
-    imports.push(
-      `import { ${allEufemiaImports.join(', ')} } from '@dnb/eufemia'`
-    )
-  }
-
-  // Eufemia shared imports (Provider is always needed, plus any detected like Theme)
-  const sharedImports = [
-    'Provider',
-    ...analysis.usedSharedExports.filter((e) => e !== 'Provider'),
-  ]
-  imports.push(
-    `import { ${sharedImports.join(', ')} } from '@dnb/eufemia/shared'`
-  )
-
-  // Styled from emotion
-  if (analysis.usesStyled) {
-    imports.push(`import styled from '@emotion/styled'`)
-  }
-
-  // Forms imports
-  if (analysis.usedFormsComponents.length > 0) {
-    imports.push(
-      `import { ${analysis.usedFormsComponents.join(', ')} } from '@dnb/eufemia/extensions/forms'`
-    )
-  }
-
-  // Extra imports (e.g. namespaces, icons, date-fns detected asynchronously)
-  imports.push(...extraImports)
 
   const importsBlock = imports.join('\n')
 
   // Handle different code patterns
-  if (analysis.usesRenderPattern) {
+  if (structure.usesRenderPattern) {
     // noInline pattern: extract the component and render it properly
     const componentCode = code
       .replace(
@@ -476,7 +153,7 @@ function generateAppComponent(code: string, extraImports: string[] = []) {
 ${componentCode}`
   }
 
-  if (analysis.hasDefaultExport) {
+  if (structure.hasDefaultExport) {
     // Code already has a default export - rename it and wrap
     const modifiedCode = code
       .replace(/^export\s+default\s+function\s+(\w+)/m, 'function $1')
@@ -492,15 +169,11 @@ ${componentCode}`
 ${modifiedCode}
 
 export default function App() {
-  return (
-    <Provider>
-      <${componentName} />
-    </Provider>
-  )
+  return <${componentName} />
 }`
   }
 
-  if (analysis.isFunctionComponent) {
+  if (structure.isFunctionComponent) {
     // Code defines a function component - extract and use it
     const fnMatch = code.match(
       // eslint-disable-next-line security/detect-unsafe-regex
@@ -517,11 +190,7 @@ export default function App() {
 ${code}
 
 export default function App() {
-  return (
-    <Provider>
-      <${componentName} />
-    </Provider>
-  )
+  return <${componentName} />
 }`
   }
 
@@ -530,9 +199,9 @@ export default function App() {
 
 export default function App() {
   return (
-    <Provider>
+    <>
       ${code}
-    </Provider>
+    </>
   )
 }`
 }
@@ -541,13 +210,42 @@ export default function App() {
  * Opens the given code in StackBlitz using their define API.
  * Creates a new project with the Eufemia starter template and the provided code.
  */
-export async function openInStackBlitz(code: string) {
-  // Analyze code to determine needed dependencies
-  const analysis = analyzeCodeForImports(code)
+export async function openInStackBlitz(
+  code: string,
+  sourceImports?: string[]
+) {
+  // Filter sourceImports to only include names used in this code snippet
+  const imports = filterImportsByUsage(sourceImports || [], code)
 
-  // Detect external imports (icons, date-fns, etc.) asynchronously
-  // These modules are loaded lazily to avoid bundling on every page
-  const external = await detectExternalImports(code, analysis)
+  // Detect external package dependencies from filtered imports
+  const dependencies: Record<string, string> = {
+    '@dnb/eufemia': 'latest',
+    react: starterPackageJson.dependencies.react,
+    'react-dom': starterPackageJson.dependencies['react-dom'],
+  }
+
+  const knownPackages = new Set(['@dnb/eufemia', 'react', 'react-dom'])
+
+  for (const stmt of imports) {
+    const fromMatch = stmt.match(/from\s+['"]([^'"]+)['"]/)
+    if (!fromMatch) {
+      continue
+    }
+
+    const source = fromMatch[1]
+    if (source.startsWith('.') || source.startsWith('/')) {
+      continue
+    }
+
+    // Extract package name (handle scoped packages like @scope/pkg)
+    const pkg = source.startsWith('@')
+      ? source.split('/').slice(0, 2).join('/')
+      : source.split('/')[0]
+
+    if (!knownPackages.has(pkg)) {
+      dependencies[pkg] = 'latest'
+    }
+  }
 
   const appCode = `import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -562,35 +260,25 @@ createRoot(document.getElementById('root')!).render(
 `
 
   const appComponent = await formatCode(
-    generateAppComponent(code, external.imports)
+    generateAppComponent(code, imports)
   )
 
-  const indexHtml = `<!doctype html>
+  // Mirrors eufemia-starter/index.html (without favicon)
+  const indexHtml = `<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Eufemia Example</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
-</html>
-`
 
-  // Build dependencies object conditionally
-  const dependencies: Record<string, string> = {
-    '@dnb/eufemia': 'latest',
-    react: '^19.0.0',
-    'react-dom': '^19.0.0',
-  }
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Eufemia Example</title>
+</head>
 
-  if (analysis.usesStyled) {
-    dependencies['@emotion/styled'] = '^11.14.0'
-  }
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
 
-  Object.assign(dependencies, external.dependencies)
+</html>`
 
   const packageJson = JSON.stringify(
     {
@@ -598,6 +286,8 @@ createRoot(document.getElementById('root')!).render(
       private: true,
       version: '0.0.0',
       type: 'module',
+      repository: starterPackageJson.repository,
+      bugs: starterPackageJson.bugs,
       scripts: {
         dev: 'vite',
         build: 'vite build',
@@ -605,25 +295,52 @@ createRoot(document.getElementById('root')!).render(
       },
       dependencies,
       devDependencies: {
-        '@types/react': '^19.0.0',
-        '@types/react-dom': '^19.0.0',
-        '@vitejs/plugin-react': '^4.4.1',
-        typescript: '~5.8.3',
-        vite: '^6.3.5',
+        '@types/react': starterPackageJson.devDependencies['@types/react'],
+        '@types/react-dom':
+          starterPackageJson.devDependencies['@types/react-dom'],
+        '@vitejs/plugin-react':
+          starterPackageJson.devDependencies['@vitejs/plugin-react'],
+        typescript: starterPackageJson.devDependencies.typescript,
+        vite: starterPackageJson.devDependencies.vite,
       },
     },
     null,
     2
   )
 
-  const viteConfig = `import { defineConfig } from 'vite'
+  // Mirrors eufemia-starter/vite.config.ts
+  // Includes the JSX loader plugin needed because @dnb/eufemia ships .js files with JSX
+  const viteConfig = `import { defineConfig, transformWithOxc } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'load+transform-js-files-as-jsx',
+      enforce: 'pre',
+      async transform(code, id) {
+        const [filepath] = id.split('?')
+        if (!/\\/src\\/.*\\.js$/.test(filepath)) {
+          return null
+        }
+        return transformWithOxc(code, filepath, {
+          lang: 'jsx',
+          jsx: { runtime: 'automatic' },
+        })
+      },
+    },
+  ],
+  optimizeDeps: {
+    esbuildOptions: {
+      loader: { '.js': 'jsx' },
+      jsx: 'automatic',
+    },
+  },
 })
 `
 
+  // Mirrors eufemia-starter/tsconfig.app.json (without comments)
   const tsConfig = JSON.stringify(
     {
       compilerOptions: {
@@ -642,7 +359,6 @@ export default defineConfig({
         noUnusedLocals: true,
         noUnusedParameters: true,
         noFallthroughCasesInSwitch: true,
-        noUncheckedSideEffectImports: true,
       },
       include: ['src'],
     },

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/react-live-babel.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/react-live-babel.test.ts
@@ -123,3 +123,165 @@ describe('injectStableName babel plugin', () => {
     expect(second).toContain('stableName: "Repeated_2"')
   })
 })
+
+describe('sourceImports injection', () => {
+  it('injects sourceImports for all file-level imports', async () => {
+    const input = `
+      import { Button } from '@dnb/eufemia/src'
+      import { trash } from '@dnb/eufemia/icons'
+      export function Demo() {
+        return <ComponentBox scope={{ trash }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('sourceImports')
+    expect(output).toContain("import { Button } from '@dnb/eufemia'")
+    expect(output).toContain("import { trash } from '@dnb/eufemia/icons'")
+  })
+
+  it('rewrites @dnb/eufemia/src/ to @dnb/eufemia/ in sourceImports', async () => {
+    const input = `
+      import { trash } from '@dnb/eufemia/src/icons'
+      export function Demo() {
+        return <ComponentBox scope={{ trash }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain("from '@dnb/eufemia/icons'")
+    expect(output).toContain(
+      `"import { trash } from '@dnb/eufemia/icons'"`
+    )
+  })
+
+  it('includes imports even without scope match', async () => {
+    const input = `
+      import styled from '@emotion/styled'
+      export function Demo() {
+        return <ComponentBox>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('sourceImports')
+    expect(output).toContain("import styled from '@emotion/styled'")
+  })
+
+  it('includes @dnb/eufemia imports without scope match', async () => {
+    const input = `
+      import { Button } from '@dnb/eufemia/src/components'
+      export function Demo() {
+        return <ComponentBox>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('sourceImports')
+    expect(output).toContain('Button')
+  })
+
+  it('includes react imports', async () => {
+    const input = `
+      import { useState } from 'react'
+      export function Demo() {
+        return <ComponentBox>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('sourceImports')
+    expect(output).toContain("import { useState } from 'react'")
+  })
+
+  it('includes external packages', async () => {
+    const input = `
+      import { format } from 'date-fns'
+      export function Demo() {
+        return <ComponentBox scope={{ format }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain("import { format } from 'date-fns'")
+  })
+
+  it('handles renamed imports with as syntax', async () => {
+    const input = `
+      import { trash as trashIcon } from '@dnb/eufemia/icons'
+      export function Demo() {
+        return <ComponentBox scope={{ trashIcon }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain(
+      "import { trash as trashIcon } from '@dnb/eufemia/icons'"
+    )
+  })
+
+  it('groups multiple specifiers from the same source', async () => {
+    const input = `
+      import { trash, add } from '@dnb/eufemia/icons'
+      export function Demo() {
+        return <ComponentBox scope={{ trash, add }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('trash, add')
+    expect(output).toContain("from '@dnb/eufemia/icons'")
+  })
+
+  it('skips internal portal imports', async () => {
+    const input = `
+      import ComponentBox from '../shared/tags/ComponentBox'
+      export function Demo() {
+        return <ComponentBox>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    // No sourceImports injected since the only import is a portal internal
+    expect(output).not.toContain('sourceImports')
+  })
+
+  it('gives each ComponentBox the same sourceImports', async () => {
+    const input = `
+      import { trash, add } from '@dnb/eufemia/icons'
+      export function First() {
+        return <ComponentBox scope={{ trash }}>code</ComponentBox>
+      }
+      export function Second() {
+        return <ComponentBox scope={{ add }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    // Both should have sourceImports since all file-level imports are included
+    const matches = output.match(/sourceImports/g)
+    expect(matches).toHaveLength(2)
+  })
+
+  it('does not inject sourceImports when file has no imports', async () => {
+    const input = `
+      export function Demo() {
+        return <ComponentBox>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).not.toContain('sourceImports')
+  })
+})

--- a/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
@@ -50,6 +50,10 @@ export default function reactLiveBabelPlugin(): Plugin {
  * derived from the enclosing export function name.
  * This gives each box a stable identity that survives HMR remounts.
  *
+ * Also injects a `sourceImports` prop with all file-level import
+ * statements (rewritten to published paths). This lets StackBlitz
+ * filter by code usage without needing hardcoded component name lists.
+ *
  * Must run before babel-plugin-react-live, which replaces JSX elements
  * with serialized code strings inside a Program visitor.
  * We use Program.enter + manual traverse so our visitor fires first.
@@ -61,6 +65,7 @@ export function injectStableName(babel: { types: typeof BabelTypes }) {
     visitor: {
       Program: {
         enter(programPath: {
+          node: { body: Array<{ type: string }> }
           traverse: (
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             visitors: Record<string, (path: any) => void>
@@ -68,11 +73,16 @@ export function injectStableName(babel: { types: typeof BabelTypes }) {
         }) {
           const counters = new Map<string, number>()
 
+          // Build a map of local name → import statement string
+          // from all file-level import declarations
+          const importsByName = buildImportMap(programPath.node.body, t)
+
           programPath.traverse({
             JSXOpeningElement(nodePath: {
               node: {
                 name: { type: string; name: string }
-                attributes: unknown[]
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                attributes: any[]
               }
               findParent: (
                 cb: (p: {
@@ -90,6 +100,7 @@ export function injectStableName(babel: { types: typeof BabelTypes }) {
                 return // stop here
               }
 
+              // Inject stableName
               const parent = nodePath.findParent(
                 (p) =>
                   (p.isFunctionDeclaration() ||
@@ -97,26 +108,165 @@ export function injectStableName(babel: { types: typeof BabelTypes }) {
                   p.node.id?.type === 'Identifier'
               )
 
-              if (!parent?.node.id?.name) {
-                return // stop here
+              if (parent?.node.id?.name) {
+                const funcName = parent.node.id.name
+                const count = (counters.get(funcName) || 0) + 1
+                counters.set(funcName, count)
+                const stableName =
+                  count === 1 ? funcName : `${funcName}_${count}`
+
+                node.attributes.push(
+                  t.jsxAttribute(
+                    t.jsxIdentifier('stableName'),
+                    t.stringLiteral(stableName)
+                  )
+                )
               }
 
-              const funcName = parent.node.id.name
-              const count = (counters.get(funcName) || 0) + 1
-              counters.set(funcName, count)
-              const stableName =
-                count === 1 ? funcName : `${funcName}_${count}`
-
-              node.attributes.push(
-                t.jsxAttribute(
-                  t.jsxIdentifier('stableName'),
-                  t.stringLiteral(stableName)
+              // Inject sourceImports with all file-level imports.
+              // StackBlitz filters these at runtime by code usage.
+              const allNames = Array.from(importsByName.keys())
+              const imports = resolveImports(allNames, importsByName)
+              if (imports.length > 0) {
+                node.attributes.push(
+                  t.jsxAttribute(
+                    t.jsxIdentifier('sourceImports'),
+                    t.jsxExpressionContainer(
+                      t.arrayExpression(
+                        imports.map((s) => t.stringLiteral(s))
+                      )
+                    )
+                  )
                 )
-              )
+              }
             },
           })
         },
       },
     },
   }
+}
+
+/**
+ * Builds a map of local imported name → { source, specifiers } from
+ * the file's import declarations.
+ *
+ * For `import { trash as trashIcon } from '@dnb/eufemia/icons'`
+ * → importsByName.get('trashIcon') = { source: '@dnb/eufemia/icons', imported: 'trash', local: 'trashIcon' }
+ */
+function buildImportMap(
+  body: Array<{ type: string }>,
+  t: typeof BabelTypes
+) {
+  const map = new Map<
+    string,
+    { source: string; imported: string; local: string; isDefault: boolean }
+  >()
+
+  for (const node of body) {
+    if (!t.isImportDeclaration(node as BabelTypes.Node)) {
+      continue
+    }
+
+    const importNode = node as unknown as BabelTypes.ImportDeclaration
+    const source = importNode.source.value
+
+    // Skip internal portal imports (ComponentBox, etc.)
+    if (
+      source.includes('/shared/tags/') ||
+      (source.includes('/shared/') && !source.includes('@dnb/'))
+    ) {
+      continue
+    }
+
+    for (const spec of importNode.specifiers) {
+      if (t.isImportSpecifier(spec)) {
+        const imported = t.isIdentifier(spec.imported)
+          ? spec.imported.name
+          : spec.imported.value
+        map.set(spec.local.name, {
+          source,
+          imported,
+          local: spec.local.name,
+          isDefault: false,
+        })
+      } else if (t.isImportDefaultSpecifier(spec)) {
+        map.set(spec.local.name, {
+          source,
+          imported: 'default',
+          local: spec.local.name,
+          isDefault: true,
+        })
+      }
+    }
+  }
+
+  return map
+}
+
+/**
+ * Resolves names to import statements, grouping specifiers by source.
+ * Rewrites `@dnb/eufemia/src/...` paths to their published equivalents.
+ */
+function resolveImports(
+  names: string[],
+  importsByName: ReturnType<typeof buildImportMap>
+): string[] {
+  // Group by source path
+  const bySource = new Map<
+    string,
+    Array<{ imported: string; local: string; isDefault: boolean }>
+  >()
+
+  for (const name of names) {
+    const entry = importsByName.get(name)
+    if (!entry) {
+      continue
+    }
+
+    const source = rewriteImportPath(entry.source)
+    if (!bySource.has(source)) {
+      bySource.set(source, [])
+    }
+    bySource.get(source)!.push(entry)
+  }
+
+  // Build import statement strings
+  const imports: string[] = []
+
+  Array.from(bySource.entries()).forEach(([source, specs]) => {
+    const defaultSpec = specs.find((s) => s.isDefault)
+    const namedSpecs = specs.filter((s) => !s.isDefault)
+
+    const parts: string[] = []
+
+    if (defaultSpec) {
+      parts.push(defaultSpec.local)
+    }
+
+    if (namedSpecs.length > 0) {
+      const specifiers = namedSpecs.map((s) =>
+        s.imported === s.local ? s.local : `${s.imported} as ${s.local}`
+      )
+      parts.push(`{ ${specifiers.join(', ')} }`)
+    }
+
+    const publishedSource = rewriteImportPath(source)
+    imports.push(`import ${parts.join(', ')} from '${publishedSource}'`)
+  })
+
+  return imports
+}
+
+/**
+ * Rewrites internal @dnb/eufemia/src/... paths to published paths.
+ * e.g. '@dnb/eufemia/src/icons' → '@dnb/eufemia/icons'
+ *      '@dnb/eufemia/src/components/Table' → '@dnb/eufemia/components/Table'
+ */
+function rewriteImportPath(source: string): string {
+  if (source === '@dnb/eufemia/src') {
+    return '@dnb/eufemia'
+  }
+
+  return source.replace('@dnb/eufemia/src/', '@dnb/eufemia/')
 }


### PR DESCRIPTION
Move import detection from runtime name lists to build-time static
analysis. The babel plugin now passes all file-level imports as
sourceImports, and openInStackBlitz filters them by code usage.

- Remove analyzeCodeForImports and all component/hook/export name lists
- Add filterImportsByUsage and analyzeCodeStructure
- Use eufemia-starter package.json as source of truth for versions
- Add JSX loader plugin to vite config (mirrors eufemia-starter)
- Remove Provider wrapper from generated main.tsx
- Remove dead FORMS_EXPORT_NAMES export from formsExports.ts
- Fix rewriteImportPath for bare @dnb/eufemia/src path

Example: https://fix-stackblitz-dynamic-impor-1th5.eufemia-e25.pages.dev/uilib/components/table#table-with-keyboard-navigation