### PR TITLE
fix(Forms): ensure `PushContainer` empties InputMasked fields on reopen

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -248,6 +248,9 @@ export default function TextMask(props: TextMaskProps): JSX.Element {
     return baseProps
   }, [rest, enhancedOptions, stripValue])
 
+  // Track previous value so we can detect transitions to null/undefined
+  const prevValueRef = useRef<TextMaskValue | undefined | null>(undefined)
+
   // Conform initial value on mount/options change
   useEffect(() => {
     if (!localRef.current || !enhancedOptions) {
@@ -259,6 +262,14 @@ export default function TextMask(props: TextMaskProps): JSX.Element {
     // Always use the value prop - never use the formatted DOM value which could be in wrong locale format
     const valueToTransform = value
     if (valueToTransform === undefined || valueToTransform === null) {
+      // Clear the element when value transitions from a real value to
+      // null/undefined, so the input does not keep showing a stale
+      // formatted value (e.g. when PushContainer clears its data).
+      // Skip on mount (prevValueRef is undefined) to preserve showMask.
+      if (prevValueRef.current != null && el.value !== '') {
+        maskitoUpdateElement(el, { value: '', selection: [0, 0] })
+      }
+      prevValueRef.current = valueToTransform
       return
     }
 
@@ -278,6 +289,8 @@ export default function TextMask(props: TextMaskProps): JSX.Element {
     if (el.value !== validated.value) {
       maskitoUpdateElement(el, validated)
     }
+
+    prevValueRef.current = valueToTransform
   }, [enhancedOptions, value, rawMask])
 
   // Compute initial defaultValue for immediate render (before Maskito attaches)

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/TextMask.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/TextMask.test.tsx
@@ -48,4 +48,46 @@ describe('TextMask', () => {
     expect(maskitoUpdateElementMock).toHaveBeenCalledTimes(1)
     expect(maskitoUpdateElementMock).toHaveBeenCalledWith(input, validated)
   })
+
+  it('clears element when value transitions from a number to null', () => {
+    const validated = { value: '1234', selection: [4, 4] as const }
+    maskitoTransformMock.mockReturnValue(validated)
+
+    const { rerender } = render(<TextMask mask={[/\d/]} value="123" />)
+
+    maskitoUpdateElementMock.mockClear()
+
+    rerender(<TextMask mask={[/\d/]} value={null} />)
+
+    const input = document.querySelector('input')
+    expect(maskitoUpdateElementMock).toHaveBeenCalledTimes(1)
+    expect(maskitoUpdateElementMock).toHaveBeenCalledWith(input, {
+      value: '',
+      selection: [0, 0],
+    })
+  })
+
+  it('clears element when value transitions from a number to undefined', () => {
+    const validated = { value: '1234', selection: [4, 4] as const }
+    maskitoTransformMock.mockReturnValue(validated)
+
+    const { rerender } = render(<TextMask mask={[/\d/]} value="123" />)
+
+    maskitoUpdateElementMock.mockClear()
+
+    rerender(<TextMask mask={[/\d/]} value={undefined} />)
+
+    const input = document.querySelector('input')
+    expect(maskitoUpdateElementMock).toHaveBeenCalledTimes(1)
+    expect(maskitoUpdateElementMock).toHaveBeenCalledWith(input, {
+      value: '',
+      selection: [0, 0],
+    })
+  })
+
+  it('does not clear element when value is null on initial mount', () => {
+    render(<TextMask mask={[/\d/]} value={null} />)
+
+    expect(maskitoUpdateElementMock).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -3185,4 +3185,47 @@ describe('PushContainer', () => {
       )
     })
   })
+
+  it('should clear Field.Currency value when opening PushContainer again after committing', async () => {
+    render(
+      <Form.Handler>
+        <Iterate.Array path="/accounts">
+          <Iterate.ViewContainer title="Account {itemNo}">
+            <Value.Currency itemPath="/amount" />
+          </Iterate.ViewContainer>
+        </Iterate.Array>
+
+        <Iterate.PushContainer
+          path="/accounts"
+          title="New account"
+          openButton={
+            <Iterate.PushContainer.OpenButton text="Add another account" />
+          }
+          showOpenButtonWhen={(list) => list.length > 0}
+        >
+          <Field.Currency itemPath="/amount" required />
+        </Iterate.PushContainer>
+      </Form.Handler>
+    )
+
+    const input = document.querySelector('input')
+
+    // Add the first item
+    await userEvent.type(input, '1000')
+    expect(input).toHaveValue('1 000 kr')
+
+    await userEvent.click(
+      document.querySelector('.dnb-forms-iterate__done-button')
+    )
+
+    // Open the PushContainer again to add another item
+    await userEvent.click(
+      document.querySelector('.dnb-forms-iterate__open-button')
+    )
+
+    const newInput = document.querySelector('input')
+
+    // The currency field should be cleared
+    expect(newInput).toHaveValue('')
+  })
 })


### PR DESCRIPTION
When a `PushContainer` item was committed and the container reopened, `Field.Currency` retained the previous value. The root cause was TextMask's useEffect bailing out on null/undefined without clearing the DOM element. Added a prevValueRef to detect value-to-null transitions and clear the input, while preserving showMask on mount.

Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1779454289452829
Reprod with bug: https://stackblitz.com/edit/u6dlg7ok-8tlaaweq?file=src%2FApp.tsx
Reprod with fix:  https://stackblitz.com/edit/u6dlg7ok-3btbnxew