### PR TITLE
chore: upgrade Node to 24.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   },
   "engines": {
     "node": ">=24.x",
-    "yarn": ">=4.0.0"
+    "yarn": ">=4.x"
   },
   "volta": {
-    "node": "24.6.0"
+    "node": "24.16.0"
   },
   "packageManager": "yarn@4.6.0"
 }

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberFormat.test.tsx
@@ -1730,7 +1730,7 @@ describe('NumberFormat compact', () => {
         <Component value={-value} compact locale="en-GB" decimals="2" />
       )
       expect(document.querySelector(displaySelector).textContent).toBe(
-        '-12.35M'
+        '-12.35m'
       )
       expect(
         document.querySelector(ariaSelector).getAttribute('data-text')
@@ -1765,7 +1765,7 @@ describe('NumberFormat compact', () => {
         />
       )
       expect(document.querySelector(displaySelector).textContent).toBe(
-        '-NOK\u00A012.35M'
+        '-NOK\u00A012.35m'
       )
       expect(
         document.querySelector(ariaSelector).getAttribute('data-text')

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -595,21 +595,21 @@ describe('Currency format with dirty number', () => {
         currency: 'CHF',
         locale: 'de-CH',
       })
-    ).toBe('CHF-123’456’789.50')
+    ).toBe("CHF-123'456'789.50")
     expect(
       formatCurrency(number, {
         currency: 'CHF',
         currencyPosition: 'before',
         locale: 'de-CH',
       })
-    ).toBe('CHF-123’456’789.50')
+    ).toBe("CHF-123'456'789.50")
     expect(
       formatCurrency(number, {
         currency: 'CHF',
         currencyPosition: 'after',
         locale: 'de-CH',
       })
-    ).toBe('-123’456’789.50 CHF')
+    ).toBe("-123'456'789.50 CHF")
     expect(
       formatCurrency(number, {
         currencyPosition: 'before',

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -363,7 +363,7 @@ describe('Field.Currency', () => {
         </Provider>
       )
 
-      expect(input).toHaveValue('1’234 Kronen')
+      expect(input).toHaveValue("1'234 Kronen")
 
       rerender(
         <Provider>


### PR DESCRIPTION
Upgrade Volta Node pin from 24.6.0 to 24.16.0 (latest Node 24) and simplify the yarn engine constraint to `>=4.x`.