### PR TITLE
chore(Portal): add brand class to body in dev mode theme switching

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -235,6 +235,100 @@ describe('eufemia-theme plugin', () => {
     })
   })
 
+  describe('dev mode applyThemeStyles behavior', () => {
+    beforeEach(() => {
+      document.body.className = ''
+      localStorage.clear()
+      delete (window as any).__applyEufemiaThemeStyles__
+      delete (window as any).__EUFEMIA_THEME_FILES__
+      delete (window as any).__EUFEMIA_THEME_NAMES__
+      delete (window as any).__EUFEMIA_DEFAULT_THEME__
+    })
+
+    afterEach(() => {
+      delete (window as any).__applyEufemiaThemeStyles__
+      delete (window as any).__EUFEMIA_THEME_FILES__
+      delete (window as any).__EUFEMIA_THEME_NAMES__
+      delete (window as any).__EUFEMIA_DEFAULT_THEME__
+    })
+
+    it('adds brand class to body when switching themes', () => {
+      const plugin = eufemiaThemePlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:eufemia-theme-styles') || ''
+
+      // Strip import statements and requestAnimationFrame to eval safely
+      const evalCode = code
+        .replace(/import '[^']+';/g, '')
+        .replace(/requestAnimationFrame\(\(\) => \{/, '{')
+        .replace(/\}\);(\s*\})/, '}$1')
+      const fn = new Function(evalCode)
+      fn()
+
+      const applyThemeStyles = (window as any).__applyEufemiaThemeStyles__
+      expect(applyThemeStyles).toBeDefined()
+
+      applyThemeStyles('sbanken')
+      expect(
+        document.body.classList.contains('eufemia-theme__sbanken')
+      ).toBe(true)
+    })
+
+    it('replaces previous brand class when switching themes', () => {
+      const plugin = eufemiaThemePlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:eufemia-theme-styles') || ''
+
+      const evalCode = code
+        .replace(/import '[^']+';/g, '')
+        .replace(/requestAnimationFrame\(\(\) => \{/, '{')
+        .replace(/\}\);(\s*\})/, '}$1')
+      const fn = new Function(evalCode)
+      fn()
+
+      const applyThemeStyles = (window as any).__applyEufemiaThemeStyles__
+      applyThemeStyles('sbanken')
+      expect(
+        document.body.classList.contains('eufemia-theme__sbanken')
+      ).toBe(true)
+
+      applyThemeStyles('eiendom')
+      expect(
+        document.body.classList.contains('eufemia-theme__eiendom')
+      ).toBe(true)
+      expect(
+        document.body.classList.contains('eufemia-theme__sbanken')
+      ).toBe(false)
+    })
+
+    it('preserves color-scheme class when switching brands', () => {
+      document.body.classList.add('eufemia-theme__color-scheme--dark')
+
+      const plugin = eufemiaThemePlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:eufemia-theme-styles') || ''
+
+      const evalCode = code
+        .replace(/import '[^']+';/g, '')
+        .replace(/requestAnimationFrame\(\(\) => \{/, '{')
+        .replace(/\}\);(\s*\})/, '}$1')
+      const fn = new Function(evalCode)
+      fn()
+
+      const applyThemeStyles = (window as any).__applyEufemiaThemeStyles__
+      applyThemeStyles('sbanken')
+
+      expect(
+        document.body.classList.contains('eufemia-theme__sbanken')
+      ).toBe(true)
+      expect(
+        document.body.classList.contains(
+          'eufemia-theme__color-scheme--dark'
+        )
+      ).toBe(true)
+    })
+  })
+
   describe('build mode __loadEufemiaTheme behavior', () => {
     let code: string
 

--- a/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
@@ -379,6 +379,14 @@ if (typeof window !== 'undefined') {
         }
       }
     }
+
+    // Add brand class to <body> so theme-scoped CSS custom properties
+    // (tokens, palette vars) resolve at the body level — needed for
+    // background-color and other body-level styles that use CSS vars.
+    var body = document.body;
+    var themeClassRe = /\\beufemia-theme__(?!color-scheme)\\S+/g;
+    body.className = body.className.replace(themeClassRe, '').trim();
+    body.classList.add('eufemia-theme__' + activeTheme);
   };
 
   // Make this available globally for setTheme to call

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -343,9 +343,9 @@ export function injectHtml(
 
   // Inject <link> tags for ALL brand theme CSS chunks.
   // All links are enabled (render-blocking) so the browser fetches them
-  // before the first paint. An early inline script then disables the
-  // inactive themes and adds the active brand class to <body>.
-  // Because all CSS is already loaded, the disable is instant — no flash.
+  // before the first paint. A head script disables inactive themes
+  // before the browser paints, and a body-opening script adds the
+  // active brand class to <body> so token selectors match immediately.
   if (themeCssPaths && Object.keys(themeCssPaths).length > 0) {
     const defaultTheme = 'ui'
     const linkTags = Object.entries(themeCssPaths)
@@ -354,10 +354,24 @@ export function injectHtml(
       })
       .join('\n')
 
-    const themeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}document.body.classList.add('eufemia-theme__'+n)}catch(e){}})()</script>`
+    // Head script: determine active theme, disable inactive theme
+    // links, and store the name on globalThis for the body script.
+    // Runs in <head> after the render-blocking links have loaded,
+    // so the disable is instant — no network delay.
+    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
-    html = html.replace('</head>', `${linkTags}\n  </head>`)
-    html = html.replace('</body>', `${themeScript}\n</body>`)
+    // Body script: add the brand class to <body> immediately after
+    // the opening tag, before any content is rendered.
+    const bodyThemeScript = `<script>(function(){var n=globalThis.__eufemiaTheme;if(n){document.body.classList.add('eufemia-theme__'+n)}})()</script>`
+
+    html = html.replace(
+      '</head>',
+      `${linkTags}\n${headThemeScript}\n  </head>`
+    )
+    html = html.replace(
+      /<body[^>]*>/,
+      (match) => `${match}\n     ${bodyThemeScript}`
+    )
   }
 
   // Inject per-page SEO meta tags (title, description, Open Graph)

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -342,15 +342,15 @@ export function injectHtml(
   )
 
   // Inject <link> tags for ALL brand theme CSS chunks.
-  // The default theme (ui) is enabled; others are disabled.
-  // An early inline script reads localStorage and swaps them
-  // before the browser paints — preventing a flash of the wrong brand.
+  // All links are enabled (render-blocking) so the browser fetches them
+  // before the first paint. An early inline script then disables the
+  // inactive themes and adds the active brand class to <body>.
+  // Because all CSS is already loaded, the disable is instant — no flash.
   if (themeCssPaths && Object.keys(themeCssPaths).length > 0) {
     const defaultTheme = 'ui'
     const linkTags = Object.entries(themeCssPaths)
       .map(([name, href]) => {
-        const disabled = name !== defaultTheme ? ' disabled' : ''
-        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}"${disabled}>`
+        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}">`
       })
       .join('\n')
 

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -499,28 +499,36 @@ function injectHtml(
   )
 
   // Inject <link> tags for ALL brand theme CSS chunks.
-  // The default theme (ui) is enabled; others are disabled.
-  // An early inline script reads localStorage and swaps them
-  // before the browser paints — preventing a flash of the wrong brand.
+  // All links are enabled (render-blocking) so the browser fetches them
+  // before the first paint. A head script disables inactive themes
+  // before the browser paints, and a body-opening script adds the
+  // active brand class to <body> so token selectors match immediately.
   if (themeCssPaths && Object.keys(themeCssPaths).length > 0) {
     const defaultTheme = 'ui'
     const linkTags = Object.entries(themeCssPaths)
       .map(([name, href]) => {
-        const disabled = name !== defaultTheme ? ' disabled' : ''
-        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}"${disabled}>`
+        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}">`
       })
       .join('\n')
 
-    // Early blocking script: read localStorage and enable the stored
-    // theme's <link> before first paint. This mirrors the existing
-    // color-scheme FOUC-prevention pattern.
-    const themeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}document.body.classList.add('eufemia-theme__'+n)}catch(e){}})()</script>`
+    // Head script: determine active theme, disable inactive theme
+    // links, and store the name on globalThis for the body script.
+    // Runs in <head> after the render-blocking links have loaded,
+    // so the disable is instant — no network delay.
+    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
-    html = html.replace('</head>', `${linkTags}\n  </head>`)
+    // Body script: add the brand class to <body> immediately after
+    // the opening tag, before any content is rendered.
+    const bodyThemeScript = `<script>(function(){var n=globalThis.__eufemiaTheme;if(n){document.body.classList.add('eufemia-theme__'+n)}})()</script>`
 
-    // Inject theme script right after the body opening tag (after the
-    // existing color-scheme body script)
-    html = html.replace('</body>', `${themeScript}\n</body>`)
+    html = html.replace(
+      '</head>',
+      `${linkTags}\n${headThemeScript}\n  </head>`
+    )
+    html = html.replace(
+      /<body[^>]*>/,
+      (match) => `${match}\n     ${bodyThemeScript}`
+    )
   }
 
   // Inject per-page SEO meta tags


### PR DESCRIPTION
In dev mode, `applyThemeStyles` disabled non-active theme `<style>` elements but did not add the brand class (e.g. `eufemia-theme__sbanken`) to `<body>`. Since theme tokens are scoped under the brand class by the PostCSS plugin, CSS custom properties like `--token-color-background-neutral` did not resolve at the body level — causing a white background in dark mode with non-default themes.

Build mode already handled this via `activateTheme()`. This adds the same body class management to the dev mode `applyThemeStyles` function.

**Changes:**
- Add brand class to `<body>` in dev mode's `applyThemeStyles`, replacing any previous brand class while preserving color-scheme classes
- 3 new tests: adding brand class, replacing when switching, preserving color-scheme