### PR TITLE
chore(Portal): skip git-branch fetch in production builds

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/BranchBanner.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/BranchBanner.tsx
@@ -5,7 +5,7 @@ export default function BranchBanner() {
   const [branch, setBranch] = useState('')
 
   useEffect(() => {
-    if (globalThis.IS_TEST) {
+    if (!import.meta.hot || globalThis.IS_TEST) {
       return // stop here
     }
 
@@ -21,11 +21,9 @@ export default function BranchBanner() {
         // ignore
       })
 
-    if (import.meta.hot) {
-      import.meta.hot.on('git-branch:update', (data) => {
-        setBranch(data.branch)
-      })
-    }
+    import.meta.hot.on('git-branch:update', (data) => {
+      setBranch(data.branch)
+    })
   }, [])
 
   if (!branch) {


### PR DESCRIPTION
Fix for #8256 prod issue.

The `BranchBanner` component was unconditionally fetching `/__git-branch` in all environments, causing a 404 in production builds (the server middleware only runs in dev via `apply: 'serve'`).

Guard the entire effect behind `import.meta.hot` so both the fetch and the HMR listener are skipped in production.