### PR TITLE
chore: simplify generated file check to catch all tracked changes

### DIFF
--- a/packages/dnb-design-system-portal/vite/client/plugins/inject-scope.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/inject-scope.ts
@@ -191,12 +191,16 @@ export function injectScope(babel: { types: typeof BabelTypes }) {
  * known Eufemia scope symbols (excluding builtins like React hooks).
  */
 export function extractScopeIdentifiers(code: string): string[] {
-  // Strip comments and string literals to avoid false matches
-  const cleaned = code
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/.*$/gm, '')
-    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
-    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+  // Strip comments and string literals in a single pass so that
+  // sequences like // inside a string (e.g. "https://...") are consumed
+  // by the string pattern first and never treated as line comments.
+  const cleaned = code.replace(
+    /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|\/\*[\s\S]*?\*\/|\/\/.*$/gm,
+    (match) => {
+      if (match[0] === "'" || match[0] === '"') return '""'
+      return '' // comment
+    }
+  )
 
   const matches = cleaned.match(/\b([A-Z][a-zA-Z0-9]*)\b/g) || []
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/verifyGeneratedEntriesCommitted.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/verifyGeneratedEntriesCommitted.test.ts
@@ -4,50 +4,77 @@
  */
 
 import * as child_process from 'child_process'
-import {
-  GENERATED_ENTRY_FILE_PATTERNS,
-  verifyGeneratedEntriesCommitted,
-} from '../verifyGeneratedEntriesCommitted'
+import { verifyGeneratedEntriesCommitted } from '../verifyGeneratedEntriesCommitted'
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
 }))
 
 describe('verifyGeneratedEntriesCommitted', () => {
-  it('does not throw when there are no generated entry changes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not throw when there are no changes', () => {
     vi.spyOn(child_process, 'execSync').mockReturnValueOnce('' as any)
 
     expect(() => verifyGeneratedEntriesCommitted()).not.toThrow()
   })
 
-  it('throws when generated entries changed during build', () => {
+  it('ignores files written by makeReleaseVersion', () => {
     vi.spyOn(child_process, 'execSync').mockReturnValueOnce(
       [
         ' M src/shared/build-info/BuildInfoData.ts',
+        ' M src/shared/build-info/BuildInfoData.cjs',
+        ' M src/style/core/scopes.scss',
+        ' M src/scope-hash.txt',
+      ].join('\n') as any
+    )
+
+    expect(() => verifyGeneratedEntriesCommitted()).not.toThrow()
+  })
+
+  it('throws when tracked files changed during build', () => {
+    vi.spyOn(child_process, 'execSync').mockReturnValueOnce(
+      [
         ' M src/components/index.ts',
         ' M src/style/dnb-ui-components.scss',
       ].join('\n') as any
     )
 
     expect(() => verifyGeneratedEntriesCommitted()).toThrow(
-      'Generated entry files changed during CI prebuild'
+      'Generated files changed during CI prebuild'
     )
   })
 
-  it('throws when git status returns monorepo-root relative paths', () => {
+  it('normalizes monorepo-root relative paths', () => {
     vi.spyOn(child_process, 'execSync').mockReturnValueOnce(
-      [
-        ' M packages/dnb-eufemia/src/shared/build-info/BuildInfoData.js',
-        ' M packages/dnb-eufemia/src/style/dnb-ui-components.scss',
-      ].join('\n') as any
+      ' M packages/dnb-eufemia/src/components/index.ts' as any
     )
 
     expect(() => verifyGeneratedEntriesCommitted()).toThrow(
-      'Generated entry files changed during CI prebuild'
+      'src/components/index.ts'
     )
   })
 
-  it('checks all changed files and filters by generated entry patterns', () => {
+  it('lists changed files in the error message', () => {
+    vi.spyOn(child_process, 'execSync').mockReturnValueOnce(
+      [
+        ' M src/components/index.ts',
+        ' M src/style/themes/ui/properties.ts',
+      ].join('\n') as any
+    )
+
+    try {
+      verifyGeneratedEntriesCommitted()
+    } catch (e) {
+      const message = (e as Error).message
+      expect(message).toContain('- src/components/index.ts')
+      expect(message).toContain('- src/style/themes/ui/properties.ts')
+    }
+  })
+
+  it('runs git status with correct options', () => {
     vi.spyOn(child_process, 'execSync').mockReturnValueOnce('' as any)
 
     verifyGeneratedEntriesCommitted()
@@ -59,26 +86,5 @@ describe('verifyGeneratedEntriesCommitted', () => {
         encoding: 'utf-8',
       })
     )
-
-    expect(
-      GENERATED_ENTRY_FILE_PATTERNS.some((pattern) =>
-        pattern.test('src/components/index.ts')
-      )
-    ).toBe(true)
-    expect(
-      GENERATED_ENTRY_FILE_PATTERNS.some((pattern) =>
-        pattern.test('src/elements/H1.ts')
-      )
-    ).toBe(true)
-    expect(
-      GENERATED_ENTRY_FILE_PATTERNS.some((pattern) =>
-        pattern.test('src/extensions/lib.js')
-      )
-    ).toBe(true)
-    expect(
-      GENERATED_ENTRY_FILE_PATTERNS.some((pattern) =>
-        pattern.test('src/shared/build-info/BuildInfoData.ts')
-      )
-    ).toBe(false)
   })
 })

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -85,4 +85,23 @@ export async function makeReleaseVersion() {
       `Success on write to scope-hash.txt with scope hash: ${scopeHash}`
     )
   }
+
+  // Restore files locally so they don't show up as dirty in git status.
+  // On CI, the modified files are needed for the published build package.
+  if (!isCI) {
+    const packageRoot = require
+      .resolve('@dnb/eufemia/package.json')
+      .replace('/package.json', '')
+
+    execSync(
+      [
+        'git checkout --',
+        'src/shared/build-info/BuildInfoData.ts',
+        'src/shared/build-info/BuildInfoData.cjs',
+        'src/style/core/scopes.scss',
+        'src/scope-hash.txt',
+      ].join(' '),
+      { cwd: packageRoot }
+    )
+  }
 }

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/verifyGeneratedEntriesCommitted.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/verifyGeneratedEntriesCommitted.ts
@@ -1,20 +1,11 @@
 import path from 'path'
 import { execSync } from 'child_process'
 
-export const GENERATED_ENTRY_FILE_PATTERNS = [
-  /^src\/index\.(ts|js)$/,
-  /^src\/components\/index\.(ts|js)$/,
-  /^src\/components\/lib\.(ts|js)$/,
-  /^src\/elements\/index\.(ts|js)$/,
-  /^src\/elements\/lib\.(ts|js)$/,
-  /^src\/fragments\/index\.(ts|js)$/,
-  /^src\/fragments\/lib\.(ts|js)$/,
-  /^src\/extensions\/index\.(ts|js)$/,
-  /^src\/extensions\/lib\.(ts|js)$/,
-  /^src\/components\/[A-Z][A-Za-z0-9]*\.(ts|js)$/,
-  /^src\/elements\/[A-Z][A-Za-z0-9]*\.(ts|js)$/,
-  /^src\/fragments\/[A-Z][A-Za-z0-9]*\.(ts|js)$/,
-  /^src\/style\/dnb-ui-(components|elements|fragments|extensions|forms)\.scss$/,
+// Files written by makeReleaseVersion on every build — expected to be dirty after prebuild.
+const RELEASE_VERSION_FILES = [
+  /^src\/shared\/build-info\/BuildInfoData\.(ts|cjs)$/,
+  /^src\/style\/core\/scopes\.scss$/,
+  /^src\/scope-hash\.txt$/,
 ]
 
 const normalizeChangedFilePath = (file: string) =>
@@ -29,23 +20,22 @@ export const verifyGeneratedEntriesCommitted = () => {
       encoding: 'utf-8',
     }
   )
-    .trim()
     .split('\n')
-    .filter(Boolean)
+    .filter((line) => line.trim())
     .map((line) => line.slice(3).trim())
     .map(normalizeChangedFilePath)
-    .filter(Boolean)
-  const changedGeneratedEntries = changedFiles.filter((file) =>
-    GENERATED_ENTRY_FILE_PATTERNS.some((pattern) => pattern.test(file))
+
+  const unexpectedChanges = changedFiles.filter(
+    (file) => !RELEASE_VERSION_FILES.some((pattern) => pattern.test(file))
   )
 
-  if (changedGeneratedEntries.length > 0) {
+  if (unexpectedChanges.length > 0) {
     throw new Error(
       [
-        'Generated entry files changed during CI prebuild.',
-        'Please run the prebuild locally and commit the generated entries before pushing.',
+        'Generated files changed during CI prebuild.',
+        'Please run the prebuild locally and commit the changes before pushing.',
         '',
-        ...changedGeneratedEntries.map((file) => `- ${file}`),
+        ...unexpectedChanges.map((file) => `- ${file}`),
       ].join('\n')
     )
   }

--- a/packages/dnb-eufemia/src/style/themes/sbanken/sbanken-theme-components.scss
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/sbanken-theme-components.scss
@@ -34,4 +34,5 @@ $fonts-path: '../../../../assets/fonts/dnb' !default;
 @use '../../../fragments/drawer-list/style/themes/dnb-drawer-list-theme-sbanken.scss';
 @use '../../../components/icon/style/themes/dnb-icon-theme-ui.scss';
 @use '../../../components/timeline/style/themes/dnb-timeline-theme-ui.scss';
+@use '../../../components/toggle-button/style/themes/dnb-toggle-button-theme-ui.scss';
 @use './sbanken-theme-forms.scss';


### PR DESCRIPTION
Because we missed some generated files in the prebuild check, we now check all tracked files for changes instead of just the generated ones. This is simpler and more robust, and it also catches any other changes that might have been accidentally left unstaged.