### PR TITLE
chore(Portal): use :where() wrapping in PostCSS theme scope plugin

### DIFF
--- a/packages/dnb-design-system-portal/postcss-eufemia-theme-scope.cjs
+++ b/packages/dnb-design-system-portal/postcss-eufemia-theme-scope.cjs
@@ -16,7 +16,10 @@
  * And component selectors like:
  *   .eufemia-scope--portal .dnb-accordion
  * to:
- *   .eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion
+ *   .eufemia-scope--portal :where(.eufemia-theme__sbanken) .dnb-accordion
+ *
+ * The :where() wrapper keeps specificity unchanged so portal-specific
+ * styles (e.g. sidebar menu) are not overridden.
  *
  * And comma patterns like:
  *   .eufemia-scope--portal, .eufemia-scope--portal .eufemia-theme__sbanken
@@ -68,15 +71,25 @@ const plugin = () => {
             return `.${scopeClass} .${brandClass}${colorSchemeMatch[1]}`
           }
 
-          // Catch-all: any other selector containing the scope class
-          // (e.g. component selectors like ".eufemia-scope--portal .dnb-accordion")
-          // Insert the brand class after the scope class so the styles
-          // only apply when the theme is active, not just when the
-          // style tag is enabled.
+          // Skip generic ".eufemia-theme" class (without brand/color-scheme
+          // suffix) — it lives on the same DOM element as the brand class,
+          // so making it a descendant selector would break matching.
+          if (
+            /\.eufemia-scope--portal\s+\.eufemia-theme(?!__)/.test(trimmed)
+          ) {
+            return sel
+          }
+
+          // Remaining selectors containing the scope class (component
+          // overrides, :where() wrappers, etc.) — insert the brand class
+          // wrapped in :where() after the scope class. This ensures styles
+          // only apply when the theme is active WITHOUT increasing
+          // specificity, which would otherwise override portal-specific
+          // styles (e.g. sidebar menu anchor colors).
           if (trimmed.includes(`.${scopeClass} `)) {
             return trimmed.replace(
               `.${scopeClass} `,
-              `.${scopeClass} .${brandClass} `
+              `.${scopeClass} :where(.${brandClass}) `
             )
           }
 

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/postcss-theme-scope.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/postcss-theme-scope.test.ts
@@ -50,23 +50,23 @@ describe('postcss-eufemia-theme-scope', () => {
     )
   })
 
-  it('scopes component selectors under brand class', async () => {
+  it('scopes component selectors under brand class with :where()', async () => {
     const css = await run(
       '.eufemia-scope--portal .dnb-accordion { --accordion-border-width: 0; }',
       '/path/to/themes/sbanken/sbanken-theme-components.scss'
     )
     expect(css).toBe(
-      '.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion { --accordion-border-width: 0; }'
+      '.eufemia-scope--portal :where(.eufemia-theme__sbanken) .dnb-accordion { --accordion-border-width: 0; }'
     )
   })
 
-  it('scopes nested component selectors under brand class', async () => {
+  it('scopes nested component selectors under brand class with :where()', async () => {
     const css = await run(
       '.eufemia-scope--portal .dnb-accordion .dnb-accordion__header { color: red; }',
       '/path/to/themes/sbanken/sbanken-theme-components.scss'
     )
     expect(css).toBe(
-      '.eufemia-scope--portal .eufemia-theme__sbanken .dnb-accordion .dnb-accordion__header { color: red; }'
+      '.eufemia-scope--portal :where(.eufemia-theme__sbanken) .dnb-accordion .dnb-accordion__header { color: red; }'
     )
   })
 
@@ -80,13 +80,23 @@ describe('postcss-eufemia-theme-scope', () => {
     )
   })
 
+  it('skips selectors already scoped with :where() brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal :where(.eufemia-theme__sbanken) .dnb-accordion { color: red; }',
+      '/path/to/themes/sbanken/sbanken-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal :where(.eufemia-theme__sbanken) .dnb-accordion { color: red; }'
+    )
+  })
+
   it('handles eiendom theme files', async () => {
     const css = await run(
       '.eufemia-scope--portal .dnb-button { color: blue; }',
       '/path/to/themes/eiendom/eiendom-theme-components.scss'
     )
     expect(css).toBe(
-      '.eufemia-scope--portal .eufemia-theme__eiendom .dnb-button { color: blue; }'
+      '.eufemia-scope--portal :where(.eufemia-theme__eiendom) .dnb-button { color: blue; }'
     )
   })
 
@@ -96,7 +106,7 @@ describe('postcss-eufemia-theme-scope', () => {
       '/path/to/themes/carnegie/carnegie-theme-components.scss'
     )
     expect(css).toBe(
-      '.eufemia-scope--portal .eufemia-theme__carnegie .dnb-card { padding: 1rem; }'
+      '.eufemia-scope--portal :where(.eufemia-theme__carnegie) .dnb-card { padding: 1rem; }'
     )
   })
 
@@ -107,6 +117,26 @@ describe('postcss-eufemia-theme-scope', () => {
     )
     expect(css).toBe(
       '.eufemia-scope--portal .eufemia-theme__sbanken, .eufemia-scope--portal .eufemia-theme__sbanken.eufemia-theme__color-scheme--light { --sb-color-text: #000; }'
+    )
+  })
+
+  it('does not scope generic .eufemia-theme selector under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal, .eufemia-scope--portal .eufemia-theme { --scrollbar-thumb-color: red; }',
+      '/path/to/themes/sbanken/sbanken-theme-basis.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal .eufemia-theme__sbanken, .eufemia-scope--portal .eufemia-theme { --scrollbar-thumb-color: red; }'
+    )
+  })
+
+  it('scopes :where() wrapped component selectors under brand class', async () => {
+    const css = await run(
+      '.eufemia-scope--portal :where(:not(.dnb-anchor--no-style)).dnb-anchor .dnb-icon--default { font-size: 1em; }',
+      '/path/to/themes/sbanken/sbanken-theme-components.scss'
+    )
+    expect(css).toBe(
+      '.eufemia-scope--portal :where(.eufemia-theme__sbanken) :where(:not(.dnb-anchor--no-style)).dnb-anchor .dnb-icon--default { font-size: 1em; }'
     )
   })
 })


### PR DESCRIPTION
Wrap the brand class in `:where()` for the catch-all pattern in the PostCSS theme scope plugin, so non-default theme component styles don't increase specificity and override portal-specific styles (e.g. sidebar menu anchor colors, icon sizes).

**Changes:**
- Use `:where(.eufemia-theme__<brand>)` instead of `.eufemia-theme__<brand>` in the catch-all selector rewrite — this contributes zero specificity
- Skip the generic `.eufemia-theme` class (without `__` suffix) that lives on the same DOM element as the brand class
- Handle `:where()`-wrapped component selectors from anchor mixins (e.g. `:where(:not(.dnb-anchor--no-style)).dnb-anchor`)
- Updated and added tests for all new patterns

Caused by PR #8251

<img width="2186" height="1126" alt="image (13)" src="https://github.com/user-attachments/assets/8706eb17-4c1d-4771-a159-c327a7da8792" />

