### PR TITLE
feat(Field.BankAccountNumber): allow typing beyond the 11-digit mask length

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -172,6 +172,7 @@ function BankAccountNumber(props: FieldBankAccountNumberProps) {
     label,
     errorMessages,
     mask,
+    allowOverflow: true,
     value,
     defaultValue,
     // @ts-expect-error - strictFunctionTypes

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/__tests__/BankAccountNumber.test.tsx
@@ -29,6 +29,15 @@ describe('Field.BankAccountNumber', () => {
     expect(input).toHaveAttribute('inputmode', 'numeric')
   })
 
+  it('should allow typing beyond the mask length', async () => {
+    render(<Field.BankAccountNumber />)
+
+    const input = document.querySelector('input')
+    await userEvent.type(input, '123456789012345')
+
+    expect(input.value).toBe('1234 56 789012345')
+  })
+
   it('should validate given function as onChangeValidator', async () => {
     const text = 'Custom Error message'
     const onChangeValidator = vi.fn((value) => {


### PR DESCRIPTION
Relies on https://github.com/dnbexperience/eufemia/pull/8257