### PR TITLE
chore(Portal): keep default theme CSS active until non-default theme loads

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -514,6 +514,68 @@ describe('prerender-utils', () => {
       expect(cssPos).toBeLessThan(headClosePos)
     })
 
+    it('injects theme CSS links and theme-swap script', () => {
+      const themeCssPaths = {
+        ui: '/assets/theme-ui.css',
+        sbanken: '/assets/theme-sbanken.css',
+      }
+      const result = injectHtml(
+        template,
+        '<h1>Hello</h1>',
+        { js: [], css: [] },
+        '',
+        undefined,
+        themeCssPaths
+      )
+
+      // Default theme link should be enabled, others disabled
+      expect(result).toContain(
+        'href="/assets/theme-ui.css" data-eufemia-theme="ui">'
+      )
+      expect(result).toContain(
+        'href="/assets/theme-sbanken.css" data-eufemia-theme="sbanken" disabled>'
+      )
+
+      // Theme script should be in the body
+      expect(result).toContain('eufemia-theme__')
+    })
+
+    it('theme script does not immediately disable default CSS for non-default themes', () => {
+      const themeCssPaths = {
+        ui: '/assets/theme-ui.css',
+        sbanken: '/assets/theme-sbanken.css',
+      }
+      const result = injectHtml(
+        template,
+        '<h1>Hello</h1>',
+        { js: [], css: [] },
+        '',
+        undefined,
+        themeCssPaths
+      )
+
+      // Extract the inline theme script
+      const scriptMatch = result.match(
+        /<script>\(function\(\)\{try\{var t=JSON[\s\S]*?<\/script>/
+      )
+      expect(scriptMatch).not.toBeNull()
+
+      const script = scriptMatch![0]
+
+      // The script should use onload to defer disabling other themes
+      expect(script).toContain('.onload=')
+
+      // The script should check l.sheet for cached CSS before falling
+      // back to onload (mirrors the Vite plugin's waitForThemeLink)
+      expect(script).toContain('.sheet')
+
+      // The script should NOT blindly disable all non-matching links
+      // (the old pattern was: links[i].disabled=links[i].getAttribute(...)!==n)
+      expect(script).not.toMatch(
+        /links\[i\]\.disabled\s*=\s*links\[i\]\.getAttribute/
+      )
+    })
+
     it('injects SEO meta tags when meta is provided', () => {
       const result = injectHtml(
         template,

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -354,24 +354,20 @@ export function injectHtml(
       })
       .join('\n')
 
-    // Head script: determine active theme, disable inactive theme
-    // links, and store the name on globalThis for the body script.
-    // Runs in <head> after the render-blocking links have loaded,
-    // so the disable is instant — no network delay.
-    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
+    // Early blocking script: read localStorage and enable the stored
+    // theme's <link> before first paint. This mirrors the existing
+    // color-scheme FOUC-prevention pattern.
+    //
+    // For non-default themes, the script enables the chosen theme's
+    // CSS link but keeps the default theme enabled as a fallback.
+    // The CSS specificity (.eufemia-scope--portal .eufemia-theme__<name>)
+    // ensures the correct theme's styles win once loaded. Only after
+    // the new theme's stylesheet has loaded do we disable the default,
+    // preventing a flash of unstyled content.
+    const themeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';document.body.classList.add('eufemia-theme__'+n);if(n==='${defaultTheme}')return;var links=document.querySelectorAll('link[data-eufemia-theme]');var d=function(){for(var j=0;j<links.length;j++){if(links[j].getAttribute('data-eufemia-theme')!==n){links[j].disabled=true}}};for(var i=0;i<links.length;i++){var a=links[i].getAttribute('data-eufemia-theme');if(a===n){var l=links[i];l.disabled=false;if(l.sheet){d()}else{l.onload=d}break}}}catch(e){}})()</script>`
 
-    // Body script: add the brand class to <body> immediately after
-    // the opening tag, before any content is rendered.
-    const bodyThemeScript = `<script>(function(){var n=globalThis.__eufemiaTheme;if(n){document.body.classList.add('eufemia-theme__'+n)}})()</script>`
-
-    html = html.replace(
-      '</head>',
-      `${linkTags}\n${headThemeScript}\n  </head>`
-    )
-    html = html.replace(
-      /<body[^>]*>/,
-      (match) => `${match}\n     ${bodyThemeScript}`
-    )
+    html = html.replace('</head>', `${linkTags}\n  </head>`)
+    html = html.replace('</body>', `${themeScript}\n</body>`)
   }
 
   // Inject per-page SEO meta tags (title, description, Open Graph)

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -511,24 +511,20 @@ function injectHtml(
       })
       .join('\n')
 
-    // Head script: determine active theme, disable inactive theme
-    // links, and store the name on globalThis for the body script.
-    // Runs in <head> after the render-blocking links have loaded,
-    // so the disable is instant — no network delay.
-    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
+    // Early blocking script: read localStorage and enable the stored
+    // theme's <link> before first paint. This mirrors the existing
+    // color-scheme FOUC-prevention pattern.
+    //
+    // For non-default themes, the script enables the chosen theme's
+    // CSS link but keeps the default theme enabled as a fallback.
+    // The CSS specificity (.eufemia-scope--portal .eufemia-theme__<name>)
+    // ensures the correct theme's styles win once loaded. Only after
+    // the new theme's stylesheet has loaded do we disable the default,
+    // preventing a flash of unstyled content.
+    const themeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';document.body.classList.add('eufemia-theme__'+n);if(n==='${defaultTheme}')return;var links=document.querySelectorAll('link[data-eufemia-theme]');var d=function(){for(var j=0;j<links.length;j++){if(links[j].getAttribute('data-eufemia-theme')!==n){links[j].disabled=true}}};for(var i=0;i<links.length;i++){var a=links[i].getAttribute('data-eufemia-theme');if(a===n){var l=links[i];l.disabled=false;if(l.sheet){d()}else{l.onload=d}break}}}catch(e){}})()</script>`
 
-    // Body script: add the brand class to <body> immediately after
-    // the opening tag, before any content is rendered.
-    const bodyThemeScript = `<script>(function(){var n=globalThis.__eufemiaTheme;if(n){document.body.classList.add('eufemia-theme__'+n)}})()</script>`
-
-    html = html.replace(
-      '</head>',
-      `${linkTags}\n${headThemeScript}\n  </head>`
-    )
-    html = html.replace(
-      /<body[^>]*>/,
-      (match) => `${match}\n     ${bodyThemeScript}`
-    )
+    html = html.replace('</head>', `${linkTags}\n  </head>`)
+    html = html.replace('</body>', `${themeScript}\n</body>`)
   }
 
   // Inject per-page SEO meta tags


### PR DESCRIPTION
The prerender early-inline script previously disabled the default theme's CSS link at the same time as enabling the non-default theme's link. Since Chrome doesn't pre-fetch disabled links, this caused a window where no component CSS was active, producing completely unstyled cards on the homepage for non-default themes (sbanken, eiendom, carnegie).

The script now keeps the default theme CSS enabled as a fallback and only disables it after the new theme's onload event fires. This works because the PostCSS scoping gives non-default themes higher CSS specificity, so the correct styles automatically win once loaded.

