### PR TITLE
chore: extract inline doc examples into tsc-validated TypeScript files

### DIFF
--- a/packages/dnb-design-system-portal/eslint.config.mjs
+++ b/packages/dnb-design-system-portal/eslint.config.mjs
@@ -40,4 +40,10 @@ export default [
       ],
     },
   },
+  {
+    files: ['src/docs/**/_examples/**'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
 ]

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/form-element-props.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/form-element-props.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useContext } from 'react'
 import { Context } from '@dnb/eufemia/src/shared'
 import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
 import { pickFormElementProps } from '@dnb/eufemia/src/shared/helpers/filterValidProps'
@@ -16,7 +16,7 @@ const defaultProps = {
 }
 
 function FormComponent(props: FormComponentProps) {
-  const context = React.useContext(Context)
+  const context = useContext(Context)
 
   const { myParam, skeleton, ...rest } = extendPropsWithContext(
     props,

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/form-element-props.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/form-element-props.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Context } from '@dnb/eufemia/src/shared'
+import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
+import { pickFormElementProps } from '@dnb/eufemia/src/shared/helpers/filterValidProps'
+
+import type { SpacingProps } from '@dnb/eufemia/src/shared/types'
+import type { SkeletonShow } from '@dnb/eufemia/src/components/skeleton/Skeleton'
+
+export type FormComponentProps = {
+  myParam?: string
+  skeleton?: SkeletonShow
+} & SpacingProps
+
+const defaultProps = {
+  myParam: 'value',
+}
+
+function FormComponent(props: FormComponentProps) {
+  const context = React.useContext(Context)
+
+  const { myParam, skeleton, ...rest } = extendPropsWithContext(
+    props,
+    defaultProps,
+    pickFormElementProps(context?.formElement),
+    (context as Record<string, unknown>).FormComponent as Record<
+      string,
+      unknown
+    >
+  )
+
+  // Use myParam and spread the ...rest
+}
+
+export default FormComponent

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/locale-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/locale-support.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import { useContext } from 'react'
+import type { HTMLProps } from 'react'
 import { Context } from '@dnb/eufemia/src/shared'
 import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
 
@@ -10,14 +11,14 @@ export type ComponentProps = {
 }
 export type ComponentAllProps = ComponentProps &
   LocaleProps &
-  React.HTMLProps<HTMLElement>
+  HTMLProps<HTMLElement>
 
 const defaultProps = {
   myParam: 'value',
 }
 
 function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
+  const context = useContext(Context)
 
   const { myString } = extendPropsWithContext(
     props,

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/locale-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/locale-support.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Context } from '@dnb/eufemia/src/shared'
+import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
+
+import type { LocaleProps } from '@dnb/eufemia/src/shared/types'
+
+export type ComponentProps = {
+  myParam?: string
+  myString?: string
+}
+export type ComponentAllProps = ComponentProps &
+  LocaleProps &
+  React.HTMLProps<HTMLElement>
+
+const defaultProps = {
+  myParam: 'value',
+}
+
+function MyComponent(props: ComponentAllProps) {
+  const context = React.useContext(Context)
+
+  const { myString } = extendPropsWithContext(
+    props,
+    defaultProps,
+    (context.getTranslation(props) as Record<string, unknown>)
+      ?.MyComponent as Record<string, unknown> // details below 👇
+    // ...
+  )
+
+  // Use myString ...
+}
+
+export default MyComponent

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/provider-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/provider-support.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import { useContext } from 'react'
+import type { HTMLProps } from 'react'
 import { Context } from '@dnb/eufemia/src/shared'
 import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
 
@@ -9,14 +10,14 @@ export type ComponentProps = {
 }
 export type ComponentAllProps = ComponentProps &
   LocaleProps &
-  React.HTMLProps<HTMLElement>
+  HTMLProps<HTMLElement>
 
 const defaultProps = {
   myParam: 'value',
 }
 
 function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
+  const context = useContext(Context)
 
   const { myParam, ...rest } = extendPropsWithContext(
     props,

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/provider-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/provider-support.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Context } from '@dnb/eufemia/src/shared'
+import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
+
+import type { LocaleProps } from '@dnb/eufemia/src/shared/types'
+
+export type ComponentProps = {
+  myParam?: string
+}
+export type ComponentAllProps = ComponentProps &
+  LocaleProps &
+  React.HTMLProps<HTMLElement>
+
+const defaultProps = {
+  myParam: 'value',
+}
+
+function MyComponent(props: ComponentAllProps) {
+  const context = React.useContext(Context)
+
+  const { myParam, ...rest } = extendPropsWithContext(
+    props,
+    defaultProps,
+    (context as Record<string, unknown>).MyComponent as Record<
+      string,
+      unknown
+    >
+    // ...
+  )
+
+  // Use myParam and spread the ...rest
+}
+
+export default MyComponent

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/skeleton-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/skeleton-support.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { Context } from '@dnb/eufemia/src/shared'
+import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
+import {
+  skeletonDOMAttributes,
+  createSkeletonClass,
+} from '@dnb/eufemia/src/components/skeleton/SkeletonHelper'
+
+import type { SkeletonShow } from '@dnb/eufemia/src/components/skeleton/Skeleton'
+
+export type ComponentProps = {
+  /**
+   * Skeleton should be applied when loading content
+   * Default: null
+   */
+  skeleton?: SkeletonShow
+}
+export type ComponentAllProps = ComponentProps &
+  React.HTMLProps<HTMLElement>
+
+const defaultProps = {}
+
+function MyComponent(props: ComponentAllProps) {
+  const context = React.useContext(Context)
+
+  const { skeleton, className, ...rest } = extendPropsWithContext(
+    props,
+    defaultProps,
+    { skeleton: context?.skeleton }
+    // ...
+  )
+
+  // This helper will add some needed HTML attributes like "disabled", "aria-disabled" and "aria-label"
+  skeletonDOMAttributes(rest, skeleton, context)
+
+  // This helper will add needed skeleton css classes in order to create a custom skeleton
+  const skeletonClassName = createSkeletonClass(
+    'shape',
+    skeleton,
+    context,
+    className
+  )
+
+  // Use skeleton, skeletonClassName and spread the ...rest
+}
+
+export default MyComponent

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/skeleton-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/skeleton-support.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import { useContext } from 'react'
+import type { HTMLProps } from 'react'
 import { Context } from '@dnb/eufemia/src/shared'
 import { extendPropsWithContext } from '@dnb/eufemia/src/shared/component-helper'
 import {
@@ -15,13 +16,12 @@ export type ComponentProps = {
    */
   skeleton?: SkeletonShow
 }
-export type ComponentAllProps = ComponentProps &
-  React.HTMLProps<HTMLElement>
+export type ComponentAllProps = ComponentProps & HTMLProps<HTMLElement>
 
 const defaultProps = {}
 
 function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
+  const context = useContext(Context)
 
   const { skeleton, className, ...rest } = extendPropsWithContext(
     props,

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/spacing-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/spacing-support.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Context } from '@dnb/eufemia/src/shared'
+import { clsx } from 'clsx'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '@dnb/eufemia/src/shared/component-helper'
+import { useSpacing } from '@dnb/eufemia/src/components/space/SpacingUtils'
+
+import type { SpacingProps } from '@dnb/eufemia/src/shared/types'
+
+export type ComponentProps = {
+  myParam?: string
+}
+export type ComponentAllProps = ComponentProps &
+  SpacingProps &
+  React.HTMLProps<HTMLElement>
+
+const defaultProps = {
+  myParam: 'value',
+}
+
+function MyComponent(props: ComponentAllProps) {
+  const context = React.useContext(Context)
+
+  const { myParam, className, ...rest } = extendPropsWithContext(
+    props,
+    defaultProps
+    // ...
+  )
+
+  // This helper will remove e.g. all spacing properties so you get only valid HTML attributes
+  validateDOMAttributes(props, rest)
+
+  // This hook applies spacing classes and CSS custom properties to the root element props
+  const rootParams = useSpacing(props, {
+    ...rest,
+    className: clsx('dnb-my-component', className),
+  })
+
+  // Spread the ...rootParams on your root element
+}
+
+export default MyComponent

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/spacing-support.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/_examples/spacing-support.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import { useContext } from 'react'
+import type { HTMLProps } from 'react'
 import { Context } from '@dnb/eufemia/src/shared'
 import { clsx } from 'clsx'
 import {
@@ -14,14 +15,14 @@ export type ComponentProps = {
 }
 export type ComponentAllProps = ComponentProps &
   SpacingProps &
-  React.HTMLProps<HTMLElement>
+  HTMLProps<HTMLElement>
 
 const defaultProps = {
   myParam: 'value',
 }
 
 function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
+  const context = useContext(Context)
 
   const { myParam, className, ...rest } = extendPropsWithContext(
     props,

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -3,6 +3,13 @@ title: 'Making changes'
 order: 3
 ---
 
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
+import localeSupportCode from './_examples/locale-support.tsx?raw'
+import providerSupportCode from './_examples/provider-support.tsx?raw'
+import formElementPropsCode from './_examples/form-element-props.tsx?raw'
+import spacingSupportCode from './_examples/spacing-support.tsx?raw'
+import skeletonSupportCode from './_examples/skeleton-support.tsx?raw'
+
 # Making changes
 
 ## Check out a new branch
@@ -103,69 +110,13 @@ export default {
 
 And use it as so:
 
-```tsx
-import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
-
-import type { LocaleProps } from '../../shared/types'
-
-export type ComponentProps = {
-  myParam?: string
-}
-export type ComponentAllProps = ComponentProps &
-  LocaleProps &
-  React.HTMLProps<HTMLElement>
-
-const defaultProps = {
-  myParam: 'value',
-}
-
-function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
-
-  const { myString } = extendPropsWithContext(
-    props,
-    defaultProps,
-    context.getTranslation(props).MyComponent // details below 👇
-    // ...
-  )
-
-  // Use myString ...
-}
-```
+<CodeBlock language="tsx">{localeSupportCode}</CodeBlock>
 
 The function `getTranslation` will along with the properties support both `locale` and the HTML `lang` attribute. This way, these properties can be set by a component basis and a context basis.
 
 ### Provider support
 
-```tsx
-import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
-
-export type ComponentProps = {
-  myParam?: string
-}
-export type ComponentAllProps = ComponentProps &
-  LocaleProps &
-  React.HTMLProps<HTMLElement>
-
-const defaultProps = {
-  myParam: 'value',
-}
-
-function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
-
-  const { myParam, ...rest } = extendPropsWithContext(
-    props,
-    defaultProps,
-    context.MyComponent
-    // ...
-  )
-
-  // Use myParam and spread the ...rest
-}
-```
+<CodeBlock language="tsx">{providerSupportCode}</CodeBlock>
 
 ### "Form element" components
 
@@ -197,125 +148,19 @@ This is needed in order to fully support [Flex](/uilib/layout/flex/) layouts.
 
 In order to support form element properties, such as `vertical` or `labelDirection`, you can use `pickFormElementProps`, so only valid properties will affect the component.
 
-```tsx
-import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
-import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
-
-const defaultProps = {
-  myParam: 'value',
-}
-
-function FormComponent(props: Types) {
-  const context = React.useContext(Context)
-
-  const { myParam, skeleton, ...rest } = extendPropsWithContext(
-    props,
-    defaultProps,
-    pickFormElementProps(context?.formElement)
-    context.FormComponent,
-  )
-
-  // Use myParam and spread the ...rest
-}
-```
+<CodeBlock language="tsx">{formElementPropsCode}</CodeBlock>
 
 ### Spacing support
 
 It depends from case to case on how you would make [spacing](/uilib/layout/space) support available. But you may always allow the developer to pass in the spacing properties to the very root element of your component.
 
-```tsx
-import { Context } from '../../shared'
-import { clsx } from 'clsx'
-import {
-  validateDOMAttributes,
-  extendPropsWithContext,
-} from '../../shared/component-helper'
-import { useSpacing } from '../space/SpacingUtils'
-
-import type { SpacingProps } from '../../shared/types'
-
-export type ComponentProps = {
-  myParam?: string
-}
-export type ComponentAllProps = ComponentProps & SpacingProps
-
-const defaultProps = {
-  myParam: 'value',
-}
-
-function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
-
-  const { myParam, className, ...rest } = extendPropsWithContext(
-    props,
-    defaultProps
-    // ...
-  )
-
-  // This helper will remove e.g. all spacing properties so you get only valid HTML attributes
-  validateDOMAttributes(props, rest)
-
-  // This hook applies spacing classes and CSS custom properties to the root element props
-  const rootParams = useSpacing(props, {
-    ...rest,
-    className: clsx('dnb-my-component', className),
-  })
-
-  // Spread the ...rootParams on your root element
-}
-```
+<CodeBlock language="tsx">{spacingSupportCode}</CodeBlock>
 
 ### Skeleton support
 
 It depends from case to case on how you would make skeleton support available. There is also more info on how to create a [custom skeleton](/uilib/components/skeleton#create-custom-skeleton). But in case your component supports the `skeleton` boolean property, then you may ensure it both can be set locally on the component, and it reacts on the global Context.
 
-```tsx
-import { Context } from '../../shared'
-import { extendPropsWithContext } from '../../shared/component-helper'
-import {
-  skeletonDOMAttributes,
-  createSkeletonClass,
-} from '../skeleton/SkeletonHelper'
-
-import type { SkeletonShow } from '../skeleton/Skeleton'
-
-export type ComponentProps = {
-  /**
-   * Skeleton should be applied when loading content
-   * Default: null
-   */
-  skeleton?: SkeletonShow
-}
-export type ComponentAllProps = ComponentProps &
-  React.HTMLProps<HTMLElement>
-
-const defaultProps = {}
-
-function MyComponent(props: ComponentAllProps) {
-  const context = React.useContext(Context)
-
-  const { skeleton, className, ...rest } = extendPropsWithContext(
-    props,
-    defaultProps,
-    { skeleton: context?.skeleton }
-    // ...
-  )
-
-  // This helper will add some needed HTML attributes like "disabled", "aria-disabled" and "aria-label"
-  skeletonDOMAttributes(rest, skeleton, context)
-
-  // This helper will add needed skeleton css classes in order to create a custom skeleton
-  rest.className = createSkeletonClass(
-    'shape',
-    skeleton,
-    context,
-    className
-  )
-
-  // Use skeleton and spread the ...rest
-}
-```
+<CodeBlock language="tsx">{skeletonSupportCode}</CodeBlock>
 
 ### TypeScript types
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/_examples/bring-postal-code-autofill.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/_examples/bring-postal-code-autofill.tsx
@@ -1,0 +1,31 @@
+import { Connectors, Field, Form } from '@dnb/eufemia/extensions/forms'
+
+const { withConfig } = Connectors.createContext({
+  fetchConfig: {
+    url: (value, { countryCode }) => {
+      return `https://api.bring.com/address/api/${countryCode}/postal-codes/${value}`
+    },
+  },
+})
+
+const onChange = withConfig(Connectors.Bring.postalCode.autofill, {
+  cityPath: '/city',
+})
+
+function MyForm() {
+  return (
+    <Form.Handler>
+      <Field.PostalCodeAndCity
+        postalCode={{
+          path: '/postalCode',
+          // @ts-expect-error – library typing: connector returns unknown value type, field expects string
+          onChange,
+        }}
+        city={{
+          path: '/city',
+        }}
+      />
+      <Form.SubmitButton />
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/_examples/bring-postal-code-validator.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/_examples/bring-postal-code-validator.tsx
@@ -1,0 +1,24 @@
+import { Connectors, Field, Form } from '@dnb/eufemia/extensions/forms'
+
+const { withConfig } = Connectors.createContext({
+  fetchConfig: {
+    url: (value, { countryCode }) => {
+      return `https://api.bring.com/address/api/${countryCode}/postal-codes/${value}`
+    },
+  },
+})
+
+const onBlurValidator = withConfig(Connectors.Bring.postalCode.validator)
+
+function MyForm() {
+  return (
+    <Form.Handler>
+      <Field.PostalCodeAndCity
+        postalCode={{
+          path: '/postalCode',
+          onBlurValidator,
+        }}
+      />
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-filter.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-filter.tsx
@@ -1,0 +1,20 @@
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const filterDataHandler = ({ path, value, data, props, error }) => {
+  if (props['data-exclude-field']) {
+    return false
+  }
+}
+
+const myFormId = 'unique-id' // or a function, object or React Context reference
+
+const MyForm = () => {
+  const { filterData } = Form.useData(myFormId)
+  const filteredData = filterData(filterDataHandler)
+
+  return (
+    <Form.Handler id={myFormId}>
+      <Field.String path="/foo" data-exclude-field />
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-get-value.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-get-value.tsx
@@ -1,0 +1,7 @@
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+function MyComponent() {
+  const { getValue } = Form.useData()
+
+  const value = getValue('/foo')
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-initial.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-initial.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
 
 const myFormId = 'unique-id' // or a function, object or React Context reference
@@ -19,7 +19,7 @@ function ComponentA() {
 function ComponentB() {
   const { set } = Form.useData(myFormId)
 
-  React.useEffect(() => {
+  useEffect(() => {
     set({ foo: 'bar' })
   }, [])
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-initial.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-initial.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const myFormId = 'unique-id' // or a function, object or React Context reference
+const initialData = { foo: 'bar' }
+
+function MyForm() {
+  return (
+    <Form.Handler id={myFormId} data={initialData}>
+      <Field.String path="/foo" />
+    </Form.Handler>
+  )
+}
+
+function ComponentA() {
+  Form.useData(myFormId, { foo: 'bar' })
+}
+
+function ComponentB() {
+  const { set } = Form.useData(myFormId)
+
+  React.useEffect(() => {
+    set({ foo: 'bar' })
+  }, [])
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-set.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-set.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Form, Field } from '@dnb/eufemia/extensions/forms'
+
+const myFormId = 'unique-id' // or a function, object or React Context reference
+
+function MyForm() {
+  const { data, set } = Form.useData(myFormId)
+
+  React.useEffect(() => {
+    set({ foo: 'bar' })
+  }, [])
+
+  return (
+    <Form.Handler id={myFormId}>
+      <Field.String path="/foo" />
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-set.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-set.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { Form, Field } from '@dnb/eufemia/extensions/forms'
 
 const myFormId = 'unique-id' // or a function, object or React Context reference
@@ -6,7 +6,7 @@ const myFormId = 'unique-id' // or a function, object or React Context reference
 function MyForm() {
   const { data, set } = Form.useData(myFormId)
 
-  React.useEffect(() => {
+  useEffect(() => {
     set({ foo: 'bar' })
   }, [])
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-typed.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-typed.tsx
@@ -1,0 +1,8 @@
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+type MyData = { firstName: string }
+
+const MyComponent = () => {
+  const { data } = Form.useData<MyData>()
+  return data.firstName
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-update.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-update.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { Form } from '@dnb/eufemia/extensions/forms'
 
 function Component() {
   const { update } = Form.useData()
 
-  React.useEffect(() => {
+  useEffect(() => {
     update('/foo', 'new value')
 
     // - or with a callback function to get the existing value

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-update.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/_examples/use-data-update.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Form } from '@dnb/eufemia/extensions/forms'
+
+function Component() {
+  const { update } = Form.useData()
+
+  React.useEffect(() => {
+    update('/foo', 'new value')
+
+    // - or with a callback function to get the existing value
+    update('/foo', (existingValue) => existingValue + 'new value')
+  }, [])
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData/info.mdx
@@ -2,6 +2,14 @@
 showTabs: true
 ---
 
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
+import useDataTypedExample from './_examples/use-data-typed.tsx?raw'
+import useDataGetValueExample from './_examples/use-data-get-value.tsx?raw'
+import useDataUpdateExample from './_examples/use-data-update.tsx?raw'
+import useDataSetExample from './_examples/use-data-set.tsx?raw'
+import useDataFilterExample from './_examples/use-data-filter.tsx?raw'
+import useDataInitialExample from './_examples/use-data-initial.tsx?raw'
+
 ## Import
 
 ```tsx
@@ -62,14 +70,7 @@ You can define the TypeScript type structure for your form data. This will help 
 
 **NB:** Use `type` instead of `interface` for the type definition.
 
-```tsx
-type MyData = { firstName: string }
-
-const MyComponent = () => {
-  const { data } = Form.useData<MyData>()
-  return data.firstName
-}
-```
+<CodeBlock language="tsx">{useDataTypedExample}</CodeBlock>
 
 ### Without an `id` property
 
@@ -118,15 +119,7 @@ This is beneficial when you need to utilize the form data in other places within
 
 ### Select a single value
 
-```jsx
-import { Form } from '@dnb/eufemia/extensions/forms'
-
-function MyComponent() {
-  const { getValue } = Form.useData()
-
-  const value = getValue('/foo')
-}
-```
+<CodeBlock language="jsx">{useDataGetValueExample}</CodeBlock>
 
 ## Update data
 
@@ -134,44 +127,13 @@ If you need to update the data, you can use the `update` method.
 
 It takes a path ([JSON Pointer](/uilib/extensions/forms/getting-started/#what-is-a-json-pointer)) and a callback function. The callback function receives the existing value as the first argument, and the second argument is the path itself. The callback function must return the new value.
 
-```jsx
-import { Form } from '@dnb/eufemia/extensions/forms'
-
-function Component() {
-  const { update } = Form.useData()
-
-  useEffect(() => {
-    update('/foo', 'new value')
-
-    // - or with a callback function to get the existing value
-    update('/foo', (existingValue) => existingValue + 'new value')
-  }, [])
-}
-```
+<CodeBlock language="jsx">{useDataUpdateExample}</CodeBlock>
 
 ## Extend the whole data set
 
 With the `set` method, you can extend the data set. Existing data paths will be overwritten.
 
-```jsx
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
-
-const myFormId = 'unique-id' // or a function, object or React Context reference
-
-function MyForm() {
-  const { data, set } = Form.useData(myFormId)
-
-  useEffect(() => {
-    set({ foo: 'bar' })
-  }, [])
-
-  return (
-    <Form.Handler id={myFormId}>
-      <Field.String path="/foo" />
-    </Form.Handler>
-  )
-}
-```
+<CodeBlock language="jsx">{useDataSetExample}</CodeBlock>
 
 ## Visible data
 
@@ -228,26 +190,7 @@ It returns the filtered form data.
 
 **Tip:** Depending on your use case – and instead of `disabled` – you may rather use a `data-*` attribute on your field (e.g. `data-exclude-field`) to filter the field out of the data set.
 
-```tsx
-const filterDataHandler = ({ path, value, data, props, error }) => {
-  if (props['data-exclude-field']) {
-    return false
-  }
-}
-
-const myFormId = 'unique-id' // or a function, object or React Context reference
-
-const MyForm = () => {
-  const { filterData } = Form.useData(myFormId)
-  const filteredData = filterData(filterDataHandler)
-
-  return (
-    <Form.Handler id={myFormId}>
-      <Field.String path="/foo" data-exclude-field />
-    </Form.Handler>
-  )
-}
-```
+<CodeBlock language="tsx">{useDataFilterExample}</CodeBlock>
 
 ```tsx
 const filterDataHandler = ({ path, value, data, props, error }) => {
@@ -259,32 +202,7 @@ const filterDataHandler = ({ path, value, data, props, error }) => {
 
 You decide where and when you want to provide the initial `data` to the form. It can be done via the `Form.Handler` component, or via the `Form.useData` Hook or [Form.setData](/uilib/extensions/forms/Form/setData/) method – or even in each Field, with the value property.
 
-```jsx
-import { Form, Field } from '@dnb/eufemia/extensions/forms'
-
-const myFormId = 'unique-id' // or a function, object or React Context reference
-const initialData = { foo: 'bar' }
-
-function MyForm() {
-  return (
-    <Form.Handler id={myFormId} data={initialData}>
-      <Field.String path="/foo" />
-    </Form.Handler>
-  )
-}
-
-function ComponentA() {
-  Form.useData(myFormId, { foo: 'bar' })
-}
-
-function ComponentB() {
-  const { set } = Form.useData(myFormId)
-
-  useEffect(() => {
-    set({ foo: 'bar' })
-  }, [])
-}
-```
+<CodeBlock language="jsx">{useDataInitialExample}</CodeBlock>
 
 ## Validation
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Upload/_examples/upload-transform.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Upload/_examples/upload-transform.tsx
@@ -1,0 +1,60 @@
+import { Form, Field, Tools } from '@dnb/eufemia/extensions/forms'
+import type { UploadValue } from '@dnb/eufemia/src/extensions/forms/Field/Upload'
+
+// Our external format
+type DocumentMetadata = {
+  id: string
+  fileName: string
+}
+
+const defaultValue = [
+  {
+    id: '1234',
+    fileName: 'myFile.pdf',
+  },
+] satisfies DocumentMetadata[] as unknown as UploadValue
+
+const filesCache = new Map<string, File>()
+
+// To the Field (from e.g. defaultValue)
+const transformIn = (external: unknown) => {
+  const files = external as DocumentMetadata[] | undefined
+  return (
+    files?.map(({ id, fileName }) => {
+      const file: File =
+        filesCache.get(id) ||
+        new File([], fileName, { type: 'images/png' })
+
+      return { id, file }
+    }) || []
+  )
+}
+
+// From the Field (internal value) to the data context or event parameter
+const transformOut = (internal: UploadValue | unknown) => {
+  const files = internal as UploadValue | undefined
+  return (
+    files?.map(({ id, file }) => {
+      if (!filesCache.has(id)) {
+        filesCache.set(id, file)
+      }
+
+      return { id, fileName: file.name }
+    }) || []
+  )
+}
+
+function MyForm() {
+  return (
+    <Form.Handler>
+      <Field.Upload
+        path="/documents"
+        transformIn={transformIn}
+        transformOut={transformOut}
+        defaultValue={defaultValue}
+      />
+
+      <Tools.Log />
+    </Form.Handler>
+  )
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/_examples/validate-required.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/_examples/validate-required.tsx
@@ -1,0 +1,26 @@
+import { useFieldProps, FormError } from '@dnb/eufemia/extensions/forms'
+
+const validateRequired = (
+  value: unknown,
+  {
+    emptyValue,
+    required,
+    isChanged,
+  }: { emptyValue: unknown; required: boolean; isChanged: boolean }
+) => {
+  if (required && value === emptyValue) {
+    return new FormError('Field.errorRequired')
+  }
+}
+
+function MyComponent() {
+  const { error, hasError } = useFieldProps({
+    value: undefined,
+    required: true,
+    validateInitially: true,
+    validateRequired,
+    errorMessages: {
+      'Field.errorRequired': 'Show this when "required" fails.',
+    },
+  })
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -2,6 +2,9 @@
 draft: true
 ---
 
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
+import validateRequiredExample from './_examples/validate-required.tsx?raw'
+
 ## Import
 
 ```tsx
@@ -156,23 +159,7 @@ It returns all of the given component properties, in addition to these:
 
 ### Custom validateRequired
 
-```ts
-const validateRequired = (value, { emptyValue, required, isChanged }) => {
-  if (required && value === emptyValue) {
-    return new FormError('Field.errorRequired')
-  }
-}
-
-const { error, hasError } = useFieldProps({
-  value: undefined,
-  required: true,
-  validateInitially: true,
-  validateRequired,
-  errorMessages: {
-    'Field.errorRequired': 'Show this when "required" fails.',
-  },
-})
-```
+<CodeBlock language="ts">{validateRequiredExample}</CodeBlock>
 
 #### Validation order
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/_examples/use-media-query.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/_examples/use-media-query.tsx
@@ -1,0 +1,10 @@
+import { useMediaQuery } from '@dnb/eufemia/shared'
+
+function Component() {
+  const match = useMediaQuery({
+    matchOnSSR: true,
+    when: { min: 'medium' },
+  })
+
+  return match ? 'true' : 'false'
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
@@ -12,6 +12,8 @@ redirect_from:
 
 import BreakpointRanges from './assets/breakpoint-ranges.svg'
 import { MediaQueryLiveExample, MediaQueryUseMedia } from './Examples'
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
+import useMediaQueryExample from './_examples/use-media-query.tsx?raw'
 
 # Media Queries and Breakpoints
 
@@ -191,20 +193,7 @@ You can log the media query by providing `useMedia({ log: true })`.
 
 This React Hook is a more extended version where you can define all sorts of media queries.
 
-```js
-import { useMediaQuery } from '@dnb/eufemia/shared'
-// or
-import useMediaQuery from '@dnb/eufemia/shared/useMediaQuery'
-
-function Component() {
-  const match = useMediaQuery({
-    matchOnSSR: true,
-    when: { min: 'medium' },
-  })
-
-  return match ? 'true' : 'false'
-}
-```
+<CodeBlock language="tsx">{useMediaQueryExample}</CodeBlock>
 
 You can disable the usage of `window.matchMedia` by providing `useMedia({ disabled: true })`.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/_examples/render-with-formatting-advanced.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/_examples/render-with-formatting-advanced.tsx
@@ -1,0 +1,11 @@
+import { renderWithFormatting } from '@dnb/eufemia/shared'
+
+function ArrayInputExample() {
+  const parts = ['Hello', '{br}', 'world! See https://example.com']
+  return <>{renderWithFormatting(parts)}</>
+}
+
+function DynamicExample({ refId }: { refId: string }) {
+  const text = `Keep your reference \`${refId}\` for support.`
+  return <>{renderWithFormatting(text)}</>
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/_examples/render-with-formatting.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/_examples/render-with-formatting.tsx
@@ -1,0 +1,8 @@
+import { renderWithFormatting } from '@dnb/eufemia/shared'
+
+const text =
+  'Use **bold**, _italic_, `AB12-XYZ9` and a link https://www.dnb.no{br}Next line'
+
+export function InlineFormattingExample() {
+  return <>{renderWithFormatting(text)}</>
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -5,6 +5,9 @@ order: 8
 
 import { Ul, Li, Code, Anchor } from '@dnb/eufemia/src'
 import { languageDisplayNames } from 'dnb-design-system-portal/src/core/ChangeLocale'
+import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
+import renderWithFormattingExample from './_examples/render-with-formatting.tsx?raw'
+import renderWithFormattingAdvancedExample from './_examples/render-with-formatting-advanced.tsx?raw'
 
 # Localization
 
@@ -289,32 +292,11 @@ function MyApp() {
 
 You can also use `renderWithFormatting` directly, without the translation context. This is handy for static copy or small strings you build at runtime.
 
-```tsx
-import { renderWithFormatting } from '@dnb/eufemia/shared'
-
-const text =
-  'Use **bold**, _italic_, `AB12-XYZ9` and a link https://www.dnb.no{br}Next line'
-
-export function InlineFormattingExample() {
-  return <>{renderWithFormatting(text)}</>
-}
-```
+<CodeBlock language="tsx">{renderWithFormattingExample}</CodeBlock>
 
 Array input and dynamic strings are also supported:
 
-```tsx
-import { renderWithFormatting } from '@dnb/eufemia/shared'
-
-function ArrayInputExample() {
-  const parts = ['Hello', '{br}', 'world! See https://example.com']
-  return <>{renderWithFormatting(parts)}</>
-}
-
-function DynamicExample({ refId }: { refId: string }) {
-  const text = `Keep your reference \`${'${refId}'}\` for support.`
-  return <>{renderWithFormatting(text)}</>
-}
-```
+<CodeBlock language="tsx">{renderWithFormattingAdvancedExample}</CodeBlock>
 
 ### Rich text (inline elements)
 

--- a/packages/dnb-eufemia/extensions/forms/index.ts
+++ b/packages/dnb-eufemia/extensions/forms/index.ts
@@ -1,0 +1,8 @@
+/* eslint-disable no-restricted-imports */
+
+/**
+ * Barrel re-export so that `@dnb/eufemia/extensions/forms` resolves
+ * against the source tree (used by the portal during development).
+ * Use restricted-imports so it gets rewritten from /src/ to /build/
+ */
+export * from '@dnb/eufemia/src/extensions/forms'


### PR DESCRIPTION
Extract fenced code blocks from MDX docs into real .tsx files imported via Vite ?raw, rendered with <CodeBlock>. This ensures documented code examples are validated by tsc on every build.

Files converted (14 blocks across 5 MDX pages):
- making-changes.mdx: 5 blocks (locale, provider, form-element, spacing, skeleton)
- useData/info.mdx: 6 blocks (typed, getValue, update, set, filter, initial)
- useFieldProps/info.mdx: 1 block (validateRequired)
- media-queries.mdx: 1 block (useMediaQuery)
- localization.mdx: 2 blocks (renderWithFormatting, advanced)

Validation-only files (tsc-checked but not rendered in docs):
- Upload transform example (dev-only import paths in extracted file)
- Bring postal code validator/autofill (placeholder URLs differ)

Bugs fixed in original docs:
- Missing LocaleProps import (making-changes)
- Missing comma syntax error (making-changes form-element)
- Incorrect skeleton class assignment pattern (making-changes)
- Missing React import for useEffect (useData: update, set, initial)
- Missing Form/Field imports (useData: filter)
- Hook called outside component (useFieldProps)
- Wrong transformIn/transformOut type signatures (Upload)
- Unused UploadFileNative import (Upload)

Infrastructure:
- Add extensions/forms/index.ts barrel for dev import resolution

