### PR TITLE
fix(Accordion): only focus content when opening tertiary variant

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionTertiary.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionTertiary.tsx
@@ -86,7 +86,7 @@ export default function AccordionTertiary(props: AccordionTertiaryProps) {
       const next = !expanded
       set({
         expanded: next,
-        shouldFocusContent: shouldFocusContentFromClick(event),
+        shouldFocusContent: next && shouldFocusContentFromClick(event),
       })
       onChange?.({ expanded: next, event })
     },

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -840,6 +840,36 @@ describe('Accordion tertiary variant', () => {
     expect(document.activeElement).toBe(content)
   })
 
+  it('does not focus content when closing via keyboard', () => {
+    render(
+      <Accordion variant="tertiary" title="Toggle" noAnimation>
+        <p>Content</p>
+      </Accordion>
+    )
+
+    setInputIntent('keyboard')
+
+    const button = document.querySelector(
+      '.dnb-accordion__tertiary-button'
+    ) as HTMLElement
+
+    // Open
+    fireEvent.click(button, { detail: 0 })
+
+    const content = document.querySelector(
+      '.dnb-accordion__tertiary-content'
+    ) as HTMLElement
+    expect(document.activeElement).toBe(content)
+
+    // Move focus back to button before closing
+    button.focus()
+
+    // Close
+    fireEvent.click(button, { detail: 0 })
+
+    expect(document.activeElement).not.toBe(content)
+  })
+
   it('does not focus content when expanded programmatically', () => {
     const { rerender } = render(
       <Accordion variant="tertiary" title="Toggle" noAnimation>

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -895,10 +895,10 @@ describe('Accordion tertiary variant', () => {
         <Accordion
           variant="tertiary"
           title="Toggle"
-          id="focus-split"
+          id="focus-split-mouse"
           noAnimation
         />
-        <Accordion.Content id="focus-split" title="Details">
+        <Accordion.Content id="focus-split-mouse" title="Details">
           <p>Remote content</p>
         </Accordion.Content>
       </>
@@ -913,7 +913,7 @@ describe('Accordion tertiary variant', () => {
     fireEvent.mouseDown(button)
     fireEvent.click(button, { detail: 1 })
 
-    const content = document.getElementById('focus-split-content')
+    const content = document.getElementById('focus-split-mouse-content')
     expect(document.activeElement).not.toBe(content)
   })
 


### PR DESCRIPTION
The tertiary accordion's `shouldFocusContent` was being set on both open and close. This meant closing via keyboard would incorrectly attempt to focus the content area.

**Fix:** Gate `shouldFocusContent` on `next` being `true`, so focus is only moved when opening.

**Test:** Added a test that verifies closing via keyboard does not focus the content.