### PR TITLE
chore: update @ungap/structured-clone to 1.3.1

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -109,7 +109,7 @@
     "@maskito/kit": "5.1.0",
     "@maskito/react": "5.1.0",
     "@navikt/fnrvalidator": "2.1.5",
-    "@ungap/structured-clone": "1.2.0",
+    "@ungap/structured-clone": "1.3.1",
     "ajv": "8.18.0",
     "ajv-errors": "3.0.0",
     "clsx": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,7 +2274,7 @@ __metadata:
     "@types/json-schema": "npm:7.0.12"
     "@typescript-eslint/eslint-plugin": "npm:8.52.0"
     "@typescript-eslint/parser": "npm:8.52.0"
-    "@ungap/structured-clone": "npm:1.2.0"
+    "@ungap/structured-clone": "npm:1.3.1"
     "@vitest/browser": "npm:4.1.5"
     "@vitest/browser-playwright": "npm:4.1.5"
     "@vitest/eslint-plugin": "npm:1.3.13"
@@ -5898,10 +5898,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ungap/structured-clone@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@ungap/structured-clone@npm:1.2.0"
-  checksum: 10/c6fe89a505e513a7592e1438280db1c075764793a2397877ff1351721fe8792a966a5359769e30242b3cd023f2efb9e63ca2ca88019d73b564488cc20e3eab12
+"@ungap/structured-clone@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@ungap/structured-clone@npm:1.3.1"
+  checksum: 10/64df206f50aef71c176f9059c1b29e1694821419c6728c446ecf39c80a811eeef156668bf51421b676494a12fd0129ccf09a44f0c641f13c27f50d5f0db6de4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix potential CWE-502 vulnerability by updating from 1.2.0 to 1.3.1.

`npm warn deprecated @ungap/structured-clone@1.2.0: Potential CWE-502 - Update to 1.3.1 or higher`

