### PR TITLE
fix(DatePicker): show picker view outline

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -814,7 +814,6 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   }
                   onOpenChange={(isOpen) => !isOpen && hidePicker()}
                   hideCloseButton
-                  hideOutline
                   preventClose={preventClose}
                   triggerOffset={0}
                   arrowEdgeOffset={4}


### PR DESCRIPTION
Remove `hideOutline` from the DatePicker Popover so the calendar dropdown shows the default popover outline border.

<img width="306" height="277" alt="Screenshot 2026-05-21 at 19 17 10" src="https://github.com/user-attachments/assets/3aad784e-39ed-4799-9a6c-52e81aa3c5bc" />
