### PR TITLE
chore: adjust Eufemia logo icon size and spacing in release info link

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/info/about-watching-releases.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/info/about-watching-releases.mdx
@@ -8,6 +8,6 @@ import { Icon } from '@dnb/eufemia/src'
 
 ## The Eufemia Repository
 
-The `@dnb/eufemia` is hosted as a sub package inside the [<Icon icon={EufemiaLogo} size="large" />**Eufemia Repository**](https://github.com/dnbexperience/eufemia) on GitHub.
+The `@dnb/eufemia` is hosted as a sub package inside the [<Icon icon={EufemiaLogo} size="default" /> **Eufemia Repository**](https://github.com/dnbexperience/eufemia) on GitHub.
 
 You can also enable [<Icon icon={GithubLogo} size="default" />notification about upcoming releases](https://help.github.com/articles/watching-and-unwatching-releases-for-a-repository/).


### PR DESCRIPTION
From:
<img width="801" height="163" alt="image" src="https://github.com/user-attachments/assets/cad4a1c9-d903-44d8-bd0f-0c14a2ff9022" />

To:

<img width="827" height="158" alt="image" src="https://github.com/user-attachments/assets/665a33ba-027f-4270-8c81-996f54625574" />
