### PR TITLE
fix(DatePicker): add hover effect for within-selection days

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2841,7 +2841,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 .dnb-date-picker__day--start-date:not(.dnb-date-picker__day--inactive):not(.dnb-date-picker__day--preview) .dnb-button:hover, .dnb-date-picker__day--end-date:not(.dnb-date-picker__day--inactive):not(.dnb-date-picker__day--preview) .dnb-button:hover {
   box-shadow: none;
 }
-html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]) {
+html:not([data-whatintent=touch]) .dnb-date-picker__day--within-selection:not(.dnb-date-picker__day--start-date):not(.dnb-date-picker__day--end-date) .dnb-button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date.dnb-date-picker__day--within-selection .dnb-button:hover:not([disabled]) {
   color: var(--token-color-text-action);
   background-color: var(--token-color-background-neutral);
   --border-color: var(--token-color-stroke-action-pressed);
@@ -2849,7 +2849,7 @@ html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-pic
   box-shadow: 0 0 0 var(--border-width) var(--border-color);
   border-color: transparent;
 }
-html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-picker__day--within-selection .dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date.dnb-date-picker__day--within-selection .dnb-button:active:not([disabled]) {
+html:not([data-whatintent=touch]) .dnb-date-picker__day--within-selection:not(.dnb-date-picker__day--start-date):not(.dnb-date-picker__day--end-date) .dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--start-date.dnb-date-picker__day--within-selection .dnb-button:active:not([disabled]), html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date.dnb-date-picker__day--within-selection .dnb-button:active:not([disabled]) {
   color: var(--token-color-text-action-pressed);
   background-color: var(--token-color-background-action-hover-subtle);
   box-shadow: none;

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -426,6 +426,9 @@
 
     // Hover states for checked date buttons
     html:not([data-whatintent='touch'])
+      &--within-selection:not(#{&}--start-date):not(#{&}--end-date)
+      .dnb-button:hover:not([disabled]),
+    html:not([data-whatintent='touch'])
       &--start-date#{&}--within-selection
       .dnb-button:hover:not([disabled]),
     html:not([data-whatintent='touch'])
@@ -440,7 +443,10 @@
       );
     }
 
-    // Active states for start and end date buttons
+    // Active states for selected date buttons
+    html:not([data-whatintent='touch'])
+      &--within-selection:not(#{&}--start-date):not(#{&}--end-date)
+      .dnb-button:active:not([disabled]),
     html:not([data-whatintent='touch'])
       &--start-date#{&}--within-selection
       .dnb-button:active:not([disabled]),


### PR DESCRIPTION
Days within the selected range (between start and end dates) now show a hover effect (neutral background + border) and an active/pressed state, matching the existing start/end date hover pattern.

<img width="398" height="365" alt="Screenshot 2026-05-21 at 19 17 44" src="https://github.com/user-attachments/assets/7be2a3d8-a9ea-41fc-a9e4-1af9097dce9b" />

So we get a contrast to the background. We did the same with the DrawerList.
