### PR TITLE
chore: add ESLint linting for MDX files

### DIFF
--- a/packages/dnb-design-system-portal/eslint.config.mjs
+++ b/packages/dnb-design-system-portal/eslint.config.mjs
@@ -1,4 +1,5 @@
 import eufemiaConfig from '@dnb/eufemia/eslint.config.mjs'
+import * as mdxPlugin from 'eslint-plugin-mdx'
 import workspacesPlugin from 'eslint-plugin-workspaces'
 
 const workspacesRecommended =
@@ -38,6 +39,38 @@ export default [
           ],
         },
       ],
+    },
+  },
+
+  // MDX linting — parse and lint .mdx files
+  {
+    ...mdxPlugin.flat,
+  },
+  {
+    files: ['**/*.mdx'],
+    rules: {
+      // Catch unused imports/variables in MDX files
+      'no-unused-vars': [
+        'error',
+        {
+          args: 'none',
+          ignoreRestSiblings: true,
+          varsIgnorePattern: '^_',
+        },
+      ],
+
+      // Components are injected via the MDX provider (src/shared/tags/index.tsx)
+      'react/jsx-no-undef': 'off',
+
+      // These rules don't apply well to MDX
+      'prettier/prettier': 'off',
+      'react/no-unescaped-entities': 'off',
+      'react/self-closing-comp': 'off', // false positives: MDX components wrapping markdown content appear "empty" to the parser
+      'no-unused-expressions': 'off',
+      'import/namespace': 'off',
+      'import/no-unresolved': 'off',
+      'workspaces/no-absolute-imports': 'off',
+      'compat/compat': 'off',
     },
   },
 ]

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -78,6 +78,7 @@
     "date-fns": "4.1.0",
     "eslint": "9.39.2",
     "eslint-plugin-jsx-a11y": "6.10.2",
+    "eslint-plugin-mdx": "3.7.0",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-workspaces": "0.11.1",

--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides.mdx
@@ -4,8 +4,6 @@ order: 6
 icon: 'story'
 ---
 
-import { Button } from '@dnb/eufemia/src'
-
 # Style guides
 
 To make sure the source code and the overall project are consistent and reliable, we have made some recommended style guides you should follow.

--- a/packages/dnb-design-system-portal/src/docs/design-system/about.mdx
+++ b/packages/dnb-design-system-portal/src/docs/design-system/about.mdx
@@ -5,7 +5,6 @@ order: 3
 ---
 
 import WelcomeAdvice from 'Docs/welcome-advice'
-import { Blockquote } from '@dnb/eufemia/src'
 
 # About Eufemia
 

--- a/packages/dnb-design-system-portal/src/docs/license.mdx
+++ b/packages/dnb-design-system-portal/src/docs/license.mdx
@@ -2,7 +2,6 @@
 title: 'License'
 ---
 
-import React from 'react'
 import license from '../../../../LICENSE?raw'
 import { Logo, P } from '@dnb/eufemia/src'
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-families.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/typography/font-families.mdx
@@ -2,8 +2,6 @@
 draft: true
 ---
 
-import { H3 } from '@dnb/eufemia/src'
-
 # Font Families
 
 <VisibilityByTheme hidden="sbanken">

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.mdx
@@ -5,7 +5,6 @@ order: 1
 accordion: true
 ---
 
-import WelcomeAdvice from 'Docs/welcome-advice.mdx'
 import WatchingReleases from 'Docs/uilib/info/about-watching-releases.mdx'
 
 # About the library

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
@@ -6,7 +6,6 @@ import {
   AccordionDefaultExample,
   AccordionLargeContentExample,
   AccordionCustomisationExample,
-  AccordionContainerExample,
   AccordionGroupExample,
   AccordionNestedExample,
   AccordionPlainVariant,

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/events.mdx
@@ -3,7 +3,6 @@ showTabs: true
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import {
   BreadcrumbEvents,
   BreadcrumbItemEvents,

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/info.mdx
@@ -2,8 +2,6 @@
 showTabs: true
 ---
 
-import { SupportedFormats } from 'Docs/uilib/components/date-format/Examples'
-
 ## Import
 
 ```tsx

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list-format/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list-format/properties.mdx
@@ -2,7 +2,6 @@
 showTabs: true
 ---
 
-import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { ListFormatProperties } from '@dnb/eufemia/src/components/list-format/ListFormatDocs'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/provider.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/provider.mdx
@@ -4,4 +4,4 @@ showTabs: true
 
 import ProviderInfo from 'Docs/uilib/usage/customisation/provider-info.mdx'
 
-<ProviderInfo></ProviderInfo>
+<ProviderInfo />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/info.mdx
@@ -2,7 +2,6 @@
 showTabs: true
 ---
 
-import { Button } from '@dnb/eufemia/src'
 import {
   SkipContentInfo1,
   SkipContentInfo2,

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/demos.mdx
@@ -8,7 +8,6 @@ import {
   StepIndicatorLoose,
   StepIndicatorCustomized,
   StepIndicatorTextOnly,
-  StepIndicatorCustomRenderer,
   StepIndicatorRouter,
   StepIndicatorStatuses,
   StepIndicatorSkeleton,

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements.mdx
@@ -4,7 +4,6 @@ icon: 'elements'
 order: 6
 ---
 
-import CodeBlock from 'dnb-design-system-portal/src/shared/tags/CodeBlock'
 import ListElements from 'dnb-design-system-portal/src/shared/parts/ListElements'
 import { StyledComponentsExample } from 'Docs/uilib/Examples'
 import { UnstyledExample } from 'Docs/uilib/elements/unstyled/Examples'

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/lists/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/lists/demos.mdx
@@ -11,7 +11,6 @@ import {
   OrderedListStylePositionExample,
   OrderedListOtherTypesExample,
   RemoveListExample,
-  DefinitionListHorizontalExampleWithoutDtValue,
   UlInsideOl,
 } from 'Docs/uilib/elements/lists/Examples'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Card/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Card/properties.mdx
@@ -3,7 +3,6 @@ showTabs: true
 hideInMenu: true
 ---
 
-import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import {
   FormCardProperties,

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SummaryList/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Value/SummaryList/properties.mdx
@@ -2,7 +2,6 @@
 showTabs: true
 ---
 
-import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { SummaryListProperties } from '@dnb/eufemia/src/extensions/forms/Value/SummaryList/SummaryListDocs'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/all-features.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/all-features.mdx
@@ -10,7 +10,6 @@ breadcrumb:
 
 import ListFormComponents from './Form/ListFormComponents'
 import ListWizardComponents from './Wizard/ListWizardComponents'
-import ListBaseValueComponents from './Value/ListBaseValueComponents'
 import ListDataContextComponents from './DataContext/ListDataContextComponents'
 import ListIterateComponents from './Iterate/ListIterateComponents'
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component.mdx
@@ -9,7 +9,6 @@ breadcrumb:
 accordion: true
 ---
 
-import ListBasisAPIs from './create-component/ListBasisAPIs'
 import {
   CreateBasicFieldComponent,
   CreateBasicValueComponent,

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -11,9 +11,8 @@ breadcrumb:
 
 import * as Examples from './Examples'
 import QuickStart from './quick-start'
-import AsyncStateReturnExample from './Form/Handler/parts/async-state-return-example.mdx'
 import AsyncChangeExample from './Form/Handler/parts/async-change-example.mdx'
-import { Ul, Li, Code, Anchor } from '@dnb/eufemia/src'
+import { Ul, Li, Anchor } from '@dnb/eufemia/src'
 import { languageDisplayNames } from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 # Getting started

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/06-css-packages.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/06-css-packages.mdx
@@ -6,8 +6,6 @@ search: 'Intro - CSS Packages'
 import Intro, {
   IntroFooter,
 } from 'dnb-design-system-portal/src/shared/tags/Intro'
-import { Next } from 'dnb-design-system-portal/src/shared/tags/Intro'
-import { Link } from '@dnb/eufemia/src'
 
 <Intro>
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/11-components-elements-extensions.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/11-components-elements-extensions.mdx
@@ -16,7 +16,7 @@ import { Button } from '@dnb/eufemia/src'
 
 Components are custom made **user interaction elements** with an internal state, your application can interact with.
 
-<div className="image-box" align="center">
+<div className="image-box" style={{ textAlign: 'center' }}>
   <Button text="Button" href="/uilib/components/button" target="_blank" />
 </div>
 
@@ -24,7 +24,7 @@ Components are custom made **user interaction elements** with an internal state,
 
 Elements are basicity ready to use styled HTML elements.
 
-<div className="image-box" align="center">
+<div className="image-box" style={{ textAlign: 'center' }}>
   <a
     className="dnb-anchor"
     href="!/uilib/components/anchor"

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/info.mdx
@@ -2,8 +2,6 @@
 showTabs: true
 ---
 
-import * as Examples from './Examples'
-
 ## Description
 
 To make it easier to build application layout and [form](/uilib/extensions/forms)-views in line with defined design sketches, there are a number of components for layout.

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/properties.mdx
@@ -5,7 +5,6 @@ showTabs: true
 import { ProviderExample } from 'Docs/uilib/layout/space/Examples'
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
-import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
 import {
   SpaceProperties,
   SpaceGlobalProperties,

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography.mdx
@@ -106,10 +106,10 @@ import { H1, H2, ... } from '@dnb/eufemia'
 
 ## Anchor
 
-- `.dnb-anchor` – <a href="/" className="dnb-anchor">Anchor with default style</a>
-- `.dnb-anchor--hover` – <a href="/" className="dnb-anchor dnb-anchor--hover">Hover style</a>
-- `.dnb-anchor--active` – <a href="/" className="dnb-anchor dnb-anchor--active">Active style</a>
-- `.dnb-anchor--focus` –  <a href="/" className="dnb-anchor dnb-anchor--focus">Focus style</a>
+- `.dnb-anchor` -- <a href="/" className="dnb-anchor">Anchor with default style</a>
+- `.dnb-anchor--hover` -- <a href="/" className="dnb-anchor dnb-anchor--hover">Hover style</a>
+- `.dnb-anchor--active` -- <a href="/" className="dnb-anchor dnb-anchor--active">Active style</a>
+- `.dnb-anchor--focus` -- <a href="/" className="dnb-anchor dnb-anchor--focus">Focus style</a>
 
 Read more about the [Anchor / Text Link](/uilib/components/anchor).
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.mdx
@@ -4,7 +4,7 @@ order: 2
 ---
 
 import { FontWeightByThemeExample } from 'Docs/uilib/typography/Examples'
-import { GetPropValue, GetPropAsPx } from './_helpers.tsx'
+import { GetPropValue } from './_helpers.tsx'
 import ChangeStyleTheme from '../../../core/ChangeStyleTheme'
 
 # Font Weights for <VisibilityByTheme.Name />

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/localization.mdx
@@ -3,7 +3,7 @@ title: 'Locale / Translation'
 order: 8
 ---
 
-import { Ul, Li, Code, Anchor } from '@dnb/eufemia/src'
+import { Ul, Li, Anchor } from '@dnb/eufemia/src'
 import { languageDisplayNames } from 'dnb-design-system-portal/src/core/ChangeLocale'
 
 # Localization

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -4,8 +4,6 @@ description: 'To ensure flexibility and the possibility of theming, the DNB CSS 
 order: 3
 ---
 
-import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
-import { Icon } from '@dnb/eufemia/src'
 import CSSDiagram from 'Docs/uilib/usage/customisation/assets/cssStructureDiagram'
 
 # CSS Styles

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/guide.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/guide.mdx
@@ -2,8 +2,6 @@
 showTabs: true
 ---
 
-import * as Examples from './Examples'
-
 ## Guide contents
 
 - [Guide contents](#guide-contents)

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/demos.mdx
@@ -7,7 +7,6 @@ import {
   ThemeSurfaceDark,
   ThemeSurfaceInitial,
 } from 'Docs/uilib/usage/customisation/theming/theme/Examples'
-import ChangeStyleTheme from '../../../../../../core/ChangeStyleTheme'
 
 ## Demos
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps.mdx
@@ -3,9 +3,6 @@ title: 'First Steps'
 order: 2
 ---
 
-import GithubLogo from 'Docs/contribute/assets/github-logo'
-import { Icon } from '@dnb/eufemia/src'
-
 # First Steps
 
 ## Good to know

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,7 +211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
   dependencies:
@@ -3781,6 +3781,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/config@npm:^8.0.0":
+  version: 8.3.4
+  resolution: "@npmcli/config@npm:8.3.4"
+  dependencies:
+    "@npmcli/map-workspaces": "npm:^3.0.2"
+    "@npmcli/package-json": "npm:^5.1.1"
+    ci-info: "npm:^4.0.0"
+    ini: "npm:^4.1.2"
+    nopt: "npm:^7.2.1"
+    proc-log: "npm:^4.2.0"
+    semver: "npm:^7.3.5"
+    walk-up-path: "npm:^3.0.1"
+  checksum: 10/ffe9cc1792aeeb54285f9e9e13d8e91a6b8965ab4f314fac998b3cd4e16eab548b839429a4475d1dd74d59cd8c82f4dd864e31c8b4641449c7b03eddc1306948
+  languageName: node
+  linkType: hard
+
 "@npmcli/config@npm:^9.0.0":
   version: 9.0.0
   resolution: "@npmcli/config@npm:9.0.0"
@@ -3851,6 +3867,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/git@npm:^5.0.0":
+  version: 5.0.8
+  resolution: "@npmcli/git@npm:5.0.8"
+  dependencies:
+    "@npmcli/promise-spawn": "npm:^7.0.0"
+    ini: "npm:^4.1.3"
+    lru-cache: "npm:^10.0.1"
+    npm-pick-manifest: "npm:^9.0.0"
+    proc-log: "npm:^4.0.0"
+    promise-inflight: "npm:^1.0.1"
+    promise-retry: "npm:^2.0.1"
+    semver: "npm:^7.3.5"
+    which: "npm:^4.0.0"
+  checksum: 10/e6f94175fb9dde13d84849b29b32ffb4c4df968822cc85df2aebfca13bf8ca76f33b1d281911f5bcddc95bccba2f9e795669c736a38de4d9c76efb5047ffb4fb
+  languageName: node
+  linkType: hard
+
 "@npmcli/git@npm:^6.0.0, @npmcli/git@npm:^6.0.1":
   version: 6.0.3
   resolution: "@npmcli/git@npm:6.0.3"
@@ -3900,6 +3933,18 @@ __metadata:
     minimatch: "npm:^5.0.1"
     read-package-json-fast: "npm:^2.0.3"
   checksum: 10/424f7cb6932d0d5cc60348e17f7c16cd3266173e161613aa16f91c32c508530642207084da8acf7f1c3a27c90218cd082076688b7c312350c6e3c0b84ea30944
+  languageName: node
+  linkType: hard
+
+"@npmcli/map-workspaces@npm:^3.0.2":
+  version: 3.0.6
+  resolution: "@npmcli/map-workspaces@npm:3.0.6"
+  dependencies:
+    "@npmcli/name-from-folder": "npm:^2.0.0"
+    glob: "npm:^10.2.2"
+    minimatch: "npm:^9.0.0"
+    read-package-json-fast: "npm:^3.0.0"
+  checksum: 10/b364b155991a4ff85db5ea5b9f809ab65936350fc36fe1e51d5ab8cd479bba57e69f02e17215c0e2126e383074c2987c268d8e589aacd26c9962e028f4da98f2
   languageName: node
   linkType: hard
 
@@ -3957,6 +4002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/name-from-folder@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@npmcli/name-from-folder@npm:2.0.0"
+  checksum: 10/75beb40373f916cfcf7327958b3ab920ab4e32d24217197927dd1c76a325c7645695011fce9cb2a8f93616f8b74946e84eebe3830303e11ed9d400dae623a99b
+  languageName: node
+  linkType: hard
+
 "@npmcli/name-from-folder@npm:^3.0.0":
   version: 3.0.0
   resolution: "@npmcli/name-from-folder@npm:3.0.0"
@@ -3987,6 +4039,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/package-json@npm:^5.1.1":
+  version: 5.2.1
+  resolution: "@npmcli/package-json@npm:5.2.1"
+  dependencies:
+    "@npmcli/git": "npm:^5.0.0"
+    glob: "npm:^10.2.2"
+    hosted-git-info: "npm:^7.0.0"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    normalize-package-data: "npm:^6.0.0"
+    proc-log: "npm:^4.0.0"
+    semver: "npm:^7.5.3"
+  checksum: 10/304a819b93f79a6e0e56cb371961a66d2db72142e310d545ecbbbe4d917025a30601aa8e63a5f0cc28f0fe281c116bdaf79b334619b105a1d027a2b769ecd137
+  languageName: node
+  linkType: hard
+
 "@npmcli/package-json@npm:^6.0.0, @npmcli/package-json@npm:^6.0.1, @npmcli/package-json@npm:^6.2.0":
   version: 6.2.0
   resolution: "@npmcli/package-json@npm:6.2.0"
@@ -4008,6 +4075,15 @@ __metadata:
   dependencies:
     infer-owner: "npm:^1.0.4"
   checksum: 10/3454465a2731cea5875ba51f80873e2205e5bd878c31517286b0ede4ea931c7bf3de895382287e906d03710fff6f9e44186bd0eee068ce578901c5d3b58e7692
+  languageName: node
+  linkType: hard
+
+"@npmcli/promise-spawn@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "@npmcli/promise-spawn@npm:7.0.2"
+  dependencies:
+    which: "npm:^4.0.0"
+  checksum: 10/94cbbbeeb20342026c3b68fc8eb09e1600b7645d4e509f2588ef5ea7cff977eb01e628cc8e014595d04a6af4b4bc5c467c950a8135920f39f7c7b57fba43f4e9
   languageName: node
   linkType: hard
 
@@ -5482,6 +5558,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/concat-stream@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "@types/concat-stream@npm:2.0.3"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/e829fde246528665b31a9b8f64c369ffc66aa2a1337d2bab1d38f4d4145701480af7c67e877dd09a7fa97fcbaa0f3baa816ed1b3e71c3ad430930acd37f4eb1f
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.8
   resolution: "@types/debug@npm:4.1.8"
@@ -5527,6 +5612,13 @@ __metadata:
   dependencies:
     "@types/unist": "npm:*"
   checksum: 10/732920d81bb7605895776841b7658b4d8cc74a43a8fa176017cc0fb0ecc1a4c82a2b75a4fe6b71aa262b649d3fb62858c6789efa3793ea1d40269953af96ecb5
+  languageName: node
+  linkType: hard
+
+"@types/is-empty@npm:^1.0.0":
+  version: 1.2.3
+  resolution: "@types/is-empty@npm:1.2.3"
+  checksum: 10/b22065de5978dacacb6b7401df03e94b9688a3ce07c7faab1bab5e943adbdd6455b190963079bb0aae12c8e56980e54c49bc6902a5805741b82fb4f7335b0c44
   languageName: node
   linkType: hard
 
@@ -5597,6 +5689,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^22.0.0":
+  version: 22.19.19
+  resolution: "@types/node@npm:22.19.19"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10/d404eb0bc391805537a172fcc607f7f9c142e20edc01a4203ec33e33a3c4e98fbe3a7ddb63725c399dd05947fac938722a6e05afe1c3d92017ac05c9a6b3ed8f
+  languageName: node
+  linkType: hard
+
 "@types/normalize-package-data@npm:^2.4.0, @types/normalize-package-data@npm:^2.4.1, @types/normalize-package-data@npm:^2.4.3":
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
@@ -5663,6 +5764,13 @@ __metadata:
   version: 0.12.0
   resolution: "@types/retry@npm:0.12.0"
   checksum: 10/bbd0b88f4b3eba7b7acfc55ed09c65ef6f2e1bcb4ec9b4dca82c66566934351534317d294a770a7cc6c0468d5573c5350abab6e37c65f8ef254443e1b028e44d
+  languageName: node
+  linkType: hard
+
+"@types/supports-color@npm:^8.0.0":
+  version: 8.1.3
+  resolution: "@types/supports-color@npm:8.1.3"
+  checksum: 10/f5a3ca4aa94ac9d45beae8aa06dcba45e6d56b77999707a2708b54a9b042f84c68e619b10ef6e4b6f447f801824adebb9ed4d7a82c0b5d5d7bf29d5ff34d53a9
   languageName: node
   linkType: hard
 
@@ -6148,6 +6256,13 @@ __metadata:
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: 10/2d882941183c66aa665118bafdab82b7a177e9add5eb2776c33e960a4f3c89cff88a1b38aba13a456de01d0dd9d66a8bea7c903268b21ea91dd1097e1e2e8243
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 10/ca0a54e35bea4ece0ecb68a47b312e1a9a6f772408d5bcb9051230aaa94b0460671c5b5c9cb3240eb5b7bc94c52476550eb221f65a0bbd0145bdc9f3113a6707
   languageName: node
   linkType: hard
 
@@ -8877,6 +8992,7 @@ __metadata:
     date-fns: "npm:4.1.0"
     eslint: "npm:9.39.2"
     eslint-plugin-jsx-a11y: "npm:6.10.2"
+    eslint-plugin-mdx: "npm:3.7.0"
     eslint-plugin-react: "npm:7.37.5"
     eslint-plugin-react-hooks: "npm:7.0.1"
     eslint-plugin-workspaces: "npm:0.11.1"
@@ -9099,6 +9215,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^10.2.1":
+  version: 10.6.0
+  resolution: "emoji-regex@npm:10.6.0"
+  checksum: 10/98cc0b0e1daed1ed25afbf69dcb921fee00f712f51aab93aa1547e4e4e8171725cc4f0098aaa645b4f611a19da11ec9f4623eb6ff2b72314b39a8f2ae7c12bf2
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -9199,6 +9322,15 @@ __metadata:
   dependencies:
     is-arrayish: "npm:^0.2.1"
   checksum: 10/d547740aa29c34e753fb6fed2c5de81802438529c12b3673bd37b6bb1fe49b9b7abdc3c11e6062fe625d8a296b3cf769a80f878865e25e685f787763eede3ffb
+  languageName: node
+  linkType: hard
+
+"error-ex@npm:^1.3.2":
+  version: 1.3.4
+  resolution: "error-ex@npm:1.3.4"
+  dependencies:
+    is-arrayish: "npm:^0.2.1"
+  checksum: 10/ae3939fd4a55b1404e877df2080c6b59acc516d5b7f08a181040f78f38b4e2399633bfed2d9a21b91c803713fff7295ac70bebd8f3657ef352a95c2cd9aa2e4b
   languageName: node
   linkType: hard
 
@@ -9629,6 +9761,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-mdx@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "eslint-mdx@npm:3.7.0"
+  dependencies:
+    acorn: "npm:^8.15.0"
+    acorn-jsx: "npm:^5.3.2"
+    espree: "npm:^9.6.1 || ^10.4.0"
+    estree-util-visit: "npm:^2.0.0"
+    remark-mdx: "npm:^3.1.0"
+    remark-parse: "npm:^11.0.0"
+    remark-stringify: "npm:^11.0.0"
+    synckit: "npm:^0.11.8"
+    unified: "npm:^11.0.5"
+    unified-engine: "npm:^11.2.2"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.3"
+  peerDependencies:
+    eslint: ">=8.0.0"
+    remark-lint-file-extension: "*"
+  peerDependenciesMeta:
+    remark-lint-file-extension:
+      optional: true
+  checksum: 10/4c83c1246086ae2628272cf93d942c872ca4cd882f3f8f18e1419793e3cab7b5456d2eb729f869d730f7fec1b9f6e64cfe1f03175575a26b306147ecc5e6ef27
+  languageName: node
+  linkType: hard
+
 "eslint-module-utils@npm:^2.12.1":
   version: 2.12.1
   resolution: "eslint-module-utils@npm:2.12.1"
@@ -9710,6 +9868,26 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
   checksum: 10/388550798548d911e2286d530a29153ca00434a06fcfc0e31e0dda46a5e7960005e532fb29ce1ccbf1e394a3af3e5cf70c47ca43778861eacc5e3ed799adb79c
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-mdx@npm:3.7.0":
+  version: 3.7.0
+  resolution: "eslint-plugin-mdx@npm:3.7.0"
+  dependencies:
+    eslint-mdx: "npm:^3.7.0"
+    mdast-util-from-markdown: "npm:^2.0.2"
+    mdast-util-mdx: "npm:^3.0.0"
+    micromark-extension-mdxjs: "npm:^3.0.0"
+    remark-mdx: "npm:^3.1.0"
+    remark-parse: "npm:^11.0.0"
+    remark-stringify: "npm:^11.0.0"
+    synckit: "npm:^0.11.8"
+    unified: "npm:^11.0.5"
+    vfile: "npm:^6.0.3"
+  peerDependencies:
+    eslint: ">=8.0.0"
+  checksum: 10/0a91fe71eabf1b33b2cf4146266807460b5b807df613fddc9c046c9eda54d19b990c12fe1042ecc7a98581bd13eda3210d6cdf6cfb2266621f5030dd0a0713c1
   languageName: node
   linkType: hard
 
@@ -9911,7 +10089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^10.0.1, espree@npm:^10.4.0":
+"espree@npm:^10.0.1, espree@npm:^10.4.0, espree@npm:^9.6.1 || ^10.4.0":
   version: 10.4.0
   resolution: "espree@npm:10.4.0"
   dependencies:
@@ -11099,7 +11277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.3, glob@npm:^10.4.5":
+"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.3, glob@npm:^10.4.5":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -11769,6 +11947,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "ignore@npm:6.0.2"
+  checksum: 10/af39e49996cd989763920e445eff897d0ae1e36b5f27b0e09e14a4fd2df89b362f92e720ecf06ef729056842366527db8561d310e904718810b92ffbcd23056d
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^5.0.2":
   version: 5.1.4
   resolution: "immutable@npm:5.1.4"
@@ -11804,6 +11989,13 @@ __metadata:
   version: 4.0.0
   resolution: "import-lazy@npm:4.0.0"
   checksum: 10/943309cc8eb01ada12700448c288b0384f77a1bc33c7e00fa4cb223c665f467a13ce9aaceb8d2e4cf586b07c1d2828040263dcc069873ce63cfc2ac6fd087971
+  languageName: node
+  linkType: hard
+
+"import-meta-resolve@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: 10/3499ee8b7eddb79be77067b368bcdf39e6f144306dea4686d08071ae7e65a2e3bdca3f98f2a0f4babdcd4ba9d9e7d379ae7e27c4b9bf8b08c1e812a28c674bf3
   languageName: node
   linkType: hard
 
@@ -11884,6 +12076,13 @@ __metadata:
   version: 3.0.1
   resolution: "ini@npm:3.0.1"
   checksum: 10/3295920f88c55ee1eae6b154164b31fbcef78fd162b60f3a888f8071c4ed6ef0828b4aea4cde143c002629ceab5980960b2171e3846c475b29878cb40dbff22e
+  languageName: node
+  linkType: hard
+
+"ini@npm:^4.1.2, ini@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "ini@npm:4.1.3"
+  checksum: 10/f536b414d1442e5b233429e2b56efcdb354109b2d65ddd489e5939d8f0f5ad23c88aa2b19c92987249d0dd63ba8192e9aeb1a02b0459549c5a9ff31acd729a5d
   languageName: node
   linkType: hard
 
@@ -12176,6 +12375,13 @@ __metadata:
   bin:
     is-docker: cli.js
   checksum: 10/b698118f04feb7eaf3338922bd79cba064ea54a1c3db6ec8c0c8d8ee7613e7e5854d802d3ef646812a8a3ace81182a085dfa0a71cc68b06f3fa794b9783b3c90
+  languageName: node
+  linkType: hard
+
+"is-empty@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "is-empty@npm:1.2.0"
+  checksum: 10/dc80e0a8ad5439d98d128d126fe69e5dcd6b474e29753107bcfe82fc7d628c9da618d48bb24878a7891f231696405ad0a854dfe3cfc955c23d24e80d9e252e62
   languageName: node
   linkType: hard
 
@@ -12903,6 +13109,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-parse-even-better-errors@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "json-parse-even-better-errors@npm:3.0.2"
+  checksum: 10/6f04ea6c9ccb783630a59297959247e921cc90b917b8351197ca7fd058fccc7079268fd9362be21ba876fc26aa5039369dd0a2280aae49aae425784794a94927
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^4.0.0":
   version: 4.0.0
   resolution: "json-parse-even-better-errors@npm:4.0.0"
@@ -13558,6 +13771,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lines-and-columns@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "lines-and-columns@npm:2.0.4"
+  checksum: 10/81ac2f943f5428a46bd4ea2561c74ba674a107d8e6cc70cd317d16892a36ff3ba0dc6e599aca8b6f8668d26c85288394c6edf7a40e985ca843acab3701b80d4c
+  languageName: node
+  linkType: hard
+
 "load-json-file@npm:^4.0.0":
   version: 4.0.0
   resolution: "load-json-file@npm:4.0.0"
@@ -13567,6 +13787,16 @@ __metadata:
     pify: "npm:^3.0.0"
     strip-bom: "npm:^3.0.0"
   checksum: 10/8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
+  languageName: node
+  linkType: hard
+
+"load-plugin@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "load-plugin@npm:6.0.3"
+  dependencies:
+    "@npmcli/config": "npm:^8.0.0"
+    import-meta-resolve: "npm:^4.0.0"
+  checksum: 10/b348f8751508020e9344b29178f7032647f1a1c9614356d6b993c06589cfb08306deb76f560cfe3fce21c976b2378f0206d581b6d1d2563abf550e4468608adc
   languageName: node
   linkType: hard
 
@@ -14064,6 +14294,26 @@ __metadata:
     micromark-util-types: "npm:^2.0.0"
     unist-util-stringify-position: "npm:^4.0.0"
   checksum: 10/69b207913fbcc0469f8c59d922af4d5509b79e809d77c9bd4781543a907fe2ecc8e6433ce0707066a27b117b13f38af3aae4f2d085e18ebd2d3ad5f1a5647902
+  languageName: node
+  linkType: hard
+
+"mdast-util-from-markdown@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "mdast-util-from-markdown@npm:2.0.3"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark: "npm:^4.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10/96f2bfb3b240c3d20a57db5d215faed795abf495c65ca2a4d61c0cf796011bc980619aa032d7984b05b67c15edc0eccd12a004a848952d3a598d108cf14901ab
   languageName: node
   linkType: hard
 
@@ -15388,6 +15638,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nopt@npm:^7.2.1":
+  version: 7.2.1
+  resolution: "nopt@npm:7.2.1"
+  dependencies:
+    abbrev: "npm:^2.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10/95a1f6dec8a81cd18cdc2fed93e6f0b4e02cf6bdb4501c848752c6e34f9883d9942f036a5e3b21a699047d8a448562d891e67492df68ec9c373e6198133337ae
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^8.0.0, nopt@npm:^8.1.0":
   version: 8.1.0
   resolution: "nopt@npm:8.1.0"
@@ -15573,6 +15834,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-install-checks@npm:^6.0.0":
+  version: 6.3.0
+  resolution: "npm-install-checks@npm:6.3.0"
+  dependencies:
+    semver: "npm:^7.1.1"
+  checksum: 10/6c20dadb878a0d2f1f777405217b6b63af1299d0b43e556af9363ee6eefaa98a17dfb7b612a473a473e96faf7e789c58b221e0d8ffdc1d34903c4f71618df3b4
+  languageName: node
+  linkType: hard
+
 "npm-install-checks@npm:^7.1.0, npm-install-checks@npm:^7.1.1":
   version: 7.1.2
   resolution: "npm-install-checks@npm:7.1.2"
@@ -15596,10 +15866,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-normalize-package-bin@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "npm-normalize-package-bin@npm:3.0.1"
+  checksum: 10/de416d720ab22137a36292ff8a333af499ea0933ef2320a8c6f56a73b0f0448227fec4db5c890d702e26d21d04f271415eab6580b5546456861cc0c19498a4bf
+  languageName: node
+  linkType: hard
+
 "npm-normalize-package-bin@npm:^4.0.0":
   version: 4.0.0
   resolution: "npm-normalize-package-bin@npm:4.0.0"
   checksum: 10/e1a0971e5640bc116c5197f9707d86dc404b6d8e13da2c7ea82baa5583b8da279a3c8607234aa1d733c2baac3b3eba87b156f021f20ae183dc4806530e61675d
+  languageName: node
+  linkType: hard
+
+"npm-package-arg@npm:^11.0.0":
+  version: 11.0.3
+  resolution: "npm-package-arg@npm:11.0.3"
+  dependencies:
+    hosted-git-info: "npm:^7.0.0"
+    proc-log: "npm:^4.0.0"
+    semver: "npm:^7.3.5"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/bacc863907edf98940286edc2fd80327901c1e8b34426d538cdc708ed66bc6567f06d742d838eaf35db6804347bb4ba56ca9cef032c4b52743b33e7a22a2678e
   languageName: node
   linkType: hard
 
@@ -15671,6 +15960,18 @@ __metadata:
     npm-package-arg: "npm:^9.0.0"
     semver: "npm:^7.3.5"
   checksum: 10/5aac6e8e602ef2f3cfa637b70480476e6446201a02d2c673fad4ff0d7051af8f33c240e7f3fa80e5ed46c10f33c2a7150acf294367ad70230b73e05cdbbbddd1
+  languageName: node
+  linkType: hard
+
+"npm-pick-manifest@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "npm-pick-manifest@npm:9.1.0"
+  dependencies:
+    npm-install-checks: "npm:^6.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+    npm-package-arg: "npm:^11.0.0"
+    semver: "npm:^7.3.5"
+  checksum: 10/e759e4fe4076da9169cf522964a80bbc096d50cd24c8c44b50b44706c4479bd9d9d018fbdb76c6ea0c6037e012e07c6c917a1ecaa7ae1a1169cddfae1c0f24b6
   languageName: node
   linkType: hard
 
@@ -16561,6 +16862,19 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 10/62085b17d64da57f40f6afc2ac1f4d95def18c4323577e1eced571db75d9ab59b297d1d10582920f84b15985cbfc6b6d450ccbf317644cfa176f3ed982ad87e2
+  languageName: node
+  linkType: hard
+
+"parse-json@npm:^7.0.0":
+  version: 7.1.1
+  resolution: "parse-json@npm:7.1.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.21.4"
+    error-ex: "npm:^1.3.2"
+    json-parse-even-better-errors: "npm:^3.0.0"
+    lines-and-columns: "npm:^2.0.3"
+    type-fest: "npm:^3.8.0"
+  checksum: 10/187275c7ac097dcfb3c7420bca2399caa4da33bcd5d5aac3604bda0e2b8eee4df61cc26aa0d79fab97f0d67bf42d41d332baa9f9f56ad27636ad785f1ae639e5
   languageName: node
   linkType: hard
 
@@ -17742,6 +18056,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proc-log@npm:^4.0.0, proc-log@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "proc-log@npm:4.2.0"
+  checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^5.0.0":
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
@@ -18168,6 +18489,16 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     npm-normalize-package-bin: "npm:^1.0.1"
   checksum: 10/fca37b3b2160b9dda7c5588b767f6a2b8ce68d03a044000e568208e20bea0cf6dd2de17b90740ce8da8b42ea79c0b3859649dadf29510bbe77224ea65326a903
+  languageName: node
+  linkType: hard
+
+"read-package-json-fast@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "read-package-json-fast@npm:3.0.2"
+  dependencies:
+    json-parse-even-better-errors: "npm:^3.0.0"
+    npm-normalize-package-bin: "npm:^3.0.0"
+  checksum: 10/8d406869f045f1d76e2a99865a8fd1c1af9c1dc06200b94d2b07eef87ed734b22703a8d72e1cd36ea36cc48e22020bdd187f88243c7dd0563f72114d38c17072
   languageName: node
   linkType: hard
 
@@ -18620,7 +18951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-mdx@npm:^3.0.0":
+"remark-mdx@npm:^3.0.0, remark-mdx@npm:^3.1.0":
   version: 3.1.1
   resolution: "remark-mdx@npm:3.1.1"
   dependencies:
@@ -19960,6 +20291,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "string-width@npm:6.1.0"
+  dependencies:
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^10.2.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10/8aefb456a230c8d7fe254049b1b2d62603da1a3b6c7fc9f3332f6779583cc1c72653f9b6e4cd0c1c92befee1565d4a0a7542d09ba4ceb6d96af02fbd8425bb03
+  languageName: node
+  linkType: hard
+
 "string.prototype.codepointat@npm:^0.2.1":
   version: 0.2.1
   resolution: "string.prototype.codepointat@npm:0.2.1"
@@ -20372,7 +20714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^9.4.0":
+"supports-color@npm:^9.0.0, supports-color@npm:^9.4.0":
   version: 9.4.0
   resolution: "supports-color@npm:9.4.0"
   checksum: 10/cb8ff8daeaf1db642156f69a9aa545b6c01dd9c4def4f90a49f46cbf24be0c245d392fcf37acd119cd1819b99dad2cc9b7e3260813f64bcfd7f5b18b5a1eefb8
@@ -20466,6 +20808,15 @@ __metadata:
   dependencies:
     "@pkgr/core": "npm:^0.2.9"
   checksum: 10/6ecd88212b5be80004376b6ea74babcba284566ff59a50d8803afcaa78c165b5d268635c1dd84532ee3f690a979409e1eda225a8a35bed2d135ffdcea06ce7b0
+  languageName: node
+  linkType: hard
+
+"synckit@npm:^0.11.8":
+  version: 0.11.12
+  resolution: "synckit@npm:0.11.12"
+  dependencies:
+    "@pkgr/core": "npm:^0.2.9"
+  checksum: 10/2f51978bfed81aaf0b093f596709a72c49b17909020f42b43c5549f9c0fe18b1fe29f82e41ef771172d729b32e9ce82900a85d2b87fa14d59f886d4df8d7a329
   languageName: node
   linkType: hard
 
@@ -21092,6 +21443,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^3.8.0":
+  version: 3.13.1
+  resolution: "type-fest@npm:3.13.1"
+  checksum: 10/9a8a2359ada34c9b3affcaf3a8f73ee14c52779e89950db337ce66fb74c3399776c697c99f2532e9b16e10e61cfdba3b1c19daffb93b338b742f0acd0117ce12
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
@@ -21268,6 +21626,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
+  languageName: node
+  linkType: hard
+
 "undici@npm:7.18.2":
   version: 7.18.2
   resolution: "undici@npm:7.18.2"
@@ -21336,7 +21701,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unified@npm:^11.0.0":
+"unified-engine@npm:^11.2.2":
+  version: 11.2.2
+  resolution: "unified-engine@npm:11.2.2"
+  dependencies:
+    "@types/concat-stream": "npm:^2.0.0"
+    "@types/debug": "npm:^4.0.0"
+    "@types/is-empty": "npm:^1.0.0"
+    "@types/node": "npm:^22.0.0"
+    "@types/unist": "npm:^3.0.0"
+    concat-stream: "npm:^2.0.0"
+    debug: "npm:^4.0.0"
+    extend: "npm:^3.0.0"
+    glob: "npm:^10.0.0"
+    ignore: "npm:^6.0.0"
+    is-empty: "npm:^1.0.0"
+    is-plain-obj: "npm:^4.0.0"
+    load-plugin: "npm:^6.0.0"
+    parse-json: "npm:^7.0.0"
+    trough: "npm:^2.0.0"
+    unist-util-inspect: "npm:^8.0.0"
+    vfile: "npm:^6.0.0"
+    vfile-message: "npm:^4.0.0"
+    vfile-reporter: "npm:^8.0.0"
+    vfile-statistics: "npm:^3.0.0"
+    yaml: "npm:^2.0.0"
+  checksum: 10/4b1befbb4c47a803ad5da28dba37c5551a7948ab6db7e6c7219ae58a13bbd70207b5fa966f0d24863924ab7910009233e39c1cfc9bf37e6ad9269e721e0df6dc
+  languageName: node
+  linkType: hard
+
+"unified@npm:^11.0.0, unified@npm:^11.0.5":
   version: 11.0.5
   resolution: "unified@npm:11.0.5"
   dependencies:
@@ -21430,6 +21824,15 @@ __metadata:
   dependencies:
     crypto-random-string: "npm:^4.0.0"
   checksum: 10/1a1e2e7d02eab1bb10f720475da735e1990c8a5ff34edd1a3b6bc31590cb4210b7a1233d779360cc622ce11c211e43afa1628dd658f35d3e6a89964b622940df
+  languageName: node
+  linkType: hard
+
+"unist-util-inspect@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "unist-util-inspect@npm:8.1.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10/f1d14b2fdf184b08de55e215b67ccce9be59b81ccb72b01295538b1642b2087f093b6e98bd830727dd5d69074dcdce3c471469a2ec8bd0aa4063b1270b23e86f
   languageName: node
   linkType: hard
 
@@ -21642,6 +22045,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"validate-npm-package-name@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "validate-npm-package-name@npm:5.0.1"
+  checksum: 10/0d583a1af23aeffea7748742cf22b6802458736fb8b60323ba5949763824d46f796474b0e1b9206beb716f9d75269e19dbd7795d6b038b29d561be95dd827381
+  languageName: node
+  linkType: hard
+
 "validate-npm-package-name@npm:^6.0.0, validate-npm-package-name@npm:^6.0.1":
   version: 6.0.2
   resolution: "validate-npm-package-name@npm:6.0.2"
@@ -21685,7 +22095,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vfile@npm:^6.0.0":
+"vfile-reporter@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "vfile-reporter@npm:8.1.1"
+  dependencies:
+    "@types/supports-color": "npm:^8.0.0"
+    string-width: "npm:^6.0.0"
+    supports-color: "npm:^9.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+    vfile: "npm:^6.0.0"
+    vfile-message: "npm:^4.0.0"
+    vfile-sort: "npm:^4.0.0"
+    vfile-statistics: "npm:^3.0.0"
+  checksum: 10/caeb1b59d3798d9c098d84da68047e8fa5fb3a245c66dc4a653d16ac1cec5bc8023ef5c529d426a21fed8dafab902ede6adea22958fbcbdc1cb999f44b783f50
+  languageName: node
+  linkType: hard
+
+"vfile-sort@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "vfile-sort@npm:4.0.0"
+  dependencies:
+    vfile: "npm:^6.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10/2d60298ccf30b6f1068560660985670ad3345cfa1f85f1feb66f0d9b74b847a81af94db26fc798e98a09eed58ea4502c7bbd69c969e26848f5badcdb90d28bc8
+  languageName: node
+  linkType: hard
+
+"vfile-statistics@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "vfile-statistics@npm:3.0.0"
+  dependencies:
+    vfile: "npm:^6.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10/0dbbc8adeb73bb24b5f723e947122e1ae7b6bd0c5ff3fd1ae0ef4a3066f74be00425102c95aa4eaa0f529ba05237255fe8342af76661b0ba6aee3f4c16ca135f
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^6.0.0, vfile@npm:^6.0.3":
   version: 6.0.3
   resolution: "vfile@npm:6.0.3"
   dependencies:
@@ -22073,6 +22519,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
+  dependencies:
+    isexe: "npm:^3.1.1"
+  bin:
+    node-which: bin/which.js
+  checksum: 10/f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
+  languageName: node
+  linkType: hard
+
 "which@npm:^5.0.0":
   version: 5.0.0
   resolution: "which@npm:5.0.0"
@@ -22367,6 +22824,15 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10/e088b37b4d4885b70b50c9fa1b7e54bd2e27f5c87205f9deaffd1fb293ab263d9c964feadb9817a7b129a5bf30a06582cb08750f810568ecc14f3cdbabb79cb3
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.0.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/9a95e8e08651c3d292ab6a5befeb5f57b76801caa097c75bb45c9a70ce19c1b11f57e87a6ef84a579ea070ed2c2c8ac541c88c0ae684d544d5f42c7e77d11b7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add eslint-plugin-mdx to parse and lint .mdx files
- Enable no-unused-vars (error) to catch unused imports in MDX
- Fix 31 unused imports across 27 MDX files
- Fix irregular whitespace (non-breaking spaces) in typography.mdx
- Fix invalid align attribute on div in intro MDX
- Fix empty component to use self-closing syntax in provider.mdx

