### PR TITLE
chore(Portal): suppress 'matched leaf route without Component' warning on redirect routes

### DIFF
--- a/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
@@ -270,10 +270,10 @@ export default function portalPagesPlugin(
           if (isFirstTab) {
             const parentSlug = file.slug.replace(/\/info$/, '')
             redirectDefs.push(
-              `  { path: '/${file.slug}', loader: () => redirect('/${parentSlug}/') },`
+              `  { path: '/${file.slug}', Component: Noop, loader: () => redirect('/${parentSlug}/') },`
             )
             redirectDefs.push(
-              `  { path: '/${file.slug}/', loader: () => redirect('/${parentSlug}/') },`
+              `  { path: '/${file.slug}/', Component: Noop, loader: () => redirect('/${parentSlug}/') },`
             )
           } else if (file.slug === '') {
             // Homepage: index route
@@ -309,10 +309,10 @@ export default function portalPagesPlugin(
                 const fromPath = String(from).replace(/\/$/, '')
                 const target = `/${file.slug}/`
                 redirectDefs.push(
-                  `  { path: '${fromPath}', loader: () => redirect('${target}') },`
+                  `  { path: '${fromPath}', Component: Noop, loader: () => redirect('${target}') },`
                 )
                 redirectDefs.push(
-                  `  { path: '${fromPath}/', loader: () => redirect('${target}') },`
+                  `  { path: '${fromPath}/', Component: Noop, loader: () => redirect('${target}') },`
                 )
               }
             }
@@ -330,6 +330,12 @@ export default function portalPagesPlugin(
         return `
 import React from 'react';
 import { redirect, useLocation } from 'react-router-dom';
+
+// No-op component for redirect routes so React Router does not warn
+// about a matched leaf route without an element or Component.
+function Noop() {
+  return null;
+}
 
 // Wrapper for page components that expect Gatsby-style props (location, etc.)
 function WithLocationProps({ Component }) {


### PR DESCRIPTION
Redirect routes (from redirect_from frontmatter and first-tab redirects) only had a loader but no Component, causing React Router to warn: 'Matched leaf route does not have an element or Component'.

Add a Noop component to these routes so the warning is suppressed. The loader redirect still executes before the component renders.