### PR TITLE
chore(InputMasked): fix character filtering

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -397,9 +397,25 @@ function appendOverflowTokens(
     return maskExpression
   }
 
+  const lastUserSlot = getLastUserSlot(maskExpression)
+
   return maskExpression.concat(
-    Array.from({ length: overflow }, () => ALL_CHARACTERS)
+    Array.from({ length: overflow }, () => lastUserSlot)
   )
+}
+
+function getLastUserSlot(maskExpression: MaskitoMaskExpression): RegExp {
+  if (!Array.isArray(maskExpression)) {
+    return ALL_CHARACTERS
+  }
+
+  for (let i = maskExpression.length - 1; i >= 0; i--) {
+    if (maskExpression[i] instanceof RegExp) {
+      return maskExpression[i] as RegExp
+    }
+  }
+
+  return ALL_CHARACTERS
 }
 
 function countUserSlots(maskExpression: MaskitoMaskExpression) {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMasked.test.tsx
@@ -484,6 +484,21 @@ describe('InputMasked component', () => {
     expect(input).toHaveValue('123 456 7890')
   })
 
+  it('should reject non-matching characters in overflow', async () => {
+    render(
+      <InputMasked
+        allowOverflow
+        mask={[/\d/, /\d/, /\d/, '-', /\d/, /\d/]}
+      />
+    )
+
+    const input = document.querySelector('input')
+
+    await userEvent.type(input, '12345abc678')
+
+    expect(input).toHaveValue('123-45678')
+  })
+
   it('should keep overflow characters when the value prop contains more digits than the mask', async () => {
     const mask = [
       /\d/,


### PR DESCRIPTION
Fixes the mask issue where you can input letters when `allowOverflow` is active.

Fixes:
https://github.com/dnbexperience/eufemia/pull/8229
https://github.com/dnbexperience/eufemia/pull/8227
https://github.com/dnbexperience/eufemia/pull/8226
https://github.com/dnbexperience/eufemia/pull/8225
https://github.com/dnbexperience/eufemia/pull/8224

Chose the chore decorator, as I'm unsure if this needs to be in the release note or not 😄