### PR TITLE
chore(Portal): add missing Avatar.Group or hasLabel in portal examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.tsx
@@ -104,10 +104,12 @@ export const AvatarIconSize = () => (
     scope={{ Bank, BankMedium }}
     data-visual-test="avatar-children-icon-primary"
   >
-    <Avatar icon={Bank} size="small" />
-    <Avatar icon={BankMedium} />
-    <Avatar icon={BankMedium} size="large" />
-    <Avatar icon={BankMedium} size="x-large" />
+    <Avatar.Group label="Bank icons">
+      <Avatar icon={Bank} size="small" />
+      <Avatar icon={BankMedium} />
+      <Avatar icon={BankMedium} size="large" />
+      <Avatar icon={BankMedium} size="x-large" />
+    </Avatar.Group>
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -65,7 +65,7 @@ export const IconFilled = () => (
       <Flex.Horizontal align="center">
         <Icon icon={Star} fill />
         <Icon icon={Heart} fill />
-        <Avatar icon={<Icon icon={Star} fill />} size="small" />
+        <Avatar icon={<Icon icon={Star} fill />} size="small" hasLabel />
         <Button icon={<Icon icon={Heart} fill />} title="Favorite" />
       </Flex.Horizontal>
     </Flex.Stack>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
@@ -265,7 +265,9 @@ export const WithAvatar = () => {
       <List.Container>
         <List.Item.Basic title="Alice Andersen">
           <List.Cell.Start>
-            <Avatar size="medium">A</Avatar>
+            <Avatar size="medium" hasLabel>
+              A
+            </Avatar>
           </List.Cell.Start>
           <List.Cell.End>
             <NumberFormat.Currency value={1234} />
@@ -274,7 +276,9 @@ export const WithAvatar = () => {
 
         <List.Item.Action title="Bob Berg" onClick={() => {}}>
           <List.Cell.Start>
-            <Avatar size="medium">B</Avatar>
+            <Avatar size="medium" hasLabel>
+              B
+            </Avatar>
           </List.Cell.Start>
           <List.Cell.End>
             <Value.Currency value={5678} />
@@ -284,7 +288,9 @@ export const WithAvatar = () => {
         <List.Item.Accordion title="Carol with image">
           <List.Item.Accordion.Header>
             <List.Cell.Start>
-              <Avatar size="medium">C</Avatar>
+              <Avatar size="medium" hasLabel>
+                C
+              </Avatar>
             </List.Cell.Start>
             <List.Cell.End>Value</List.Cell.End>
           </List.Item.Accordion.Header>

--- a/packages/dnb-eufemia/src/components/list/stories/List.stories.tsx
+++ b/packages/dnb-eufemia/src/components/list/stories/List.stories.tsx
@@ -291,7 +291,9 @@ export function ListWithAvatar() {
         <List.Container>
           <List.Item.Basic title="Alice Andersen">
             <List.Cell.Start>
-              <Avatar size="medium">A</Avatar>
+              <Avatar size="medium" hasLabel>
+                A
+              </Avatar>
             </List.Cell.Start>
             <List.Cell.End>
               <Value.Currency value={1234} showEmpty />
@@ -300,7 +302,9 @@ export function ListWithAvatar() {
 
           <List.Item.Action title="Bob Berg" onClick={() => {}}>
             <List.Cell.Start>
-              <Avatar size="medium">B</Avatar>
+              <Avatar size="medium" hasLabel>
+                B
+              </Avatar>
             </List.Cell.Start>
             <List.Cell.End>
               <Value.Currency value={5678} showEmpty />
@@ -309,7 +313,9 @@ export function ListWithAvatar() {
 
           <List.Item.Basic title="Carol with image">
             <List.Cell.Start>
-              <Avatar size="medium">C</Avatar>
+              <Avatar size="medium" hasLabel>
+                C
+              </Avatar>
             </List.Cell.Start>
             <List.Cell.End>Value</List.Cell.End>
           </List.Item.Basic>


### PR DESCRIPTION
Fixes `Avatar group required` console warnings on portal pages by adding `hasLabel` to decorative Avatar usages in List and Icon examples, and wrapping the Avatar icon-size demo in `Avatar.Group`.

**Fixed files:**
- `icon/Examples.tsx` — Avatar with star icon: added `hasLabel`
- `list/Examples.tsx` — Avatar initials in list rows: added `hasLabel`
- `avatar/Examples.tsx` — AvatarIconSize demo: wrapped in `Avatar.Group`
- `list/stories/List.stories.tsx` — Avatar in stories: added `hasLabel`