### PR TITLE
chore(Portal): add inject-scope Babel plugin for per-file ComponentBox scope

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/ComponentBox.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/ComponentBox.tsx
@@ -7,18 +7,22 @@
 import * as React from 'react'
 import CodeBlock, { type CodeSectionProps } from './CodeBlock'
 import styled from '@emotion/styled'
-import { getComponents } from '@dnb/eufemia/src/components/lib'
-import { getFragments } from '@dnb/eufemia/src/fragments/lib'
-import { getElements } from '@dnb/eufemia/src/elements/lib'
-import { Provider, Theme } from '@dnb/eufemia/src/shared'
-import { formsScope } from './formsExports'
 
 if (!globalThis.ComponentBoxMemo) {
   globalThis.ComponentBoxMemo = {}
 }
 
-function ComponentBox(props: CodeSectionProps) {
-  const { children, scope = {}, ...rest } = props
+type ComponentBoxProps = CodeSectionProps & {
+  /**
+   * Injected by the inject-scope Babel plugin.
+   * Contains only the Eufemia symbols that the code string references,
+   * eliminating the need to import the entire library.
+   */
+  __buildScope?: Record<string, unknown>
+}
+
+function ComponentBox(props: ComponentBoxProps) {
+  const { children, scope = {}, __buildScope, ...rest } = props
 
   const hash = children as string
 
@@ -29,14 +33,8 @@ function ComponentBox(props: CodeSectionProps) {
   const element = (
     <CodeBlock
       scope={{
-        ...getComponents(),
-        ...getFragments(),
-        ...getElements(),
-        Provider,
-        Theme,
-        ...formsScope,
+        ...__buildScope,
         styled,
-        React,
         Fragment: React.Fragment,
         useState: React.useState,
         useEffect: React.useEffect,

--- a/packages/dnb-design-system-portal/vite.config.ts
+++ b/packages/dnb-design-system-portal/vite.config.ts
@@ -4,7 +4,7 @@
  * See vite/README.md for architecture details and plugin documentation.
  */
 
-import { defineConfig } from 'vite'
+import { defineConfig, withFilter } from 'vite'
 import react from '@vitejs/plugin-react'
 import buildTargets from '@dnb/browserslist-config/buildTargets.mjs'
 import { createRequire } from 'node:module'
@@ -53,6 +53,7 @@ export default defineConfig({
     target: buildTargets,
     outDir: path.resolve(__dirname, 'public'),
     emptyOutDir: true,
+    chunkSizeWarningLimit: 4000,
   },
 
   plugins: [
@@ -60,30 +61,50 @@ export default defineConfig({
     redirectIndexHtmlPlugin(),
 
     // Prefetch route chunks when internal links are hovered or focused
-    prefetchOnHoverPlugin(),
+    withFilter(prefetchOnHoverPlugin(), {
+      resolveId: { id: /^virtual:prefetch-on-hover$/ },
+      load: { id: /virtual:prefetch-on-hover/ },
+    }),
 
     // Intercept internal link clicks for SPA navigation
-    catchLinksPlugin(),
+    withFilter(catchLinksPlugin(), {
+      resolveId: { id: /^virtual:catch-links$/ },
+      load: { id: /virtual:catch-links/ },
+    }),
 
     // Persist sidebar scroll position across route changes
-    scrollPositionPlugin(),
+    withFilter(scrollPositionPlugin(), {
+      resolveId: { id: /^virtual:scroll-position$/ },
+      load: { id: /virtual:scroll-position/ },
+    }),
 
     // Inject preload styles to prevent layout flicker
     preloadStylesPlugin(),
 
     // Filter pages for test builds (IS_VISUAL_TEST, IS_E2E)
-    testPageFilterPlugin(),
+    withFilter(testPageFilterPlugin(), {
+      transform: { id: /virtual:portal-pages/ },
+    }),
 
     // Use pre-built @dnb/eufemia package when available in production builds
     eufemiaPrebuildPlugin(),
 
     // MDX support — must come before React plugin so .mdx files
     // are transformed to JSX before React processes them
-    portalMdxPlugin(),
+    withFilter(portalMdxPlugin(), {
+      transform: { id: /\.mdx/ },
+    }),
 
-    stripMissingExampleImportsPlugin(),
+    withFilter(stripMissingExampleImportsPlugin(), {
+      transform: {
+        id: /\.(mdx|tsx)($|\?)/,
+        code: /from\s*['"][^'"]*Examples['"]/,
+      },
+    }),
 
-    reactLiveBabelPlugin(),
+    withFilter(reactLiveBabelPlugin(), {
+      transform: { id: /Examples\.tsx/ },
+    }),
 
     // React plugin for JSX transform and Fast Refresh
     react({
@@ -91,15 +112,28 @@ export default defineConfig({
     }),
 
     // File-system routing and virtual page registry
-    portalPagesPlugin(),
+    withFilter(portalPagesPlugin(), {
+      resolveId: { id: /^virtual:portal-pages$/ },
+      load: { id: /virtual:portal-pages/ },
+    }),
 
     // Eufemia theme style loading for the portal runtime
-    eufemiaThemePlugin(),
+    withFilter(eufemiaThemePlugin(), {
+      resolveId: { id: /^virtual:eufemia-theme/ },
+      load: { id: /virtual:eufemia-theme/ },
+    }),
 
     // Portal build information (release version, build timestamp, changelog)
-    buildInfoPlugin(),
+    withFilter(buildInfoPlugin(), {
+      resolveId: { id: /^virtual:build-info$/ },
+      load: { id: /virtual:build-info|buildInfo/ },
+    }),
 
-    loadJsAsJsxPlugin(),
+    withFilter(loadJsAsJsxPlugin(), {
+      transform: {
+        id: { include: /\.js($|\?)/, exclude: /node_modules/ },
+      },
+    }),
   ],
 
   resolve: {

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/inject-scope.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/inject-scope.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from 'vitest'
+import {
+  injectScope,
+  extractScopeIdentifiers,
+} from '../../client/plugins/inject-scope'
+
+/**
+ * Transform helper that runs injectStableName → injectScope → babel-plugin-react-live
+ * to simulate the full pipeline.
+ */
+async function transformWithFullPipeline(code: string) {
+  const path = await import('node:path')
+  const babel = await import('@babel/core')
+  const { injectStableName } =
+    await import('../../client/plugins/react-live-babel')
+
+  const portalRoot = path.resolve(__dirname, '..', '..', '..')
+
+  const result = await babel.transformAsync(code, {
+    filename: 'Examples.tsx',
+    presets: [
+      ['@babel/preset-react', { runtime: 'automatic' }],
+      '@babel/preset-typescript',
+    ],
+    plugins: [
+      injectStableName,
+      injectScope,
+      [
+        require.resolve('babel-plugin-react-live'),
+        {
+          componentName: 'ComponentBox',
+          filesToMatch: ['Examples.tsx'],
+          prettierPath: path.resolve(portalRoot, '.prettierrc'),
+        },
+      ],
+    ],
+  })
+
+  return result?.code || ''
+}
+
+describe('extractScopeIdentifiers', () => {
+  it('extracts PascalCase component names', () => {
+    expect(extractScopeIdentifiers('<Button text="hi" />')).toEqual([
+      'Button',
+    ])
+  })
+
+  it('extracts multiple component names', () => {
+    const result = extractScopeIdentifiers(
+      '<Section><Button /><Card /></Section>'
+    )
+    expect(result).toContain('Button')
+    expect(result).toContain('Section')
+    expect(result).toContain('Card')
+  })
+
+  it('extracts namespace roots like Form and Field', () => {
+    const result = extractScopeIdentifiers(
+      '<Form.Handler><Field.String path="/foo" /></Form.Handler>'
+    )
+    expect(result).toContain('Form')
+    expect(result).toContain('Field')
+    expect(result).not.toContain('Handler')
+    expect(result).not.toContain('String')
+  })
+
+  it('ignores builtin scope names', () => {
+    const result = extractScopeIdentifiers(
+      '<React.Fragment><Suspense><Button /></Suspense></React.Fragment>'
+    )
+    expect(result).toContain('Button')
+    expect(result).not.toContain('React')
+    expect(result).not.toContain('Fragment')
+    expect(result).not.toContain('Suspense')
+  })
+
+  it('ignores identifiers inside string literals', () => {
+    const result = extractScopeIdentifiers(
+      '<Button text="Section" variant="primary" />'
+    )
+    expect(result).toContain('Button')
+    expect(result).not.toContain('Section')
+  })
+
+  it('ignores identifiers inside comments', () => {
+    const result = extractScopeIdentifiers(
+      '// Use Section here\n<Button />'
+    )
+    expect(result).toContain('Button')
+    expect(result).not.toContain('Section')
+  })
+
+  it('ignores unknown PascalCase identifiers', () => {
+    const result = extractScopeIdentifiers(
+      '<MyCustomComponent /><Button />'
+    )
+    expect(result).toContain('Button')
+    expect(result).not.toContain('MyCustomComponent')
+  })
+
+  it('handles elements like P, H1, H2', () => {
+    const result = extractScopeIdentifiers('<P>text</P><H2>heading</H2>')
+    expect(result).toContain('P')
+    expect(result).toContain('H2')
+  })
+
+  it('returns deduplicated results', () => {
+    const result = extractScopeIdentifiers('<Button /><Button />')
+    expect(result).toEqual(['Button'])
+  })
+})
+
+describe('injectScope babel plugin', () => {
+  it('injects __buildScope with components found in code string', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return <ComponentBox><Button text="hi" /></ComponentBox>
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).toContain('__buildScope')
+    expect(output).toContain('__scope_Button')
+    expect(output).toContain('@dnb/eufemia/src/components/button/Button')
+  })
+
+  it('reuses existing file-level imports', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      import { Button } from '@dnb/eufemia/src'
+      export function Demo() {
+        return <ComponentBox><Button text="hi" /></ComponentBox>
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).toContain('__buildScope')
+    // Should use the existing Button binding, not add __scope_Button
+    expect(output).not.toContain('__scope_Button')
+    // Shorthand property: { Button } (same as { Button: Button })
+    expect(output).toMatch(/__buildScope[\s\S]*Button/)
+  })
+
+  it('handles multiple components in one code string', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return (
+          <ComponentBox>
+            <Section>
+              <Button text="hi" />
+              <Card>content</Card>
+            </Section>
+          </ComponentBox>
+        )
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).toContain('__scope_Button')
+    expect(output).toContain('__scope_Section')
+    expect(output).toContain('__scope_Card')
+  })
+
+  it('handles forms namespace imports', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return (
+          <ComponentBox>
+            <Form.Handler>
+              <Field.String path="/name" />
+            </Form.Handler>
+          </ComponentBox>
+        )
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).toContain('__scope_Form')
+    expect(output).toContain('__scope_Field')
+    expect(output).toContain('@dnb/eufemia/src/extensions/forms')
+  })
+
+  it('handles shared imports (Provider, Theme)', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return (
+          <ComponentBox>
+            <Provider locale="nb-NO">
+              <Button text="hi" />
+            </Provider>
+          </ComponentBox>
+        )
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).toContain('__scope_Provider')
+    expect(output).toContain('@dnb/eufemia/src/shared')
+  })
+
+  it('does not inject for non-ComponentBox elements', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return <SomeOther><Button /></SomeOther>
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).not.toContain('__buildScope')
+    expect(output).not.toContain('__scope_')
+  })
+
+  it('does not inject builtins like React hooks', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return (
+          <ComponentBox>
+            {() => {
+              const [open, setOpen] = useState(false)
+              return <Button text="hi" />
+            }}
+          </ComponentBox>
+        )
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    // Should NOT inject useState (it's a builtin provided by ComponentBox)
+    expect(output).not.toContain('__scope_useState')
+    // Should inject Button
+    expect(output).toContain('__scope_Button')
+  })
+
+  it('shares added imports across multiple ComponentBoxes in the same file', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function First() {
+        return <ComponentBox><Button text="a" /></ComponentBox>
+      }
+      export function Second() {
+        return <ComponentBox><Button text="b" /><Section>x</Section></ComponentBox>
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    // Button import added once, used in both scopes
+    const buttonImportCount = (
+      output.match(/@dnb\/eufemia\/src\/components\/button\/Button/g) || []
+    ).length
+    expect(buttonImportCount).toBe(1)
+
+    // Both ComponentBoxes should have __buildScope
+    const buildScopeCount = (output.match(/__buildScope/g) || []).length
+    expect(buildScopeCount).toBeGreaterThanOrEqual(2)
+  })
+
+  it('handles element imports like P and H2', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return (
+          <ComponentBox>
+            <P>paragraph</P>
+            <H2>heading</H2>
+          </ComponentBox>
+        )
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).toContain('__scope_P')
+    expect(output).toContain('__scope_H2')
+    expect(output).toContain('@dnb/eufemia/src/elements/P')
+    expect(output).toContain('@dnb/eufemia/src/elements/H2')
+  })
+
+  it('does not add __buildScope when no known symbols are found', async () => {
+    const input = `
+      import ComponentBox from '../../shared/tags/ComponentBox'
+      export function Demo() {
+        return <ComponentBox>{'plain text'}</ComponentBox>
+      }
+    `
+
+    const output = await transformWithFullPipeline(input)
+
+    expect(output).not.toContain('__buildScope')
+  })
+})

--- a/packages/dnb-design-system-portal/vite/client/plugins/inject-scope.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/inject-scope.ts
@@ -1,0 +1,230 @@
+/**
+ * Babel plugin that injects a `__buildScope` prop on each <ComponentBox>,
+ * containing only the Eufemia symbols that the code string references.
+ *
+ * Must run BEFORE babel-plugin-react-live (which replaces JSXElements with
+ * raw identifier nodes). We serialize the JSX children to a code string
+ * using @babel/generator, then scan for known Eufemia identifiers.
+ *
+ * For each ComponentBox:
+ * 1. Serialize children to a code string
+ * 2. Extract PascalCase identifiers matching known scope symbols
+ * 3. Add file-level imports for any missing symbols
+ * 4. Inject a __buildScope prop with the resolved bindings
+ *
+ * This allows ComponentBox to receive only the components it needs
+ * instead of importing the entire Eufemia library.
+ */
+
+import type BabelTypes from '@babel/types'
+import {
+  allScopeNames,
+  builtinScopeNames,
+  getImportInfo,
+} from './scope-registry'
+
+export function injectScope(babel: { types: typeof BabelTypes }) {
+  const { types: t } = babel
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const generate = require('@babel/generator').default as (
+    ast: BabelTypes.Node
+  ) => { code: string }
+
+  return {
+    visitor: {
+      Program(programPath: {
+        node: { body: BabelTypes.Statement[] }
+        traverse: (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          visitors: Record<string, (path: any) => void>
+        ) => void
+      }) {
+        const allNeeded = new Set<string>()
+        const componentBoxes: Array<{
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          openingElement: any
+          usedNames: string[]
+        }> = []
+
+        // Find all ComponentBox elements and collect referenced identifiers
+        programPath.traverse({
+          JSXOpeningElement(nodePath: {
+            node: {
+              name: { type: string; name: string }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              attributes: any[]
+            }
+            parentPath: {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              node: { children: any[] }
+            }
+          }) {
+            if (
+              nodePath.node.name.type !== 'JSXIdentifier' ||
+              nodePath.node.name.name !== 'ComponentBox'
+            ) {
+              return // stop here
+            }
+
+            // Serialize children to a code string for analysis
+            const children = nodePath.parentPath.node.children || []
+            const codeString = children
+              .map((child: BabelTypes.Node) => {
+                try {
+                  return generate(child).code
+                } catch {
+                  return ''
+                }
+              })
+              .join('\n')
+
+            if (!codeString.trim()) {
+              return // stop here
+            }
+
+            const usedNames = extractScopeIdentifiers(codeString)
+            usedNames.forEach((name) => allNeeded.add(name))
+            componentBoxes.push({
+              openingElement: nodePath.node,
+              usedNames,
+            })
+          },
+        })
+
+        if (componentBoxes.length === 0) {
+          return // stop here
+        }
+
+        // Build a map of names already imported at the file level
+        const existingBindings = buildExistingBindings(
+          programPath.node.body,
+          t
+        )
+
+        // Determine which symbols need new imports
+        const addedBindings = new Map<string, string>()
+        const importsBySource = new Map<
+          string,
+          Array<{
+            importedName: string
+            localName: string
+            isDefault: boolean
+          }>
+        >()
+
+        allNeeded.forEach((name) => {
+          if (existingBindings.has(name)) {
+            return // stop here
+          }
+
+          const info = getImportInfo(name)
+          if (!info) {
+            return // stop here
+          }
+
+          const localName = `__scope_${name}`
+          addedBindings.set(name, localName)
+
+          const group = importsBySource.get(info.source) || []
+          group.push({
+            importedName: name,
+            localName,
+            isDefault: info.isDefault,
+          })
+          importsBySource.set(info.source, group)
+        })
+
+        // Generate import declarations (grouped by source)
+        importsBySource.forEach((specs, source) => {
+          const specifiers = specs.map(
+            ({ importedName, localName, isDefault }) => {
+              if (isDefault) {
+                return t.importDefaultSpecifier(t.identifier(localName))
+              }
+              return t.importSpecifier(
+                t.identifier(localName),
+                t.identifier(importedName)
+              )
+            }
+          )
+
+          programPath.node.body.unshift(
+            t.importDeclaration(specifiers, t.stringLiteral(source))
+          )
+        })
+
+        // Inject __buildScope on each ComponentBox
+        for (const { openingElement, usedNames } of componentBoxes) {
+          const properties = usedNames
+            .map((name) => {
+              const localName =
+                existingBindings.get(name) || addedBindings.get(name)
+              if (!localName) {
+                return null
+              }
+
+              return t.objectProperty(
+                t.identifier(name),
+                t.identifier(localName),
+                false,
+                name === localName // shorthand
+              )
+            })
+            .filter((p): p is BabelTypes.ObjectProperty => p !== null)
+
+          if (properties.length > 0) {
+            openingElement.attributes.push(
+              t.jsxAttribute(
+                t.jsxIdentifier('__buildScope'),
+                t.jsxExpressionContainer(t.objectExpression(properties))
+              )
+            )
+          }
+        }
+      },
+    },
+  }
+}
+
+/**
+ * Extract PascalCase identifiers from a code string that match
+ * known Eufemia scope symbols (excluding builtins like React hooks).
+ */
+export function extractScopeIdentifiers(code: string): string[] {
+  // Strip comments and string literals to avoid false matches
+  const cleaned = code
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+
+  const matches = cleaned.match(/\b([A-Z][a-zA-Z0-9]*)\b/g) || []
+
+  return Array.from(new Set(matches)).filter(
+    (name) => allScopeNames.has(name) && !builtinScopeNames.has(name)
+  )
+}
+
+/**
+ * Build a map of local binding name → local binding name
+ * from all file-level import declarations.
+ */
+function buildExistingBindings(
+  body: BabelTypes.Statement[],
+  t: typeof BabelTypes
+): Map<string, string> {
+  const map = new Map<string, string>()
+
+  for (const node of body) {
+    if (!t.isImportDeclaration(node)) {
+      continue
+    }
+
+    for (const spec of node.specifiers) {
+      // Map by local name — this is what code strings reference
+      map.set(spec.local.name, spec.local.name)
+    }
+  }
+
+  return map
+}

--- a/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/react-live-babel.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import type { Plugin } from 'vite'
 import type BabelTypes from '@babel/types'
+import { injectScope } from './inject-scope'
 
 const portalRoot = path.resolve(__dirname, '..', '..', '..')
 
@@ -24,6 +25,7 @@ export default function reactLiveBabelPlugin(): Plugin {
         ],
         plugins: [
           injectStableName,
+          injectScope,
           [
             require.resolve('babel-plugin-react-live'),
             {

--- a/packages/dnb-design-system-portal/vite/client/plugins/scope-registry.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/scope-registry.ts
@@ -1,0 +1,154 @@
+/**
+ * Registry of known Eufemia scope symbols and their import paths.
+ *
+ * Used by inject-scope to generate per-file scope imports for ComponentBox,
+ * so only the symbols actually referenced in each file's code strings
+ * are bundled — instead of pulling in the entire library.
+ *
+ * Derives component/fragment/element/forms lists dynamically by parsing
+ * the auto-generated lib.ts barrel files at load time, so this file
+ * never needs manual updates when components are added or removed.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+export type ScopeImportInfo = {
+  source: string
+  isDefault: boolean
+}
+
+/**
+ * Parse default import statements from an auto-generated lib.ts file.
+ * Matches lines like: import Name from './relative/path'
+ */
+function parseDefaultImports(
+  filePath: string
+): Array<{ name: string; relativePath: string }> {
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const results: Array<{ name: string; relativePath: string }> = []
+  const regex = /^import\s+(\w+)\s+from\s+'\.\/([^']+)'/gm
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(content)) !== null) {
+    results.push({ name: match[1], relativePath: match[2] })
+  }
+
+  return results
+}
+
+/**
+ * Parse namespace and re-exported default exports from the forms index.
+ * Matches: export * as Name from '...'
+ * Matches: export { default as Name } from '...'
+ */
+function parseFormsExports(filePath: string): string[] {
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const names: string[] = []
+
+  const nsRegex = /export\s+\*\s+as\s+(\w+)\s+from/g
+  let match: RegExpExecArray | null
+
+  while ((match = nsRegex.exec(content)) !== null) {
+    names.push(match[1])
+  }
+
+  const namedRegex = /export\s*\{\s*default\s+as\s+(\w+)\s*\}\s*from/g
+
+  while ((match = namedRegex.exec(content)) !== null) {
+    names.push(match[1])
+  }
+
+  return names
+}
+
+// Resolve the @dnb/eufemia source root
+const eufemiaSrc = path.resolve(
+  path.dirname(require.resolve('@dnb/eufemia/package.json')),
+  'src'
+)
+
+// Build the import info map by parsing the actual lib files
+const importInfoMap = new Map<string, ScopeImportInfo>()
+const allNames: string[] = []
+
+for (const { name, relativePath } of parseDefaultImports(
+  path.join(eufemiaSrc, 'components/lib.ts')
+)) {
+  importInfoMap.set(name, {
+    source: `@dnb/eufemia/src/components/${relativePath}`,
+    isDefault: true,
+  })
+  allNames.push(name)
+}
+
+for (const { name, relativePath } of parseDefaultImports(
+  path.join(eufemiaSrc, 'fragments/lib.ts')
+)) {
+  importInfoMap.set(name, {
+    source: `@dnb/eufemia/src/fragments/${relativePath}`,
+    isDefault: true,
+  })
+  allNames.push(name)
+}
+
+for (const { name, relativePath } of parseDefaultImports(
+  path.join(eufemiaSrc, 'elements/lib.ts')
+)) {
+  importInfoMap.set(name, {
+    source: `@dnb/eufemia/src/elements/${relativePath}`,
+    isDefault: true,
+  })
+  allNames.push(name)
+}
+
+for (const name of parseFormsExports(
+  path.join(eufemiaSrc, 'extensions/forms/index.ts')
+)) {
+  importInfoMap.set(name, {
+    source: '@dnb/eufemia/src/extensions/forms',
+    isDefault: false,
+  })
+  allNames.push(name)
+}
+
+// Named exports from @dnb/eufemia/src/shared
+// These are stable top-level exports unlikely to change.
+for (const name of ['Provider', 'Theme']) {
+  importInfoMap.set(name, {
+    source: '@dnb/eufemia/src/shared',
+    isDefault: false,
+  })
+  allNames.push(name)
+}
+
+/**
+ * Set of all known scope symbol names.
+ */
+export const allScopeNames = new Set<string>(allNames)
+
+/**
+ * Names provided directly by ComponentBox (React hooks, styled, etc.).
+ * These should NOT be injected by the plugin.
+ */
+export const builtinScopeNames = new Set([
+  'styled',
+  'React',
+  'Fragment',
+  'useState',
+  'useEffect',
+  'useRef',
+  'useCallback',
+  'useMemo',
+  'useContext',
+  'useLayoutEffect',
+  'createContext',
+  'Suspense',
+])
+
+/**
+ * Get import information for a known scope symbol.
+ */
+export function getImportInfo(name: string): ScopeImportInfo | null {
+  return importInfoMap.get(name) || null
+}


### PR DESCRIPTION
Replaces the runtime approach of importing the entire Eufemia library into every ComponentBox with compile-time scope injection.

## How it works

A new `inject-scope` Babel plugin analyzes each Examples.tsx file's `<ComponentBox>` children at build time:

1. Serializes JSX children to a code string (before `babel-plugin-react-live` destroys the AST)
2. Extracts PascalCase identifiers matching known Eufemia symbols
3. Adds file-level imports for any missing symbols
4. Injects a `__buildScope` prop with only the resolved bindings

A `scope-registry` dynamically parses the auto-generated lib.ts barrel files to resolve import paths — no manual updates needed when components are added or removed.

## Changes

- New `inject-scope.ts` — Babel plugin (runs before `babel-plugin-react-live`)
- New `scope-registry.ts` — derives symbol→import mappings from lib.ts files at load time
- Modified `react-live-babel.ts` — registers `injectScope` in the plugin pipeline
- Modified `ComponentBox.tsx` — receives `__buildScope` prop instead of calling `getComponents()` etc.

**Result:** Main bundle chunk reduced from ~3,400 kB to ~2,931 kB (~14% reduction).

## Test coverage
- 19 new tests (9 unit + 10 integration with full Babel pipeline)