### PR TITLE
feat(StepIndicator): transition chevron icon during open/closing

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -10,7 +10,9 @@ import type { ButtonProps } from '../button/Button'
 import Button from '../button/Button'
 import Section from '../section/Section'
 import HeightAnimation from '../height-animation/HeightAnimation'
-import chevron_down from '../../icons/chevron_down'
+import { chevron_down, chevron_up } from '../../icons'
+import Icon from '../icon/Icon'
+import IconPrimary from '../icon-primary/IconPrimary'
 import {
   validateDOMAttributes,
   combineDescribedBy,
@@ -22,6 +24,11 @@ import {
   skeletonDOMAttributes,
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
+
+const chevronIcon = Icon.transition({
+  collapsed: chevron_down,
+  expanded: chevron_up,
+})
 
 type StepIndicatorTriggerButtonProps = ButtonProps & {
   isNested?: boolean
@@ -131,7 +138,12 @@ function StepIndicatorTriggerButton({
             aria-label={label} // To support NVDA properly
             wrap
             variant="tertiary"
-            icon={chevron_down}
+            icon={
+              <IconPrimary
+                icon={chevronIcon}
+                transitionState={open ? 'expanded' : 'collapsed'}
+              />
+            }
             iconPosition="right"
           >
             {(typeof item === 'string' ? item : item && item.title) || ''}

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -1021,15 +1021,6 @@ button.dnb-button::-moz-focus-inner {
 }
 .dnb-step-indicator__trigger__button .dnb-button__icon {
   --button-icon-margin-top: 0.25rem;
-  transition: transform 400ms var(--easing-default);
-}
-@media (prefers-reduced-motion: reduce) {
-  .dnb-step-indicator__trigger__button .dnb-button__icon {
-    transition-duration: 0.01ms;
-  }
-}
-.dnb-step-indicator__trigger__button--expanded .dnb-button__icon {
-  transform: rotate(180deg);
 }
 .dnb-step-indicator__item__wrapper {
   display: flex;

--- a/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
+++ b/packages/dnb-eufemia/src/components/step-indicator/style/dnb-step-indicator.scss
@@ -40,14 +40,6 @@
     }
     .dnb-button__icon {
       --button-icon-margin-top: 0.25rem;
-      transition: transform 400ms var(--easing-default);
-
-      @include utilities.reducedMotion() {
-        transition-duration: 0.01ms;
-      }
-    }
-    &--expanded .dnb-button__icon {
-      transform: rotate(180deg);
     }
   }
 


### PR DESCRIPTION
Migrate the StepIndicator chevron icon to use `Icon.transition()` for smooth open/close animations, replacing CSS-based rotation.

Preview: https://feat-icon-transition-step-in.eufemia-e25.pages.dev/uilib/components/step-indicator/demos#stepindicator-in-loose-mode