### PR TITLE
feat(Icon): add `Icon.transition()` for animating between two icons

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -27,6 +27,7 @@ import {
   Button,
   Flex,
   Avatar,
+  FormStatus,
 } from '@dnb/eufemia/src'
 import styled from '@emotion/styled'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
@@ -235,10 +236,22 @@ export function AllIconsTest() {
 }
 
 export function IconTransitionExample() {
+  const notSupported = !Icon.transition.isSupported && (
+    <FormStatus state="warning" top>
+      Your browser does not support the Web Animations API, so the icon
+      transition will fall back to a simple crossfade.
+    </FormStatus>
+  )
   return (
     <ComponentBox
       data-visual-test="icon-transition"
-      scope={{ arrow_down, arrow_up, arrow_left, arrow_right }}
+      scope={{
+        arrow_down,
+        arrow_up,
+        arrow_left,
+        arrow_right,
+        notSupported,
+      }}
     >
       {() => {
         const directionIcon = Icon.transition({
@@ -258,21 +271,24 @@ export function IconTransitionExample() {
         }
 
         return (
-          <Flex.Horizontal align="center" gap="small">
-            <Icon icon={directionIcon} />
+          <>
+            <Flex.Horizontal align="center" gap="small">
+              <Icon icon={directionIcon} />
 
-            <Field.Selection
-              variant="button"
-              value="down"
-              optionsLayout="horizontal"
-              onChange={handleChange}
-            >
-              <Field.Option value="down" title="Down" />
-              <Field.Option value="up" title="Up" />
-              <Field.Option value="left" title="Left" />
-              <Field.Option value="right" title="Right" />
-            </Field.Selection>
-          </Flex.Horizontal>
+              <Field.Selection
+                variant="button"
+                value="down"
+                optionsLayout="horizontal"
+                onChange={handleChange}
+              >
+                <Field.Option value="down" title="Down" />
+                <Field.Option value="up" title="Up" />
+                <Field.Option value="left" title="Left" />
+                <Field.Option value="right" title="Right" />
+              </Field.Selection>
+            </Flex.Horizontal>
+            {notSupported}
+          </>
         )
       }}
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -9,6 +9,12 @@ import {
   bell as Bell,
   star as Star,
   heart as Heart,
+  arrow_down,
+  arrow_up,
+  arrow_left,
+  arrow_right,
+  question,
+  close,
 } from '@dnb/eufemia/src/icons'
 import * as PrimaryIconsMedium from '@dnb/eufemia/src/icons/dnb/primary_icons_medium'
 import * as SecondaryIconsMedium from '@dnb/eufemia/src/icons/dnb/secondary_icons_medium'
@@ -23,6 +29,7 @@ import {
   Avatar,
 } from '@dnb/eufemia/src'
 import styled from '@emotion/styled'
+import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export const IconDefault = () => (
   <ComponentBox
@@ -224,5 +231,88 @@ export function AllIconsTest() {
       <AllPrimaryIcons />
       <AllSecondaryIcons />
     </>
+  )
+}
+
+export function IconTransitionExample() {
+  return (
+    <ComponentBox
+      data-visual-test="icon-transition"
+      scope={{ arrow_down, arrow_up, arrow_left, arrow_right }}
+    >
+      {() => {
+        const directionIcon = Icon.transition({
+          down: arrow_down,
+          up: arrow_up,
+          left: arrow_left,
+          right: arrow_right,
+        })
+
+        const handleChange = (direction) => {
+          const iconEl = document.querySelector(
+            '[data-visual-test="icon-transition"] .dnb-icon'
+          ) as HTMLElement
+          if (iconEl) {
+            Icon.transition.activate(iconEl, direction)
+          }
+        }
+
+        return (
+          <Flex.Horizontal align="center" gap="small">
+            <Icon icon={directionIcon} />
+
+            <Field.Selection
+              variant="button"
+              value="down"
+              optionsLayout="horizontal"
+              onChange={handleChange}
+            >
+              <Field.Option value="down" title="Down" />
+              <Field.Option value="up" title="Up" />
+              <Field.Option value="left" title="Left" />
+              <Field.Option value="right" title="Right" />
+            </Field.Selection>
+          </Flex.Horizontal>
+        )
+      }}
+    </ComponentBox>
+  )
+}
+
+export function IconTransitionFallbackExample() {
+  return (
+    <ComponentBox
+      data-visual-test="icon-transition-fallback"
+      scope={{ question, close }}
+    >
+      {() => {
+        const helpIcon = Icon.transition({ question, close })
+
+        const handleChange = (state) => {
+          const iconEl = document.querySelector(
+            '[data-visual-test="icon-transition-fallback"] .dnb-icon'
+          ) as HTMLElement
+          if (iconEl) {
+            Icon.transition.activate(iconEl, state)
+          }
+        }
+
+        return (
+          <Flex.Horizontal align="center" gap="small">
+            <Icon icon={helpIcon} />
+
+            <Field.Selection
+              variant="button"
+              value="question"
+              optionsLayout="horizontal"
+              onChange={handleChange}
+            >
+              <Field.Option value="question" title="Question" />
+              <Field.Option value="close" title="Close" />
+            </Field.Selection>
+          </Flex.Horizontal>
+        )
+      }}
+    </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.mdx
@@ -9,6 +9,8 @@ import {
   IconInheritSized,
   IconColors,
   IconsSizes,
+  IconTransitionExample,
+  IconTransitionFallbackExample,
 } from 'Docs/uilib/components/icon/Examples'
 
 ## Demos
@@ -46,3 +48,17 @@ The official supported sizes are `default` and `medium`.
 **NB:** If you need to use the `large`, `x-large` or `xx-large` sizes, then you should use the `*_medium` version of the icon. Ensure you import the `*_medium` version of the icon.
 
 <IconsSizes />
+
+### Icon transition
+
+Use `Icon.transition()` to animate between SVG icon states. Define named states and use `Icon.transition.activate(element, state)` to switch between them.
+
+When icons have compatible path structures (same number and type of segments), the transition animates via CSS `d` property interpolation. This suits directional variants like `arrow_down` ↔ `arrow_up` or `chevron_down` ↔ `chevron_up`.
+
+<IconTransitionExample />
+
+### Icon transition fallback
+
+When icons have incompatible path structures (e.g. `question` ↔ `close`), `Icon.transition()` automatically falls back to a transform/opacity crossfade using stacked SVGs. The same `Icon.transition.activate()` API works for both modes.
+
+<IconTransitionFallbackExample />

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -13,6 +13,9 @@ exports[`Accordion scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -91,17 +94,44 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Accordion component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 .dnb-accordion {
   --accordion-color-text: var(--accordion-color-text--default);
   --accordion-color-description: var(

--- a/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -13,6 +13,9 @@ exports[`Anchor scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -91,6 +94,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -100,12 +136,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -153,10 +183,6 @@ p > .dnb-icon {
  * Anchor
  *
  */
-/*
-* Tooltip component
-*
-*/
 /*
  * Anchor mixins
  *

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -21,6 +21,9 @@ exports[`Autocomplete scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -99,6 +102,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -108,12 +144,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -159,10 +189,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -303,10 +329,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`Breadcrumb scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -13,6 +13,9 @@ exports[`Button scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -91,6 +94,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -100,12 +136,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -151,10 +181,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -295,10 +321,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -21,6 +21,9 @@ exports[`DatePicker scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -99,6 +102,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -108,12 +144,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -159,10 +189,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -303,10 +329,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -25,6 +25,9 @@ exports[`Dialog scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -103,6 +106,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -112,12 +148,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -163,10 +193,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -307,10 +333,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`Drawer scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -104,6 +107,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -113,12 +149,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -164,10 +194,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -308,10 +334,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -13,6 +13,9 @@ exports[`Dropdown scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -91,6 +94,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -108,12 +144,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -159,10 +189,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -303,10 +329,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *
@@ -1010,15 +1032,7 @@ legend.dnb-form-label {
 }
 
 /*
-* Tooltip component
-*
-*/
-/*
 * Dropdown component
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`GlobalError scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`GlobalStatus scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`HelpButton scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
@@ -1,14 +1,16 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import Context from '../../shared/Context'
 import { extendPropsWithContext } from '../../shared/component-helper'
-import type { IconAllProps, IconProps } from '../icon/Icon'
+import type { IconAllProps, IconFunction, IconProps } from '../icon/Icon'
 import { prerenderIcon, prepareIcon } from '../icon/Icon'
+import { transition } from '../icon/IconTransition'
 import { useSpacing } from '../space/SpacingUtils'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 // NB: The path reflects the tsdown.config.ts -> external: '../../icons/dnb/primary_icons'
 import * as primaryIcons from '../../icons/dnb/primary_icons'
 import * as primaryIconsMedium from '../../icons/dnb/primary_icons_medium'
-import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export * from '../icon/Icon'
 
@@ -29,10 +31,8 @@ export default function IconPrimary(localProps: IconAllProps) {
     context.IconPrimary
   )
 
-  const { icon, size, wrapperParams, iconParams, alt } = prepareIcon(
-    props,
-    context
-  )
+  const { icon, size, wrapperParams, iconParams, alt, transitionState } =
+    prepareIcon(props, context)
 
   const spacingProps = useSpacing(props, {
     className: wrapperParams.className,
@@ -46,12 +46,36 @@ export default function IconPrimary(localProps: IconAllProps) {
     listOfIcons: icons,
   })
 
+  const ref = useRef<HTMLSpanElement>(null)
+  const { ref: externalRef, ...restWrapperParams } =
+    wrapperParams as typeof wrapperParams & {
+      ref?: React.Ref<HTMLSpanElement>
+    }
+  const combinedRef = useCombinedRef(ref, externalRef)
+
+  useEffect(() => {
+    if (!transitionState || !ref.current) {
+      return // stop here
+    }
+
+    const iconFn = icon as IconFunction
+    if (iconFn?.__iconTransitionStyle) {
+      for (const [key, value] of Object.entries(
+        iconFn.__iconTransitionStyle
+      )) {
+        ref.current.style.setProperty(key, value)
+      }
+    }
+
+    transition.activate(ref.current, transitionState)
+  }, [transitionState, icon])
+
   if (!IconContainer) {
     return null
   }
 
   return (
-    <span {...wrapperParams} {...spacingProps}>
+    <span {...restWrapperParams} ref={combinedRef} {...spacingProps}>
       <IconContainer {...iconParams} />
     </span>
   )

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
@@ -1,11 +1,12 @@
-import { useContext, useEffect, useRef } from 'react'
+import { useContext, useRef } from 'react'
 import Context from '../../shared/Context'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import type { IconAllProps, IconFunction, IconProps } from '../icon/Icon'
 import { prerenderIcon, prepareIcon } from '../icon/Icon'
-import { transition } from '../icon/IconTransition'
+import { transition, suppressTransitions } from '../icon/IconTransition'
 import { useSpacing } from '../space/SpacingUtils'
 import useCombinedRef from '../../shared/helpers/useCombinedRef'
+import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 // NB: The path reflects the tsdown.config.ts -> external: '../../icons/dnb/primary_icons'
@@ -47,13 +48,14 @@ export default function IconPrimary(localProps: IconAllProps) {
   })
 
   const ref = useRef<HTMLSpanElement>(null)
+  const isInitialMount = useRef(true)
   const { ref: externalRef, ...restWrapperParams } =
     wrapperParams as typeof wrapperParams & {
       ref?: React.Ref<HTMLSpanElement>
     }
   const combinedRef = useCombinedRef(ref, externalRef)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!transitionState || !ref.current) {
       return // stop here
     }
@@ -67,7 +69,14 @@ export default function IconPrimary(localProps: IconAllProps) {
       }
     }
 
-    transition.activate(ref.current, transitionState)
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      suppressTransitions(ref.current, () => {
+        transition.activate(ref.current, transitionState)
+      })
+    } else {
+      transition.activate(ref.current, transitionState)
+    }
   }, [transitionState, icon])
 
   if (!IconContainer) {

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -1,10 +1,4 @@
-import {
-  isValidElement,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react'
+import { isValidElement, useContext, useMemo, useRef } from 'react'
 import type {
   ComponentType,
   HTMLProps,
@@ -29,7 +23,8 @@ import type { SkeletonShow } from '../Skeleton'
 import type { FormStatusIcon } from '../FormStatus'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import useCombinedRef from '../../shared/helpers/useCombinedRef'
-import { transition } from './IconTransition'
+import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
+import { transition, suppressTransitions } from './IconTransition'
 
 export const DefaultIconSize = 16
 export const DefaultIconSizes = {
@@ -166,13 +161,14 @@ export default function Icon(localProps: IconAllProps) {
   const icon = iconProp ?? children
 
   const ref = useRef<HTMLSpanElement>(null)
+  const isInitialMount = useRef(true)
   const { ref: externalRef, ...restWrapperParams } =
     wrapperParams as typeof wrapperParams & {
       ref?: React.Ref<HTMLSpanElement>
     }
   const combinedRef = useCombinedRef(ref, externalRef)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!transitionState || !ref.current) {
       return // stop here
     }
@@ -186,7 +182,14 @@ export default function Icon(localProps: IconAllProps) {
       }
     }
 
-    transition.activate(ref.current, transitionState)
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      suppressTransitions(ref.current, () => {
+        transition.activate(ref.current, transitionState)
+      })
+    } else {
+      transition.activate(ref.current, transitionState)
+    }
   }, [transitionState, icon])
 
   if (!icon) {

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -1,4 +1,10 @@
-import { isValidElement, useContext, useMemo } from 'react'
+import {
+  isValidElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import type {
   ComponentType,
   HTMLProps,
@@ -22,6 +28,8 @@ import type { SpacingProps } from '../../shared/types'
 import type { SkeletonShow } from '../Skeleton'
 import type { FormStatusIcon } from '../FormStatus'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
+import useCombinedRef from '../../shared/helpers/useCombinedRef'
+import { transition } from './IconTransition'
 
 export const DefaultIconSize = 16
 export const DefaultIconSizes = {
@@ -51,7 +59,10 @@ export type IconSVGProps = SVGProps<SVGSVGElement> & {
   title?: string
 }
 
-export type IconFunction = (props?: IconSVGProps) => JSX.Element
+export type IconFunction = ((props?: IconSVGProps) => JSX.Element) & {
+  __iconTransitionStyle?: Record<string, string>
+  __iconTransitionFallback?: boolean
+}
 
 /** For internal usage */
 type IconType = string | ReactElement<SVGElement> | IconFunction | false
@@ -121,6 +132,11 @@ export type IconProps = {
   width?: `${IconSize}` | `${number}%` | number
   height?: `${IconSize}` | `${number}%` | number
   children?: IconIcon
+
+  /**
+   * Activates a named Icon.transition() state on the icon element.
+   */
+  transitionState?: string
 }
 
 export type IconAllProps = IconProps &
@@ -145,8 +161,33 @@ export default function Icon(localProps: IconAllProps) {
     iconParams,
     alt,
     children,
+    transitionState,
   } = usePrepareIcon(props, context)
   const icon = iconProp ?? children
+
+  const ref = useRef<HTMLSpanElement>(null)
+  const { ref: externalRef, ...restWrapperParams } =
+    wrapperParams as typeof wrapperParams & {
+      ref?: React.Ref<HTMLSpanElement>
+    }
+  const combinedRef = useCombinedRef(ref, externalRef)
+
+  useEffect(() => {
+    if (!transitionState || !ref.current) {
+      return // stop here
+    }
+
+    const iconFn = icon as IconFunction
+    if (iconFn?.__iconTransitionStyle) {
+      for (const [key, value] of Object.entries(
+        iconFn.__iconTransitionStyle
+      )) {
+        ref.current.style.setProperty(key, value)
+      }
+    }
+
+    transition.activate(ref.current, transitionState)
+  }, [transitionState, icon])
 
   if (!icon) {
     return null
@@ -160,7 +201,7 @@ export default function Icon(localProps: IconAllProps) {
   }
 
   return (
-    <span {...wrapperParams}>
+    <span {...restWrapperParams} ref={combinedRef}>
       <IconContainer {...iconParams} />
     </span>
   )
@@ -364,6 +405,7 @@ export function prepareIcon(
     title,
     skeleton,
     className,
+    transitionState: _transitionState,
     ...attributes
   } = props
 
@@ -423,6 +465,12 @@ export function prepareIcon(
   )
 
   const iconToRender = getIcon(props)
+
+  if (typeof iconToRender === 'function') {
+    if (iconToRender.__iconTransitionFallback) {
+      wrapperParams.className += ' dnb-icon--transition-fallback'
+    }
+  }
 
   return {
     ...props,
@@ -522,3 +570,4 @@ function getIcon(props) {
 }
 
 withComponentMarkers(Icon, { _supportsSpacingProps: true })
+Icon.transition = transition

--- a/packages/dnb-eufemia/src/components/icon/IconTransition.tsx
+++ b/packages/dnb-eufemia/src/components/icon/IconTransition.tsx
@@ -1,0 +1,226 @@
+import { cloneElement } from 'react'
+import type { IconFunction, IconSVGProps } from './Icon'
+
+type Point = { cmd: string; x: number; y: number }
+
+/** True when the browser supports the CSS `d` property (Safari does not). */
+const supportsCssDProperty =
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('d: path("M0 0")')
+
+// Creates a morphable icon that transitions between SVG icon states via CSS `d` interpolation.
+// When the paths are structurally incompatible or CSS `d` is unsupported,
+// it falls back to stacked SVGs with a transform/opacity crossfade.
+export function transition(
+  states: Record<string, IconFunction>
+): IconFunction {
+  const entries = Object.entries(states)
+  const [defaultName, defaultIcon] = entries[0]
+  const defaultPoints = parsePath(extractPathD(defaultIcon))
+
+  const isCompatible =
+    transition.isSupported &&
+    defaultPoints.length > 0 &&
+    entries.every(([name, icon]) => {
+      const d = extractPathD(icon)
+
+      if (!isFullyParseable(d)) {
+        return false
+      }
+
+      if (name === defaultName) {
+        return true
+      }
+
+      const points = parsePath(d)
+      return points.length === defaultPoints.length
+    })
+
+  if (!isCompatible) {
+    return createFallbackTransition(entries, defaultName)
+  }
+
+  const style: Record<string, string> = {}
+
+  for (const [name, icon] of entries) {
+    const points =
+      name === defaultName
+        ? defaultPoints
+        : alignPath(defaultPoints, parsePath(extractPathD(icon)))
+
+    style[`--icon-transition-${name}`] =
+      `path('${pointsToString(points)}')`
+  }
+
+  style['--icon-transition-default'] =
+    `var(--icon-transition-${defaultName})`
+
+  const iconFn: IconFunction = (props?: IconSVGProps) => defaultIcon(props)
+  iconFn.__iconTransitionStyle = style
+  Object.defineProperty(iconFn, 'name', { value: defaultIcon.name })
+
+  return iconFn
+}
+
+/** Fallback: renders all SVGs stacked, toggling visibility via class. */
+function createFallbackTransition(
+  entries: Array<[string, IconFunction]>,
+  defaultName: string
+): IconFunction {
+  const iconFn: IconFunction = (props?: IconSVGProps) => (
+    <>
+      {entries.map(([name, iconRenderer]) => {
+        const element = iconRenderer(props)
+        return cloneElement(
+          element as React.ReactElement<Record<string, unknown>>,
+          {
+            key: name,
+            'data-icon-state': name,
+            ...(name === defaultName
+              ? { className: 'dnb-icon__state--active' }
+              : {}),
+          }
+        )
+      })}
+    </>
+  )
+
+  iconFn.__iconTransitionFallback = true
+  Object.defineProperty(iconFn, 'name', {
+    value: entries[0][1].name,
+  })
+
+  return iconFn
+}
+
+/**
+ * Activates a named transition state on an icon element.
+ * Works for both d-interpolation and fallback transitions.
+ */
+transition.activate = (element: HTMLElement, state: string) => {
+  if (element.classList.contains('dnb-icon--transition-fallback')) {
+    element.querySelectorAll('svg[data-icon-state]').forEach((svg) => {
+      svg.classList.toggle(
+        'dnb-icon__state--active',
+        (svg as SVGElement).dataset.iconState === state
+      )
+    })
+  } else {
+    element.style.setProperty(
+      '--icon-transition',
+      `var(--icon-transition-${state})`
+    )
+  }
+}
+
+transition.isSupported = supportsCssDProperty
+
+function extractPathD(iconFn: IconFunction): string {
+  const svg = iconFn() as React.ReactElement<
+    React.SVGProps<SVGSVGElement> & {
+      children?: React.ReactElement<{ d?: string }>
+    }
+  >
+
+  return svg.props.children?.props?.d
+}
+
+/** Returns true when every command in the path is one parsePath handles (M/L/H/V). */
+function isFullyParseable(d: string | undefined): boolean {
+  if (!d) {
+    return false
+  }
+
+  const parts = d.match(/[a-zA-Z][^a-zA-Z]*/g) || []
+  return parts.every((part) => 'mlhvMLHV'.includes(part[0]))
+}
+
+/** Parses an SVG path `d` string into absolute M/L points. */
+function parsePath(d: string | undefined): Point[] {
+  if (!d) {
+    return []
+  }
+
+  const parts = d.match(/[a-zA-Z][^a-zA-Z]*/g) || []
+  const points: Point[] = []
+  let x = 0
+  let y = 0
+
+  for (const part of parts) {
+    const command = part[0]
+    const type = command.toLowerCase()
+    const numbers = Array.from(
+      part.slice(1).matchAll(/-?\d*\.?\d+/g),
+      (match) => Number(match[0])
+    )
+    const isRelative = command === type
+    const resolve = (current: number, value: number) =>
+      isRelative ? current + value : value
+
+    if (type === 'm' || type === 'l') {
+      for (let i = 0; i < numbers.length; i += 2) {
+        x = resolve(x, numbers[i])
+        y = resolve(y, numbers[i + 1])
+        points.push({
+          cmd: i === 0 && type === 'm' ? 'M' : 'L',
+          x,
+          y,
+        })
+      }
+    } else if (type === 'h') {
+      x = resolve(x, numbers[0])
+      points.push({ cmd: 'L', x, y })
+    } else if (type === 'v') {
+      y = resolve(y, numbers[0])
+      points.push({ cmd: 'L', x, y })
+    }
+  }
+
+  return points
+}
+
+function pointsToString(points: Point[]): string {
+  return points
+    .map((point) => `${point.cmd}${point.x} ${point.y}`)
+    .join(' ')
+}
+
+function squaredDistance(pointsA: Point[], pointsB: Point[]): number {
+  return pointsA.reduce(
+    (sum, point, i) =>
+      sum + (point.x - pointsB[i].x) ** 2 + (point.y - pointsB[i].y) ** 2,
+    0
+  )
+}
+
+/** Reverses subpath point order when it reduces squared distance to the reference. */
+function alignPath(reference: Point[], target: Point[]): Point[] {
+  if (reference.length !== target.length || reference.length === 0) {
+    return target
+  }
+
+  // Split into subpaths (each starting with M)
+  const subpaths: Array<[Point[], Point[]]> = []
+
+  for (let i = 0; i < reference.length; i++) {
+    if (reference[i].cmd === 'M') {
+      subpaths.push([[], []])
+    }
+
+    subpaths[subpaths.length - 1][0].push(reference[i])
+    subpaths[subpaths.length - 1][1].push(target[i])
+  }
+
+  return subpaths.flatMap(([referenceSubpath, targetSubpath]) => {
+    const reversed = [...targetSubpath].reverse().map((point, index) => ({
+      ...point,
+      cmd: index === 0 ? 'M' : 'L',
+    }))
+
+    return squaredDistance(referenceSubpath, reversed) <
+      squaredDistance(referenceSubpath, targetSubpath)
+      ? reversed
+      : targetSubpath
+  })
+}

--- a/packages/dnb-eufemia/src/components/icon/IconTransition.tsx
+++ b/packages/dnb-eufemia/src/components/icon/IconTransition.tsx
@@ -114,6 +114,33 @@ transition.activate = (element: HTMLElement, state: string) => {
   }
 }
 
+/**
+ * Runs a callback with all CSS transitions disabled on the element
+ * and its SVG children, then restores them after a forced reflow.
+ */
+export function suppressTransitions(
+  element: HTMLElement,
+  callback: () => void
+) {
+  const targets = [
+    element,
+    ...Array.from(element.querySelectorAll<SVGElement>('svg, svg path')),
+  ]
+
+  for (const el of targets) {
+    el.style.setProperty('transition', 'none')
+  }
+
+  callback()
+
+  // Force reflow so the state change is committed without transitions
+  element.getBoundingClientRect()
+
+  for (const el of targets) {
+    el.style.removeProperty('transition')
+  }
+}
+
 transition.isSupported = supportsCssDProperty
 
 function extractPathD(iconFn: IconFunction): string {

--- a/packages/dnb-eufemia/src/components/icon/__tests__/IconTransition.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/IconTransition.test.tsx
@@ -1,0 +1,239 @@
+import { render, act } from '@testing-library/react'
+import { createRef } from 'react'
+import Icon from '../Icon'
+import { transition } from '../IconTransition'
+import arrow_down from '../../../icons/dnb/arrow_down'
+import arrow_up from '../../../icons/dnb/arrow_up'
+import arrow_left from '../../../icons/dnb/arrow_left'
+import arrow_right from '../../../icons/dnb/arrow_right'
+import chevron_down from '../../../icons/dnb/chevron_down'
+import chevron_up from '../../../icons/dnb/chevron_up'
+
+describe('Icon.transition', () => {
+  beforeEach(() => {
+    transition.isSupported = true
+  })
+
+  afterEach(() => {
+    transition.isSupported = false
+  })
+
+  it('is exposed as a static method on Icon', () => {
+    expect(Icon.transition).toBe(transition)
+  })
+
+  it('returns a function', () => {
+    const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+    expect(typeof icon).toBe('function')
+  })
+
+  it('renders the default (first) icon unchanged', () => {
+    const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+    render(<Icon icon={icon} />)
+
+    const path = document.querySelector('.dnb-icon svg path')
+    expect(path).toBeInTheDocument()
+
+    // The SVG attribute keeps the original path data — no modification
+    // so the icon renders identically to a non-transition icon
+    expect(path.getAttribute('d')).toBe('m3 9.75 5 5m0 0 5-5m-5 5V1.25')
+  })
+
+  it('sets named CSS custom properties on the wrapper when transitionState is provided', () => {
+    const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+    render(<Icon icon={icon} transitionState="asc" />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    expect(style).toContain('--icon-transition-asc')
+    expect(style).toContain('--icon-transition-desc')
+    expect(style).toContain('--icon-transition-default')
+    expect(style).toContain('var(--icon-transition-asc)')
+  })
+
+  it('does not set CSS custom properties without transitionState', () => {
+    const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+    render(<Icon icon={icon} />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    expect(style).toBeNull()
+  })
+
+  it('normalizes paths to absolute coordinates', () => {
+    const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+    render(<Icon icon={icon} transitionState="asc" />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    // arrow_down: m3 9.75 5 5m0 0 5-5m-5 5V1.25
+    expect(style).toContain(
+      "path('M3 9.75 L8 14.75 M8 14.75 L13 9.75 M8 14.75 L8 1.25')"
+    )
+
+    // arrow_up: m3 6.25 5-5m0 0 5 5m-5-5v13.5
+    // Last subpath reversed by alignPath to match arrow_down's direction
+    expect(style).toContain(
+      "path('M3 6.25 L8 1.25 M8 1.25 L13 6.25 M8 14.75 L8 1.25')"
+    )
+  })
+
+  it('supports more than two icon states', () => {
+    const icon = Icon.transition({
+      down: arrow_down,
+      up: arrow_up,
+      left: arrow_left,
+      right: arrow_right,
+    })
+
+    render(<Icon icon={icon} transitionState="down" />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    expect(style).toContain('--icon-transition-down')
+    expect(style).toContain('--icon-transition-up')
+    expect(style).toContain('--icon-transition-left')
+    expect(style).toContain('--icon-transition-right')
+    expect(style).toContain('--icon-transition-default')
+    expect(style).toContain('var(--icon-transition-down)')
+  })
+
+  it('defaults to the first state', () => {
+    const icon = Icon.transition({
+      left: arrow_left,
+      right: arrow_right,
+    })
+
+    render(<Icon icon={icon} transitionState="left" />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    expect(style).toContain(
+      '--icon-transition-default: var(--icon-transition-left)'
+    )
+  })
+
+  it('preserves icon props like width and height', () => {
+    const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+    render(<Icon icon={icon} width="32" height="32" />)
+
+    const svg = document.querySelector('.dnb-icon svg')
+    expect(svg.getAttribute('width')).toBe('32')
+    expect(svg.getAttribute('height')).toBe('32')
+  })
+
+  it('aligns cross-wired paths to avoid midpoint collapse', () => {
+    const icon = Icon.transition({
+      collapsed: chevron_down,
+      expanded: chevron_up,
+    })
+
+    render(<Icon icon={icon} transitionState="collapsed" />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    // chevron_down (default, kept as-is): M13 5.5 L8 10.5 L3 5.5
+    expect(style).toContain("path('M13 5.5 L8 10.5 L3 5.5')")
+
+    // chevron_up aligned to match chevron_down's point order:
+    // Original: M3 10.5 L8 5.5 L13 10.5 → Reversed: M13 10.5 L8 5.5 L3 10.5
+    expect(style).toContain("path('M13 10.5 L8 5.5 L3 10.5')")
+  })
+
+  describe('when CSS d interpolation is not supported', () => {
+    beforeEach(() => {
+      transition.isSupported = false
+    })
+
+    it('uses fallback crossfade even for structurally compatible paths', () => {
+      const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+      render(<Icon icon={icon} />)
+
+      const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+      expect(
+        wrapper.classList.contains('dnb-icon--transition-fallback')
+      ).toBe(true)
+
+      const svgs = wrapper.querySelectorAll('svg[data-icon-state]')
+      expect(svgs).toHaveLength(2)
+      expect(svgs[0].getAttribute('data-icon-state')).toBe('asc')
+      expect(svgs[1].getAttribute('data-icon-state')).toBe('desc')
+    })
+  })
+
+  describe('transitionState prop', () => {
+    it('activates CSS d transition state via inline style', () => {
+      const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+      render(<Icon icon={icon} transitionState="desc" />)
+
+      const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+      expect(wrapper.style.getPropertyValue('--icon-transition')).toBe(
+        'var(--icon-transition-desc)'
+      )
+    })
+
+    it('activates fallback state by toggling active class on SVGs', () => {
+      transition.isSupported = false
+
+      const icon = Icon.transition({
+        collapsed: chevron_down,
+        expanded: chevron_up,
+      })
+
+      render(<Icon icon={icon} transitionState="expanded" />)
+
+      const svgs = document.querySelectorAll('svg[data-icon-state]')
+      expect(svgs[0].classList.contains('dnb-icon__state--active')).toBe(
+        false
+      )
+      expect(svgs[1].classList.contains('dnb-icon__state--active')).toBe(
+        true
+      )
+    })
+
+    it('updates when transitionState changes', () => {
+      const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+
+      const { rerender } = render(
+        <Icon icon={icon} transitionState="asc" />
+      )
+
+      const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+      expect(wrapper.style.getPropertyValue('--icon-transition')).toBe(
+        'var(--icon-transition-asc)'
+      )
+
+      act(() => {
+        rerender(<Icon icon={icon} transitionState="desc" />)
+      })
+
+      expect(wrapper.style.getPropertyValue('--icon-transition')).toBe(
+        'var(--icon-transition-desc)'
+      )
+    })
+
+    it('preserves an external ref passed to Icon', () => {
+      const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
+      const externalRef = createRef<HTMLSpanElement>()
+
+      render(<Icon icon={icon} ref={externalRef} transitionState="desc" />)
+
+      expect(externalRef.current).toBeInstanceOf(HTMLSpanElement)
+      expect(externalRef.current.classList.contains('dnb-icon')).toBe(true)
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/components/icon/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`Icon scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -86,5 +89,38 @@ p > .dnb-icon {
 }
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
+}
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
 }"
 `;

--- a/packages/dnb-eufemia/src/components/icon/style/dnb-icon.scss
+++ b/packages/dnb-eufemia/src/components/icon/style/dnb-icon.scss
@@ -3,6 +3,8 @@
 *
 */
 
+@use '../../../style/core/utilities.scss' as utilities;
+
 .dnb-icon {
   display: inline-block;
 
@@ -125,5 +127,51 @@
       content: none !important;
     }
     color: var(--skeleton-color) !important;
+  }
+
+  // Icon.transition() — animate between SVG path states via CSS d property.
+  // non-scaling-stroke keeps stroke width constant when a 16×16 icon is
+  // displayed at a larger size (e.g. medium/24px wrapper).
+  &[style*='--icon-transition'] svg path {
+    d: var(--icon-transition, var(--icon-transition-default));
+    vector-effect: non-scaling-stroke;
+    transition: d 400ms var(--easing-default);
+
+    @include utilities.reducedMotion() {
+      transition-duration: 0.01ms;
+    }
+  }
+
+  // Icon.transition() fallback — crossfade stacked SVGs with transform
+  // when CSS d interpolation is not supported or paths are incompatible.
+  &--transition-fallback {
+    position: relative;
+
+    svg[data-icon-state] {
+      transition:
+        opacity 500ms var(--easing-default) 80ms,
+        transform 600ms var(--easing-default);
+
+      &:not(:first-of-type) {
+        position: absolute;
+        inset: 0;
+      }
+
+      &:not(.dnb-icon__state--active) {
+        opacity: 0;
+        transform: scale(0.5);
+      }
+
+      &.dnb-icon__state--active {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @include utilities.reducedMotion() {
+      svg[data-icon-state] {
+        transition-duration: 0.01ms;
+      }
+    }
   }
 }

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -21,6 +21,9 @@ exports[`InputMasked scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -99,6 +102,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -108,12 +144,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -159,10 +189,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -303,10 +329,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`Input scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -21,6 +21,9 @@ exports[`Modal scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -99,6 +102,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -108,12 +144,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -159,10 +189,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -303,10 +329,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`Pagination scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`SkipContent > scss has to match snapshot 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`Slider scss > has to match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`StepIndicator scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`Tag scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -95,6 +98,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -104,12 +140,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -155,10 +185,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -299,10 +325,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -69,6 +69,12 @@ legend.dnb-form-label {
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -147,21 +153,52 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
 *
 */
 /*
-* Tooltip component
+* Icon component
 *
 */
 /*
- * Utilities
- */
-/*
- * Utilities
- */
+* Tooltip component
+*
+*/
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -210,7 +247,7 @@ p > .dnb-icon {
 *
 */
 /*
-* Tooltip component
+* Icon component
 *
 */
 /*
@@ -352,7 +389,7 @@ button .dnb-form-status__text {
   }
 }
 /*
-* Tooltip component
+* Icon component
 *
 */
 /*
@@ -1024,7 +1061,7 @@ button.dnb-button::-moz-focus-inner {
 *
 */
 /*
-* Tooltip component
+* Icon component
 *
 */
 /*
@@ -1440,7 +1477,7 @@ html[data-whatinput=keyboard] .dnb-checkbox__input:not([disabled]):focus ~ .dnb-
 *
 */
 /*
-* Tooltip component
+* Icon component
 *
 */
 /*
@@ -1763,7 +1800,7 @@ html[data-whatinput=keyboard] .dnb-radio__input:focus ~ .dnb-radio__dot {
 }
 
 /*
-* Tooltip component
+* Icon component
 *
 */
 /*

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -13,6 +13,9 @@ exports[`Upload scss > should match style dependencies css 1`] = `
 * Icon component
 *
 */
+/*
+ * Utilities
+ */
 .dnb-icon {
   display: inline-block;
   vertical-align: middle;
@@ -91,6 +94,39 @@ p > .dnb-icon {
 .dnb-icon.dnb-skeleton {
   color: var(--skeleton-color) !important;
 }
+.dnb-icon[style*="--icon-transition"] svg path {
+  d: var(--icon-transition, var(--icon-transition-default));
+  vector-effect: non-scaling-stroke;
+  transition: d 400ms var(--easing-default);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon[style*="--icon-transition"] svg path {
+    transition-duration: 0.01ms;
+  }
+}
+.dnb-icon--transition-fallback {
+  position: relative;
+}
+.dnb-icon--transition-fallback svg[data-icon-state] {
+  transition: opacity 500ms var(--easing-default) 80ms, transform 600ms var(--easing-default);
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(:first-of-type) {
+  position: absolute;
+  inset: 0;
+}
+.dnb-icon--transition-fallback svg[data-icon-state]:not(.dnb-icon__state--active) {
+  opacity: 0;
+  transform: scale(0.5);
+}
+.dnb-icon--transition-fallback svg[data-icon-state].dnb-icon__state--active {
+  opacity: 1;
+  transform: scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-icon--transition-fallback svg[data-icon-state] {
+    transition-duration: 0.01ms;
+  }
+}
 
 /*
 * Used for snapshot testing
@@ -108,12 +144,6 @@ p > .dnb-icon {
 * Tooltip component
 *
 */
-/*
- * Utilities
- */
-/*
- * Utilities
- */
 :root {
   --tooltip-z-index: var(--z-index-tooltip);
 }
@@ -159,10 +189,6 @@ p > .dnb-icon {
 
 /*
 * Used for snapshot testing
-*
-*/
-/*
-* Tooltip component
 *
 */
 /*
@@ -303,10 +329,6 @@ button .dnb-form-status__text {
     border-color: var(--token-color-stroke-error);
   }
 }
-/*
-* Tooltip component
-*
-*/
 /*
 * Button component
 *
@@ -967,10 +989,6 @@ button.dnb-button::-moz-focus-inner {
   border: none;
 }
 
-/*
-* Tooltip component
-*
-*/
 /*
 * Upload component
 *


### PR DESCRIPTION
Use native CSS d interpolation to transition between icon families like arrow or chevron. In other words, use native CSS to do the work. So the footprint is is minimal code-wise.

It includes also a fallback transition/animation for when not identical segment count is detected. The fallback is based on the `InlineHelpButton` animation.

Following up commits for each effected components are ready for PR is merged.

Relevant changes: https://github.com/dnbexperience/eufemia/pull/8249/changes/413cafeb726020a4738e04eaef94dfc845e8c126
With Interpolation: https://feat-icon-transition.eufemia-e25.pages.dev/uilib/components/icon#icon-transition
With Fallback: https://feat-icon-transition.eufemia-e25.pages.dev/uilib/components/icon/#icon-transition-fallback


How it may look when used in components:

https://github.com/user-attachments/assets/098f5844-869e-4414-b105-c7644c927e1b


