### PR TITLE
chore: fix flaky DateFormat tooltip test

### DIFF
--- a/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
@@ -788,11 +788,12 @@ describe('DateFormat', () => {
 
       // When tooltip is active, aria-describedby should point to the tooltip id
       const tooltipId = timeElem.getAttribute('aria-describedby')
-      const tooltipElem = document.body.querySelector(
-        '#' + tooltipId
-      ).parentElement
 
+      let tooltipElem: Element
       await waitFor(() => {
+        tooltipElem = document.body.querySelector(
+          '#' + tooltipId
+        ).parentElement
         expect(tooltipElem).toHaveClass(
           'dnb-tooltip',
           'dnb-tooltip--active'


### PR DESCRIPTION
Move `document.body.querySelector('#' + tooltipId)` inside the `waitFor` block so it retries until the tooltip DOM element exists, fixing a race condition where `aria-describedby` is set before the tooltip element is in the DOM.