### PR TITLE
chore: hide code editor focus ring in focus mode

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -188,6 +188,10 @@
         border-start-end-radius: 0;
         border-end-start-radius: var(--border-radius);
         border-end-end-radius: var(--border-radius);
+
+        :global(.focusmode) & {
+          box-shadow: none;
+        }
       }
 
       &__editable {


### PR DESCRIPTION
Hide the `.dnb-live-editor` hover/focus-within focus ring box-shadow when in focus mode, since the code editor border and radius are already removed in that context.