### PR TITLE
chore(Portal): resolve transitive CSS deps during prerender to prevent flicker

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -10,7 +10,11 @@ import {
   getOutputPath,
 } from '../../prod/prerender-utils'
 import { getContentScript } from '@dnb/eufemia/src/shared/ColorSchemeScript'
-import type { RouteEntry, SSRManifest } from '../../prod/prerender-utils'
+import type {
+  RouteEntry,
+  SSRManifest,
+  ClientManifest,
+} from '../../prod/prerender-utils'
 
 describe('prerender-utils', () => {
   describe('collectUrls', () => {
@@ -265,6 +269,135 @@ describe('prerender-utils', () => {
         manifest
       )
       expect(preloads.js).toEqual(['/assets/button-abc123.js'])
+    })
+
+    it('collects transitive CSS from client manifest imports', () => {
+      const ssrManifest: SSRManifest = {
+        '../../src/docs/index.tsx': ['/assets/docs-abc.js'],
+      }
+      const clientManifest: ClientManifest = {
+        '../../src/docs/index.tsx': {
+          file: 'assets/docs-abc.js',
+          imports: ['_Card-chunk.js'],
+        },
+        '_Card-chunk.js': {
+          file: 'assets/Card-chunk.js',
+          css: ['assets/Card-styles.css'],
+        },
+      }
+
+      const preloads = getRoutePreloads('/', ssrManifest, clientManifest)
+      expect(preloads.css).toContain('/assets/Card-styles.css')
+    })
+
+    it('collects CSS through multiple levels of imports', () => {
+      const ssrManifest: SSRManifest = {
+        '../../src/docs/index.tsx': ['/assets/docs-abc.js'],
+      }
+      const clientManifest: ClientManifest = {
+        '../../src/docs/index.tsx': {
+          file: 'assets/docs-abc.js',
+          imports: ['_MenuWrapper.js'],
+        },
+        '_MenuWrapper.js': {
+          file: 'assets/MenuWrapper.js',
+          imports: ['_Card.js'],
+        },
+        '_Card.js': {
+          file: 'assets/Card.js',
+          css: ['assets/Card.css'],
+        },
+      }
+
+      const preloads = getRoutePreloads('/', ssrManifest, clientManifest)
+      expect(preloads.css).toContain('/assets/Card.css')
+    })
+
+    it('skips the index.html entry point to avoid duplicating template CSS', () => {
+      const ssrManifest: SSRManifest = {
+        '../../src/docs/index.tsx': ['/assets/docs-abc.js'],
+      }
+      const clientManifest: ClientManifest = {
+        '../../src/docs/index.tsx': {
+          file: 'assets/docs-abc.js',
+          imports: ['index.html', '_Card.js'],
+        },
+        'index.html': {
+          file: 'assets/index-entry.js',
+          css: ['assets/index-entry.css'],
+        },
+        '_Card.js': {
+          file: 'assets/Card.js',
+          css: ['assets/Card.css'],
+        },
+      }
+
+      const preloads = getRoutePreloads('/', ssrManifest, clientManifest)
+      expect(preloads.css).toContain('/assets/Card.css')
+      expect(preloads.css).not.toContain('/assets/index-entry.css')
+    })
+
+    it('does not loop on circular imports', () => {
+      const ssrManifest: SSRManifest = {
+        '../../src/docs/index.tsx': ['/assets/docs-abc.js'],
+      }
+      const clientManifest: ClientManifest = {
+        '../../src/docs/index.tsx': {
+          file: 'assets/docs-abc.js',
+          imports: ['_A.js'],
+        },
+        '_A.js': {
+          file: 'assets/A.js',
+          imports: ['_B.js'],
+          css: ['assets/A.css'],
+        },
+        '_B.js': {
+          file: 'assets/B.js',
+          imports: ['_A.js'],
+          css: ['assets/B.css'],
+        },
+      }
+
+      const preloads = getRoutePreloads('/', ssrManifest, clientManifest)
+      expect(preloads.css).toContain('/assets/A.css')
+      expect(preloads.css).toContain('/assets/B.css')
+    })
+
+    it('works without a client manifest (backwards compatible)', () => {
+      const preloads = getRoutePreloads('/', manifest)
+      expect(preloads.js).toEqual(['/assets/index-xyz789.js'])
+      expect(preloads.css).toEqual(['/assets/index-abc.css'])
+    })
+
+    it('works with null client manifest', () => {
+      const preloads = getRoutePreloads('/', manifest, null)
+      expect(preloads.js).toEqual(['/assets/index-xyz789.js'])
+      expect(preloads.css).toEqual(['/assets/index-abc.css'])
+    })
+
+    it('deduplicates CSS found via both SSR and client manifests', () => {
+      const ssrManifest: SSRManifest = {
+        '../../src/docs/index.tsx': [
+          '/assets/docs-abc.js',
+          '/assets/shared.css',
+        ],
+      }
+      const clientManifest: ClientManifest = {
+        '../../src/docs/index.tsx': {
+          file: 'assets/docs-abc.js',
+          imports: ['_Chunk.js'],
+        },
+        '_Chunk.js': {
+          file: 'assets/Chunk.js',
+          css: ['assets/shared.css'],
+        },
+      }
+
+      const preloads = getRoutePreloads('/', ssrManifest, clientManifest)
+      const cssCount = preloads.css.filter(
+        (c) => c === '/assets/shared.css'
+      ).length
+      expect(cssCount).toBe(1)
     })
   })
 

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -18,6 +18,17 @@ export type RouteEntry = {
 
 export type SSRManifest = Record<string, string[]>
 
+export type ClientManifestEntry = {
+  file: string
+  name?: string
+  src?: string
+  isDynamicEntry?: boolean
+  imports?: string[]
+  css?: string[]
+}
+
+export type ClientManifest = Record<string, ClientManifestEntry>
+
 export type MdxNode = {
   fields: { slug: string }
   frontmatter: Record<string, unknown>
@@ -166,10 +177,17 @@ export function getMdPath(
 /**
  * Map a URL to its per-route preload assets from the SSR manifest.
  * Returns JS files for modulepreload and CSS files for stylesheet links.
+ *
+ * When a client manifest is provided, performs a BFS through chunk
+ * imports to discover transitive CSS dependencies. Without this,
+ * CSS modules imported by non-route source files (e.g. shared menu
+ * components) would only load after JS executes, causing a layout
+ * flicker on prerendered pages.
  */
 export function getRoutePreloads(
   url: string,
-  ssrManifest: SSRManifest
+  ssrManifest: SSRManifest,
+  clientManifest?: ClientManifest | null
 ): { js: string[]; css: string[] } {
   const routePath = url.replace(/^\/|\/$/g, '') || 'index'
 
@@ -191,6 +209,52 @@ export function getRoutePreloads(
           jsPreloads.add(asset)
         } else if (asset.endsWith('.css')) {
           cssPreloads.add(asset)
+        }
+      }
+    }
+  }
+
+  if (clientManifest && jsPreloads.size > 0) {
+    const fileToEntry = new Map<string, ClientManifestEntry>()
+    for (const entry of Object.values(clientManifest)) {
+      if (entry.file) {
+        fileToEntry.set('/' + entry.file, entry)
+      }
+    }
+
+    const visited = new Set<string>()
+    const queue = Array.from(jsPreloads)
+
+    while (queue.length > 0) {
+      const chunk = queue.shift()!
+      if (visited.has(chunk)) {
+        continue
+      }
+      visited.add(chunk)
+
+      const entry = fileToEntry.get(chunk)
+      if (!entry) {
+        continue
+      }
+
+      if (entry.css) {
+        for (const css of entry.css) {
+          cssPreloads.add('/' + css)
+        }
+      }
+
+      if (entry.imports) {
+        for (const imp of entry.imports) {
+          if (imp === 'index.html') {
+            continue
+          }
+          const impEntry = clientManifest[imp]
+          if (impEntry?.file) {
+            const impPath = '/' + impEntry.file
+            if (!visited.has(impPath)) {
+              queue.push(impPath)
+            }
+          }
         }
       }
     }

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -38,6 +38,7 @@ async function prerender() {
     build: {
       outDir,
       ssrManifest: true,
+      manifest: true,
     },
   })
 
@@ -75,6 +76,15 @@ async function prerender() {
   const ssrManifest = fs.existsSync(manifestPath)
     ? JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
     : {}
+
+  // Read the client build manifest for chunk dependency tracking.
+  // The client manifest has `imports` and `css` fields per chunk,
+  // letting us follow transitive CSS dependencies that the SSR
+  // manifest alone cannot resolve.
+  const clientManifestPath = path.resolve(outDir, '.vite', 'manifest.json')
+  const clientManifest = fs.existsSync(clientManifestPath)
+    ? JSON.parse(fs.readFileSync(clientManifestPath, 'utf-8'))
+    : null
 
   const contentScript = getContentScript()
   let urls = collectUrls(routes)
@@ -134,7 +144,7 @@ async function prerender() {
     if (result.redirect) {
       writeHtml(url, buildRedirectHtml(result.redirect))
     } else {
-      const preloads = getRoutePreloads(url, ssrManifest)
+      const preloads = getRoutePreloads(url, ssrManifest, clientManifest)
       const meta = getPageMeta(url, allMdxNodes)
       const mdPath = getMdPath(url, allMdxNodes)
       const html = injectHtml(
@@ -348,7 +358,7 @@ function getMdPath(url, allMdxNodes) {
   return null
 }
 
-function getRoutePreloads(url, ssrManifest) {
+function getRoutePreloads(url, ssrManifest, clientManifest) {
   const routePath = url.replace(/^\/|\/$/g, '') || 'index'
 
   const candidates = [
@@ -369,6 +379,62 @@ function getRoutePreloads(url, ssrManifest) {
           jsPreloads.add(asset)
         } else if (asset.endsWith('.css')) {
           cssPreloads.add(asset)
+        }
+      }
+    }
+  }
+
+  // Use the client manifest to find CSS chunks that are transitively
+  // imported by the route's JS chunks. Without this, CSS modules
+  // imported by non-route source files (e.g. shared menu components)
+  // would only load after JS executes, causing a layout flicker on
+  // prerendered pages.
+  if (clientManifest && jsPreloads.size > 0) {
+    // Build a lookup from output file path to manifest entry
+    const fileToEntry = new Map()
+    for (const entry of Object.values(clientManifest)) {
+      if (entry.file) {
+        fileToEntry.set('/' + entry.file, entry)
+      }
+    }
+
+    // BFS through chunk imports to collect all transitive CSS
+    const visited = new Set()
+    const queue = [...jsPreloads]
+
+    while (queue.length > 0) {
+      const chunk = queue.shift()
+      if (visited.has(chunk)) {
+        continue
+      }
+      visited.add(chunk)
+
+      const entry = fileToEntry.get(chunk)
+      if (!entry) {
+        continue
+      }
+
+      // Collect CSS associated with this chunk
+      if (entry.css) {
+        for (const css of entry.css) {
+          cssPreloads.add('/' + css)
+        }
+      }
+
+      // Follow static imports (skip the entry point — its CSS
+      // is already in the HTML template)
+      if (entry.imports) {
+        for (const imp of entry.imports) {
+          if (imp === 'index.html') {
+            continue
+          }
+          const impEntry = clientManifest[imp]
+          if (impEntry?.file) {
+            const impPath = '/' + impEntry.file
+            if (!visited.has(impPath)) {
+              queue.push(impPath)
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem

After #8233 replaced Emotion-styled card components with `Card.Action`/`Card.List` sub-components, the home page cards started flickering on load. The old Emotion styles were extracted during `renderToString` and inlined as `<style>` tags in `<head>` — always render-blocking. The new CSS module styles (`MainMenu.module.scss`) compile into a lazy-loaded CSS chunk that only loads after JS executes, causing a visible layout shift.

## Solution

Use Vite's client build manifest (`manifest: true`) to BFS through chunk import dependencies and discover transitive CSS files. These are then injected as render-blocking `<link rel="stylesheet">` tags in the prerendered HTML, ensuring CSS modules imported by shared components (not just route files) are available before first paint.

### Changes

- **prerender.mjs**: Enable `manifest: true` in client build, load the client manifest, pass it to `getRoutePreloads`, and add BFS traversal through chunk `imports`/`css` fields
- **prerender-utils.ts**: Sync the testable source-of-truth with the same BFS logic and add `ClientManifest` types
- **prerender-utils.test.ts**: Add 7 tests covering transitive CSS resolution, multi-level imports, circular import safety, entry-point deduplication, and backwards compatibility