### PR TITLE
feat(Field.Number): add explicit placeholder prop with type and docs

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -26,6 +26,27 @@ describe('Field.Currency', () => {
     expect(input).toHaveValue('123 NOK')
   })
 
+  it('should use custom placeholder when provided', () => {
+    render(<Field.Currency placeholder="Enter amount" />)
+
+    const placeholder = document.querySelector('.dnb-input__placeholder')
+    expect(placeholder).toHaveTextContent('Enter amount')
+  })
+
+  it('should show currency symbol as default placeholder', () => {
+    render(<Field.Currency />)
+
+    const placeholder = document.querySelector('.dnb-input__placeholder')
+    expect(placeholder).toHaveTextContent('kr')
+  })
+
+  it('should show empty placeholder when set to empty string', () => {
+    render(<Field.Currency placeholder="" />)
+
+    const placeholder = document.querySelector('.dnb-input__placeholder')
+    expect(placeholder).toBeNull()
+  })
+
   it('should align input correctly', () => {
     render(
       <>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -71,6 +71,8 @@ export type FieldNumberProps = FieldProps<number, undefined | number> & {
   align?: InputAlign
   /** If `true`, shows increment/decrement step control buttons. */
   showStepControls?: boolean
+  /** Text showing in place of the value if no value is given. */
+  placeholder?: string
 }
 
 const defaultMinimum = Number.MIN_SAFE_INTEGER

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/NumberDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/NumberDocs.ts
@@ -71,6 +71,11 @@ export const NumberProperties: PropertiesTableProps = {
     type: ['"on"', 'string'],
     status: 'optional',
   },
+  placeholder: {
+    doc: 'Text showing in place of the value if no value is given.',
+    type: 'string',
+    status: 'optional',
+  },
   prefix: {
     doc: 'Text added before the value input.',
     type: 'string',


### PR DESCRIPTION
## Summary

Adds explicit `placeholder` type support to `Field.Number` (and by inheritance, `Field.Currency`).


