### PR TITLE
fix(Table): use stable totalCount state for isLast instead of mutable ref

### DIFF
--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -142,7 +142,9 @@ const Table = (componentProps: TableAllProps) => {
   const { elementRef } = useStickyHeader(allProps)
   const mergedRef = useCombinedRef(elementRef, ref)
 
-  const { trCountRef, rerenderAlias } = useHandleOddEven({ children })
+  const { trCountRef, rerenderAlias, totalCount } = useHandleOddEven({
+    children,
+  })
   const collapseTrCallbacks = useRef<(() => void)[]>([])
 
   useEffect(() => {
@@ -186,6 +188,7 @@ const Table = (componentProps: TableAllProps) => {
         value={{
           trCountRef,
           rerenderAlias,
+          totalCount,
           collapseTrCallbacks,
           allProps: {
             ...allProps,

--- a/packages/dnb-eufemia/src/components/table/TableContext.ts
+++ b/packages/dnb-eufemia/src/components/table/TableContext.ts
@@ -13,6 +13,7 @@ type TableContextProps = {
     count: number
   }>
   rerenderAlias: Record<string, never>
+  totalCount: number
   collapseTrCallbacks: RefObject<(() => void)[]>
   allProps: TableAllProps & Translation['Table']
   hasAccordionRows?: boolean

--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -226,7 +226,9 @@ function useHandleTrVariant({ variant }) {
     currentVariant = count % 2 ? 'odd' : 'even'
   }
   const isLast =
-    typeof countRef !== 'undefined' && countRef.count === count
+    tableContext?.totalCount > 0
+      ? tableContext.totalCount === count
+      : typeof countRef !== 'undefined' && countRef.count === count
   return {
     currentVariant,
     isLast,
@@ -240,6 +242,11 @@ function useHandleTrVariant({ variant }) {
 export function useHandleOddEven({ children }) {
   // Create this ref in order to "auto" set even/odd class in tr elements
   const trCountRef = useRef({ count: 0 })
+
+  // Stable total count, updated after all Tr effects have settled.
+  // Reading countRef.count during render is unreliable because each Tr
+  // mutates it via increment(), so intermediate renders see partial values.
+  const [totalCount, setTotalCount] = useState(0)
 
   // When the alias changes, all tr's will rerender and get a new even/odd color
   // This is useful, when one tr gets removed
@@ -258,7 +265,12 @@ export function useHandleOddEven({ children }) {
     isMounted.current = true
   }, [children, forceRerender])
 
-  return { trCountRef, rerenderAlias, setRerenderAlias }
+  // Runs after all child (Tr) effects, so trCountRef.current.count is final.
+  useEffect(() => {
+    setTotalCount(trCountRef.current.count)
+  })
+
+  return { trCountRef, rerenderAlias, totalCount, setRerenderAlias }
 }
 
 Tr.AccordionContent = TableAccordionContentRow

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableTr.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableTr.test.tsx
@@ -446,4 +446,29 @@ describe('TableTr', () => {
       )
     })
   })
+
+  describe('isLast', () => {
+    it('should only set --last on the last Tr', () => {
+      render(
+        <Table>
+          <tbody>
+            <TableTr>
+              <td>row 1</td>
+            </TableTr>
+            <TableTr>
+              <td>row 2</td>
+            </TableTr>
+            <TableTr>
+              <td>row 3</td>
+            </TableTr>
+          </tbody>
+        </Table>
+      )
+
+      const rows = document.querySelectorAll('tbody tr')
+      expect(rows[0].classList.contains('dnb-table__tr--last')).toBe(false)
+      expect(rows[1].classList.contains('dnb-table__tr--last')).toBe(false)
+      expect(rows[2].classList.contains('dnb-table__tr--last')).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Problem

When a parent re-render causes Table's `children` reference to change (e.g. toggling "Show Code" in LiveProvider), `forceRerender()` resets `countRef.count = 0` and each `Tr` re-increments it via effects. During React's bail-out check renders, each row reads the mutable `countRef.count` at a point where it equals that row's own count, so `isLast` evaluates to `true` for every row. This causes all rows to get `dnb-table__tr--last` and lose their bottom `border-radius`.

## Solution

- Add a `totalCount` state in `useHandleOddEven` that captures the final `trCountRef.current.count` in a dependency-free `useEffect` (fires after all child Tr effects have settled).
- Thread `totalCount` through `TableContext`.
- In `useHandleTrVariant`, prefer `totalCount` over the mutable `countRef.count` for `isLast` computation.

This replaces the unreliable mutable ref read with a stable state value that correctly reflects the total number of rows.