### PR TITLE
chore(Portal): support namespace imports (import * as) for open in StackBlitz

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge/Examples.tsx
@@ -29,9 +29,9 @@ export const ChildrenWithAge = (props) => {
   )
 }
 
-export const ChildrenWithAgeWizard = (props) => {
+export const ChildrenWithAgeWizard = () => {
   return (
-    <ComponentBox scope={{ Blocks, props }}>
+    <ComponentBox scope={{ Blocks }}>
       {() => {
         const MyForm = () => {
           const myTranslations = {
@@ -74,7 +74,6 @@ export const ChildrenWithAgeWizard = (props) => {
                       'joint-responsibility',
                       'daycare',
                     ]}
-                    {...props}
                   />
                   <Wizard.Buttons />
                 </Wizard.Step>
@@ -83,7 +82,6 @@ export const ChildrenWithAgeWizard = (props) => {
                   <Blocks.ChildrenWithAge
                     mode="summary"
                     toWizardStep={0}
-                    {...props}
                   />
 
                   <Form.ButtonRow>

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/openInStackBlitz.test.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/openInStackBlitz.test.ts
@@ -89,6 +89,26 @@ describe('filterImportsByUsage', () => {
 
     expect(result).toEqual(["import { useState } from 'react'"])
   })
+
+  it('keeps namespace imports when name is used', () => {
+    const result = filterImportsByUsage(
+      ["import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'"],
+      '<Blocks.ChildrenWithAge />'
+    )
+
+    expect(result).toEqual([
+      "import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'",
+    ])
+  })
+
+  it('removes namespace imports when name is not used', () => {
+    const result = filterImportsByUsage(
+      ["import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'"],
+      '<Button>Click</Button>'
+    )
+
+    expect(result).toEqual([])
+  })
 })
 
 describe('analyzeCodeStructure', () => {

--- a/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
+++ b/packages/dnb-design-system-portal/src/shared/tags/openInStackBlitz.ts
@@ -39,6 +39,16 @@ export function filterImportsByUsage(
 
     const source = fromMatch[1]
 
+    // Handle namespace imports (e.g. "import * as Blocks from ...")
+    const namespaceMatch = stmt.match(/^import\s+\*\s+as\s+(\w+)/)
+    if (namespaceMatch) {
+      const namespaceName = namespaceMatch[1]
+      if (new RegExp(`\\b${namespaceName}\\b`).test(code)) {
+        result.push(`import * as ${namespaceName} from '${source}'`)
+      }
+      continue
+    }
+
     // Extract default import name (e.g. "styled" from "import styled from ...")
     const defaultMatch = stmt.match(/^import\s+(\w+)[\s,]/)
     const defaultName =

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/react-live-babel.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/react-live-babel.test.ts
@@ -284,4 +284,20 @@ describe('sourceImports injection', () => {
 
     expect(output).not.toContain('sourceImports')
   })
+
+  it('handles namespace imports (import * as)', async () => {
+    const input = `
+      import * as Blocks from '@dnb/eufemia/src/extensions/forms/blocks'
+      export function Demo() {
+        return <ComponentBox scope={{ Blocks }}>code</ComponentBox>
+      }
+    `
+
+    const output = await transform(input)
+
+    expect(output).toContain('sourceImports')
+    expect(output).toContain(
+      "import * as Blocks from '@dnb/eufemia/extensions/forms/blocks'"
+    )
+  })
 })

--- a/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
@@ -160,7 +160,13 @@ function buildImportMap(
 ) {
   const map = new Map<
     string,
-    { source: string; imported: string; local: string; isDefault: boolean }
+    {
+      source: string
+      imported: string
+      local: string
+      isDefault: boolean
+      isNamespace: boolean
+    }
   >()
 
   for (const node of body) {
@@ -189,6 +195,7 @@ function buildImportMap(
           imported,
           local: spec.local.name,
           isDefault: false,
+          isNamespace: false,
         })
       } else if (t.isImportDefaultSpecifier(spec)) {
         map.set(spec.local.name, {
@@ -196,6 +203,15 @@ function buildImportMap(
           imported: 'default',
           local: spec.local.name,
           isDefault: true,
+          isNamespace: false,
+        })
+      } else if (t.isImportNamespaceSpecifier(spec)) {
+        map.set(spec.local.name, {
+          source,
+          imported: '*',
+          local: spec.local.name,
+          isDefault: false,
+          isNamespace: true,
         })
       }
     }
@@ -235,8 +251,18 @@ function resolveImports(
   const imports: string[] = []
 
   Array.from(bySource.entries()).forEach(([source, specs]) => {
+    const namespaceSpec = specs.find((s) => s.isNamespace)
     const defaultSpec = specs.find((s) => s.isDefault)
-    const namedSpecs = specs.filter((s) => !s.isDefault)
+    const namedSpecs = specs.filter((s) => !s.isDefault && !s.isNamespace)
+
+    const publishedSource = rewriteImportPath(source)
+
+    // Namespace imports must be their own statement
+    if (namespaceSpec) {
+      imports.push(
+        `import * as ${namespaceSpec.local} from '${publishedSource}'`
+      )
+    }
 
     const parts: string[] = []
 
@@ -251,8 +277,9 @@ function resolveImports(
       parts.push(`{ ${specifiers.join(', ')} }`)
     }
 
-    const publishedSource = rewriteImportPath(source)
-    imports.push(`import ${parts.join(', ')} from '${publishedSource}'`)
+    if (parts.length > 0) {
+      imports.push(`import ${parts.join(', ')} from '${publishedSource}'`)
+    }
   })
 
   return imports

--- a/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
@@ -231,7 +231,12 @@ function resolveImports(
   // Group by source path
   const bySource = new Map<
     string,
-    Array<{ imported: string; local: string; isDefault: boolean }>
+    Array<{
+      imported: string
+      local: string
+      isDefault: boolean
+      isNamespace: boolean
+    }>
   >()
 
   for (const name of names) {


### PR DESCRIPTION


Fixes the "Open in StackBlitz" feature not including namespace imports like `import * as Blocks from '...'`.

The babel plugin's `buildImportMap` only handled named and default import specifiers, skipping `ImportNamespaceSpecifier` entirely. The runtime `filterImportsByUsage` also couldn't parse namespace import strings.

### Changes

- **react-live-babel.ts**: Handle `ImportNamespaceSpecifier` in `buildImportMap` and generate `import * as Name` statements in `resolveImports`
- **openInStackBlitz.ts**: Parse and match namespace imports in `filterImportsByUsage`
- Added tests for both

Preview: https://fix-stackblitz-namespace-imp.eufemia-e25.pages.dev/uilib/extensions/forms/blocks/ChildrenWithAge/demos