### PR TITLE
chore(Portal): scope all non-default theme selectors under brand class in portal PostCSS plugin

### DIFF
--- a/packages/dnb-design-system-portal/postcss-eufemia-theme-scope.cjs
+++ b/packages/dnb-design-system-portal/postcss-eufemia-theme-scope.cjs
@@ -13,6 +13,11 @@
  * to:
  *   .eufemia-scope--portal .eufemia-theme__sbanken.eufemia-theme__color-scheme--dark
  *
+ * And component selectors like:
+ *   .eufemia-scope--portal .dnb-accordion
+ * to:
+ *   .eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion
+ *
  * And comma patterns like:
  *   .eufemia-scope--portal, .eufemia-scope--portal .eufemia-theme__sbanken
  * to:
@@ -61,6 +66,18 @@ const plugin = () => {
           )
           if (colorSchemeMatch) {
             return `.${scopeClass} .${brandClass}${colorSchemeMatch[1]}`
+          }
+
+          // Catch-all: any other selector containing the scope class
+          // (e.g. component selectors like ".eufemia-scope--portal .dnb-accordion")
+          // Insert the brand class after the scope class so the styles
+          // only apply when the theme is active, not just when the
+          // style tag is enabled.
+          if (trimmed.includes(`.${scopeClass} `)) {
+            return trimmed.replace(
+              `.${scopeClass} `,
+              `.${scopeClass} .${brandClass} `
+            )
           }
 
           return sel

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/postcss-theme-scope.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/postcss-theme-scope.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import postcss from 'postcss'
+import plugin from '../../../postcss-eufemia-theme-scope.cjs'
+
+async function run(input: string, filePath: string) {
+  const result = await postcss([plugin()]).process(input, {
+    from: filePath,
+  })
+  return result.css
+}
+
+describe('postcss-eufemia-theme-scope', () => {
+  it('does not modify selectors for default theme files', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .dnb-accordion { color: red; }',
+      '/path/to/themes/ui/ui-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .dnb-accordion { color: red; }'
+    )
+  })
+
+  it('does not modify selectors for non-theme files', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .dnb-accordion { color: red; }',
+      '/path/to/components/accordion/style/dnb-accordion.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .dnb-accordion { color: red; }'
+    )
+  })
+
+  it('scopes standalone scope class under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal { --sb-color-text: #000; }',
+      '/path/to/themes/sbanken/sbanken-theme-basis.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken { --sb-color-text: #000; }'
+    )
+  })
+
+  it('scopes color scheme selectors under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .eufemia-theme__color-scheme--dark { --sb-color-text: #fff; }',
+      '/path/to/themes/sbanken/sbanken-theme-dark-mode.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken.eufemia-theme__color-scheme--dark { --sb-color-text: #fff; }'
+    )
+  })
+
+  it('scopes component selectors under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .dnb-accordion { --accordion-border-width: 0; }',
+      '/path/to/themes/sbanken/sbanken-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion { --accordion-border-width: 0; }'
+    )
+  })
+
+  it('scopes nested component selectors under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .dnb-accordion .dnb-accordion__header { color: red; }',
+      '/path/to/themes/sbanken/sbanken-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion .dnb-accordion__header { color: red; }'
+    )
+  })
+
+  it('skips selectors already scoped under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion { color: red; }',
+      '/path/to/themes/sbanken/sbanken-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion { color: red; }'
+    )
+  })
+
+  it('handles eiendom theme files', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .dnb-button { color: blue; }',
+      '/path/to/themes/eiendom/eiendom-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__eiendom .dnb-button { color: blue; }'
+    )
+  })
+
+  it('handles carnegie theme files', async () => {
+    const css = await run(
+      '.eufemia-scope--portal .dnb-card { padding: 1rem; }',
+      '/path/to/themes/carnegie/carnegie-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__carnegie .dnb-card { padding: 1rem; }'
+    )
+  })
+
+  it('handles comma-separated selectors with mixed patterns', async () => {
+    const css = await run(
+      '.eufemia-scope--portal, .eufemia-scope--portal .eufemia-theme__color-scheme--light { --sb-color-text: #000; }',
+      '/path/to/themes/sbanken/sbanken-theme-basis.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken, .eufemia-scope--portal .eufemia-theme__sbanken.eufemia-theme__color-scheme--light { --sb-color-text: #000; }'
+    )
+  })
+})


### PR DESCRIPTION
The `postcss-eufemia-theme-scope` plugin only scoped `:root`-replacement and color-scheme selectors. Component selectors like `.dnb-accordion` from sbanken/eiendom/carnegie theme files were left un-scoped, relying solely on style-tag disabling which can fail during Vite HMR (e.g. after a branch switch), causing wrong theme colors to leak into the portal.

This adds a catch-all that scopes all remaining selectors from non-default theme files under their brand class (e.g. `.eufemia-theme__sbanken`), providing CSS-level isolation regardless of style-tag state.

### Changes
- **`postcss-eufemia-theme-scope.cjs`** — added catch-all to scope component selectors (e.g. `.eufemia-scope--portal .dnb-accordion` → `.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion`)
- **`postcss-theme-scope.test.ts`** — added 10 tests covering all selector patterns, all non-default themes, and edge cases