### PR TITLE
chore(Portal): use pkg-pr-new version in StackBlitz for PR previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Build
         run: yarn workspace dnb-design-system-portal build
+        env:
+          VITE_EUFEMIA_STACKBLITZ_VERSION: 'https://pkg.pr.new/@dnb/eufemia@${{ github.event.pull_request.head.sha }}'
 
       - name: Deploy to Cloudflare Pages (branch preview)
         id: pages_deploy

--- a/packages/dnb-design-system-portal/src/declaration.d.ts
+++ b/packages/dnb-design-system-portal/src/declaration.d.ts
@@ -1,5 +1,13 @@
 declare module '*.scss'
 
+type ImportMetaEnv = {
+  readonly VITE_EUFEMIA_STACKBLITZ_VERSION?: string
+}
+
+type ImportMeta = {
+  readonly env: ImportMetaEnv
+}
+
 declare module '*.module.scss' {
   const classes: { readonly [key: string]: string }
   export default classes

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/openInStackBlitz.test.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/openInStackBlitz.test.ts
@@ -5,6 +5,7 @@ import {
   generateAppComponent,
   formatCode,
   openInStackBlitz,
+  eufemiaVersion,
 } from '../openInStackBlitz'
 
 describe('filterImportsByUsage', () => {
@@ -231,7 +232,7 @@ describe('openInStackBlitz', () => {
       form.fields['project[files][package.json]']
     )
 
-    expect(packageJson.dependencies['@dnb/eufemia']).toBe('latest')
+    expect(packageJson.dependencies['@dnb/eufemia']).toBe(eufemiaVersion)
     expect(
       Object.keys(packageJson.dependencies).filter(
         (k: string) => k === '@dnb/eufemia'
@@ -288,6 +289,22 @@ describe('openInStackBlitz', () => {
     expect(packageJson.dependencies).toHaveProperty('@dnb/eufemia')
     expect(packageJson.dependencies).toHaveProperty('react')
     expect(packageJson.dependencies).toHaveProperty('react-dom')
+
+    form.cleanup()
+  })
+
+  it('uses eufemiaVersion for @dnb/eufemia dependency', async () => {
+    const form = mockFormSubmission()
+
+    await openInStackBlitz('<Button>Click</Button>', [
+      "import { Button } from '@dnb/eufemia'",
+    ])
+
+    const packageJson = JSON.parse(
+      form.fields['project[files][package.json]']
+    )
+
+    expect(packageJson.dependencies['@dnb/eufemia']).toBe(eufemiaVersion)
 
     form.cleanup()
   })

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -13,6 +13,15 @@ import * as prettierPluginEstree from 'prettier/plugins/estree'
 import starterPackageJson from 'eufemia-starter/package.json'
 
 /**
+ * The version of @dnb/eufemia to install in StackBlitz.
+ * On PR preview deployments, this is a pkg-pr-new URL pointing to the
+ * pre-release built from the same commit. Falls back to 'latest' in
+ * production or local development.
+ */
+export const eufemiaVersion: string =
+  import.meta.env.VITE_EUFEMIA_STACKBLITZ_VERSION || 'latest'
+
+/**
  * Filters sourceImports to only include names actually used in the code.
  * Each sourceImport is a full import statement string from the babel plugin.
  */
@@ -219,7 +228,7 @@ export async function openInStackBlitz(
 
   // Detect external package dependencies from filtered imports
   const dependencies: Record<string, string> = {
-    '@dnb/eufemia': 'latest',
+    '@dnb/eufemia': eufemiaVersion,
     react: starterPackageJson.dependencies.react,
     'react-dom': starterPackageJson.dependencies['react-dom'],
   }


### PR DESCRIPTION
Example: https://feat-stackblitz-preview-vers.eufemia-e25.pages.dev/uilib/components/table#table-with-keyboard-navigation

<img width="406" height="123" alt="Screenshot 2026-05-21 at 20 57 55" src="https://github.com/user-attachments/assets/9a62fccf-707d-442c-9da2-9d4ae37f487b" />
