### PR TITLE
chore(CI): fix release version detection for semantic-release v25

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -7,7 +7,7 @@
 // run: yarn nodemon --exec 'babel-node --extensions .js,.ts,.tsx ./scripts/postbuild/getNextReleaseVersion.js' --ext js --watch './scripts/**/*'
 // run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/postbuild/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
 
-const { runCommand } = require('../tools/cliTools')
+const { execFile } = require('child_process')
 const simpleGit = require('simple-git')
 
 try {
@@ -16,7 +16,7 @@ try {
   // .env is optional — CI provides env vars directly
 }
 
-const command = 'yarn workspace @dnb/eufemia semantic-release --dry-run'
+const srBin = require.resolve('semantic-release/bin/semantic-release.js')
 const releaseBranches = ['release', 'beta', 'alpha']
 
 // run this script if it is called from bash / command line
@@ -29,7 +29,19 @@ async function getNextReleaseVersion() {
 
   if (releaseBranches.includes(branchName)) {
     try {
-      const log = await runCommand(command, { timeout: 120000 })
+      const log = await new Promise((resolve) => {
+        execFile(
+          process.execPath,
+          [srBin, '--dry-run'],
+          { timeout: 120000 },
+          (_error, stdout, stderr) => {
+            // Resolve with combined output regardless of exit code —
+            // semantic-release may exit non-zero in dry-run mode
+            // even after printing the next version.
+            resolve((stdout || '') + (stderr || ''))
+          }
+        )
+      })
       const nextVersion = log.match(
         /The next release version is ([^\n]*)/
       )?.[1]


### PR DESCRIPTION
Replace `runCommand` with `execFile` + `require.resolve` to fix two issues with `getNextReleaseVersion.js`:

- **Yarn Berry binary resolution**: `yarn workspace @dnb/eufemia semantic-release` can't find the binary in Yarn Berry's node_modules layout
- **stderr rejection**: `runCommand` rejects when semantic-release v25 writes warnings to stderr via its signale logger

The fix resolves the binary path directly via `require.resolve('semantic-release/bin/semantic-release.js')` and uses `execFile` to handle combined stdout/stderr output regardless of exit code.

<img width="287" height="74" alt="Screenshot 2026-05-27 at 13 27 05" src="https://github.com/user-attachments/assets/d83d0576-c151-48f7-87bf-8e5022baf73c" />

