### PR TITLE
chore: fix flaky Pagination startupPage derivation test

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -10,7 +10,12 @@ import {
   loadScss,
   wait,
 } from '../../../core/test-utils/testSetup'
-import { createEvent, fireEvent, render } from '@testing-library/react'
+import {
+  createEvent,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react'
 import type { PaginationProps } from '../Pagination'
 import Pagination, { createPagination, Bar } from '../Pagination'
 import Anchor from '../../anchor/Anchor'
@@ -316,9 +321,9 @@ describe('Infinity scroller', () => {
 
     render(<MyComponent />)
 
-    await waitForComponent()
-
-    expect(onStartup).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(onStartup).toHaveBeenCalledTimes(1)
+    })
     expect(onStartup).toHaveBeenCalledWith(
       expect.objectContaining({ pageNumber: 3 })
     )


### PR DESCRIPTION
The "should derive startupPage from currentPage set after mount" test used a fixed 20ms delay (`wait(20)`) which was a race condition — the async state updates from `useEffect` → `setCurrentPage(3)` → `setStartupPage(3)` plus the 1ms `setTimeout(startup, 1)` could sometimes not complete within that window.

Replaced with `waitFor` from testing-library which polls until the assertion passes, making it deterministic.