### PR TITLE
chore(Icon): apply transition custom properties during render for imperative API

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -238,8 +238,8 @@ export function AllIconsTest() {
 export function IconTransitionExample() {
   const notSupported = !Icon.transition.isSupported && (
     <FormStatus state="warning" top>
-      Your browser does not support the Web Animations API, so the icon
-      transition will fall back to a simple crossfade.
+      Your browser does not support CSS <code>d</code> path interpolation,
+      so the icon transition will fall back to a simple crossfade.
     </FormStatus>
   )
   return (

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -173,15 +173,6 @@ export default function Icon(localProps: IconAllProps) {
       return // stop here
     }
 
-    const iconFn = icon as IconFunction
-    if (iconFn?.__iconTransitionStyle) {
-      for (const [key, value] of Object.entries(
-        iconFn.__iconTransitionStyle
-      )) {
-        ref.current.style.setProperty(key, value)
-      }
-    }
-
     if (isInitialMount.current) {
       isInitialMount.current = false
       suppressTransitions(ref.current, () => {
@@ -472,6 +463,12 @@ export function prepareIcon(
   if (typeof iconToRender === 'function') {
     if (iconToRender.__iconTransitionFallback) {
       wrapperParams.className += ' dnb-icon--transition-fallback'
+    }
+    if (iconToRender.__iconTransitionStyle) {
+      wrapperParams.style = {
+        ...wrapperParams.style,
+        ...iconToRender.__iconTransitionStyle,
+      }
     }
   }
 

--- a/packages/dnb-eufemia/src/components/icon/__tests__/IconTransition.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/IconTransition.test.tsx
@@ -55,7 +55,7 @@ describe('Icon.transition', () => {
     expect(style).toContain('var(--icon-transition-asc)')
   })
 
-  it('does not set CSS custom properties without transitionState', () => {
+  it('sets CSS custom properties even without transitionState', () => {
     const icon = Icon.transition({ asc: arrow_down, desc: arrow_up })
 
     render(<Icon icon={icon} />)
@@ -63,7 +63,9 @@ describe('Icon.transition', () => {
     const wrapper = document.querySelector('.dnb-icon') as HTMLElement
     const style = wrapper.getAttribute('style')
 
-    expect(style).toBeNull()
+    expect(style).toContain('--icon-transition-asc')
+    expect(style).toContain('--icon-transition-desc')
+    expect(style).toContain('--icon-transition-default')
   })
 
   it('normalizes paths to absolute coordinates', () => {


### PR DESCRIPTION
The `Icon.transition()` CSS custom properties (`--icon-transition-*`) were only applied inside a `useLayoutEffect` that required the `transitionState` prop. When using the imperative API (`Icon.transition.activate()`), these properties were never set on the DOM element.

This caused the CSS `d` property to resolve to `none` (its initial value) when `activate` set `--icon-transition: var(--icon-transition-up)` but `--icon-transition-up` didn't exist — making the icon path invisible. Firefox correctly treats this as invalid at computed-value time; Chrome may be more lenient.

**Fix:** Move the `__iconTransitionStyle` application from the layout effect into `prepareIcon()`, so the custom properties are always present on the wrapper element regardless of which API is used.

Also corrects the portal demo warning text to reference the actual technique (CSS `d` path interpolation) instead of "Web Animations API".

Preview: https://chore-icon-transition-fix.eufemia-e25.pages.dev/uilib/components/icon#icon-transition