### PR TITLE
feat(HelpButton): transition inline icon during open/closing

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -1001,68 +1001,8 @@ button.dnb-button::-moz-focus-inner {
  * HelpButton component
  *
  */
-.dnb-help-button__inline svg {
-  will-change: transform;
-}
-.dnb-help-button__inline svg:nth-of-type(2) {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(1) {
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(2) {
-  animation: rotate-icon-in 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(1) {
-  opacity: 0;
-  animation: animate-question 400ms var(--easing-default) 200ms forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
-  animation: rotate-icon-out 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
-  animation-duration: 0ms;
-}
-@media (prefers-reduced-motion: reduce) {
-  .dnb-help-button__inline svg {
-    animation-duration: 0.01ms !important;
-  }
-}
-@keyframes rotate-icon-in {
-  from {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-}
-@keyframes rotate-icon-out {
-  0% {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-  30% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-}
-@keyframes animate-question {
-  from {
-    opacity: 0;
-    transform: rotate(10deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(0deg);
-  }
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) .dnb-icon--transition-fallback svg[data-icon-state] {
+  transition-duration: 0ms;
 }
 
 .dnb-help-button__content .dnb-section {

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1002,68 +1002,8 @@ button.dnb-button::-moz-focus-inner {
  * HelpButton component
  *
  */
-.dnb-help-button__inline svg {
-  will-change: transform;
-}
-.dnb-help-button__inline svg:nth-of-type(2) {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(1) {
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(2) {
-  animation: rotate-icon-in 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(1) {
-  opacity: 0;
-  animation: animate-question 400ms var(--easing-default) 200ms forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
-  animation: rotate-icon-out 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
-  animation-duration: 0ms;
-}
-@media (prefers-reduced-motion: reduce) {
-  .dnb-help-button__inline svg {
-    animation-duration: 0.01ms !important;
-  }
-}
-@keyframes rotate-icon-in {
-  from {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-}
-@keyframes rotate-icon-out {
-  0% {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-  30% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-}
-@keyframes animate-question {
-  from {
-    opacity: 0;
-    transform: rotate(10deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(0deg);
-  }
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) .dnb-icon--transition-fallback svg[data-icon-state] {
+  transition-duration: 0ms;
 }
 
 .dnb-help-button__content .dnb-section {

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -21,7 +21,14 @@ import CardContext from '../card/CardContext'
 import type { SpacingProps } from '../../shared/types'
 import Dialog from '../Dialog'
 import { question as QuestionIcon, close as CloseIcon } from '../../icons'
+import { transition } from '../icon/IconTransition'
+import IconPrimary from '../icon-primary/IconPrimary'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
+
+const helpButtonIcon = transition({
+  question: QuestionIcon,
+  close: CloseIcon,
+})
 
 export type HelpProps = {
   title?: ReactNode
@@ -129,16 +136,19 @@ function HelpButtonInline(props: HelpButtonInlineProps) {
       <HelpButtonInstance
         bounding
         size={size ?? 'small'}
-        icon={HelpButtonIcon}
+        icon={
+          <IconPrimary
+            icon={helpButtonIcon}
+            transitionState={isOpen ? 'close' : 'question'}
+          />
+        }
         title={!isOpen && !wasOpenRef.current ? help?.title : undefined}
         {...rest}
         id={controlId}
         className={clsx(
           'dnb-help-button__inline',
-          isOpen && 'dnb-help-button__inline--open',
-          isUserIntent && 'dnb-help-button__inline--user-intent',
-          typeof wasOpenRef.current === 'boolean' &&
-            'dnb-help-button__inline--was-open',
+          isUserIntent !== undefined &&
+            'dnb-help-button__inline--user-intent',
           className
         )}
         selected={isOpen}
@@ -318,15 +328,6 @@ function HelpButtonInlineContentComponent(
         {children}
       </Section>
     </HeightAnimation>
-  )
-}
-
-function HelpButtonIcon() {
-  return (
-    <>
-      <QuestionIcon />
-      <CloseIcon />
-    </>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -1,4 +1,3 @@
-import { act } from 'react'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { makeUniqueId } from '../../../shared/component-helper'
@@ -27,10 +26,10 @@ describe('HelpButtonInline', () => {
     const button = document.querySelector('button')
 
     await userEvent.click(button)
-    expect(button).toHaveClass('dnb-help-button__inline--open')
+    expect(button).toHaveAttribute('aria-expanded', 'true')
 
     await userEvent.click(button)
-    expect(button).not.toHaveClass('dnb-help-button__inline--open')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('should toggle open state when Space key gets pressed', async () => {
@@ -40,22 +39,25 @@ describe('HelpButtonInline', () => {
 
     await userEvent.tab()
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).not.toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'false'
     )
 
     await userEvent.type(document.querySelector('button'), '{Space}')
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'true'
     )
 
     await userEvent.keyboard('{Space}')
     expect(document.querySelector('button')).toHaveFocus()
 
     // Will not close when Space is pressed
-    expect(document.querySelector('button')).toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'true'
     )
   })
 
@@ -66,20 +68,23 @@ describe('HelpButtonInline', () => {
 
     await userEvent.tab()
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).not.toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'false'
     )
 
     await userEvent.keyboard('{Enter}')
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'true'
     )
 
     await userEvent.keyboard('{Enter}')
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).not.toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'false'
     )
   })
 
@@ -90,21 +95,24 @@ describe('HelpButtonInline', () => {
 
     await userEvent.tab()
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).not.toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'false'
     )
 
     await userEvent.keyboard('{Enter}')
     expect(document.querySelector('button')).toHaveFocus()
-    expect(document.querySelector('button')).toHaveClass(
-      'dnb-help-button__inline--open'
+    expect(document.querySelector('button')).toHaveAttribute(
+      'aria-expanded',
+      'true'
     )
 
     await userEvent.keyboard('{Escape}')
     await waitFor(() => {
       expect(document.querySelector('button')).toHaveFocus()
-      expect(document.querySelector('button')).not.toHaveClass(
-        'dnb-help-button__inline--open'
+      expect(document.querySelector('button')).toHaveAttribute(
+        'aria-expanded',
+        'false'
       )
     })
   })
@@ -397,10 +405,10 @@ describe('HelpButtonInline', () => {
     const button = document.querySelector('button')
 
     await userEvent.type(button, '{Space}')
-    expect(button).toHaveClass('dnb-help-button__inline--open')
+    expect(button).toHaveAttribute('aria-expanded', 'true')
 
     await userEvent.type(button, '{Escape}')
-    expect(button).not.toHaveClass('dnb-help-button__inline--open')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('should display title when open', async () => {
@@ -585,7 +593,7 @@ describe('HelpButtonInline', () => {
     // Open the help button
     await userEvent.click(button)
     await waitFor(() => {
-      expect(button).toHaveClass('dnb-help-button__inline--open')
+      expect(button).toHaveAttribute('aria-expanded', 'true')
     })
 
     // Get the content section element (where onKeyDown is attached when focusOnOpen is true)
@@ -617,63 +625,43 @@ describe('HelpButtonInline', () => {
 })
 
 describe('animation end reset', () => {
-  const simulateAnimationEnd = (
-    element: Element = document.querySelector('.dnb-height-animation')
-  ) => {
-    act(() => {
-      element.dispatchEvent(new CustomEvent('transitionend'))
-    })
-  }
-
-  it('should remove --was-open class after closing animation ends', async () => {
+  it('should switch icon state when toggled', async () => {
     render(<HelpButtonInline help={{ title: 'Help title' }} />)
 
     const button = document.querySelector('button')
-
-    await userEvent.click(button)
-    expect(button).toHaveClass('dnb-help-button__inline--open')
-    expect(button).toHaveClass('dnb-help-button__inline--was-open')
-
-    await userEvent.click(button)
-    expect(button).not.toHaveClass('dnb-help-button__inline--open')
-
-    await waitFor(() => {
-      expect(button).not.toHaveClass('dnb-help-button__inline--was-open')
-    })
-  })
-
-  it('should remove --was-open class when using separate content', async () => {
-    const id = makeUniqueId()
-
-    render(
-      <>
-        <HelpButtonInline contentId={id} help={{ title: 'Help title' }} />
-        <HelpButtonInlineContent contentId={id} />
-      </>
+    const questionSvg = button.querySelector(
+      'svg[data-icon-state="question"]'
     )
+    const closeSvg = button.querySelector('svg[data-icon-state="close"]')
 
-    const button = document.querySelector('button')
+    expect(questionSvg).toHaveClass('dnb-icon__state--active')
+    expect(closeSvg).not.toHaveClass('dnb-icon__state--active')
 
     await userEvent.click(button)
-    expect(button).toHaveClass('dnb-help-button__inline--was-open')
-
-    await userEvent.click(button)
-
-    const heightAnimation = document.querySelector('.dnb-height-animation')
-    if (heightAnimation) {
-      simulateAnimationEnd(heightAnimation)
-    }
-
     await waitFor(() => {
-      expect(button).not.toHaveClass('dnb-help-button__inline--was-open')
+      expect(questionSvg).not.toHaveClass('dnb-icon__state--active')
+      expect(closeSvg).toHaveClass('dnb-icon__state--active')
+    })
+
+    await userEvent.click(button)
+    await waitFor(() => {
+      expect(questionSvg).toHaveClass('dnb-icon__state--active')
+      expect(closeSvg).not.toHaveClass('dnb-icon__state--active')
     })
   })
 
-  it('should not have --was-open class initially', () => {
+  it('should use transition fallback class', () => {
+    render(<HelpButtonInline help={{ title: 'Help title' }} />)
+
+    const icon = document.querySelector('.dnb-icon')
+    expect(icon).toHaveClass('dnb-icon--transition-fallback')
+  })
+
+  it('should not have --user-intent class initially', () => {
     render(<HelpButtonInline help={{ title: 'Help title' }} />)
 
     const button = document.querySelector('button')
-    expect(button).not.toHaveClass('dnb-help-button__inline--was-open')
+    expect(button).not.toHaveClass('dnb-help-button__inline--user-intent')
   })
 })
 

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -993,68 +993,8 @@ button.dnb-button::-moz-focus-inner {
  * HelpButton component
  *
  */
-.dnb-help-button__inline svg {
-  will-change: transform;
-}
-.dnb-help-button__inline svg:nth-of-type(2) {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(1) {
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(2) {
-  animation: rotate-icon-in 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(1) {
-  opacity: 0;
-  animation: animate-question 400ms var(--easing-default) 200ms forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
-  animation: rotate-icon-out 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
-  animation-duration: 0ms;
-}
-@media (prefers-reduced-motion: reduce) {
-  .dnb-help-button__inline svg {
-    animation-duration: 0.01ms !important;
-  }
-}
-@keyframes rotate-icon-in {
-  from {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-}
-@keyframes rotate-icon-out {
-  0% {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-  30% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-}
-@keyframes animate-question {
-  from {
-    opacity: 0;
-    transform: rotate(10deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(0deg);
-  }
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) .dnb-icon--transition-fallback svg[data-icon-state] {
+  transition-duration: 0ms;
 }
 
 .dnb-help-button__content .dnb-section {

--- a/packages/dnb-eufemia/src/components/help-button/style/dnb-help-button-inline.scss
+++ b/packages/dnb-eufemia/src/components/help-button/style/dnb-help-button-inline.scss
@@ -6,83 +6,10 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
 .dnb-help-button__inline {
-  svg {
-    // To avoid the animations from jumping in Safari
-    will-change: transform;
-  }
-
-  svg:nth-of-type(2) {
-    position: absolute;
-    inset: 0;
-    margin: auto;
-    opacity: 0;
-  }
-
-  &--open {
-    svg:nth-of-type(1) {
-      opacity: 0;
-    }
-    svg:nth-of-type(2) {
-      animation: rotate-icon-in 400ms var(--easing-default) forwards;
-    }
-  }
-
-  &:not(#{&}--open)#{&}--was-open {
-    svg:nth-of-type(1) {
-      opacity: 0;
-      animation: animate-question 400ms var(--easing-default) 200ms
-        forwards;
-    }
-    svg:nth-of-type(2) {
-      animation: rotate-icon-out 400ms var(--easing-default) forwards;
-    }
-  }
-
+  // Disable the fallback crossfade animation when not triggered by the user
   &:not(#{&}--user-intent) {
-    svg {
-      animation-duration: 0ms;
-    }
-  }
-
-  @include utilities.reducedMotion() {
-    svg {
-      animation-duration: 0.01ms !important;
-    }
-  }
-
-  @keyframes rotate-icon-in {
-    from {
-      opacity: 0;
-      transform: rotate(0deg);
-    }
-    to {
-      opacity: 1;
-      transform: rotate(90deg);
-    }
-  }
-
-  @keyframes rotate-icon-out {
-    0% {
-      opacity: 1;
-      transform: rotate(90deg);
-    }
-    30% {
-      opacity: 1;
-    }
-    100% {
-      opacity: 0;
-      transform: rotate(0deg);
-    }
-  }
-
-  @keyframes animate-question {
-    from {
-      opacity: 0;
-      transform: rotate(10deg);
-    }
-    to {
-      opacity: 1;
-      transform: rotate(0deg);
+    .dnb-icon--transition-fallback svg[data-icon-state] {
+      transition-duration: 0ms;
     }
   }
 }

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -997,68 +997,8 @@ button.dnb-button::-moz-focus-inner {
  * HelpButton component
  *
  */
-.dnb-help-button__inline svg {
-  will-change: transform;
-}
-.dnb-help-button__inline svg:nth-of-type(2) {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(1) {
-  opacity: 0;
-}
-.dnb-help-button__inline--open svg:nth-of-type(2) {
-  animation: rotate-icon-in 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(1) {
-  opacity: 0;
-  animation: animate-question 400ms var(--easing-default) 200ms forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--open).dnb-help-button__inline--was-open svg:nth-of-type(2) {
-  animation: rotate-icon-out 400ms var(--easing-default) forwards;
-}
-.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) svg {
-  animation-duration: 0ms;
-}
-@media (prefers-reduced-motion: reduce) {
-  .dnb-help-button__inline svg {
-    animation-duration: 0.01ms !important;
-  }
-}
-@keyframes rotate-icon-in {
-  from {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-}
-@keyframes rotate-icon-out {
-  0% {
-    opacity: 1;
-    transform: rotate(90deg);
-  }
-  30% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    transform: rotate(0deg);
-  }
-}
-@keyframes animate-question {
-  from {
-    opacity: 0;
-    transform: rotate(10deg);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(0deg);
-  }
+.dnb-help-button__inline:not(.dnb-help-button__inline--user-intent) .dnb-icon--transition-fallback svg[data-icon-state] {
+  transition-duration: 0ms;
 }
 
 .dnb-help-button__content .dnb-section {


### PR DESCRIPTION
Migrate the HelpButtonInline icon to use `Icon.transition()` for smooth animations, replacing CSS-based approach.

Preview: https://feat-icon-transition-help-bu.eufemia-e25.pages.dev/uilib/components/help-button/demos#help-button-used-in-form-help-inline