### PR TITLE
chore: add vitest/no-focused-tests ESLint rule

### DIFF
--- a/packages/dnb-eufemia/eslint.config.mjs
+++ b/packages/dnb-eufemia/eslint.config.mjs
@@ -381,6 +381,7 @@ export default [
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,
+      'vitest/no-focused-tests': 'error',
       'no-console': 'off',
       'compat/compat': 'off',
       '@typescript-eslint/no-require-imports': 'off',


### PR DESCRIPTION
The `@vitest/eslint-plugin` recommended config does not include `no-focused-tests` (unlike `eslint-plugin-jest` which had `jest/no-focused-tests` in its recommended set). This adds it explicitly so `it.only`, `describe.only`, etc. are flagged as errors and can't slip into CI.