### PR TITLE
chore(Breadcrumb): deprecate removed backgroundColor and collapsedStyleType props

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -19,6 +19,10 @@ import { clsx } from 'clsx'
 // Components
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import { useSpacing } from '../space/SpacingUtils'
+import type {
+  SectionBackgroundColor,
+  SectionVariants,
+} from '../section/Section'
 import Section from '../section/Section'
 import Button from '../button/Button'
 import Accordion from '../accordion/Accordion'
@@ -114,6 +118,16 @@ export type BreadcrumbProps = {
   backToText?: ReactNode
 
   /**
+   * @deprecated No longer supported after the Breadcrumb redesign.
+   */
+  backgroundColor?: SectionBackgroundColor
+
+  /**
+   * @deprecated No longer supported after the Breadcrumb redesign.
+   */
+  collapsedStyleType?: SectionVariants
+
+  /**
    * If variant='collapse', you can override collapsed state for the collapsed content by updating this value.
    * Default: `null`
    */
@@ -179,6 +193,8 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
     goBackText, // has a translation in context
     homeText,
     backToText, // has a translation in context
+    backgroundColor: _backgroundColor, // deprecated
+    collapsedStyleType: _collapsedStyleType, // deprecated
     collapsed: overrideCollapsed,
     spacing,
     noAnimation,

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbDocs.ts
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbDocs.ts
@@ -41,6 +41,16 @@ export const BreadcrumbProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
+  backgroundColor: {
+    doc: 'No longer supported after the Breadcrumb redesign.',
+    type: 'Various',
+    status: 'deprecated',
+  },
+  collapsedStyleType: {
+    doc: 'No longer supported after the Breadcrumb redesign.',
+    type: ['"error"', '"information"', '"warning"', '"success"'],
+    status: 'deprecated',
+  },
   className: {
     doc: 'Custom `className` for the component root.',
     type: 'string',


### PR DESCRIPTION
These props were removed in the Breadcrumb redesign but were part of the public API. Re-add them as deprecated to avoid breaking consumers on upgrade. The props are accepted but no longer have any effect.

Not sure if we want to do this or not, but I would classify this as a breaking change when one remove publicly documented properties.

