### PR TITLE
fix(Field.MultiSelection): match popover border-radius on first and last items

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
@@ -163,6 +163,29 @@
     }
   }
 
+  // When the popover has no inner space, items are flush against the
+  // popover edges. Apply matching border-radius so backgrounds and
+  // borders follow the popover's rounded corners in every state.
+  .dnb-popover--no-inner-space &__list {
+    > li:first-child {
+      border-top-left-radius: var(--popover-border-radius);
+      border-top-right-radius: var(--popover-border-radius);
+
+      &::after {
+        border-radius: inherit;
+      }
+    }
+
+    > li:last-of-type {
+      border-bottom-left-radius: var(--popover-border-radius);
+      border-bottom-right-radius: var(--popover-border-radius);
+
+      &::after {
+        border-radius: inherit;
+      }
+    }
+  }
+
   &__popover-content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
When the MultiSelection popover has no inner space (no search, tags, or confirm features), items are flush against the popover edges. This adds matching border-radius to the first and last items so their backgrounds and borders follow the popover's rounded corners in every visual state (selected, hover, focus, active).

Preview: https://fix-field-multi-selection-po.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection/demos

Fix:
<img width="404" height="234" alt="Screenshot 2026-05-27 at 15 04 51" src="https://github.com/user-attachments/assets/cf8e8336-2305-4417-87c3-b05c50f2c6e0" />

Issue:
<img width="410" height="224" alt="Screenshot 2026-05-27 at 15 05 29" src="https://github.com/user-attachments/assets/85649e82-8ced-444b-9f42-80a0aa7a08a1" />

