### PR TITLE
fix(DatePicker): improve keyboard navigation in calendar

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -425,7 +425,11 @@ function DatePicker(externalProps: DatePickerAllProps) {
   const translation = useTranslation().DatePicker
 
   const focusCalendarTable = useCallback(
-    () => calendarContainerRef.current?.querySelector('table'),
+    () =>
+      calendarContainerRef.current?.querySelector<HTMLElement>(
+        'td[aria-selected="true"] button'
+      ) ||
+      calendarContainerRef.current?.querySelector<HTMLElement>('table'),
     []
   )
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -25,7 +25,6 @@ import {
   startOfDay,
   differenceInCalendarDays,
   differenceInMonths,
-  lastDayOfMonth,
   setDate,
 } from 'date-fns'
 
@@ -42,6 +41,7 @@ import Button from '../button/Button'
 import type { DatePickerContextValue } from './DatePickerContext'
 import DatePickerContext from './DatePickerContext'
 import type { InternalLocale } from '../../shared/Context'
+import useIsomorphicLayoutEffect from '../../shared/helpers/useIsomorphicLayoutEffect'
 import type { DatePickerChangeEvent } from './DatePickerProvider'
 import type { DatePickerDates } from './hooks/useDates'
 import type { CalendarNavButtonProps } from './DatePickerCalendarNavigator'
@@ -146,6 +146,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     hoverDate,
     setHoverDate,
     setSubmittedDates,
+    views,
+    setViews,
     props: { onDaysRender, yearNavigation },
     translation: {
       DatePicker: { firstDay: defaultFirstDayOfWeek, selectedMonth },
@@ -172,6 +174,8 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
   const tableRef = useRef<ElementRef<'table'> | null>(null)
   const days = useRef<Record<string, Array<DatePickerCalendarDay>>>({})
   const cache = useRef<Record<string, DatePickerCalendarDay[][]>>({})
+  const focusedDateRef = useRef<Date | null>(null)
+  const pendingFocusDateRef = useRef<Date | null>(null)
   const currentDatesRef = useRef({
     startDate,
     endDate,
@@ -196,6 +200,44 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
   const onMouseLeaveHandler = useCallback(() => {
     setHoverDate(undefined)
   }, [setHoverDate])
+
+  const focusDayButton = useCallback((date: Date) => {
+    if (tableRef.current) {
+      const dateStr = format(date, 'yyyy-MM-dd')
+      const button = tableRef.current.querySelector(
+        `td[data-date="${dateStr}"] button`
+      ) as HTMLElement
+      button?.focus({ preventScroll: true })
+    }
+  }, [])
+
+  const focusEndCalendar = useCallback(() => {
+    const viewsContainer = tableRef.current?.closest(
+      '.dnb-date-picker__views'
+    )
+    const endTable = viewsContainer?.querySelectorAll('table')?.[1]
+    const endDateValue = currentDatesRef.current.endDate
+    const endButton = endDateValue
+      ? (endTable?.querySelector(
+          `td[data-date="${format(endDateValue, 'yyyy-MM-dd')}"] button`
+        ) as HTMLElement | undefined)
+      : null
+
+    if (endButton) {
+      endButton.focus({ preventScroll: true })
+    } else {
+      ;(endTable as HTMLElement | undefined)?.focus({
+        preventScroll: true,
+      })
+    }
+  }, [])
+
+  useIsomorphicLayoutEffect(() => {
+    if (pendingFocusDateRef.current) {
+      focusDayButton(pendingFocusDateRef.current)
+      pendingFocusDateRef.current = null
+    }
+  }, [views, focusDayButton])
 
   const callOnSelect = useCallback(
     (
@@ -325,120 +367,166 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
       if (!keysToHandle.includes(pressedKey)) {
         return
       }
+
+      // Handle Enter/Space
+      if (pressedKey === 'Enter' || pressedKey === 'Space') {
+        event.preventDefault()
+
+        if (focusedDateRef.current) {
+          const focusedDate = focusedDateRef.current
+
+          if (!isRange) {
+            focusedDateRef.current = null
+
+            updateDates(
+              {
+                startDate: startOfDay(focusedDate),
+                endDate: startOfDay(focusedDate),
+              },
+              (allDates) => {
+                callOnSelect({
+                  ...allDates,
+                  event,
+                  nr,
+                  hidePicker: true,
+                })
+              }
+            )
+
+            return
+          }
+
+          // Range mode: use same selection logic as mouse clicks
+          setHasClickedCalendarDay(true)
+
+          const { startDate: currentStart, endDate: currentEnd } =
+            currentDatesRef.current
+
+          if (!currentStart || (resetDate && currentStart && currentEnd)) {
+            // First selection: set start date, clear end date
+            // Keep focusedDateRef so arrow keys continue from this date
+            updateDates(
+              {
+                startDate: startOfDay(focusedDate),
+                endDate: undefined,
+              },
+              (allDates) => {
+                callOnSelect({
+                  ...allDates,
+                  event,
+                  nr,
+                  hidePicker: false,
+                })
+              }
+            )
+          } else {
+            // Second selection: create range
+            focusedDateRef.current = null
+
+            const range = toRange(currentStart, focusedDate)
+
+            updateDates(
+              {
+                startDate: startOfDay(range.startDate),
+                endDate: startOfDay(range.endDate),
+              },
+              (allDates) => {
+                callOnSelect({
+                  ...allDates,
+                  event,
+                  nr,
+                  hidePicker: true,
+                })
+              }
+            )
+          }
+
+          return
+        }
+
+        // Focus is on the table (no date navigated to)
+        if (isRange && nr === 0) {
+          focusEndCalendar()
+        } else {
+          callOnSelect({ event, nr, hidePicker: true })
+        }
+        return
+      }
+
+      // Handle arrow keys: move focus without changing the date
       event.preventDefault()
 
       const currentDates = currentDatesRef.current
       const dateType = !isRange || nr === 0 ? 'start' : 'end'
-      const currentDate = currentDates[`${dateType}Date`]
+      const currentFocused =
+        focusedDateRef.current || currentDates[`${dateType}Date`]
+      const viewMonth = views.find((v) => v.nr === nr)?.month
 
-      let newDate = currentDate
-        ? keyNavCalc(currentDate, pressedKey)
-        : currentDates[`${dateType}Month`] ||
+      let newDate = currentFocused
+        ? keyNavCalc(currentFocused, pressedKey)
+        : viewMonth ||
           (isRange && nr === 1 ? addMonths(new Date(), 1) : new Date())
 
       if (
-        newDate === currentDate &&
-        (pressedKey === 'Enter' || pressedKey === 'Space')
+        // in case we don't have a focused date, then we use the current view month
+        (viewMonth && !currentFocused) ||
+        // if we have a larger gap between the new date and the current view month
+        (viewMonth &&
+          currentFocused &&
+          Math.abs(differenceInMonths(newDate, viewMonth)) > 1)
       ) {
-        return callOnSelect({
-          event,
-          nr,
-          hidePicker: true,
-        })
-      }
-
-      const dates: {
-        startDate?: Date
-        endDate?: Date
-        startMonth?: Date
-        endMonth?: Date
-      } = {}
-
-      const currentMonth = currentDates[`${dateType}Month`]
-
-      if (
-        // in case we don't have a start/end date, then we use the current month date
-        (currentMonth && !currentDate) ||
-        // if we have a larger gap between the new date and the current month in the calendar
-        (currentMonth &&
-          Math.abs(differenceInMonths(newDate, currentMonth)) > 1)
-      ) {
-        newDate = !isRange
-          ? currentMonth
-          : nr === 0
-            ? setDate(currentMonth, 1)
-            : lastDayOfMonth(currentMonth)
-
-        // only to make sure we navigate the calendar to the new date
-      } else if (currentMonth && !isSameMonth(currentDate, currentMonth)) {
-        dates[`${dateType}Month`] = newDate
+        newDate = !isRange ? viewMonth : setDate(viewMonth, 1)
       }
 
       newDate = findValid(newDate, pressedKey)
 
       if (hasReachedEnd(newDate)) {
-        return // Stop here
+        return // stop here
       }
 
-      dates[`${dateType}Date`] = newDate
-
-      // set fallbacks
-      if (!isRange) {
-        dates.endDate = newDate
-      } else {
-        if (!startDate) {
-          dates.startDate = newDate
-        }
-        if (!endDate) {
-          dates.endDate = newDate
-        }
-      }
-
-      // make sure we stay on the same month
+      // Prevent navigating to different month when onlyMonth or hideNavigation
       if (onlyMonth || hideNavigation) {
-        if (
-          !isSameMonth(dates.startDate, startDate) ||
-          !isSameMonth(dates.endDate, startDate) // Heads up, should this not be context.endDate?
-        ) {
+        if (viewMonth && !isSameMonth(newDate, viewMonth)) {
           return
         }
       }
 
-      updateDates(dates, () => {
-        // call after state update, so the input get's the latest state as well
-        callOnSelect({
-          event,
-          nr,
-          hidePicker: false,
-          ...dates,
-        })
-      })
-      currentDatesRef.current = {
-        ...currentDates,
-        ...dates,
-        startMonth:
-          dates.startMonth ?? dates.startDate ?? currentDates.startMonth,
-        endMonth: dates.endMonth ?? dates.endDate ?? currentDates.endMonth,
-      }
+      focusedDateRef.current = newDate
 
-      // and set the focus back again
-      if (tableRef && tableRef.current) {
-        tableRef.current.focus({ preventScroll: true })
+      // Navigate to a different month if needed
+      if (viewMonth && !isSameMonth(newDate, viewMonth)) {
+        // Keep focus on the table during re-render to prevent the Popover from closing
+        tableRef.current?.focus({ preventScroll: true })
+
+        const updatedViews = views.map((view) => {
+          if (view.nr === nr) {
+            return { ...view, month: newDate }
+          }
+          return view
+        })
+        setViews(updatedViews)
+        pendingFocusDateRef.current = newDate
+      } else {
+        focusDayButton(newDate)
       }
     },
     [
       callOnSelect,
       findValid,
+      focusDayButton,
+      focusEndCalendar,
       hasReachedEnd,
       onKeyDown,
-      startDate,
-      endDate,
       updateDates,
       hideNavigation,
       isRange,
       keyNavCalc,
       nr,
       onlyMonth,
+      resetDate,
+      setHasClickedCalendarDay,
+      views,
+      setViews,
     ]
   )
 
@@ -621,6 +709,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                     <td
                       key={'day' + i}
                       role="gridcell"
+                      data-date={format(day.date, 'yyyy-MM-dd')}
                       className={clsx(
                         'dnb-date-picker__day',
                         'dnb-no-focus',
@@ -775,6 +864,9 @@ function onHoverDay({
   hoverDate?: Date
   setHoverDate: (date: Date) => void
 }) {
+  if (day.isStartDate || day.isEndDate) {
+    return // stop here – no hover effect needed on the already-selected date
+  }
   if (!isSameDay(day.date, hoverDate)) {
     setHoverDate?.(day.date)
   }

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1605,6 +1605,122 @@ describe('DatePicker component', () => {
     expect(rightPickerTitle).toHaveTextContent('september 2024')
   })
 
+  it('should keep focus in the left calendar after selecting a start date with keyboard', async () => {
+    render(
+      <DatePicker range startDate="2024-10-01" endDate="2024-10-15" />
+    )
+
+    await userEvent.click(getDatePickerTriggerButton())
+
+    const [leftTable, rightTable] = Array.from(
+      document.querySelectorAll('.dnb-date-picker__calendar table')
+    )
+
+    // Navigate to another date in the left calendar
+    await userEvent.keyboard('{ArrowRight}')
+
+    // Select the date with Enter
+    await userEvent.keyboard('{Enter}')
+
+    // Focus should remain in the left calendar, not jump to the right one
+    expect(leftTable.contains(document.activeElement)).toBe(true)
+    expect(rightTable.contains(document.activeElement)).toBe(false)
+  })
+
+  it('should set startDate when selecting in the right calendar as the first selection', async () => {
+    const onChange = vi.fn()
+
+    render(
+      <DatePicker
+        range
+        startDate="2024-10-01"
+        endDate="2024-10-15"
+        onChange={onChange}
+      />
+    )
+
+    await userEvent.click(getDatePickerTriggerButton())
+
+    const tables = document.querySelectorAll(
+      '.dnb-date-picker__calendar table'
+    )
+    const rightTable = tables[1] as HTMLTableElement
+
+    // Focus the right calendar table, then navigate to a date
+    rightTable.focus()
+    await userEvent.keyboard('{ArrowRight}')
+
+    // Select the date with Enter — this is the first selection
+    await userEvent.keyboard('{Enter}')
+
+    // Should set startDate (not endDate) and keep the picker open
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: expect.any(String),
+        endDate: null,
+      })
+    )
+
+    const pickerElement = document.querySelector('.dnb-date-picker--open')
+    expect(pickerElement).toBeInTheDocument()
+  })
+
+  it('should continue arrow key navigation from selected date in right calendar', async () => {
+    render(
+      <DatePicker range startDate="2024-10-01" endDate="2024-10-15" />
+    )
+
+    await userEvent.click(getDatePickerTriggerButton())
+
+    const tables = document.querySelectorAll(
+      '.dnb-date-picker__calendar table'
+    )
+    const rightTable = tables[1] as HTMLTableElement
+
+    // Focus the right calendar table and navigate to a date
+    rightTable.focus()
+    await userEvent.keyboard('{ArrowDown}')
+    await userEvent.keyboard('{ArrowRight}')
+
+    const focusedLabel = document.activeElement.getAttribute('aria-label')
+
+    // Select the date with Enter (first selection)
+    await userEvent.keyboard('{Enter}')
+
+    // Press arrow key — should continue from the selected date, not jump to 1st
+    await userEvent.keyboard('{ArrowRight}')
+
+    const nextLabel = document.activeElement.getAttribute('aria-label')
+
+    // The next focused date should be one day after the previously selected date
+    expect(nextLabel).not.toContain('1.')
+    expect(nextLabel).not.toBe(focusedLabel)
+  })
+
+  it('should focus the first day of the month when pressing arrow key without a prior selection', async () => {
+    render(<DatePicker range />)
+
+    await userEvent.click(getDatePickerTriggerButton())
+
+    const tables = document.querySelectorAll(
+      '.dnb-date-picker__calendar table'
+    ) as NodeListOf<HTMLTableElement>
+
+    // Focus the left calendar and press ArrowDown
+    tables[0].focus()
+    await userEvent.keyboard('{ArrowDown}')
+
+    const leftFocused = document.activeElement
+    expect(leftFocused.getAttribute('aria-label')).toContain('1.')
+
+    // Focus the right calendar and press ArrowDown
+    tables[1].focus()
+    await userEvent.keyboard('{ArrowDown}')
+
+    const rightFocused = document.activeElement
+    expect(rightFocused.getAttribute('aria-label')).toContain('1.')
+  })
+
   it('should keep the picker open during tab navigation when showInput is true', async () => {
     render(<DatePicker showInput date="2024-10-01" />)
 
@@ -1616,12 +1732,11 @@ describe('DatePicker component', () => {
     await userEvent.keyboard('{ArrowRight>32}')
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true')
-    expect(document.activeElement.nodeName).toBe('TABLE')
+    expect(document.activeElement.nodeName).toBe('BUTTON')
 
     await userEvent.keyboard('{ArrowRight}')
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true')
-    expect(document.activeElement.nodeName).toBe('TABLE')
   })
 
   it('has a reacting start date input with valid value', async () => {
@@ -2815,6 +2930,82 @@ describe('DatePicker component', () => {
     fireEvent.click(buttonElement)
 
     expect(element.classList).toContain('dnb-date-picker--open')
+
+    await waitFor(() => {
+      const selectedDayButton = document.querySelector(
+        'td[aria-selected="true"] button'
+      )
+      expect(document.activeElement).toBe(selectedDayButton)
+    })
+  })
+
+  it('should focus on selected start day when opening with a date set', async () => {
+    render(
+      <DatePicker
+        id="custom-id"
+        label="Input Label"
+        showInput
+        startDate="2019-01-15"
+        noAnimation
+      />
+    )
+
+    const buttonElement = document.querySelector(
+      'button.dnb-input__submit-button__button'
+    )
+
+    fireEvent.click(buttonElement)
+
+    await waitFor(() => {
+      const selectedDayButton = document.querySelector(
+        'td[aria-selected="true"] button'
+      )
+      expect(document.activeElement).toBe(selectedDayButton)
+    })
+  })
+
+  it('should focus on selected start day in range mode when opening with dates set', async () => {
+    render(
+      <DatePicker
+        id="custom-id"
+        label="Input Label"
+        showInput
+        range
+        startDate="2019-01-15"
+        endDate="2019-02-15"
+        noAnimation
+      />
+    )
+
+    const buttonElement = document.querySelector(
+      'button.dnb-input__submit-button__button'
+    )
+
+    fireEvent.click(buttonElement)
+
+    await waitFor(() => {
+      const selectedDayButton = document.querySelector(
+        'td[aria-selected="true"] button'
+      )
+      expect(document.activeElement).toBe(selectedDayButton)
+    })
+  })
+
+  it('should focus on table when opening without a date set', async () => {
+    render(
+      <DatePicker
+        id="custom-id"
+        label="Input Label"
+        showInput
+        noAnimation
+      />
+    )
+
+    const buttonElement = document.querySelector(
+      'button.dnb-input__submit-button__button'
+    )
+
+    fireEvent.click(buttonElement)
 
     const tableElement = document.querySelector('table')
 
@@ -4344,17 +4535,24 @@ describe('DatePicker component', () => {
       document.querySelectorAll('.dnb-date-picker__input')
     ) as Array<HTMLInputElement>
 
+    // Arrow keys move focus without changing the selected date
     await userEvent.keyboard('{ArrowRight}')
 
-    expect(screen.getByLabelText('mandag 28. april 2025')).toHaveAttribute(
+    // Focus should be on Monday April 28 (skipping weekend)
+    expect(document.activeElement).toBe(
+      screen.getByLabelText('mandag 28. april 2025')
+    )
+
+    // The selected date should NOT change yet
+    expect(screen.getByLabelText('fredag 25. april 2025')).toHaveAttribute(
       'aria-current',
       'date'
     )
-
-    expect(day.value).toBe('28')
+    expect(day.value).toBe('25')
     expect(month.value).toBe('04')
     expect(year.value).toBe('2025')
 
+    // Weekend days are still rendered
     expect(
       screen.getByLabelText('lørdag 26. april 2025')
     ).toBeInTheDocument()
@@ -4362,8 +4560,15 @@ describe('DatePicker component', () => {
       screen.getByLabelText('søndag 27. april 2025')
     ).toBeInTheDocument()
 
+    // Navigate back with ArrowLeft (from focused April 28)
     await userEvent.keyboard('{ArrowLeft}')
 
+    // Focus should skip weekends and land back on Friday April 25
+    expect(document.activeElement).toBe(
+      screen.getByLabelText('fredag 25. april 2025')
+    )
+
+    // The selected date should still be April 25
     expect(screen.getByLabelText('fredag 25. april 2025')).toHaveAttribute(
       'aria-current',
       'date'

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2892,6 +2892,15 @@ html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date:not(.dnb-date-
 .dnb-date-picker__day--inactive .dnb-button[disabled], .dnb-date-picker__day--disabled .dnb-button[disabled] {
   box-shadow: none;
 }
+.dnb-date-picker__day--selectable .dnb-button:focus-visible:not([disabled]) {
+  z-index: 2;
+  color: var(--token-color-component-button-text-action-hover);
+  background-color: var(--token-color-background-action-hover-subtle);
+  --border-color: var(--token-color-stroke-action-focus);
+  --border-width: var(--focus-ring-width);
+  box-shadow: 0 0 0 var(--border-width) var(--border-color);
+  border-color: transparent;
+}
 html:not([data-whatintent=touch]) .dnb-date-picker__day--inactive .dnb-button[disabled] {
   cursor: default;
 }

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -486,6 +486,18 @@
       }
     }
 
+    // Focus state for keyboard navigation (hover visual + focus outline)
+    &--selectable .dnb-button:focus-visible:not([disabled]) {
+      z-index: 2;
+      color: var(--token-color-component-button-text-action-hover);
+      background-color: var(--token-color-background-action-hover-subtle);
+
+      @include utilities.fakeBorder(
+        var(--token-color-stroke-action-focus),
+        var(--focus-ring-width)
+      );
+    }
+
     html:not([data-whatintent='touch']) &--inactive .dnb-button[disabled] {
       cursor: default;
     }

--- a/packages/dnb-eufemia/src/components/popover/Popover.tsx
+++ b/packages/dnb-eufemia/src/components/popover/Popover.tsx
@@ -302,10 +302,15 @@ export default function Popover(props: PopoverProps) {
 
       focusTarget.focus({ preventScroll: true })
 
-      setTimeout(() => {
-        focusTarget?.focus({ preventScroll: true })
-        onFocusComplete?.()
-      }, 10) // Ensure focus happens after any potential rendering
+      timers.push(
+        setTimeout(() => {
+          // Only re-focus if focus hasn't moved to another element inside the popover
+          if (!tooltipRef.current?.contains(document.activeElement)) {
+            focusTarget?.focus({ preventScroll: true })
+          }
+          onFocusComplete?.()
+        }, 10) // Ensure focus happens after any potential rendering
+      )
 
       return true
     }
@@ -340,6 +345,13 @@ export default function Popover(props: PopoverProps) {
         return undefined // stop here
       }
 
+      // Ignore keyboard events targeting the body element, as this
+      // indicates focus was temporarily lost during a React re-render
+      // rather than a deliberate user interaction outside the popover.
+      if (event instanceof KeyboardEvent && target === document.body) {
+        return undefined // stop here
+      }
+
       const insideContent =
         !!tooltipRef.current && tooltipRef.current.contains(target)
       const triggerElement = getCurrentTriggerElement()
@@ -348,11 +360,21 @@ export default function Popover(props: PopoverProps) {
         typeof triggerElement.contains === 'function' &&
         triggerElement.contains(target as Node)
 
-      if (!insideContent && !insideTrigger) {
+      // Also check horizontalRef when targetElement has both refs,
+      // so clicks on sibling elements (e.g. DatePicker inputs) stay inside the trigger area
+      const horizontalElement = isPopoverTargetElementObject(
+        externalTargetElement
+      )
+        ? resolveTargetNode(externalTargetElement.horizontalRef)
+        : null
+      const insideHorizontal =
+        !!horizontalElement && horizontalElement.contains(target as Node)
+
+      if (!insideContent && !insideTrigger && !insideHorizontal) {
         toggle(false)
       }
     },
-    [preventClose, getCurrentTriggerElement, toggle]
+    [preventClose, getCurrentTriggerElement, toggle, externalTargetElement]
   )
 
   const handleDocumentTouchStart = useCallback((event: TouchEvent) => {


### PR DESCRIPTION
Preview: https://fix-date-picker-keyboard-nav.eufemia-e25.pages.dev/uilib/components/date-picker/demos

## Summary

Improves keyboard navigation in the DatePicker calendar by separating visual focus movement from date selection.

## Changes

### DatePicker
- Focus the currently selected date button when opening the calendar (instead of the table element)

### DatePickerCalendar
- Arrow keys now move visual focus between day buttons without changing the selected date
- Enter/Space confirms the focused date as the selection
- In range mode, Enter/Space sets start or end date based on selection state (not calendar position), and keeps focus on the selected date
- Selecting in either calendar as the first pick sets the start date; the second pick completes the range
- Month navigation via arrow keys triggers a re-render and restores focus via `useLayoutEffect`
- Added `data-date` attributes to day cells for focus targeting
- Skip hover effect on already-selected dates

### Popover
- Prevent `setTimeout` re-focus from stealing focus when it has already moved to another element inside the popover
- Ignore keyboard events targeting `document.body` during React re-renders to avoid false popover close

### Styles
- Added `focus-visible` styles for keyboard-navigated day buttons with hover visual + focus outline
