### PR TITLE
chore(Starter): remove `transformWithOxc` from vite config

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -319,27 +319,11 @@ createRoot(document.getElementById('root')!).render(
 
   // Mirrors eufemia-starter/vite.config.ts
   // Includes the JSX loader plugin needed because @dnb/eufemia ships .js files with JSX
-  const viteConfig = `import { defineConfig, transformWithOxc } from 'vite'
+  const viteConfig = `import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: 'load+transform-js-files-as-jsx',
-      enforce: 'pre',
-      async transform(code, id) {
-        const [filepath] = id.split('?')
-        if (!/\\/src\\/.*\\.js$/.test(filepath)) {
-          return null
-        }
-        return transformWithOxc(code, filepath, {
-          lang: 'jsx',
-          jsx: { runtime: 'automatic' },
-        })
-      },
-    },
-  ],
+  plugins: [react()],
   optimizeDeps: {
     esbuildOptions: {
       loader: { '.js': 'jsx' },

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -318,7 +318,6 @@ createRoot(document.getElementById('root')!).render(
   )
 
   // Mirrors eufemia-starter/vite.config.ts
-  // Includes the JSX loader plugin needed because @dnb/eufemia ships .js files with JSX
   const viteConfig = `import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 

--- a/packages/eufemia-starter/vite.config.ts
+++ b/packages/eufemia-starter/vite.config.ts
@@ -1,31 +1,9 @@
-import { defineConfig, transformWithOxc } from 'vite'
-import path from 'node:path'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: 'load+transform-js-files-as-jsx',
-      enforce: 'pre',
-      async transform(code, id) {
-        // Vite appends query params to ids (e.g. ?v=hash). Strip them first.
-        const [filepath] = id.split('?')
-
-        // Treat any JS file under a src/ folder as JSX (starter and workspace packages)
-        if (!/\/src\/.*\.js$/.test(filepath)) {
-          return null
-        }
-
-        // Use the exposed transform from Vite instead of calling esbuild directly
-        return transformWithOxc(code, filepath, {
-          lang: 'jsx',
-          jsx: { runtime: 'automatic' },
-        })
-      },
-    },
-  ],
+  plugins: [react()],
 
   // Ensure dependency pre-bundling treats .js files as JSX where needed
   optimizeDeps: {
@@ -39,12 +17,13 @@ export default defineConfig({
 
   // Expose Eufemia's static assets (fonts) at "/assets/..." for dev environments like StackBlitz
   // This ensures URLs like "/assets/fonts/dnb/DNB-Regular.woff2" resolve to real files
-  publicDir: path.resolve(__dirname, '../dnb-eufemia/assets'),
+  publicDir: new URL('../dnb-eufemia/assets', import.meta.url).pathname,
 
   // Add some basic security headers, including a Content Security Policy (CSP)
   preview: {
     headers: getHeaders(),
   },
+
   // For local testing of CSP. Does not work on StackBlitz
   // server: {
   //   headers: getHeaders(),

--- a/packages/eufemia-starter/vite.config.ts
+++ b/packages/eufemia-starter/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
 
-  // Ensure dependency pre-bundling treats .js files as JSX where needed
+  // Ensure dependency pre-bundling handles .js files that may contain JSX
   optimizeDeps: {
     esbuildOptions: {
       loader: {


### PR DESCRIPTION
With Vite v8 we don't need `transformWithOxc` anymore it seems. Works well at least when testing.

Also, replace `path.resolve(__dirname, ...)` with `new URL(..., import.meta.url).pathname` in the eufemia-starter vite config, removing the `path` import.