### PR TITLE
feat(Breadcrumb): transition chevron icon during open/closing

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -25,6 +25,7 @@ import type {
 } from '../section/Section'
 import Section from '../section/Section'
 import Button from '../button/Button'
+import Icon from '../icon/Icon'
 import Accordion from '../accordion/Accordion'
 
 // Shared
@@ -35,6 +36,12 @@ import type {
   SpaceTypeMedia,
   SpacingProps,
 } from '../../shared/types'
+import { chevron_down, chevron_up } from '../../icons'
+
+const toggleIcon = Icon.transition({
+  collapsed: chevron_down,
+  expanded: chevron_up,
+})
 import type { SkeletonShow } from '../skeleton/Skeleton'
 
 // Internal
@@ -325,7 +332,10 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
                 className="dnb-breadcrumb__toggle"
                 text={backToText}
                 variant="tertiary"
-                icon="chevron_down"
+                icon={toggleIcon}
+                transitionState={
+                  !isCollapsedRef.current ? 'expanded' : 'collapsed'
+                }
                 iconPosition="left"
                 onClick={onClick ?? onClickHandler}
                 aria-expanded={!isCollapsedRef.current}

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1300,18 +1300,6 @@ button.dnb-button::-moz-focus-inner {
     display: none;
   }
 }
-.dnb-breadcrumb {
-  /* stylelint-disable no-descending-specificity */
-}
-.dnb-breadcrumb__toggle .dnb-button__icon {
-  transition: transform 400ms var(--easing-default);
-}
-.dnb-breadcrumb__toggle[aria-expanded=true] .dnb-button__icon {
-  transform: rotate(180deg);
-}
-.dnb-breadcrumb {
-  /* stylelint-enable no-descending-specificity */
-}
 .dnb-breadcrumb__collapse .dnb-breadcrumb__list.dnb-section {
   flex-direction: column;
   align-items: flex-start;

--- a/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
+++ b/packages/dnb-eufemia/src/components/breadcrumb/style/dnb-breadcrumb.scss
@@ -151,16 +151,6 @@
     }
   }
 
-  /* stylelint-disable no-descending-specificity */
-  &__toggle .dnb-button__icon {
-    transition: transform 400ms var(--easing-default);
-  }
-
-  &__toggle[aria-expanded='true'] .dnb-button__icon {
-    transform: rotate(180deg);
-  }
-  /* stylelint-enable no-descending-specificity */
-
   &__collapse &__list.dnb-section {
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
Migrate the Breadcrumb chevron icon to use `Icon.transition()` for smooth open/close animations, replacing CSS-based rotation.

Preview: https://feat-icon-transition-breadcr.eufemia-e25.pages.dev/uilib/components/breadcrumb/demos#always-be-collapsed-variantcollapse