### PR TITLE
fix: use CSS variable chain for primary button color in xmlns reset

### DIFF
--- a/packages/dnb-eufemia/src/style/core/reset.scss
+++ b/packages/dnb-eufemia/src/style/core/reset.scss
@@ -379,7 +379,7 @@
 @mixin resetLegacyStyles() {
   html[xmlns='http://www.w3.org/1999/xhtml'] {
     .dnb-anchor--active {
-      color: var(--color-mint-green) !important;
+      color: var(--anchor-color) !important;
     }
 
     a.dnb-button--primary {

--- a/packages/dnb-eufemia/src/style/core/reset.scss
+++ b/packages/dnb-eufemia/src/style/core/reset.scss
@@ -383,7 +383,7 @@
     }
 
     a.dnb-button--primary {
-      color: var(--color-white);
+      color: var(--button-color-text, var(--button-color-text--default));
     }
 
     // reset lists


### PR DESCRIPTION
Motivation: Found in the light of https://github.com/dnbexperience/eufemia/pull/8268

The legacy reset hardcoded color: var(--color-white) on a.dnb-button--primary under html[xmlns], bypassing the component's --button-color-text variable chain. This caused disabled, focus, and themed states to be ignored for <a> primary buttons on e-Platform.

Use the same var(--button-color-text) reference the component uses, so state overrides (hover, focus, disabled) and theme customizations are respected while still winning the specificity battle against legacy anchor styles.

