### PR TITLE
chore(Table): fix false positive highlight warning for inherited labels

### DIFF
--- a/packages/dnb-eufemia/src/components/table/__tests__/useTableHighlight.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/useTableHighlight.test.tsx
@@ -270,4 +270,68 @@ describe('useTableHighlight', () => {
 
     consoleSpy.mockRestore()
   })
+
+  it('should not warn when cells inherit highlight from a Tr with aria-label', () => {
+    const log = vi.fn()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(log)
+
+    const HighlightTable = () => {
+      const highlightRef = useTableHighlight()
+
+      return (
+        <Table ref={highlightRef}>
+          <thead>
+            <TableTr>
+              <TableTh>A</TableTh>
+              <TableTh>B</TableTh>
+            </TableTr>
+          </thead>
+          <tbody>
+            <TableTr highlight aria-label="Highlighted row">
+              <TableTh>Row header</TableTh>
+              <TableTd>1</TableTd>
+            </TableTr>
+          </tbody>
+        </Table>
+      )
+    }
+
+    render(<HighlightTable />)
+
+    expect(log).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('should not warn when Td is in a column with a highlighted Th', () => {
+    const log = vi.fn()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(log)
+
+    const HighlightTable = () => {
+      const highlightRef = useTableHighlight()
+
+      return (
+        <Table ref={highlightRef}>
+          <thead>
+            <TableTr>
+              <TableTh highlight aria-label="Highlighted column">
+                A
+              </TableTh>
+            </TableTr>
+          </thead>
+          <tbody>
+            <TableTr>
+              <TableTd>1</TableTd>
+            </TableTr>
+          </tbody>
+        </Table>
+      )
+    }
+
+    render(<HighlightTable />)
+
+    expect(log).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
 })

--- a/packages/dnb-eufemia/src/components/table/useTableHighlight.ts
+++ b/packages/dnb-eufemia/src/components/table/useTableHighlight.ts
@@ -26,20 +26,43 @@ function applyHighlight(table: HTMLTableElement) {
     highlightedColumns.add((th as HTMLTableCellElement).cellIndex)
   }
 
-  // Warn about highlighted cells missing an aria-label
+  // Warn about highlighted cells missing an aria-label.
+  // Skip cells whose highlight was inherited from a parent Tr or will
+  // be propagated from a column Th — only the Tr/Th needs the label.
   const allHighlighted = table.querySelectorAll(
     '.dnb-table__th--highlight, .dnb-table__td--highlight'
   )
   for (const cell of Array.from(allHighlighted)) {
     if (
-      !cell.getAttribute('aria-label') &&
-      !cell.getAttribute('aria-labelledby')
+      cell.getAttribute('aria-label') ||
+      cell.getAttribute('aria-labelledby')
     ) {
-      const tag = cell.tagName === 'TH' ? 'Th' : 'Td'
-      warn(
-        `Table.${tag}: a highlighted cell should have an \`aria-label\` or \`aria-labelledby\` attribute to describe the highlight for screen readers.`
-      )
+      continue
     }
+
+    const row = cell.closest('tr')
+    const rowHasLabel =
+      row &&
+      (row.getAttribute('aria-label') ||
+        row.getAttribute('aria-labelledby'))
+
+    // Cell inside a highlighted Tr — the row provides the label
+    if (rowHasLabel) {
+      continue
+    }
+
+    // Td in a column with a highlighted Th — the Th provides the label
+    if (
+      cell.tagName === 'TD' &&
+      highlightedColumns.has((cell as HTMLTableCellElement).cellIndex)
+    ) {
+      continue
+    }
+
+    const tag = cell.tagName === 'TH' ? 'Th' : 'Td'
+    warn(
+      `Table.${tag}: a highlighted cell should have an \`aria-label\` or \`aria-labelledby\` attribute to describe the highlight for screen readers.`
+    )
   }
 
   const applied: { cell: HTMLTableCellElement; classes: string[] }[] = []


### PR DESCRIPTION
The `useTableHighlight` hook warns about highlighted cells missing `aria-label`, but it didn't account for cells that inherit their highlight from a parent `Tr` or a column `Th` — where the label is already present on the parent element.

**Changes:**

- Skip the warning for cells inside a `Tr` that has `aria-label` or `aria-labelledby`
- Skip the warning for `Td` cells in a column with a highlighted `Th` (the `Th` provides the label)
- Add tests for both inherited-label scenarios

Preview: https://chore-table-highlight-warnin.eufemia-e25.pages.dev/uilib/components/table#cell-highlighting