### PR TITLE
chore: remove deprecated downlevelIteration option

### DIFF
--- a/tools/eufemia-llm-metadata/tsconfig.json
+++ b/tools/eufemia-llm-metadata/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "../../../..",
     "outDir": "./out",
-    "downlevelIteration": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "target": "es2020",


### PR DESCRIPTION
The `downlevelIteration` compiler option is deprecated since TypeScript 5.6 and unnecessary when targeting ES2015 or later (this config targets es2020).

