### PR TITLE
chore(DatePicker): jump focus to other calendar on arrow key month crossing

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -368,6 +368,18 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         return
       }
 
+      // Sync focusedDateRef from DOM when a date button is focused
+      // (e.g. after cross-calendar focus jump or mouse click on a day)
+      if (tableRef.current) {
+        const td = document.activeElement?.closest('td[data-date]')
+        if (td && tableRef.current.contains(td)) {
+          const dateStr = td.getAttribute('data-date')
+          if (dateStr) {
+            focusedDateRef.current = startOfDay(new Date(dateStr))
+          }
+        }
+      }
+
       // Handle Enter/Space
       if (pressedKey === 'Enter' || pressedKey === 'Space') {
         event.preventDefault()
@@ -495,6 +507,30 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
 
       // Navigate to a different month if needed
       if (viewMonth && !isSameMonth(newDate, viewMonth)) {
+        // In range mode, jump to the other calendar if it shows the target month
+        if (isRange) {
+          const otherNr = nr === 0 ? 1 : 0
+          const otherViewMonth = views.find((v) => v.nr === otherNr)?.month
+
+          if (otherViewMonth && isSameMonth(newDate, otherViewMonth)) {
+            const viewsContainer = tableRef.current?.closest(
+              '.dnb-date-picker__views'
+            )
+            const otherTable =
+              viewsContainer?.querySelectorAll('table')?.[otherNr]
+            const dateStr = format(newDate, 'yyyy-MM-dd')
+            const button = otherTable?.querySelector(
+              `td[data-date="${dateStr}"] button`
+            ) as HTMLElement | undefined
+
+            if (button) {
+              focusedDateRef.current = null
+              button.focus({ preventScroll: true })
+              return // stop here
+            }
+          }
+        }
+
         // Keep focus on the table during re-render to prevent the Popover from closing
         tableRef.current?.focus({ preventScroll: true })
 

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1538,7 +1538,7 @@ describe('DatePicker component', () => {
   })
 
   it('should set correct month based date selected with keyboard navigation', async () => {
-    render(<DatePicker range date="2024-10-01" />)
+    render(<DatePicker date="2024-10-01" />)
 
     await userEvent.click(getDatePickerTriggerButton())
 
@@ -1546,13 +1546,13 @@ describe('DatePicker component', () => {
       '.dnb-date-picker__calendar .dnb-date-picker__header__title'
     )
 
-    const firstDayButton = document.querySelector(
-      '.dnb-date-picker__calendar .dnb-date-picker__day button'
-    ) as HTMLButtonElement
-    await userEvent.click(firstDayButton)
-
     expect(pickerTitle).toHaveTextContent('oktober 2024')
 
+    // Focus Oct 1 and navigate left into September
+    const oct1Button = document.querySelector(
+      '.dnb-date-picker__calendar td[data-date="2024-10-01"] button'
+    ) as HTMLButtonElement
+    oct1Button.focus()
     await userEvent.keyboard('{ArrowLeft}')
 
     expect(pickerTitle).toHaveTextContent('september 2024')
@@ -1564,7 +1564,7 @@ describe('DatePicker component', () => {
 
   it('should set correct month based date selected with keyboard navigation in range mode', async () => {
     render(
-      <DatePicker range startDate="2024-10-01" endDate="2024-10-02" />
+      <DatePicker range startDate="2024-10-15" endDate="2024-11-15" />
     )
 
     await userEvent.click(getDatePickerTriggerButton())
@@ -1574,35 +1574,68 @@ describe('DatePicker component', () => {
         '.dnb-date-picker__calendar .dnb-date-picker__header__title'
       )
     )
-
-    const firstRangeDayButton = document.querySelector(
-      '.dnb-date-picker__calendar .dnb-date-picker__day button'
-    ) as HTMLButtonElement
-    await userEvent.click(firstRangeDayButton)
+    const tables = document.querySelectorAll(
+      '.dnb-date-picker__calendar table'
+    ) as NodeListOf<HTMLTableElement>
 
     expect(leftPickerTitle).toHaveTextContent('oktober 2024')
-    expect(rightPickerTitle).toHaveTextContent('oktober 2024')
+    expect(rightPickerTitle).toHaveTextContent('november 2024')
 
+    // Navigate left past October — left calendar changes to September
+    const oct1Button = tables[0].querySelector(
+      'td[data-date="2024-10-01"] button'
+    ) as HTMLButtonElement
+    oct1Button.focus()
     await userEvent.keyboard('{ArrowLeft}')
 
     expect(leftPickerTitle).toHaveTextContent('september 2024')
-    expect(rightPickerTitle).toHaveTextContent('oktober 2024')
+    expect(rightPickerTitle).toHaveTextContent('november 2024')
 
-    await userEvent.keyboard('{ArrowRight>32}')
+    // Navigate right from September — October is not in either calendar,
+    // so the left calendar changes to October
+    await userEvent.keyboard('{ArrowRight}')
 
-    expect(leftPickerTitle).toHaveTextContent('november 2024')
-    expect(rightPickerTitle).toHaveTextContent('oktober 2024')
+    expect(leftPickerTitle).toHaveTextContent('oktober 2024')
+    expect(rightPickerTitle).toHaveTextContent('november 2024')
 
-    // Tab to right picker and navigate to december
-    await userEvent.keyboard('{Tab>3}{ArrowRight>62}')
+    // Navigate right from October into November — should jump to right calendar
+    // without changing either calendar's month
+    const oct31Button = tables[0].querySelector(
+      'td[data-date="2024-10-31"] button'
+    ) as HTMLButtonElement
+    oct31Button.focus()
+    await userEvent.keyboard('{ArrowRight}')
 
-    expect(leftPickerTitle).toHaveTextContent('november 2024')
+    expect(leftPickerTitle).toHaveTextContent('oktober 2024')
+    expect(rightPickerTitle).toHaveTextContent('november 2024')
+    expect(tables[1].contains(document.activeElement)).toBe(true)
+
+    // Navigate right past November — right calendar changes to December
+    const nov30Button = tables[1].querySelector(
+      'td[data-date="2024-11-30"] button'
+    ) as HTMLButtonElement
+    nov30Button.focus()
+    await userEvent.keyboard('{ArrowRight}')
+
+    expect(leftPickerTitle).toHaveTextContent('oktober 2024')
     expect(rightPickerTitle).toHaveTextContent('desember 2024')
 
-    await userEvent.keyboard('{ArrowLeft>70}')
+    // Navigate left from December — November is not in either calendar,
+    // so the right calendar changes to November
+    await userEvent.keyboard('{ArrowLeft}')
 
-    expect(leftPickerTitle).toHaveTextContent('november 2024')
-    expect(rightPickerTitle).toHaveTextContent('september 2024')
+    expect(rightPickerTitle).toHaveTextContent('november 2024')
+
+    // Navigate left from November into October — should jump to left calendar
+    const nov1Button = tables[1].querySelector(
+      'td[data-date="2024-11-01"] button'
+    ) as HTMLButtonElement
+    nov1Button.focus()
+    await userEvent.keyboard('{ArrowLeft}')
+
+    expect(leftPickerTitle).toHaveTextContent('oktober 2024')
+    expect(rightPickerTitle).toHaveTextContent('november 2024')
+    expect(tables[0].contains(document.activeElement)).toBe(true)
   })
 
   it('should keep focus in the left calendar after selecting a start date with keyboard', async () => {
@@ -1719,6 +1752,54 @@ describe('DatePicker component', () => {
 
     const rightFocused = document.activeElement
     expect(rightFocused.getAttribute('aria-label')).toContain('1.')
+  })
+
+  it('should jump focus to the other calendar when arrow key crosses into its month', async () => {
+    render(
+      <DatePicker range startDate="2024-10-31" endDate="2024-11-05" />
+    )
+
+    await userEvent.click(getDatePickerTriggerButton())
+
+    const tables = document.querySelectorAll(
+      '.dnb-date-picker__calendar table'
+    ) as NodeListOf<HTMLTableElement>
+    const leftTable = tables[0]
+    const rightTable = tables[1]
+
+    // Navigate to Oct 31 in the left calendar
+    leftTable.focus()
+    await userEvent.keyboard('{ArrowDown}')
+
+    // Move right from the last day of October — should jump to the right calendar
+    const lastDayButton = leftTable.querySelector(
+      'td[data-date="2024-10-31"] button'
+    ) as HTMLButtonElement
+    lastDayButton.focus()
+    await userEvent.keyboard('{ArrowRight}')
+
+    // Focus should now be in the right calendar on Nov 1
+    expect(rightTable.contains(document.activeElement)).toBe(true)
+    expect(
+      document.activeElement.closest('td').getAttribute('data-date')
+    ).toBe('2024-11-01')
+
+    // Arrow keys should continue working from the new position
+    await userEvent.keyboard('{ArrowRight}')
+    expect(rightTable.contains(document.activeElement)).toBe(true)
+    expect(
+      document.activeElement.closest('td').getAttribute('data-date')
+    ).toBe('2024-11-02')
+
+    // Now test the reverse: navigate back to Nov 1, then go left into Oct
+    await userEvent.keyboard('{ArrowLeft}') // Nov 2 → Nov 1
+    await userEvent.keyboard('{ArrowLeft}') // Nov 1 → should jump to Oct 31
+
+    // Focus should jump to the left calendar on Oct 31
+    expect(leftTable.contains(document.activeElement)).toBe(true)
+    expect(
+      document.activeElement.closest('td').getAttribute('data-date')
+    ).toBe('2024-10-31')
   })
 
   it('should keep the picker open during tab navigation when showInput is true', async () => {


### PR DESCRIPTION
Preview: https://chore-date-picker-keyboard-n.eufemia-e25.pages.dev/uilib/components/date-picker/demos?focusmode=DatePickerLinked#linked-datepickers

In range mode with two calendars, when arrow key navigation crosses into the month already shown by the other calendar, focus now jumps to that calendar instead of changing the current calendar's month view.

**Changes:**

- **Cross-calendar focus jump**: When navigating right from the left calendar's last day into the right calendar's month (or vice versa), focus moves to the corresponding date button in the other calendar. Neither calendar's month changes.
- **DOM-based `focusedDateRef` sync**: At the start of each keydown handler, syncs the focused date ref from the currently active date button in the DOM. This ensures correct navigation after cross-calendar jumps, mouse clicks on day buttons, or any other focus transfer.
- **Updated tests**: Rewrote month navigation tests to verify the new cross-calendar behavior and added a dedicated test for the focus jump in both directions.