### PR TITLE
docs(ProgressIndicator): improve documentation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
@@ -161,12 +161,6 @@ export const ProgressIndicatorLinearDefaultExample = () => (
   </ComponentBox>
 )
 
-export const ProgressIndicatorLinearSmallExample = () => (
-  <ComponentBox>
-    <ProgressIndicator type="linear" size="small" />
-  </ComponentBox>
-)
-
 export const ProgressIndicatorLinearLabelHorizontalExample = () => (
   <ComponentBox>
     <ProgressIndicator

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/Examples.tsx
@@ -8,7 +8,6 @@ import styled from '@emotion/styled'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
 import {
   ProgressIndicator,
-  Button,
   Dialog,
   Flex,
   IconPrimary,
@@ -18,12 +17,6 @@ import {
 export const ProgressIndicatorDefaultExample = () => (
   <ComponentBox>
     <ProgressIndicator />
-  </ComponentBox>
-)
-
-export const ProgressIndicatorCircularExample = () => (
-  <ComponentBox>
-    <ProgressIndicator type="circular" />
   </ComponentBox>
 )
 
@@ -80,37 +73,6 @@ export const ProgressIndicatorCircularPrimaryExample = () => (
       size="large"
       noAnimation
     />
-  </ComponentBox>
-)
-
-export const ProgressIndicatorCircularRandomExample = () => (
-  <ComponentBox>
-    {() => {
-      const ChangeValue = () => {
-        const [value, setValue] = useState(50)
-        return (
-          <Flex.Horizontal align="center">
-            <ProgressIndicator
-              type="circular"
-              progress={value}
-              showDefaultLabel
-              labelDirection="horizontal"
-              noAnimation
-            />
-            <Button
-              left
-              size="small"
-              variant="secondary"
-              onClick={() => setValue(Math.random() * 100)}
-            >
-              Change
-            </Button>
-          </Flex.Horizontal>
-        )
-      }
-
-      return <ChangeValue />
-    }}
   </ComponentBox>
 )
 
@@ -233,35 +195,6 @@ export const ProgressIndicatorLinearLargeExample = () => (
   </ComponentBox>
 )
 
-export const ProgressIndicatorLinearRandomExample = () => (
-  <ComponentBox>
-    {() => {
-      const ChangeValue = () => {
-        const [value, setValue] = useState(50)
-        return (
-          <Flex.Horizontal align="center">
-            <ProgressIndicator
-              type="linear"
-              progress={value}
-              noAnimation
-            />
-            <Button
-              left
-              size="small"
-              variant="secondary"
-              onClick={() => setValue(Math.random() * 100)}
-            >
-              Change
-            </Button>
-          </Flex.Horizontal>
-        )
-      }
-
-      return <ChangeValue />
-    }}
-  </ComponentBox>
-)
-
 export const ProgressIndicatorLinearRandomTransitionExample = () => (
   <ComponentBox>
     {() => {
@@ -280,57 +213,6 @@ export const ProgressIndicatorLinearRandomTransitionExample = () => (
       }
       return <Example />
     }}
-  </ComponentBox>
-)
-
-export const ProgressIndicatorLinearRandomOnCompleteExample = () => (
-  <ComponentBox>
-    {() => {
-      const Example = () => {
-        const random = (min, max) =>
-          Math.floor(Math.random() * (max - min + 1)) + min
-        const [show, setShow] = useState(true)
-        useEffect(() => {
-          const timer = setInterval(
-            () => setShow(!show),
-            random(2400, 4200)
-          )
-          return () => clearTimeout(timer)
-        })
-        return (
-          <ProgressIndicator
-            type="linear"
-            size="large"
-            show={show}
-            onComplete={() => {
-              console.log('onCompleteLinear')
-            }}
-          />
-        )
-      }
-      return <Example />
-    }}
-  </ComponentBox>
-)
-
-export const ProgressIndicatorLinearDialogExample = () => (
-  <ComponentBox>
-    <Dialog
-      spacing={false}
-      maxWidth="12rem"
-      fullscreen={false}
-      alignContent="centered"
-      hideCloseButton
-      triggerAttributes={{ text: 'Show' }}
-      preventClose={false}
-    >
-      <ProgressIndicator
-        type="linear"
-        showDefaultLabel
-        top="large"
-        bottom="large"
-      />
-    </Dialog>
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.mdx
@@ -12,7 +12,6 @@ import {
   ProgressIndicatorCircularRandomOnCompleteExample,
   ProgressIndicatorCircularDialogExample,
   ProgressIndicatorLinearDefaultExample,
-  ProgressIndicatorLinearSmallExample,
   ProgressIndicatorLinearLabelHorizontalExample,
   ProgressIndicatorLinearLabelVerticalExample,
   ProgressIndicatorLinearLargeExample,
@@ -34,10 +33,6 @@ When the duration is unknown, omit the `progress` prop to show a continuous anim
 The `linear` type works well for wider layouts, such as the top of a page or section.
 
 <ProgressIndicatorLinearDefaultExample />
-
-A smaller linear variant can be useful for inline or compact contexts.
-
-<ProgressIndicatorLinearSmallExample />
 
 ### Determinate (known progress)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/demos.mdx
@@ -4,12 +4,10 @@ showTabs: true
 
 import {
   ProgressIndicatorDefaultExample,
-  ProgressIndicatorCircularExample,
   ProgressIndicatorCircularLabelHorizontalExample,
   ProgressIndicatorCircularLabelVerticalExample,
   ProgressIndicatorCircularLabelInsideExample,
   ProgressIndicatorCircularPrimaryExample,
-  ProgressIndicatorCircularRandomExample,
   ProgressIndicatorCircularRandomTransitionExample,
   ProgressIndicatorCircularRandomOnCompleteExample,
   ProgressIndicatorCircularDialogExample,
@@ -18,10 +16,7 @@ import {
   ProgressIndicatorLinearLabelHorizontalExample,
   ProgressIndicatorLinearLabelVerticalExample,
   ProgressIndicatorLinearLargeExample,
-  ProgressIndicatorLinearRandomExample,
   ProgressIndicatorLinearRandomTransitionExample,
-  ProgressIndicatorLinearRandomOnCompleteExample,
-  ProgressIndicatorLinearDialogExample,
   ProgressIndicatorCountdownExample,
   ProgressIndicatorCustomCountdown,
   ProgressIndicatorCustomHorizontal,
@@ -30,91 +25,81 @@ import {
 
 ## Demos
 
-### Default ProgressIndicator is Circular
+### Indeterminate (unknown progress)
+
+When the duration is unknown, omit the `progress` prop to show a continuous animation. The default type is `circular`.
 
 <ProgressIndicatorDefaultExample />
 
-### Default Circular ProgressIndicator
-
-<ProgressIndicatorCircularExample />
-
-### Circular ProgressIndicator with a label in a horizontal direction
-
-<ProgressIndicatorCircularLabelHorizontalExample />
-
-### Circular ProgressIndicator with a label in a vertical direction
-
-<ProgressIndicatorCircularLabelVerticalExample />
-
-### Circular ProgressIndicator with a label inside
-
-Inside labels must be carefully sized, and are generally meant for just an icon or a number.
-
-<ProgressIndicatorCircularLabelInsideExample />
-
-### Shows a large Circular ProgressIndicator with a static 50% in progress
-
-<ProgressIndicatorCircularPrimaryExample />
-
-### Circular ProgressIndicator with random value
-
-<ProgressIndicatorCircularRandomExample />
-
-### Circular ProgressIndicator with random progress value to show the transition
-
-<ProgressIndicatorCircularRandomTransitionExample />
-
-### Circular ProgressIndicator with random `onComplete` callback
-
-<ProgressIndicatorCircularRandomOnCompleteExample />
-
-### Circular ProgressIndicator inside a Dialog
-
-<ProgressIndicatorCircularDialogExample />
-
-### Default Linear ProgressIndicator
+The `linear` type works well for wider layouts, such as the top of a page or section.
 
 <ProgressIndicatorLinearDefaultExample />
 
-### Small Linear ProgressIndicator
+A smaller linear variant can be useful for inline or compact contexts.
 
 <ProgressIndicatorLinearSmallExample />
 
-### Linear ProgressIndicator with a label in a horizontal direction
+### Determinate (known progress)
 
-<ProgressIndicatorLinearLabelHorizontalExample />
+Set the `progress` prop (0–100) when you know how far along the process is. This gives the user a clear expectation of remaining time.
 
-### Linear ProgressIndicator with a label in a vertical direction
-
-<ProgressIndicatorLinearLabelVerticalExample />
-
-### Shows a large Linear ProgressIndicator with a static 50% in progress
+<ProgressIndicatorCircularPrimaryExample />
 
 <ProgressIndicatorLinearLargeExample />
 
-### Linear ProgressIndicator with random value
+### Labels
 
-<ProgressIndicatorLinearRandomExample />
+Labels help users understand what is loading. Use `showDefaultLabel` for the built-in "In progress..." text, or provide a custom `label`.
 
-### Linear ProgressIndicator with random progress value to show the transition
+#### Horizontal label
+
+<ProgressIndicatorCircularLabelHorizontalExample />
+
+<ProgressIndicatorLinearLabelHorizontalExample />
+
+#### Vertical label
+
+The default label direction is vertical.
+
+<ProgressIndicatorCircularLabelVerticalExample />
+
+<ProgressIndicatorLinearLabelVerticalExample />
+
+#### Inside label (circular only)
+
+Inside labels are placed in the center of the circle. Use sparingly — they work best for short content like an icon or a number.
+
+<ProgressIndicatorCircularLabelInsideExample />
+
+### Animated progress transitions
+
+When the `progress` value changes, the indicator animates smoothly between values.
+
+<ProgressIndicatorCircularRandomTransitionExample />
 
 <ProgressIndicatorLinearRandomTransitionExample />
 
-### Linear ProgressIndicator with random `onComplete` callback
+### Controlling visibility with `show`
 
-<ProgressIndicatorLinearRandomOnCompleteExample />
+Use the `show` prop to toggle the indicator. The `onComplete` callback fires after the exit animation finishes, which is useful for sequencing UI updates.
 
-### Linear ProgressIndicator inside a Dialog
+<ProgressIndicatorCircularRandomOnCompleteExample />
 
-<ProgressIndicatorLinearDialogExample />
+### Inside a Dialog
 
-### Countdown indicator
+A ProgressIndicator can be placed inside a Dialog to block interaction while a process completes.
+
+<ProgressIndicatorCircularDialogExample />
+
+### Countdown
+
+The `countdown` type animates counterclockwise and is suited for timers, session expiry, or time-limited actions. Combine it with `labelDirection="inside"` to display a value in the center.
 
 <ProgressIndicatorCountdownExample />
 
 ### Style customization
 
-The sizes and colors can be customized with the properties `size`, `customColors`, and `customCircleWidth` if needed. The types `circular` and `countdown` has a few more options than `linear`.
+The sizes and colors can be customized with the properties `size`, `customColors`, and `customCircleWidth` if needed. The types `circular` and `countdown` have a few more options than `linear`.
 
 <ProgressIndicatorCustomCountdown />
 <ProgressIndicatorCustomHorizontal />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/info.mdx
@@ -10,11 +10,44 @@ import { ProgressIndicator } from '@dnb/eufemia'
 
 ## Description
 
-Use a ProgressIndicator whenever the user has to wait for more than _150ms_. This component is also known as:
+The ProgressIndicator component shows a visual indicator during loading or processing states. Use it whenever the user has to wait for more than _150ms_.
 
-- Indicator (Activity-Indicator)
-- Loader (Pre-loader)
-- Spinner
+It supports three types: `circular` (default), `linear`, and `countdown`. Each type can display either a **determinate** state (with a known progress value) or an **indeterminate** state (when the duration is unknown).
+
+This component is also known as: Indicator (Activity-Indicator), Loader (Pre-loader), Spinner.
+
+### Determinate vs indeterminate
+
+- **Determinate**: Use when the progress percentage is known (e.g. file uploads, multi-step processes). Set the `progress` prop to a value between `0` and `100`.
+- **Indeterminate**: Use when the duration is unknown (e.g. fetching data, waiting for a response). Omit the `progress` prop to show a continuous animation.
+
+### Types
+
+- **`circular`** (default): A spinning ring. Works well inline or centered in a container. Supports label placement inside, horizontally, or vertically.
+- **`linear`**: A horizontal bar. Suited for wider layouts or when vertical space is limited. Common at the top of a page or section.
+- **`countdown`**: A circular variant that animates counterclockwise, useful for timers or session expiry indicators.
+
+### Visibility
+
+Use the `show` prop to control when the indicator appears and disappears. When `show` transitions to `false`, the indicator animates out and fires the `onComplete` callback once the exit animation finishes.
+
+## Accessibility
+
+- The component uses `role="progressbar"` with `aria-valuenow` for determinate states, giving screen readers the current progress.
+- For indeterminate states, `role="alert"` is used to announce that loading is in progress.
+- Use the `title` prop to provide a descriptive accessible label (e.g. `"Loading account details"`).
+- The `showDefaultLabel` prop adds a visible "In progress..." label, which also helps screen reader users understand the context.
+
+## When to use
+
+- Processing or loading states lasting more than 150ms.
+- File uploads, data fetching, or form submissions where the user needs feedback.
+- Timers or countdowns using the `countdown` type.
+
+## When not to use
+
+- For full-page or section-level loading states, consider the [Skeleton](/uilib/components/skeleton) component instead.
+- For processes lasting less than 150ms — no loading indicator is needed.
 
 ## Relevant links
 


### PR DESCRIPTION
Motivation from task list:

* Enhance ProgressIndicator docs 
    * To little info in general?
    * Too many examples?
    * Examples should get more text?

Removed duplicate demos and added more clarifying info