### PR TITLE
fix(PhoneNumber, PostalCodeAndCity): remove placeholders from `PhoneNumber` and postal code

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -69,7 +69,6 @@ export type FieldPhoneNumberProps = Omit<
 // Important for the default value to be defined here, and not after the useFieldProps call, to avoid the UI jumping
 // back to +47 once the user empty the field so handleChange send out undefined.
 const defaultCountryCode = '+47'
-const defaultPlaceholder = '00 00 00 00'
 const defaultMask = [
   /\d/,
   /\d/,
@@ -563,9 +562,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
             : (numberLabel ?? defaultLabel)
         }
         labelSrOnly={numberLabel === false ? true : undefined}
-        placeholder={
-          placeholder ?? (isDefault ? defaultPlaceholder : undefined)
-        }
+        placeholder={placeholder}
         mask={
           // E.164 allows up to 15 digits total (country code + subscriber number).
           // The country code (1–3 digits) is in a separate field, so the subscriber

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/__tests__/PhoneNumber.test.tsx
@@ -364,14 +364,8 @@ describe('Field.PhoneNumber', { retry: isCI ? 5 : 0 }, () => {
     expect(numberElement.value).toBe('999999991234567')
   })
 
-  it('should only have a placeholder when +47 is given', async () => {
-    const { rerender } = render(<Field.PhoneNumber />)
-
-    expect(
-      document.querySelector('.dnb-input__placeholder').textContent
-    ).toBe('00 00 00 00')
-
-    rerender(<Field.PhoneNumber value="+41" />)
+  it('should not have a default placeholder', () => {
+    render(<Field.PhoneNumber />)
 
     expect(
       document.querySelector('.dnb-input__placeholder')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/PostalCodeAndCity.tsx
@@ -83,7 +83,6 @@ function PostalCodeAndCity(props: FieldPostalCodeAndCityProps) {
         case 'CH': {
           props.mask = [/\d/, /\d/, /\d/, /\d/]
           props.pattern = '^[0-9]{4}$'
-          props.placeholder = '0000'
           break
         }
         default:

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -308,7 +308,6 @@ describe('Field.PostalCodeAndCity', () => {
 
       await userEvent.type(postalCodeNo, '{Backspace>4}987654')
       expect(postalCodeNo).toHaveValue('9876')
-      expect(postalCodeNo).toHaveAttribute('aria-placeholder', '0000')
     })
 
     it('should use value from countryCode inside iterate', async () => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/C081G91GCT0/p1779865215343589

Field.PhoneNumber has a placeholder of 00 00 00 00, why? If so, why do not other Fields have default placeholder values? (From task list)


Currently the `PhoneNumber` and `PostalCode` inputs have country specific placeholders. `NationalIdentityNumber`, `BankAccountNumber` etc does not have placeholders. Since these two components are the odd ones out, and we have validation and masks that takes care of the expected formatting, I think it would be ok to remove the country specific placeholders for these two components. 🤔

Feel free to close the pull request if we should keep the place holders instead 🙏

