### PR TITLE
chore(Popover): fix flaky focus preventScroll test

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -1656,23 +1656,23 @@ describe('Popover', () => {
       document.querySelector('button[aria-controls]')
     )) as HTMLButtonElement
 
+    // Spy before clicking so we capture all focus calls
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+
     await userEvent.click(trigger)
 
-    const content = (await waitFor(() =>
-      document.querySelector('.dnb-popover__content')
-    )) as HTMLElement
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-popover__content')
+      ).toBeInTheDocument()
+    })
 
-    // Spy on the content element's focus method
-    // Note: focus is called immediately and again after 10ms, so we spy after opening
-    // to catch at least the second call
-    const focusSpy = vi.spyOn(content, 'focus')
-
-    // Wait for the second focus call (after 10ms delay)
+    // Wait for the delayed focus call (after 10ms)
     await waitFor(
       () => {
         expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
       },
-      { timeout: 100 }
+      { timeout: 200 }
     )
 
     focusSpy.mockRestore()


### PR DESCRIPTION
The "calls focus with preventScroll when opening" test was flaky because it attached the `focus` spy **after** the popover opened. The focus calls (immediate + 10ms delay) could fire before the spy was in place, causing a timeout.

**Fix:** Spy on `HTMLElement.prototype.focus` before clicking the trigger so all focus calls are captured reliably.