### PR TITLE
fix(DateFormat): preserve leading zeros when `hideYear`/`hideCurrentYear` used with `dateStyle="short"`

### DIFF
--- a/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
@@ -121,11 +121,14 @@ function formatDateWithoutYear(
   const parts = formatter.formatToParts(date)
 
   // Remove year parts and any adjacent literal separators
+  const isYearType = (type: string) =>
+    type === 'year' || type === 'relatedYear'
+
   const filtered: typeof parts = []
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]
 
-    if (part.type === 'year' || part.type === 'relatedYear') {
+    if (isYearType(part.type)) {
       continue
     }
 
@@ -133,12 +136,11 @@ function formatDateWithoutYear(
     if (part.type === 'literal') {
       const prev = parts[i - 1]
       const next = parts[i + 1]
-      const prevIsYear =
-        prev?.type === 'year' || prev?.type === 'relatedYear'
-      const nextIsYear =
-        next?.type === 'year' || next?.type === 'relatedYear'
 
-      if (prevIsYear || nextIsYear) {
+      if (
+        (prev && isYearType(prev.type)) ||
+        (next && isYearType(next.type))
+      ) {
         continue
       }
     }

--- a/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
@@ -102,6 +102,53 @@ export function getDateTimeSeparator(
   }
 }
 
+/**
+ * Formats a date without the year by using formatToParts with the original
+ * dateStyle, then stripping the year and any adjacent separators.
+ * This preserves the locale-specific formatting (e.g. leading zeros for short style).
+ */
+function formatDateWithoutYear(
+  date: Date,
+  locale: AnyLocale,
+  dateStyle: NonNullable<Intl.DateTimeFormatOptions['dateStyle']>,
+  timeZone?: string
+): string {
+  const formatter = new Intl.DateTimeFormat(locale, {
+    dateStyle,
+    ...(timeZone ? { timeZone } : {}),
+  })
+
+  const parts = formatter.formatToParts(date)
+
+  // Remove year parts and any adjacent literal separators
+  const filtered: typeof parts = []
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]
+
+    if (part.type === 'year' || part.type === 'relatedYear') {
+      continue
+    }
+
+    // Skip literal separators adjacent to the year
+    if (part.type === 'literal') {
+      const prev = parts[i - 1]
+      const next = parts[i + 1]
+      const prevIsYear =
+        prev?.type === 'year' || prev?.type === 'relatedYear'
+      const nextIsYear =
+        next?.type === 'year' || next?.type === 'relatedYear'
+
+      if (prevIsYear || nextIsYear) {
+        continue
+      }
+    }
+
+    filtered.push(part)
+  }
+
+  return filtered.map((p) => p.value).join('')
+}
+
 export function formatDate(
   dateValue: FormatDateInput,
   {
@@ -153,27 +200,12 @@ export function formatDate(
   }
 
   if (shouldHideYear) {
-    const dateOnlyOptionsByStyle: Record<
-      NonNullable<typeof dateStyle>,
-      Intl.DateTimeFormatOptions
-    > = {
-      full: { weekday: 'long', month: 'long', day: 'numeric' },
-      long: { month: 'long', day: 'numeric' },
-      medium: { month: 'short', day: 'numeric' },
-      short: { month: 'numeric', day: 'numeric' },
-    }
-
-    const dateOnlyOptions: Intl.DateTimeFormatOptions = {
-      ...dateOnlyOptionsByStyle[dateStyle],
-      ...(finalOptions.timeZone
-        ? { timeZone: finalOptions.timeZone }
-        : {}),
-    }
-
-    const datePart = new Intl.DateTimeFormat(
+    const datePart = formatDateWithoutYear(
+      date,
       locale,
-      dateOnlyOptions
-    ).format(date)
+      dateStyle,
+      finalOptions.timeZone
+    )
 
     if (finalOptions.timeStyle) {
       const timeOnlyOptions: Intl.DateTimeFormatOptions = {

--- a/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormat.test.tsx
@@ -112,6 +112,27 @@ describe('DateFormat', () => {
       }
     })
 
+    it('should preserve leading zeros with dateStyle="short" and hideYear', () => {
+      const { container } = render(
+        <DateFormat value="2026-08-01" dateStyle="short" hideYear />
+      )
+      const dateFormat = container.querySelector('.dnb-date-format')
+      expect(dateFormat?.textContent).toBe('01.08')
+    })
+
+    it('should preserve leading zeros with dateStyle="short" and hideCurrentYear', () => {
+      const now = new Date('2026-06-15T12:00:00.000Z')
+      vi.useFakeTimers({ now: now.getTime() })
+
+      const { container } = render(
+        <DateFormat value="2026-08-01" dateStyle="short" hideCurrentYear />
+      )
+      const dateFormat = container.querySelector('.dnb-date-format')
+      expect(dateFormat?.textContent).toBe('01.08')
+
+      vi.useRealTimers()
+    })
+
     it('should hide year for dates in other years when hideYear is true', () => {
       const { container } = render(
         <DateFormat value="2024-02-04" dateStyle="medium" hideYear />

--- a/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormatUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormatUtils.test.ts
@@ -107,6 +107,24 @@ describe('DateFormatUtils', () => {
         expect(otherYear).toMatch(/\d{1,2}/)
       }
     })
+
+    it('preserves leading zeros with dateStyle short and hideYear', () => {
+      const result = formatDate('2026-08-01', {
+        locale: 'nb-NO',
+        options: { dateStyle: 'short' },
+        hideYear: true,
+      })
+      expect(result).toBe('01.08')
+    })
+
+    it('preserves leading zeros with dateStyle short and hideYear for en-GB', () => {
+      const result = formatDate('2026-08-01', {
+        locale: 'en-GB',
+        options: { dateStyle: 'short' },
+        hideYear: true,
+      })
+      expect(result).toBe('01/08')
+    })
   })
 
   describe('getDateTimeSeparator', () => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1779859766335859

Replace manual Intl.DateTimeFormatOptions mapping with formatToParts-based approach that strips the year from the original dateStyle output. This preserves locale-specific formatting (e.g. leading zeros for short style) instead of losing them by using { month: 'numeric', day: 'numeric' }.

Before: <DateFormat dateStyle="short" hideYear>2026-08-01</DateFormat> → 1.8
After:  <DateFormat dateStyle="short" hideYear>2026-08-01</DateFormat> → 01.08

