### PR TITLE
chore: replace dead ::after selectors with text-decoration equivalents

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1194,8 +1194,8 @@ button.dnb-button::-moz-focus-inner {
 .dnb-breadcrumb--variant-single .dnb-breadcrumb__bar .dnb-button .dnb-button__icon {
   color: var(--token-color-icon-neutral);
 }
-.dnb-breadcrumb--variant-single .dnb-breadcrumb__bar .dnb-button .dnb-button__text::after {
-  display: none;
+.dnb-breadcrumb--variant-single .dnb-breadcrumb__bar .dnb-button .dnb-button__text {
+  text-decoration: none;
 }
 .dnb-breadcrumb__list.dnb-section {
   display: flex;

--- a/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
+++ b/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
@@ -24,8 +24,8 @@
       color: var(--token-color-icon-neutral);
     }
 
-    .dnb-button__text::after {
-      display: none;
+    .dnb-button__text {
+      text-decoration: none;
     }
   }
 

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -355,9 +355,6 @@ html[data-whatinput=touch] .dnb-table > thead > tr > th.dnb-table--sortable .dnb
   --border-width: 0.125rem;
   right: -0.5rem;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--sortable .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after {
-  visibility: hidden;
-}
 .dnb-table > thead > tr > th.dnb-table--sortable[align=right], .dnb-table .dnb-table__th.dnb-table--sortable[align=right] {
   padding-right: 0.5rem;
 }
@@ -373,17 +370,14 @@ html[data-whatinput=touch] .dnb-table > thead > tr > th.dnb-table--sortable .dnb
 .dnb-table > thead > tr > th.dnb-table--sortable[align=right] .dnb-table__sort-button.dnb-button--tertiary.dnb-button--icon-position-right .dnb-button__text, .dnb-table .dnb-table__th.dnb-table--sortable[align=right] .dnb-table__sort-button.dnb-button--tertiary.dnb-button--icon-position-right .dnb-button__text {
   padding-right: 0;
 }
-.dnb-table > thead > tr > th.dnb-table--sortable[align=right] .dnb-table__sort-button.dnb-button--tertiary.dnb-button--icon-position-right .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--sortable[align=right] .dnb-table__sort-button.dnb-button--tertiary.dnb-button--icon-position-right .dnb-button__text::after {
-  right: 0;
-}
 html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sort-off .dnb-table__sort-button.dnb-button:hover[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sort-off .dnb-table__sort-button.dnb-button:hover[disabled] {
   cursor: not-allowed;
 }
 html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sort-off .dnb-table__sort-button.dnb-button:hover:not([disabled]):not(:focus) .dnb-icon, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--sort-off .dnb-table__sort-button.dnb-button:hover:not([disabled]):not(:focus) .dnb-icon {
   opacity: 0;
 }
-.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:not(:hover) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:not(:hover) .dnb-button__text::after {
-  opacity: 0;
+.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:not(:hover) .dnb-button__text, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:not(:hover) .dnb-button__text {
+  text-decoration-color: transparent;
 }
 .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button .dnb-icon, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button .dnb-icon {
   opacity: 1;
@@ -391,21 +385,14 @@ html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--sort-o
 html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover[disabled], html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover[disabled] {
   cursor: not-allowed;
 }
-html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text::after {
-  color: var(--token-color-text-action);
-  opacity: 1;
+html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text, html:not([data-whatintent=touch]) .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:not([disabled]) .dnb-button__text {
+  text-decoration-color: var(--token-color-text-action);
 }
 .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled], .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus[disabled] {
   cursor: not-allowed;
 }
-.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text::after {
-  opacity: 0;
-}
-.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus:not(:active) .dnb-button__text::after {
-  visibility: visible;
-}
-html[data-whatinput=keyboard] .dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus .dnb-button__text::after, html[data-whatinput=keyboard] .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:hover:focus .dnb-button__text::after {
-  visibility: hidden;
+.dnb-table > thead > tr > th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text, .dnb-table .dnb-table__th.dnb-table--active .dnb-table__sort-button.dnb-button:focus:not([disabled]) .dnb-button__text {
+  text-decoration-color: transparent;
 }
 .dnb-table > thead > tr > th.dnb-table--reversed .dnb-table__sort-button.dnb-button .dnb-icon, .dnb-table .dnb-table__th.dnb-table--reversed .dnb-table__sort-button.dnb-button .dnb-icon {
   transform: rotate(180deg);

--- a/packages/dnb-eufemia/src/components/table/style/table-header-buttons.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-header-buttons.scss
@@ -123,11 +123,6 @@
           right: -0.5rem;
         }
       }
-
-      // webkit fix
-      &:hover:focus:not(:active) .dnb-button__text::after {
-        visibility: hidden;
-      }
     }
 
     &[align='right'] {
@@ -144,10 +139,6 @@
           }
           .dnb-button__text {
             padding-right: 0;
-
-            &::after {
-              right: 0;
-            }
           }
         }
       }
@@ -171,8 +162,8 @@
   & &__th#{&}--active {
     .dnb-table__sort-button.dnb-button {
       // hide underline
-      &:not(:hover) .dnb-button__text::after {
-        opacity: 0;
+      &:not(:hover) .dnb-button__text {
+        text-decoration-color: transparent;
       }
 
       .dnb-icon {
@@ -181,28 +172,16 @@
 
       // and underline on hover
       @include utilities.hover() {
-        .dnb-button__text::after {
-          color: var(--token-color-text-action);
-          opacity: 1;
+        .dnb-button__text {
+          text-decoration-color: var(--token-color-text-action);
         }
       }
 
       @include utilities.focus() {
         // hide underline
-        .dnb-button__text::after {
-          opacity: 0;
+        .dnb-button__text {
+          text-decoration-color: transparent;
         }
-      }
-
-      // webkit fix
-      &:hover:focus:not(:active) .dnb-button__text::after {
-        visibility: visible;
-      }
-
-      html[data-whatinput='keyboard']
-        &:hover:focus
-        .dnb-button__text::after {
-        visibility: hidden;
       }
     }
   }

--- a/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
@@ -46,10 +46,8 @@
   & > thead > tr > th#{&}--sortable,
   & &__th#{&}--sortable {
     .dnb-table__sort-button.dnb-button {
-      & .dnb-button__text::after {
-        bottom: -0.0625rem;
-        left: 0;
-        opacity: 0;
+      & .dnb-button__text {
+        text-decoration-color: transparent;
       }
     }
   }


### PR DESCRIPTION
The tertiary button underline moved from ::after pseudo-element to text-decoration, but Table sort buttons, Breadcrumb, and Sbanken theme still had ::after selectors targeting the now-removed pseudo-element.

Replace with text-decoration-color / text-decoration equivalents to match the current tertiary button implementation.