### PR TITLE
fix(HelpButton): prevent VoiceOver from announcing title twice

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -135,6 +135,11 @@ export type ButtonProps = {
    * Provide a string or a React Element to be shown as the tooltip content.
    */
   tooltip?: ButtonTooltip
+  /**
+   * Whether to omit the aria-describedby attribute on the tooltip.
+   * Use when the tooltip content duplicates the button's accessible name.
+   */
+  omitDescribedBy?: boolean
   id?: string
   /**
    * If you want the button to behave as a link. Use with caution! A link should normally visually be a link and not a button.
@@ -266,6 +271,7 @@ function Button({ ref, ...restProps }: ButtonProps) {
     title,
     customContent,
     tooltip,
+    omitDescribedBy,
     status,
     statusState,
     statusProps,
@@ -469,6 +475,7 @@ function Button({ ref, ...restProps }: ButtonProps) {
           id={resolvedId + '-tooltip'}
           targetElement={elementRef}
           tooltip={tooltip}
+          omitDescribedBy={omitDescribedBy}
         />
       )}
     </>

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, type ReactNode } from 'react'
 /**
  * Web HelpButton Component
  *
@@ -72,6 +72,14 @@ export default function HelpButtonInstance(localProps: ButtonProps) {
   }
   if (params.tooltip) {
     params.title = null
+  }
+
+  if (
+    params['aria-label'] &&
+    params['aria-label'] ===
+      convertJsxToString(params.tooltip as ReactNode)
+  ) {
+    params.omitDescribedBy = true
   }
 
   return <Button onClick={onClick} {...params} />

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
@@ -79,6 +79,20 @@ describe('HelpButton', () => {
     ).toBeInTheDocument()
   })
 
+  it('should not set aria-describedby when tooltip matches aria-label', async () => {
+    render(<HelpButton {...props} title="Hjelpetekst" />)
+
+    const button = document.querySelector('.dnb-button')
+
+    expect(button.getAttribute('aria-label')).toBe('Hjelpetekst')
+
+    // Simulate focus to trigger tooltip
+    fireEvent.focus(button)
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(button).not.toHaveAttribute('aria-describedby')
+  })
+
   describe('with bell icon', () => {
     it('should have correct aria-label', () => {
       render(<HelpButton {...props} icon="bell" />)

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -48,6 +48,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     size,
     keepInDOM = false,
     targetRefreshKey,
+    omitDescribedBy,
   } = restProps
 
   const { internalId, isControlled } = useContext(TooltipContext)
@@ -177,7 +178,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   const overlayOpen = Boolean(isOpen || isOverlayHovered)
 
-  const describedById = overlayOpen ? internalId : null
+  const describedById = overlayOpen && !omitDescribedBy ? internalId : null
 
   /**
    * Get our "target"

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -681,7 +681,7 @@ describe('Tooltip', () => {
         expect(ariaDescribedBy).toContain('tooltip')
       })
 
-      it('should set aria-describedby even when omitDescribedBy is true (prop is ignored)', () => {
+      it('should not set aria-describedby when omitDescribedBy is true', () => {
         render(
           <Tooltip open showDelay={0} omitDescribedBy>
             Tooltip content
@@ -691,12 +691,10 @@ describe('Tooltip', () => {
         const buttonElem = document.querySelector('button')
         const ariaDescribedBy = buttonElem.getAttribute('aria-describedby')
 
-        // omitDescribedBy is no longer handled in TooltipWithEvents
-        expect(ariaDescribedBy).toBeTruthy()
-        expect(ariaDescribedBy).toContain('tooltip')
+        expect(ariaDescribedBy).toBeNull()
       })
 
-      it('should set aria-describedby even when omitDescribedBy is true with targetSelector (prop is ignored)', () => {
+      it('should not set aria-describedby when omitDescribedBy is true with targetSelector', () => {
         render(
           <>
             <button id="test-button">Button</button>
@@ -715,11 +713,10 @@ describe('Tooltip', () => {
         const buttonElem = document.querySelector('#test-button')
         const ariaDescribedBy = buttonElem.getAttribute('aria-describedby')
 
-        // omitDescribedBy is no longer handled in TooltipWithEvents
-        expect(ariaDescribedBy).toBeTruthy()
+        expect(ariaDescribedBy).toBeNull()
       })
 
-      it('should combine existing aria-describedby with tooltip id when omitDescribedBy is true (prop is ignored)', () => {
+      it('should preserve existing aria-describedby when omitDescribedBy is true', () => {
         const buttonWithAria = (
           <button aria-describedby="existing-id">Button</button>
         )
@@ -739,9 +736,8 @@ describe('Tooltip', () => {
         const ariaDescribedBy =
           buttonElem?.getAttribute('aria-describedby')
 
-        // omitDescribedBy is no longer handled, so aria-describedby includes both
-        expect(ariaDescribedBy).toContain('existing-id')
-        expect(ariaDescribedBy).toContain('tooltip')
+        expect(ariaDescribedBy).toBe('existing-id')
+        expect(ariaDescribedBy).not.toContain('tooltip')
       })
     })
   })


### PR DESCRIPTION
The HelpButton trigger had both aria-label and a tooltip with the same text (e.g. "Hjelpetekst"). When VoiceOver focused the button, it read the aria-label as the accessible name, then the tooltip's aria-describedby content as the description — announcing the title twice.

Re-enable omitDescribedBy support in Tooltip so it can skip setting aria-describedby. Wire it through Button, and set it automatically in HelpButtonInstance when the tooltip text matches the aria-label.

Closes #5918

