### PR TITLE
fix(Input): allow clicks through hidden clear button area

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -1366,6 +1366,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 }
 .dnb-input--clear.dnb-input__submit-element {
   opacity: 0;
+  pointer-events: none;
   transition: opacity 200ms ease-in-out;
 }
 .dnb-input--clear.dnb-input__submit-element .dnb-button {
@@ -1392,6 +1393,7 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 }
 .dnb-input[data-has-content=true] .dnb-input--clear {
   opacity: 1;
+  pointer-events: auto;
 }
 .dnb-input--has-submit-element .dnb-input--clear.dnb-input__submit-element {
   margin-right: 2.5rem;

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1366,6 +1366,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 }
 .dnb-input--clear.dnb-input__submit-element {
   opacity: 0;
+  pointer-events: none;
   transition: opacity 200ms ease-in-out;
 }
 .dnb-input--clear.dnb-input__submit-element .dnb-button {
@@ -1392,6 +1393,7 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 }
 .dnb-input[data-has-content=true] .dnb-input--clear {
   opacity: 1;
+  pointer-events: auto;
 }
 .dnb-input--has-submit-element .dnb-input--clear.dnb-input__submit-element {
   margin-right: 2.5rem;

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1366,6 +1366,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 }
 .dnb-input--clear.dnb-input__submit-element {
   opacity: 0;
+  pointer-events: none;
   transition: opacity 200ms ease-in-out;
 }
 .dnb-input--clear.dnb-input__submit-element .dnb-button {
@@ -1392,6 +1393,7 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 }
 .dnb-input[data-has-content=true] .dnb-input--clear {
   opacity: 1;
+  pointer-events: auto;
 }
 .dnb-input--has-submit-element .dnb-input--clear.dnb-input__submit-element {
   margin-right: 2.5rem;

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -1362,6 +1362,7 @@ html[data-whatinput=keyboard] .dnb-input__status--error .dnb-input__border:focus
 }
 .dnb-input--clear.dnb-input__submit-element {
   opacity: 0;
+  pointer-events: none;
   transition: opacity 200ms ease-in-out;
 }
 .dnb-input--clear.dnb-input__submit-element .dnb-button {
@@ -1388,6 +1389,7 @@ html:not([data-whatintent=touch]) .dnb-input--clear.dnb-input__submit-element .d
 }
 .dnb-input[data-has-content=true] .dnb-input--clear {
   opacity: 1;
+  pointer-events: auto;
 }
 .dnb-input--has-submit-element .dnb-input--clear.dnb-input__submit-element {
   margin-right: 2.5rem;

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -438,6 +438,7 @@
   // Input clear button styles
   &--clear.dnb-input__submit-element {
     opacity: 0;
+    pointer-events: none;
     transition: opacity 200ms ease-in-out;
 
     .dnb-button {
@@ -478,6 +479,7 @@
 
   &[data-has-content='true'] &--clear {
     opacity: 1;
+    pointer-events: auto;
   }
 
   &--has-submit-element &--clear.dnb-input__submit-element {


### PR DESCRIPTION
Preview: https://fix-input-clear-button-point.eufemia-e25.pages.dev/uilib/components/input#input-with-clear-button

When `showClearButton` is set but the input has no content, the invisible clear button still blocks pointer events in its area. This prevents clicking on that part of the input to focus it.

**Fix:** Add `pointer-events: none` to the clear button when it's hidden (`opacity: 0`) and restore `pointer-events: auto` when it becomes visible (`[data-has-content='true']`).