### PR TITLE
chore(Tests): normalize `--update/-u` to `--update=true`

### DIFF
--- a/tools/repo-utils/node-utils.js
+++ b/tools/repo-utils/node-utils.js
@@ -9,7 +9,13 @@ const splitVitestArgs = (args) => {
 
   for (const arg of args) {
     if (arg.startsWith('-')) {
-      vitestArgs.push(arg)
+      // Normalize bare --update/-u to --update=true so the flag
+      // does not consume the next positional file argument.
+      if (arg === '--update' || arg === '-u') {
+        vitestArgs.push('--update=true')
+      } else {
+        vitestArgs.push(arg)
+      }
     } else {
       filters.push(arg)
     }

--- a/tools/repo-utils/node-utils.mjs
+++ b/tools/repo-utils/node-utils.mjs
@@ -9,7 +9,13 @@ const splitVitestArgs = (args) => {
 
   for (const arg of args) {
     if (arg.startsWith('-')) {
-      vitestArgs.push(arg)
+      // Normalize bare --update/-u to --update=true so the flag
+      // does not consume the next positional file argument.
+      if (arg === '--update' || arg === '-u') {
+        vitestArgs.push('--update=true')
+      } else {
+        vitestArgs.push(arg)
+      }
     } else {
       filters.push(arg)
     }

--- a/tools/repo-utils/node-utils.test.js
+++ b/tools/repo-utils/node-utils.test.js
@@ -39,6 +39,17 @@ assert.deepStrictEqual(splitVitestArgs(['--update=true', 'button']), {
   vitestArgs: ['--update=true'],
 })
 
+// bare --update and -u are normalized to --update=true
+assert.deepStrictEqual(splitVitestArgs(['--update', 'button']), {
+  filters: ['button'],
+  vitestArgs: ['--update=true'],
+})
+
+assert.deepStrictEqual(splitVitestArgs(['-u', 'button']), {
+  filters: ['button'],
+  vitestArgs: ['--update=true'],
+})
+
 assert.deepStrictEqual(
   prepareVitestRun(
     ['--update=true', 'button', 'missing'],


### PR DESCRIPTION
Vitest's `--update` flag accepts an optional type argument, so a bare `--update` consumes the next positional value as the type instead of treating it as a test file filter. This caused `yarn test table --update` to silently skip `Table.test.tsx` (the alphabetically first file).

Normalizing `--update` and `-u` to `--update=true` in `splitVitestArgs` prevents the flag from swallowing test files, so `yarn test table --update` now works as expected.