### PR TITLE
chore(Portal): add title to icon-only buttons for accessibility

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -66,7 +66,7 @@ export const IconFilled = () => (
         <Icon icon={Star} fill />
         <Icon icon={Heart} fill />
         <Avatar icon={<Icon icon={Star} fill />} size="small" />
-        <Button icon={<Icon icon={Heart} fill />} />
+        <Button icon={<Icon icon={Heart} fill />} title="Favorite" />
       </Flex.Horizontal>
     </Flex.Stack>
   </ComponentBox>

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -187,6 +187,7 @@ export default function PortalToolsMenu({
         iconSize: 'medium',
         skeleton: false,
         left: 'x-small',
+        title: 'Portal Tools',
         tooltip: (
           <Tooltip
             placement={tooltipPosition}

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -209,6 +209,7 @@ function CopyCodeButton({
       className={className}
       variant={variant}
       icon={copied ? checkIcon : copyIcon}
+      title="Copy to clipboard"
       tooltip={copied ? 'Copied!' : 'Copy to clipboard'}
       onClick={handleCopy}
     />


### PR DESCRIPTION
Adds `title` props to icon-only `<Button>` components in the portal that were missing accessible labels, triggering the dev warning "Icon-only Button requires either a 'title' or 'aria-label' prop for accessibility."

### Changes

- **PortalToolsMenu**: Added `title: 'Portal Tools'` to the Drawer trigger button
- **CopyCodeButton** (CodeBlock): Added `title="Copy to clipboard"` — this was logged on every demo page since each `ComponentBox` renders one
- **Icon demos**: Added `title="Favorite"` to the icon-only Button in the filled icon example