### PR TITLE
chore: remove per-component html[data-visual-test] SCSS selectors for preventing animation during visual tests

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -375,7 +375,10 @@ html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:hover:not([di
     width: 60%;
   }
 }
-.dnb-accordion > .dnb-accordion__header--no-animation .dnb-accordion__header__icon, html[data-visual-test] .dnb-accordion .dnb-accordion__header .dnb-accordion__header__icon {
+.dnb-accordion {
+  /* stylelint-disable-next-line no-descending-specificity */
+}
+.dnb-accordion > .dnb-accordion__header--no-animation .dnb-accordion__header__icon {
   transition: none;
 }
 .dnb-accordion__variant--tertiary {

--- a/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
@@ -349,9 +349,8 @@
     }
   }
 
-  // stylelint-disable-next-line
-  & > &__header--no-animation &__header__icon,
-  html[data-visual-test] & &__header &__header__icon {
+  /* stylelint-disable-next-line no-descending-specificity */
+  & > &__header--no-animation &__header__icon {
     transition: none;
   }
 

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -249,9 +249,6 @@ sup :where(:not(.dnb-anchor--no-style)).dnb-anchor, sub :where(:not(.dnb-anchor-
 :where(:not(.dnb-anchor--no-style)).dnb-anchor {
   transition: box-shadow 200ms ease-in-out, color 200ms ease-in-out, background 200ms ease-in-out;
 }
-html[data-visual-test] :where(:not(.dnb-anchor--no-style)).dnb-anchor {
-  transition: none;
-}
 :where(:not(.dnb-anchor--no-style)).dnb-anchor .dnb-icon {
   display: inline;
   vertical-align: middle;
@@ -386,9 +383,6 @@ html[data-visual-test] :where(:not(.dnb-anchor--no-style)).dnb-anchor {
   }
   :not(.dnb-anchor--no-style).dnb-anchor {
     transition: box-shadow 200ms ease-in-out, color 200ms ease-in-out, background 200ms ease-in-out;
-  }
-  html[data-visual-test] :not(.dnb-anchor--no-style).dnb-anchor {
-    transition: none;
   }
   :not(.dnb-anchor--no-style).dnb-anchor .dnb-icon {
     display: inline;

--- a/packages/dnb-eufemia/src/components/anchor/style/anchor-mixins.scss
+++ b/packages/dnb-eufemia/src/components/anchor/style/anchor-mixins.scss
@@ -174,10 +174,6 @@
     color 200ms ease-in-out,
     background 200ms ease-in-out;
 
-  html[data-visual-test] & {
-    transition: none;
-  }
-
   // other stuff, not related to the Anchor directly
   .dnb-icon {
     display: inline;

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -2002,9 +2002,6 @@ html[data-visual-test] .dnb-progress-indicator {
 .dnb-progress-indicator--no-animation, .dnb-progress-indicator--no-animation.dnb-progress-indicator--complete {
   animation-duration: 0ms;
 }
-html[data-visual-test] .dnb-progress-indicator__bar-transition {
-  transition: none;
-}
 .dnb-progress-indicator--full-width {
   width: 100%;
   min-width: 1rem;
@@ -2164,9 +2161,6 @@ html[data-visual-test] .dnb-progress-indicator__bar-transition {
 }
 .dnb-autocomplete .dnb-input__submit-button__button .dnb-icon {
   transition: transform 400ms ease-out;
-}
-html[data-visual-test] .dnb-autocomplete .dnb-input__submit-button__button .dnb-icon {
-  transition-duration: 1ms !important;
 }
 .dnb-autocomplete .dnb-input__inner__element {
   position: relative;

--- a/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/dnb-autocomplete.scss
@@ -114,10 +114,6 @@
 
   .dnb-input__submit-button__button .dnb-icon {
     transition: transform 400ms ease-out;
-
-    html[data-visual-test] & {
-      transition-duration: 1ms !important;
-    }
   }
 
   // Support for "suffixValue"

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1258,15 +1258,6 @@ button.dnb-button::-moz-focus-inner {
 .dnb-breadcrumb__multiple.dnb-height-animation--parallax .dnb-breadcrumb__item {
   transform: translateX(0);
 }
-.dnb-breadcrumb {
-  /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
-}
-html[data-visual-test] .dnb-breadcrumb__multiple .dnb-breadcrumb__item {
-  transition: none;
-}
-.dnb-breadcrumb {
-  /* stylelint-enable */
-}
 @media screen and (max-width: 60em) {
   .dnb-breadcrumb--variant-responsive .dnb-breadcrumb__bar .dnb-breadcrumb__multiple {
     display: none;

--- a/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
+++ b/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
@@ -139,14 +139,6 @@
     transform: translateX(0);
   }
 
-  /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
-  &__multiple &__item {
-    html[data-visual-test] & {
-      transition: none;
-    }
-  }
-  /* stylelint-enable */
-
   &--variant-responsive &__bar &__multiple {
     @include utilities.allBelow(medium) {
       display: none;

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1012,11 +1012,6 @@ exports[`Button scss > has to match theme css for sbanken 1`] = `
   background-color: currentcolor;
   bottom: -0.0625rem;
   transition: color 250ms ease-in-out;
-}
-html[data-visual-test] .dnb-button--tertiary .dnb-button__text::after {
-  transition: none;
-}
-.dnb-button--tertiary .dnb-button__text::after {
   left: var(--button-tertiary-underline-left);
   right: var(--button-tertiary-underline-right);
 }
@@ -1224,11 +1219,6 @@ exports[`Button scss > has to match theme css for ui 1`] = `
   background-color: currentcolor;
   bottom: -0.0625rem;
   transition: color 250ms ease-in-out;
-}
-html[data-visual-test] .dnb-button--tertiary .dnb-button__text::after {
-  transition: none;
-}
-.dnb-button--tertiary .dnb-button__text::after {
   left: var(--button-tertiary-underline-left);
   right: var(--button-tertiary-underline-right);
 }

--- a/packages/dnb-eufemia/src/components/button/style/button--tertiary.scss
+++ b/packages/dnb-eufemia/src/components/button/style/button--tertiary.scss
@@ -23,9 +23,6 @@
       @include button-mixins.drawUnderlineBorder() {
         bottom: -0.0625rem;
         transition: color 250ms ease-in-out;
-        html[data-visual-test] & {
-          transition: none;
-        }
         left: var(--button-tertiary-underline-left);
         right: var(--button-tertiary-underline-right);
       }

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -1001,7 +1001,7 @@ button.dnb-button::-moz-focus-inner {
 .dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
   animation: rotate-icon-out 400ms var(--easing-default) forwards;
 }
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg, html[data-visual-test] .dnb-help-button__inline svg {
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
   animation-duration: 0ms;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -1145,10 +1145,7 @@ html[data-dnb-modal-active] .eufemia-portal-root {
 .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
   animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards;
 }
-.dnb-modal {
-  /* stylelint-disable-next-line */
-}
-html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
+.dnb-modal__overlay--no-animation {
   animation-delay: 0ms !important;
   animation-duration: 0ms !important;
 }
@@ -1467,10 +1464,10 @@ html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
     right: calc(-1 * var(--dialog-spacing) / 2);
   }
 }
-html:not([data-visual-test]) .dnb-dialog {
+.dnb-dialog {
   animation: show-modal var(--modal-animation-duration) ease-out;
 }
-html:not([data-visual-test]) .dnb-dialog--hide {
+.dnb-dialog--hide {
   animation: hide-modal 220ms ease-in-out forwards;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/packages/dnb-eufemia/src/components/dialog/style/dnb-dialog.scss
+++ b/packages/dnb-eufemia/src/components/dialog/style/dnb-dialog.scss
@@ -209,12 +209,10 @@
   }
 
   // Animation in
-  html:not([data-visual-test]) & {
-    animation: show-modal var(--modal-animation-duration) ease-out;
-  }
+  animation: show-modal var(--modal-animation-duration) ease-out;
 
   // Animation out
-  html:not([data-visual-test]) &--hide {
+  &--hide {
     animation: hide-modal 220ms ease-in-out forwards;
   }
 

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1002,7 +1002,7 @@ button.dnb-button::-moz-focus-inner {
 .dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
   animation: rotate-icon-out 400ms var(--easing-default) forwards;
 }
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg, html[data-visual-test] .dnb-help-button__inline svg {
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
   animation-duration: 0ms;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -1146,10 +1146,7 @@ html[data-dnb-modal-active] .eufemia-portal-root {
 .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
   animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards;
 }
-.dnb-modal {
-  /* stylelint-disable-next-line */
-}
-html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
+.dnb-modal__overlay--no-animation {
   animation-delay: 0ms !important;
   animation-duration: 0ms !important;
 }
@@ -1389,32 +1386,32 @@ html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
   border-radius: 0;
   box-shadow: none;
 }
-html:not([data-visual-test]) .dnb-drawer {
+.dnb-drawer {
   opacity: 0.1;
   animation: show-drawer var(--modal-animation-duration) ease-out forwards;
 }
-html:not([data-visual-test]) .dnb-drawer--left {
+.dnb-drawer--left {
   transform: translate3d(-20rem, 0, 0);
 }
-html:not([data-visual-test]) .dnb-drawer--right {
+.dnb-drawer--right {
   transform: translate3d(20rem, 0, 0);
 }
-html:not([data-visual-test]) .dnb-drawer--top {
+.dnb-drawer--top {
   transform: translate3d(0, -20rem, 0);
 }
-html:not([data-visual-test]) .dnb-drawer--bottom {
+.dnb-drawer--bottom {
   transform: translate3d(0, 20rem, 0);
 }
-html:not([data-visual-test]) .dnb-drawer--hide.dnb-drawer--left {
+.dnb-drawer--hide.dnb-drawer--left {
   animation: hide-drawer-left var(--modal-animation-duration) ease-in-out forwards;
 }
-html:not([data-visual-test]) .dnb-drawer--hide.dnb-drawer--right {
+.dnb-drawer--hide.dnb-drawer--right {
   animation: hide-drawer-right var(--modal-animation-duration) ease-in-out forwards;
 }
-html:not([data-visual-test]) .dnb-drawer--hide.dnb-drawer--top {
+.dnb-drawer--hide.dnb-drawer--top {
   animation: hide-drawer-top var(--modal-animation-duration) ease-in-out forwards;
 }
-html:not([data-visual-test]) .dnb-drawer--hide.dnb-drawer--bottom {
+.dnb-drawer--hide.dnb-drawer--bottom {
   animation: hide-drawer-bottom var(--modal-animation-duration) ease-in-out forwards;
 }
 .dnb-drawer--no-animation {

--- a/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
@@ -125,43 +125,40 @@
     @include modal-mixins.modalFullscreen();
   }
 
-  html:not([data-visual-test]) & {
-    opacity: 0.1;
-    animation: show-drawer var(--modal-animation-duration) ease-out
-      forwards;
-  }
+  opacity: 0.1;
+  animation: show-drawer var(--modal-animation-duration) ease-out forwards;
 
   // Animations in
-  html:not([data-visual-test]) &--left {
+  &--left {
     transform: translate3d(-20rem, 0, 0);
   }
 
-  html:not([data-visual-test]) &--right {
+  &--right {
     transform: translate3d(20rem, 0, 0);
   }
 
-  html:not([data-visual-test]) &--top {
+  &--top {
     transform: translate3d(0, -20rem, 0);
   }
 
-  html:not([data-visual-test]) &--bottom {
+  &--bottom {
     transform: translate3d(0, 20rem, 0);
   }
 
   // Animations out
-  html:not([data-visual-test]) &--hide#{&}--left {
+  &--hide#{&}--left {
     animation: hide-drawer-left var(--modal-animation-duration) ease-in-out
       forwards;
   }
-  html:not([data-visual-test]) &--hide#{&}--right {
+  &--hide#{&}--right {
     animation: hide-drawer-right var(--modal-animation-duration)
       ease-in-out forwards;
   }
-  html:not([data-visual-test]) &--hide#{&}--top {
+  &--hide#{&}--top {
     animation: hide-drawer-top var(--modal-animation-duration) ease-in-out
       forwards;
   }
-  html:not([data-visual-test]) &--hide#{&}--bottom {
+  &--hide#{&}--bottom {
     animation: hide-drawer-bottom var(--modal-animation-duration)
       ease-in-out forwards;
   }

--- a/packages/dnb-eufemia/src/components/height-animation/style/dnb-height-animation.scss
+++ b/packages/dnb-eufemia/src/components/height-animation/style/dnb-height-animation.scss
@@ -13,11 +13,6 @@
   will-change: height;
   transition: var(--height-animation);
 
-  html[data-visual-test] &,
-  html[data-visual-test] & * {
-    transition: none !important;
-  }
-
   @include utilities.reducedMotion() {
     --height-animation-duration: 0.01ms;
     transition-duration: 0.01ms !important;

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -993,7 +993,7 @@ button.dnb-button::-moz-focus-inner {
 .dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
   animation: rotate-icon-out 400ms var(--easing-default) forwards;
 }
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg, html[data-visual-test] .dnb-help-button__inline svg {
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
   animation-duration: 0ms;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/packages/dnb-eufemia/src/components/help-button/style/dnb-help-button-inline.scss
+++ b/packages/dnb-eufemia/src/components/help-button/style/dnb-help-button-inline.scss
@@ -38,8 +38,7 @@
     }
   }
 
-  &:not(#{&}--user-intent),
-  html[data-visual-test] & {
+  &:not(#{&}--user-intent) {
     svg {
       animation-duration: 0ms;
     }

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -997,7 +997,7 @@ button.dnb-button::-moz-focus-inner {
 .dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
   animation: rotate-icon-out 400ms var(--easing-default) forwards;
 }
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg, html[data-visual-test] .dnb-help-button__inline svg {
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
   animation-duration: 0ms;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -1141,10 +1141,7 @@ html[data-dnb-modal-active] .eufemia-portal-root {
 .dnb-modal-root__inner:last-of-type .dnb-modal__overlay--hide {
   animation: hide-modal-overlay var(--modal-animation-duration) ease-out forwards;
 }
-.dnb-modal {
-  /* stylelint-disable-next-line */
-}
-html[data-visual-test] .dnb-modal__overlay, .dnb-modal__overlay--no-animation {
+.dnb-modal__overlay--no-animation {
   animation-delay: 0ms !important;
   animation-duration: 0ms !important;
 }

--- a/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
@@ -97,8 +97,6 @@ html[data-dnb-modal-active] {
     }
   }
 
-  /* stylelint-disable-next-line */
-  html[data-visual-test] &__overlay,
   &__overlay--no-animation {
     animation-delay: 0ms !important;
     animation-duration: 0ms !important;

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -1197,9 +1197,6 @@ html[data-visual-test] .dnb-progress-indicator {
 .dnb-progress-indicator--no-animation, .dnb-progress-indicator--no-animation.dnb-progress-indicator--complete {
   animation-duration: 0ms;
 }
-html[data-visual-test] .dnb-progress-indicator__bar-transition {
-  transition: none;
-}
 .dnb-progress-indicator--full-width {
   width: 100%;
   min-width: 1rem;

--- a/packages/dnb-eufemia/src/components/popover/style/dnb-popover.scss
+++ b/packages/dnb-eufemia/src/components/popover/style/dnb-popover.scss
@@ -52,7 +52,6 @@
     animation: show-popover 200ms var(--easing-default) forwards;
   }
 
-  html[data-visual-test] &--active,
   &--active#{&}--no-animation {
     animation-duration: 0ms;
   }
@@ -67,10 +66,6 @@
 
   &--fixed {
     position: fixed;
-  }
-
-  html[data-visual-test] &--hide {
-    animation: hide-popover 1ms linear 1s forwards;
   }
 
   &__portal {

--- a/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/progress-indicator/__tests__/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -238,9 +238,6 @@ html[data-visual-test] .dnb-progress-indicator {
 .dnb-progress-indicator--no-animation, .dnb-progress-indicator--no-animation.dnb-progress-indicator--complete {
   animation-duration: 0ms;
 }
-html[data-visual-test] .dnb-progress-indicator__bar-transition {
-  transition: none;
-}
 .dnb-progress-indicator--full-width {
   width: 100%;
   min-width: 1rem;

--- a/packages/dnb-eufemia/src/components/progress-indicator/style/dnb-progress-indicator.scss
+++ b/packages/dnb-eufemia/src/components/progress-indicator/style/dnb-progress-indicator.scss
@@ -291,10 +291,6 @@
     animation-duration: 0ms;
   }
 
-  html[data-visual-test] &__bar-transition {
-    transition: none;
-  }
-
   &--full-width {
     width: 100%;
     min-width: 1rem;

--- a/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.tsx.snap
@@ -98,9 +98,6 @@ exports[`Skeleton scss > has to match style dependencies css 1`] = `
   background-position-x: 30rem;
   animation: skeletonFontAnimation 5s linear infinite var(--skeleton-delay);
 }
-html[data-visual-test] .dnb-skeleton--font, html[data-visual-test] .dnb-skeleton--font .dnb-skeleton--show-font, html[data-visual-test] .dnb-skeleton--font .dnb-p {
-  animation: none !important;
-}
 .dnb-skeleton__figure {
   position: relative;
   border-radius: var(--token-radius-sm);

--- a/packages/dnb-eufemia/src/components/skeleton/style/dnb-skeleton.scss
+++ b/packages/dnb-eufemia/src/components/skeleton/style/dnb-skeleton.scss
@@ -130,10 +130,6 @@
     background-position-x: 30rem;
     animation: skeletonFontAnimation 5s linear infinite
       var(--skeleton-delay);
-
-    html[data-visual-test] & {
-      animation: none !important;
-    }
   }
 
   &__figure {

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -1208,9 +1208,6 @@ html[data-whatinput=keyboard] .dnb-slider__marker:focus {
     transition-duration: 0.01ms;
   }
 }
-html[data-visual-test] .dnb-slider__thumb, html[data-visual-test] .dnb-slider__line {
-  transition: none !important;
-}
 .dnb-slider__button-helper {
   pointer-events: none;
   z-index: 2;

--- a/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
+++ b/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
@@ -272,11 +272,6 @@
     }
   }
 
-  html[data-visual-test] &__thumb,
-  html[data-visual-test] &__line {
-    transition: none !important;
-  }
-
   // make sure the helper is not click able
   &__button-helper {
     pointer-events: none;

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -1088,9 +1088,6 @@ button.dnb-button::-moz-focus-inner {
 .dnb-step-indicator__item:last-child .dnb-step-indicator__item__wrapper::before {
   display: none;
 }
-html[data-visual-test] .dnb-step-indicator__item__icon {
-  transition-duration: 1ms !important;
-}
 .dnb-step-indicator__button {
   white-space: normal;
   text-align: left;

--- a/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
+++ b/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
@@ -148,10 +148,6 @@
         display: none;
       }
     }
-
-    html[data-visual-test] &__icon {
-      transition-duration: 1ms !important;
-    }
   }
 
   &__button {

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -239,9 +239,6 @@ html[data-visual-test] .dnb-table, html[data-visual-test] .dnb-table__container 
     transition-duration: 0.01ms;
   }
 }
-html[data-visual-test] .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button > .dnb-icon, html[data-visual-test] .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button > .dnb-icon {
-  transition: none;
-}
 .dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button {
   position: relative;
   z-index: 1;
@@ -1069,7 +1066,7 @@ html:not([data-whatintent=touch]) .dnb-table__td__button:hover:not([disabled]) .
     transition-duration: 0.01ms;
   }
 }
-.dnb-table__tr--clickable.dnb-table__tr--no-animation .dnb-table__button .dnb-icon, html[data-visual-test] .dnb-table__tr--clickable .dnb-table__button .dnb-icon {
+.dnb-table__tr--clickable.dnb-table__tr--no-animation .dnb-table__button .dnb-icon {
   transition: none !important;
 }
 
@@ -1213,10 +1210,6 @@ html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-
 
 .dnb-table__tr__accordion-content--parallax .dnb-table__tr__accordion-content__inner__spacing {
   transform: translateY(0);
-}
-
-html[data-visual-test] .dnb-table__tr__accordion-content--parallax .dnb-table__tr__accordion-content__inner__spacing {
-  transition: none;
 }
 
 .dnb-table__tr__accordion-content--expanded > td.dnb-table__td {

--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -83,8 +83,7 @@
       }
     }
   }
-  &__tr--clickable#{&}__tr--no-animation &__button .dnb-icon,
-  html[data-visual-test] &__tr--clickable &__button .dnb-icon {
+  &__tr--clickable#{&}__tr--no-animation &__button .dnb-icon {
     transition: none !important;
   }
 
@@ -248,9 +247,6 @@
     &--parallax &__inner {
       &__spacing {
         transform: translateY(0);
-        html[data-visual-test] & {
-          transition: none;
-        }
       }
     }
 

--- a/packages/dnb-eufemia/src/components/table/style/table-header-buttons.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-header-buttons.scss
@@ -28,10 +28,6 @@
         @include utilities.reducedMotion() {
           transition-duration: 0.01ms;
         }
-
-        html[data-visual-test] & {
-          transition: none;
-        }
       }
 
       position: relative;

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -69,11 +69,7 @@ exports[`Tabs scss > has to match style dependencies css 1`] = `
 }
 .dnb-tabs__tabs__tablist {
   overscroll-behavior: contain;
-}
-html:not([data-visual-test]) .dnb-tabs__tabs__tablist {
   scroll-behavior: smooth;
-}
-.dnb-tabs__tabs__tablist {
   scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
 }
 @supports not (scrollbar-color: auto) {
@@ -369,9 +365,6 @@ html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-ta
 }
 .dnb-tabs__cached--hidden * {
   height: 0 !important;
-}
-html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-tabs .dnb-tabs__button, html[data-visual-test] .dnb-tabs .dnb-tabs__button__snap, html[data-visual-test] .dnb-tabs .dnb-tabs__scroll-nav-button {
-  transition: none !important;
 }
 .dnb-tabs__content:focus-visible {
   position: relative;
@@ -463,11 +456,7 @@ exports[`Tabs scss > have to match default theme snapshot 1`] = `
 }
 .dnb-tabs__tabs__tablist {
   overscroll-behavior: contain;
-}
-html:not([data-visual-test]) .dnb-tabs__tabs__tablist {
   scroll-behavior: smooth;
-}
-.dnb-tabs__tabs__tablist {
   scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
 }
 @supports not (scrollbar-color: auto) {
@@ -763,9 +752,6 @@ html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-ta
 }
 .dnb-tabs__cached--hidden * {
   height: 0 !important;
-}
-html[data-visual-test] .dnb-tabs .dnb-tabs__cached, html[data-visual-test] .dnb-tabs .dnb-tabs__button, html[data-visual-test] .dnb-tabs .dnb-tabs__button__snap, html[data-visual-test] .dnb-tabs .dnb-tabs__scroll-nav-button {
-  transition: none !important;
 }
 .dnb-tabs__content:focus-visible {
   position: relative;

--- a/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
+++ b/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
@@ -377,13 +377,6 @@
     }
   }
 
-  html[data-visual-test] & &__cached,
-  html[data-visual-test] & &__button,
-  html[data-visual-test] & &__button__snap,
-  html[data-visual-test] & &__scroll-nav-button {
-    transition: none !important;
-  }
-
   // Make focus ring when keyboard is used to navigate
   &__content:focus-visible {
     position: relative;

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
@@ -295,12 +295,10 @@ button .dnb-form-status__text {
   line-height: var(--line-height-basis);
   overflow-y: auto;
   overscroll-behavior: contain;
-}
-html:not([data-visual-test]) .dnb-textarea__textarea {
   scroll-behavior: smooth;
 }
 @media (prefers-reduced-motion: reduce) {
-  html:not([data-visual-test]) .dnb-textarea__textarea {
+  .dnb-textarea__textarea {
     scroll-behavior: auto;
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
@@ -49,10 +49,6 @@
       animation-duration: 1.3s;
       animation-delay: 200ms; // to get a nicer fade in
 
-      html[data-visual-test] & {
-        animation: none;
-      }
-
       font-weight: var(--font-weight-bold);
     }
   }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -47,11 +47,6 @@ exports[`DrawerList scss > has to match style dependencies css 1`] = `
 .dnb-drawer-list__portal__style {
   position: absolute;
   transition: top 300ms var(--easing-default), left 300ms var(--easing-default), width 300ms var(--easing-default);
-}
-html[data-visual-test] .dnb-drawer-list__portal__style {
-  transition: none !important;
-}
-.dnb-drawer-list__portal__style {
   z-index: calc(var(--modal-z-index, 3200) + 300);
 }
 .dnb-drawer-list__portal__style--fixed {
@@ -106,12 +101,10 @@ html[data-visual-test] .dnb-drawer-list__portal__style {
   transition: max-height 300ms var(--easing-default);
   overflow-y: auto;
   overscroll-behavior: contain;
-}
-html:not([data-visual-test]) .dnb-drawer-list--scroll .dnb-drawer-list__options {
   scroll-behavior: smooth;
 }
 @media (prefers-reduced-motion: reduce) {
-  html:not([data-visual-test]) .dnb-drawer-list--scroll .dnb-drawer-list__options {
+  .dnb-drawer-list--scroll .dnb-drawer-list__options {
     scroll-behavior: auto;
   }
 }
@@ -144,7 +137,7 @@ html:not([data-visual-test]) .dnb-drawer-list--scroll .dnb-drawer-list__options 
     transition-duration: 0.01ms;
   }
 }
-html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-drawer-list--scroll.dnb-drawer-list--no-animation .dnb-drawer-list__options {
+.dnb-drawer-list--scroll.dnb-drawer-list--no-animation .dnb-drawer-list__options {
   transition: none !important;
 }
 .dnb-drawer-list--open .dnb-drawer-list__options {
@@ -283,7 +276,7 @@ html[data-visual-test] .dnb-drawer-list--scroll .dnb-drawer-list__options, .dnb-
 .dnb-drawer-list--open .dnb-drawer-list__list:not(.dnb-drawer-list--open .dnb-drawer-list__list--no-animation) {
   animation: drawer-list-slide-top-down 200ms ease-out 1 forwards;
 }
-html[data-visual-test] .dnb-drawer-list--open .dnb-drawer-list__list, .dnb-drawer-list--open .dnb-drawer-list__list--no-animation {
+.dnb-drawer-list--open .dnb-drawer-list__list--no-animation {
   animation-duration: 1ms !important;
 }
 .dnb-drawer-list--hidden .dnb-drawer-list__list {
@@ -361,7 +354,7 @@ html[data-visual-test] .dnb-drawer-list--open .dnb-drawer-list__list, .dnb-drawe
 .dnb-drawer-list:not(.dnb-drawer-list--open) .dnb-drawer-list__list:not(.dnb-drawer-list:not(.dnb-drawer-list--open) .dnb-drawer-list__list--no-animation) {
   animation: drawer-list-slide-top-up 150ms ease-out 1 forwards;
 }
-html[data-visual-test] .dnb-drawer-list:not(.dnb-drawer-list--open) .dnb-drawer-list__list, .dnb-drawer-list:not(.dnb-drawer-list--open) .dnb-drawer-list__list--no-animation {
+.dnb-drawer-list:not(.dnb-drawer-list--open) .dnb-drawer-list__list--no-animation {
   animation-duration: 1ms !important;
 }
 

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -18,7 +18,6 @@
     &:not(#{&}--no-animation) {
       animation: drawer-list-slide-top-down 200ms ease-out 1 forwards;
     }
-    html[data-visual-test] &,
     &--no-animation {
       animation-duration: 1ms !important;
     }
@@ -33,7 +32,6 @@
     &:not(#{&}--no-animation) {
       animation: drawer-list-slide-top-up 150ms ease-out 1 forwards;
     }
-    html[data-visual-test] &,
     &--no-animation {
       animation-duration: 1ms !important;
     }
@@ -88,10 +86,6 @@
       top 300ms var(--easing-default),
       left 300ms var(--easing-default),
       width 300ms var(--easing-default);
-
-    html[data-visual-test] & {
-      transition: none !important;
-    }
 
     // higher than modal --modal-z-index:
     z-index: calc(var(--modal-z-index, 3200) + 300);
@@ -170,7 +164,6 @@
       transition-duration: 0.01ms;
     }
   }
-  html[data-visual-test] &--scroll &__options,
   &--scroll#{&}--no-animation &__options {
     transition: none !important;
   }

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -64,13 +64,12 @@
 
 @mixin htmlDefault() {
   html {
-    &:not([data-visual-test]) {
-      scroll-behavior: smooth;
+    scroll-behavior: smooth;
 
-      @media (prefers-reduced-motion: reduce) {
-        scroll-behavior: auto;
-      }
+    @media (prefers-reduced-motion: reduce) {
+      scroll-behavior: auto;
     }
+
     font-size: 100%;
 
     // IS_SAFARI_MOBILE

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -244,12 +244,10 @@
   overflow-y: $mode;
   overscroll-behavior: contain;
 
-  html:not([data-visual-test]) & {
-    scroll-behavior: smooth;
+  scroll-behavior: smooth;
 
-    @media (prefers-reduced-motion: reduce) {
-      scroll-behavior: auto;
-    }
+  @media (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
   }
 
   @include scrollbarAppearance();
@@ -263,9 +261,7 @@
   }
   overscroll-behavior: contain;
 
-  html:not([data-visual-test]) & {
-    scroll-behavior: smooth;
-  }
+  scroll-behavior: smooth;
 
   @include scrollbarAppearance();
 }


### PR DESCRIPTION
Because we set in in the test setup CSS anyway.