### PR TITLE
fix(Dialog): use role="dialog" on all platforms to prevent VoiceOver double titles

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -296,7 +296,7 @@ describe('Dialog', () => {
     })
   })
 
-  it('respects focusSelector over close button', async () => {
+  it('respects focusSelector over dialog container and close button', async () => {
     render(
       <Dialog noAnimation open title="Title" focusSelector="#focus-me">
         <Dialog.Body>
@@ -308,6 +308,10 @@ describe('Dialog', () => {
     await waitFor(() => {
       expect(document.activeElement?.id).toBe('focus-me')
     })
+
+    const content = document.querySelector('.dnb-modal__content')
+    expect(content).toBeInTheDocument()
+    expect(document.activeElement).not.toBe(content)
 
     const closeBtn = document.querySelector(
       'button.dnb-modal__close-button'

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -290,11 +290,9 @@ describe('Dialog', () => {
     render(<Dialog noAnimation open title="Title" />)
 
     await waitFor(() => {
-      const title = document.querySelector(
-        '.dnb-modal__title'
-      ) as HTMLHeadingElement
-      expect(title).toBeInTheDocument()
-      expect(document.activeElement).toBe(title)
+      const content = document.querySelector('.dnb-modal__content')
+      expect(content).toBeInTheDocument()
+      expect(document.activeElement).toBe(content)
     })
   })
 
@@ -613,9 +611,9 @@ describe('Dialog', () => {
 
     // Wait a bit more for focus management to complete
     await waitFor(() => {
-      const modalTitle = document.querySelector('.dnb-modal__title')
-      expect(modalTitle).toBeInTheDocument()
-      expect(document.activeElement).toBe(modalTitle)
+      const content = document.querySelector('.dnb-modal__content')
+      expect(content).toBeInTheDocument()
+      expect(document.activeElement).toBe(content)
     })
 
     // Verify that focus is NOT on the submit button

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -6,7 +6,6 @@ import type { ModalContentProps } from '../../modal/types'
 import Button from '../../button/Button'
 import Provider from '../../../shared/Provider'
 import { loadScss, axeComponent } from '../../../core/test-utils/testSetup'
-import * as helpers from '../../../shared/helpers'
 import { fireEvent, render, waitFor, screen } from '@testing-library/react'
 import { Form } from '../../../extensions/forms'
 import Translation from '../../../shared/Translation'
@@ -213,25 +212,6 @@ describe('Dialog', () => {
     const elem = document.querySelector('.dnb-modal__content')
     expect(elem.getAttribute('role')).toBe('dialog')
     expect(elem).toHaveAttribute('aria-modal')
-
-    Object.defineProperty(helpers, 'IS_MAC', {
-      value: true,
-      writable: true,
-    })
-
-    rerender(
-      <Dialog {...props} open={true} title="re-render">
-        <button>button</button>
-      </Dialog>
-    )
-
-    expect(elem.getAttribute('role')).toBe('region')
-    expect(elem).not.toHaveAttribute('aria-modal')
-
-    Object.defineProperty(helpers, 'IS_MAC', {
-      value: false,
-      writable: true,
-    })
 
     rerender(
       <Dialog

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -197,8 +197,6 @@ export default function ModalContent(props: ModalContentProps) {
                 usedContentId
               ) as HTMLElement
               if (dialogContainer) {
-                dialogContainer.setAttribute('tabIndex', '-1')
-                dialogContainer.classList.add('dnb-no-focus')
                 focusElement = dialogContainer
               }
             } else {
@@ -477,6 +475,7 @@ export default function ModalContent(props: ModalContentProps) {
 
   const contentParams = {
     role,
+    tabIndex: -1,
     'aria-modal': true,
     'aria-labelledby': combineLabelledBy(
       props,
@@ -490,6 +489,7 @@ export default function ModalContent(props: ModalContentProps) {
     'aria-label': !title && !labelledBy ? dialogTitle : undefined,
     className: clsx(
       'dnb-modal__content',
+      'dnb-no-focus',
       fullscreen === true
         ? 'dnb-modal__content--fullscreen'
         : fullscreen === 'auto' && 'dnb-modal__content--auto-fullscreen',

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -190,10 +190,17 @@ export default function ModalContent(props: ModalContentProps) {
                 warn('A Dialog or Drawer needs a h1 as its first element!')
               }
 
-              firstHeading.setAttribute('tabIndex', '-1')
-              firstHeading.classList.add('dnb-no-focus')
-
-              focusElement = firstHeading
+              // Focus the dialog container instead of the heading to
+              // prevent VoiceOver from announcing the title twice —
+              // once via aria-labelledby and once as the focused heading.
+              const dialogContainer = document.getElementById(
+                usedContentId
+              ) as HTMLElement
+              if (dialogContainer) {
+                dialogContainer.setAttribute('tabIndex', '-1')
+                dialogContainer.classList.add('dnb-no-focus')
+                focusElement = dialogContainer
+              }
             } else {
               const focusHelper = elem.querySelector(
                 '.dnb-modal__close-button, .dnb-modal__focus-helper'
@@ -215,7 +222,13 @@ export default function ModalContent(props: ModalContentProps) {
         noAnimation ? 0 : timeoutDuration || 0
       )
     }
-  }, [contentRef, animationDuration, focusSelector, noAnimation])
+  }, [
+    contentRef,
+    animationDuration,
+    focusSelector,
+    noAnimation,
+    usedContentId,
+  ])
 
   const androidFocusHelperRef = useRef<() => void>(null)
   androidFocusHelperRef.current = () => {

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -21,7 +21,7 @@ import {
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import ModalContext from './ModalContext'
-import { IS_IOS, IS_SAFARI, IS_MAC, isAndroid } from '../../shared/helpers'
+import { isAndroid } from '../../shared/helpers'
 import type {
   ModalCloseHandlerParams,
   ModalContentProps,
@@ -460,15 +460,11 @@ export default function ModalContent(props: ModalContentProps) {
     }
   }, [children, setFocus])
 
-  const useDialogRole = !(IS_MAC || IS_SAFARI || IS_IOS)
-  let role = dialogRole || 'dialog'
-  if (!useDialogRole && role === 'dialog') {
-    role = 'region'
-  }
+  const role = dialogRole || 'dialog'
 
   const contentParams = {
     role,
-    'aria-modal': useDialogRole ? true : undefined,
+    'aria-modal': true,
     'aria-labelledby': combineLabelledBy(
       props,
       title ? usedContentId + '-title' : null,

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1496,28 +1496,15 @@ describe('Modal component', () => {
   })
 
   it('should have correct role and aria-modal', () => {
-    let elem
-
     const { rerender } = render(<Modal {...props} open />)
-    elem = document.querySelector('.dnb-modal__content')
+    const elem = document.querySelector('.dnb-modal__content')
     expect(elem).toHaveAttribute('role', 'dialog')
     expect(elem).toHaveAttribute('aria-modal')
 
-    Object.defineProperty(helpers, 'IS_MAC', {
-      value: true,
-      writable: true,
-    })
-
     rerender(<Modal {...props} open title="re-render" />)
 
-    elem = document.querySelector('.dnb-modal__content')
-    expect(elem).toHaveAttribute('role', 'region')
-    expect(elem).not.toHaveAttribute('aria-modal')
-
-    Object.defineProperty(helpers, 'IS_MAC', {
-      value: false,
-      writable: true,
-    })
+    expect(elem).toHaveAttribute('role', 'dialog')
+    expect(elem).toHaveAttribute('aria-modal')
   })
 
   it('should have a close button', () => {
@@ -1570,7 +1557,7 @@ describe('Modal component', () => {
         .getAttribute('aria-describedby')
     ).toBe('dnb-modal-modal_id-content')
     expect(
-      document.querySelector('.dnb-dialog__header').getAttribute('id')
+      document.querySelector('.dnb-modal__title').getAttribute('id')
     ).toBe('dnb-modal-modal_id-title')
     expect(
       document.querySelector('.dnb-dialog__content').getAttribute('id')

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -353,11 +353,11 @@ describe('Modal component', () => {
     // Open modal
     fireEvent.click(document.querySelector('button'))
 
-    // Focus moves to title
+    // Focus moves to dialog container
     await waitFor(() => {
-      const title = document.querySelector('h1') as HTMLHeadingElement
-      expect(title).toBeInTheDocument()
-      expect(document.activeElement).toBe(title)
+      const content = document.querySelector('.dnb-modal__content')
+      expect(content).toBeInTheDocument()
+      expect(document.activeElement).toBe(content)
     })
   })
 

--- a/packages/dnb-eufemia/src/components/modal/parts/ModalHeader.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/ModalHeader.tsx
@@ -56,12 +56,10 @@ export default function ModalHeader({
   const fontSize = size || 'large'
 
   return (
-    <Section
-      id={showTitle ? 'dnb-modal-' + context.id + '-title' : undefined}
-      {...sectionProps}
-    >
+    <Section {...sectionProps}>
       {showTitle ? (
         <Space
+          id={'dnb-modal-' + context.id + '-title'}
           element="h1"
           top="zero"
           bottom="small"

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -324,7 +324,7 @@ export type ModalContentProps = {
   /**
    * Internal
    */
-  dialogRole?: 'dialog' | 'alertdialog' | 'region'
+  dialogRole?: 'dialog' | 'alertdialog'
   contentRef?: RefObject<HTMLElement>
   scrollRef?: RefObject<HTMLElement>
   open?: boolean

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -317,7 +317,7 @@ export type ModalContentProps = {
   children?: ReactNode | ((props: ModalContentProps) => ReactNode)
 
   /**
-   * The displayed text for the 'close' button. Defaults to `Lukk`.
+   * The displayed text for the 'close' button. Resolved from locale translations.
    */
   closeTitle?: string
 


### PR DESCRIPTION
On macOS/Safari/iOS, ModalContent downgraded role="dialog" to role="region" and omitted aria-modal as a workaround for older VoiceOver bugs. This caused VoiceOver to announce the title twice: once as the region's accessible name (via aria-labelledby) when entering the landmark, and again when focus moved to the h1 heading.

Modern VoiceOver handles role="dialog" with aria-modal correctly. Remove the platform-specific workaround so all platforms use the standard dialog role.

Deploy preview: https://fix-dialog-voiceover-double.eufemia-e25.pages.dev/uilib/components/dialog/demos

Closes #5919


From:
<img width="1063" height="632" alt="Screenshot 2026-05-29 at 12 52 24" src="https://github.com/user-attachments/assets/86278de3-b955-47d2-9ffa-25d9456079da" />


To:

<img width="1094" height="627" alt="Screenshot 2026-05-29 at 12 53 24" src="https://github.com/user-attachments/assets/b418180d-174e-42f5-8584-f82d58f9e2e2" />

