### PR TITLE
chore(eslint): support Default: validation in sync-docs-jsdoc

### DIFF
--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/basic/BasicDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/basic/BasicDocs.ts
@@ -1,6 +1,11 @@
 type PropertiesTableProps = Record<
   string,
-  { doc: string; type: string | string[]; status: string }
+  {
+    doc: string
+    type: string | string[]
+    status: string
+    defaultValue?: string
+  }
 >
 
 export const BasicProperties: PropertiesTableProps = {
@@ -17,6 +22,12 @@ export const BasicProperties: PropertiesTableProps = {
   size: {
     doc: 'The size of the component. Defaults to `medium`.',
     type: ['"small"', '"medium"', '"large"'],
+    status: 'optional',
+  },
+  zebra: {
+    doc: 'Use `false` to disable alternating row background colors.',
+    type: 'boolean',
+    defaultValue: 'true',
     status: 'optional',
   },
 }

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
@@ -3,9 +3,15 @@ import { RuleTester } from 'eslint'
 import rule from '../rules/sync-docs-jsdoc'
 
 const ruleExports = rule as typeof rule & {
-  extractDocsFromFile: (filePath: string) => Map<string, string>
+  extractDocsFromFile: (
+    filePath: string
+  ) => Map<string, { doc: string; defaultValue: string | null }>
   extractJsdocText: (commentValue: string) => string
   extractJsdocTags: (commentValue: string) => string[]
+  splitDefaultFromDoc: (fullText: string) => {
+    docText: string
+    defaultValue: string | null
+  }
 }
 
 const fixturesDir = path.resolve(__dirname, 'fixtures/sync-docs-jsdoc')
@@ -111,6 +117,20 @@ tester.run('sync-docs-jsdoc', rule, {
            * @deprecated Use newProp instead.
            */
           content?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+    },
+
+    // ── JSDoc with matching Default: line ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Use \`false\` to disable alternating row background colors.
+           * Default: \`true\`
+           */
+          zebra?: boolean
         }
       `,
       filename: path.join(fixturesDir, 'basic/types.ts'),
@@ -503,6 +523,96 @@ tester.run('sync-docs-jsdoc', rule, {
       filename: path.join(fixturesDir, 'basic/types.ts'),
       errors: [{ messageId: 'mismatchedJsdoc' }],
     },
+
+    // ── Missing Default: line when docs has defaultValue ──
+    {
+      code: `
+        export type BasicProps = {
+          /** Use \`false\` to disable alternating row background colors. */
+          zebra?: boolean
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Use \`false\` to disable alternating row background colors.
+           * Default: \`true\`
+           */
+          zebra?: boolean
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── Wrong Default: value ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Use \`false\` to disable alternating row background colors.
+           * Default: \`false\`
+           */
+          zebra?: boolean
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Use \`false\` to disable alternating row background colors.
+           * Default: \`true\`
+           */
+          zebra?: boolean
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── Wrong doc text but correct Default: line ──
+    {
+      code: `
+        export type BasicProps = {
+          /**
+           * Wrong description.
+           * Default: \`true\`
+           */
+          zebra?: boolean
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Use \`false\` to disable alternating row background colors.
+           * Default: \`true\`
+           */
+          zebra?: boolean
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      errors: [{ messageId: 'mismatchedJsdoc' }],
+    },
+
+    // ── requireJsdoc with defaultValue — includes Default: line ──
+    {
+      code: `
+        export type BasicProps = {
+          zebra?: boolean
+        }
+      `,
+      output: `
+        export type BasicProps = {
+          /**
+           * Use \`false\` to disable alternating row background colors.
+           * Default: \`true\`
+           */
+          zebra?: boolean
+        }
+      `,
+      filename: path.join(fixturesDir, 'basic/types.ts'),
+      options: [{ requireJsdoc: true }],
+      errors: [{ messageId: 'missingJsdoc' }],
+    },
   ],
 })
 
@@ -515,24 +625,45 @@ describe('extractDocsFromFile', () => {
     const docsPath = path.join(fixturesDir, 'basic/BasicDocs.ts')
     const docs = extractDocsFromFile(docsPath)
 
-    expect(docs.get('content')).toBe('Content of the component.')
-    expect(docs.get('label')).toBe('Label for the component.')
-    expect(docs.get('size')).toBe(
-      'The size of the component. Defaults to `medium`.'
-    )
-    expect(docs.size).toBe(3)
+    expect(docs.get('content')).toEqual({
+      doc: 'Content of the component.',
+      defaultValue: null,
+    })
+    expect(docs.get('label')).toEqual({
+      doc: 'Label for the component.',
+      defaultValue: null,
+    })
+    expect(docs.get('size')).toEqual({
+      doc: 'The size of the component. Defaults to `medium`.',
+      defaultValue: null,
+    })
+    expect(docs.get('zebra')).toEqual({
+      doc: 'Use `false` to disable alternating row background colors.',
+      defaultValue: 'true',
+    })
+    expect(docs.size).toBe(4)
   })
 
   it('extracts docs from a multi-export Docs file', () => {
     const docsPath = path.join(fixturesDir, 'multi-export/MultiDocs.ts')
     const docs = extractDocsFromFile(docsPath)
 
-    expect(docs.get('value')).toBe('The current value.')
-    expect(docs.get('label')).toBe('Label for the field.')
-    expect(docs.get('onChange')).toBe('Called when the value changes.')
-    expect(docs.get('onFocus')).toBe(
-      'Called when the field receives focus.'
-    )
+    expect(docs.get('value')).toEqual({
+      doc: 'The current value.',
+      defaultValue: null,
+    })
+    expect(docs.get('label')).toEqual({
+      doc: 'Label for the field.',
+      defaultValue: null,
+    })
+    expect(docs.get('onChange')).toEqual({
+      doc: 'Called when the value changes.',
+      defaultValue: null,
+    })
+    expect(docs.get('onFocus')).toEqual({
+      doc: 'Called when the field receives focus.',
+      defaultValue: null,
+    })
     expect(docs.size).toBe(4)
   })
 
@@ -543,11 +674,18 @@ describe('extractDocsFromFile', () => {
     )
     const docs = extractDocsFromFile(docsPath)
 
-    expect(docs.get('aria-label')).toBe(
-      'Accessible label for the component.'
-    )
-    expect(docs.get('data-testid')).toBe('Test ID for the component.')
-    expect(docs.get('name')).toBe('The name attribute.')
+    expect(docs.get('aria-label')).toEqual({
+      doc: 'Accessible label for the component.',
+      defaultValue: null,
+    })
+    expect(docs.get('data-testid')).toEqual({
+      doc: 'Test ID for the component.',
+      defaultValue: null,
+    })
+    expect(docs.get('name')).toEqual({
+      doc: 'The name attribute.',
+      defaultValue: null,
+    })
     expect(docs.size).toBe(3)
   })
 })
@@ -650,5 +788,52 @@ describe('extractJsdocTags', () => {
     expect(
       extractJsdocTags('* @deprecated Use newProp instead. ')
     ).toEqual(['@deprecated Use newProp instead.'])
+  })
+})
+
+// ── Unit tests for splitDefaultFromDoc ──
+
+describe('splitDefaultFromDoc', () => {
+  const { splitDefaultFromDoc } = ruleExports
+
+  it('splits a doc with Default: line', () => {
+    expect(
+      splitDefaultFromDoc('Some description. Default: `true`')
+    ).toEqual({
+      docText: 'Some description.',
+      defaultValue: 'true',
+    })
+  })
+
+  it('handles Default: with trailing period', () => {
+    expect(
+      splitDefaultFromDoc('Some description. Default: `false`.')
+    ).toEqual({
+      docText: 'Some description.',
+      defaultValue: 'false',
+    })
+  })
+
+  it('returns null defaultValue when no Default: line', () => {
+    expect(splitDefaultFromDoc('Just a plain description.')).toEqual({
+      docText: 'Just a plain description.',
+      defaultValue: null,
+    })
+  })
+
+  it('handles backtick values with special characters', () => {
+    expect(
+      splitDefaultFromDoc('The size of the component. Default: `medium`')
+    ).toEqual({
+      docText: 'The size of the component.',
+      defaultValue: 'medium',
+    })
+  })
+
+  it('handles numeric default values', () => {
+    expect(splitDefaultFromDoc('The count. Default: `0`')).toEqual({
+      docText: 'The count.',
+      defaultValue: '0',
+    })
   })
 })

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
@@ -58,20 +58,25 @@ function extractFromObjectLiteral(objLiteral, docs) {
       continue
     }
 
+    let doc = null
+    let defaultValue = null
+
     for (const innerProp of prop.initializer.properties) {
       if (!ts.isPropertyAssignment(innerProp)) {
         continue
       }
 
       const innerName = getTsPropertyName(innerProp)
-      if (innerName !== 'doc') {
-        continue
-      }
 
-      const docValue = getStringLiteralValue(innerProp.initializer)
-      if (docValue !== null) {
-        docs.set(propName, docValue)
+      if (innerName === 'doc') {
+        doc = getStringLiteralValue(innerProp.initializer)
+      } else if (innerName === 'defaultValue') {
+        defaultValue = getStringLiteralValue(innerProp.initializer)
       }
+    }
+
+    if (doc !== null) {
+      docs.set(propName, { doc, defaultValue })
     }
   }
 }
@@ -120,6 +125,24 @@ function extractJsdocText(commentValue) {
     )
     .join(' ')
     .trim()
+}
+
+/**
+ * Separates the main doc text from a trailing `Default: \`...\`` line.
+ * Returns { docText, defaultValue } where defaultValue is the inner
+ * content of the backticks, or null if no default line is present.
+ */
+function splitDefaultFromDoc(fullText) {
+  const match = fullText.match(/^(.*?)\s*Default:\s*`([^`]*)`\.?$/)
+
+  if (match) {
+    return {
+      docText: match[1].replace(/\s+$/, ''),
+      defaultValue: match[2],
+    }
+  }
+
+  return { docText: fullText, defaultValue: null }
 }
 
 function extractJsdocTags(commentValue) {
@@ -244,6 +267,31 @@ module.exports = {
     const requireJsdoc = options.requireJsdoc === true
     const sourceCode = context.sourceCode || context.getSourceCode()
 
+    function buildExpectedDoc(doc, defaultValue) {
+      if (defaultValue != null) {
+        return `${doc}\nDefault: \`${defaultValue}\``
+      }
+
+      return doc
+    }
+
+    function buildJsdocBlock(indent, doc, defaultValue, tags) {
+      const lines = [`/**`, `${indent} * ${doc}`]
+
+      if (defaultValue != null) {
+        lines.push(`${indent} * Default: \`${defaultValue}\``)
+      }
+
+      if (tags.length > 0) {
+        for (const tag of tags) {
+          lines.push(`${indent} * ${tag}`)
+        }
+      }
+
+      lines.push(`${indent} */`)
+      return lines.join('\n')
+    }
+
     function checkProperty(node) {
       const propName = getEslintPropertyName(node)
 
@@ -251,7 +299,8 @@ module.exports = {
         return // stop here
       }
 
-      const expectedDoc = docsData.docs.get(propName)
+      const { doc: expectedDoc, defaultValue: expectedDefault } =
+        docsData.docs.get(propName)
       const docsFile = docsData.fileMap.get(propName)
 
       const comments = sourceCode.getCommentsBefore(node)
@@ -265,15 +314,18 @@ module.exports = {
 
       if (!jsdocComment) {
         if (requireJsdoc) {
+          const expected = buildExpectedDoc(expectedDoc, expectedDefault)
           context.report({
             node: node.key,
             messageId: 'missingJsdoc',
-            data: { docsFile, expected: expectedDoc },
+            data: { docsFile, expected },
             fix(fixer) {
               const line = sourceCode.lines[node.loc.start.line - 1]
               const match = line.match(/^(\s*)/)
               const indent = match ? match[1] : ''
-              const jsdoc = `/**\n${indent} * ${expectedDoc}\n${indent} */\n${indent}`
+              const jsdoc =
+                buildJsdocBlock(indent, expectedDoc, expectedDefault, []) +
+                `\n${indent}`
               return fixer.insertTextBefore(node, jsdoc)
             },
           })
@@ -282,35 +334,34 @@ module.exports = {
         return // stop here
       }
 
-      const existingDoc = extractJsdocText(jsdocComment.value)
+      const fullJsdocText = extractJsdocText(jsdocComment.value)
       const tags = extractJsdocTags(jsdocComment.value)
+      const { docText: existingDoc, defaultValue: existingDefault } =
+        splitDefaultFromDoc(fullJsdocText)
 
-      if (existingDoc !== expectedDoc) {
+      const docMatches = existingDoc === expectedDoc
+      const defaultMatches =
+        (expectedDefault == null && existingDefault == null) ||
+        existingDefault === expectedDefault
+
+      if (!docMatches || !defaultMatches) {
+        const expected = buildExpectedDoc(expectedDoc, expectedDefault)
         context.report({
           node: node.key,
           messageId: 'mismatchedJsdoc',
-          data: { docsFile, expected: expectedDoc },
+          data: { docsFile, expected },
           fix(fixer) {
-            let replacement
-
-            if (tags.length > 0) {
-              const commentNode = jsdocComment
-              const startLine =
-                sourceCode.lines[commentNode.loc.start.line - 1]
-              const indentMatch = startLine.match(/^(\s*)/)
-              const indent = indentMatch ? indentMatch[1] : ''
-              const tagLines = tags
-                .map((tag) => `${indent} * ${tag}`)
-                .join('\n')
-              replacement = `/**\n${indent} * ${expectedDoc}\n${tagLines}\n${indent} */`
-            } else {
-              const commentNode = jsdocComment
-              const startLine =
-                sourceCode.lines[commentNode.loc.start.line - 1]
-              const indentMatch = startLine.match(/^(\s*)/)
-              const indent = indentMatch ? indentMatch[1] : ''
-              replacement = `/**\n${indent} * ${expectedDoc}\n${indent} */`
-            }
+            const commentNode = jsdocComment
+            const startLine =
+              sourceCode.lines[commentNode.loc.start.line - 1]
+            const indentMatch = startLine.match(/^(\s*)/)
+            const indent = indentMatch ? indentMatch[1] : ''
+            const replacement = buildJsdocBlock(
+              indent,
+              expectedDoc,
+              expectedDefault,
+              tags
+            )
 
             return fixer.replaceTextRange(jsdocComment.range, replacement)
           },
@@ -328,3 +379,4 @@ module.exports = {
 module.exports.extractDocsFromFile = extractDocsFromFile
 module.exports.extractJsdocText = extractJsdocText
 module.exports.extractJsdocTags = extractJsdocTags
+module.exports.splitDefaultFromDoc = splitDefaultFromDoc


### PR DESCRIPTION
Enhances the `sync-docs-jsdoc` ESLint rule to support `Default: \`...\`` validation in JSDoc comments.

### Changes

- **Extraction**: `extractFromObjectLiteral` now reads both `doc` and `defaultValue` from *Docs files
- **Comparison**: New `splitDefaultFromDoc` helper separates the `Default: \`...\`` line from the doc text before comparing, preventing false mismatch reports
- **Auto-fix**: Generates or corrects the `Default:` line when `defaultValue` is present in the Docs file
- **Tests**: Added rule test cases (valid matching default, missing default, wrong default, wrong doc with correct default, requireJsdoc with default) and `splitDefaultFromDoc` unit tests — all 51 tests pass