### PR TITLE
feat(Menu): transition accordion chevron icon during open/closing

### DIFF
--- a/packages/dnb-eufemia/src/components/menu/MenuAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuAccordion.tsx
@@ -2,11 +2,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import { clsx } from 'clsx'
 import IconPrimary from '../IconPrimary'
+import Icon from '../icon/Icon'
+import { chevron_down, chevron_up } from '../../icons'
 import HeightAnimation from '../height-animation/HeightAnimation'
 import { MenuContext, useMenuContext } from './MenuContext'
 import MenuItemContent from './MenuItemContent'
 import useMenuItemRegistration from './useMenuItemRegistration'
 import type { MenuAccordionProps, MenuContextValue } from './types'
+
+const accordionIcon = Icon.transition({
+  collapsed: chevron_down,
+  expanded: chevron_up,
+})
 
 export default function MenuAccordion(props: MenuAccordionProps) {
   const {
@@ -164,7 +171,10 @@ export default function MenuAccordion(props: MenuAccordionProps) {
         <MenuItemContent icon={icon} text={text} />
 
         <span className="dnb-menu__accordion__indicator">
-          <IconPrimary icon="chevron_right" />
+          <IconPrimary
+            icon={accordionIcon}
+            transitionState={isOpen ? 'expanded' : 'collapsed'}
+          />
         </span>
       </div>
 

--- a/packages/dnb-eufemia/src/components/menu/style/dnb-menu.scss
+++ b/packages/dnb-eufemia/src/components/menu/style/dnb-menu.scss
@@ -188,15 +188,10 @@
       align-items: center;
       flex-shrink: 0;
       margin-inline-start: auto;
-
-      .dnb-icon {
-        transition: transform 400ms var(--easing-default);
-        transform: rotate(90deg);
-      }
     }
 
     &--open > &__trigger &__indicator .dnb-icon {
-      transform: rotate(270deg);
+      --icon-transition: var(--icon-transition-expanded);
     }
 
     .dnb-menu__list {


### PR DESCRIPTION
Migrate the MenuAccordion chevron icon to use `Icon.transition()` for smooth open/close animations, replacing CSS-based rotation.

Preview: https://feat-icon-transition-menu.eufemia-e25.pages.dev/uilib/components/menu/demos#accordion