### PR TITLE
chore(CI): prevent Playwright install hanging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,11 +76,10 @@ jobs:
             %USERPROFILE%\AppData\Local\ms-playwright
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
       - name: Install Playwright browsers
-        run: yarn workspace dnb-design-system-portal playwright install --with-deps firefox
+        run: yarn workspace dnb-design-system-portal playwright install firefox
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: yarn workspace dnb-design-system-portal playwright install-deps firefox
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Prebuild Library
         run: yarn workspace @dnb/eufemia prebuild:ci

--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -58,11 +58,12 @@ jobs:
             %USERPROFILE%\AppData\Local\ms-playwright
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
       - name: Install Playwright browsers
-        run: yarn workspace @dnb/eufemia playwright install --with-deps firefox
+        run: yarn workspace @dnb/eufemia playwright install firefox
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: yarn workspace @dnb/eufemia playwright install-deps firefox
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
 
       - name: Icons fetch and prebuild
         run: yarn workspace @dnb/eufemia prebuild:figma:ci

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -161,11 +161,12 @@ jobs:
             %USERPROFILE%\AppData\Local\ms-playwright
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
       - name: Install Playwright browsers
-        run: yarn workspace @dnb/eufemia playwright install --with-deps firefox
+        run: yarn workspace @dnb/eufemia playwright install firefox
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: yarn workspace @dnb/eufemia playwright install-deps firefox
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
 
       - name: Prebuild Library
         if: env.RUN_POST_BUILD == 'true'


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/26507991157/job/78065316551

Split 'playwright install --with-deps' into separate 'playwright install'
and 'playwright install-deps' steps so the browser download no longer
blocks on system dependency installation.

- Remove --with-deps from the browser download step
- Run install-deps unconditionally (system deps are not cached)
- Keep HOMEBREW_NO_AUTO_UPDATE=1 on install-deps for macOS runners

