### PR TITLE
chore: remove redundant tsconfig options

### DIFF
--- a/tools/eufemia-llm-metadata/tsconfig.json
+++ b/tools/eufemia-llm-metadata/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "rootDir": "../../../..",
     "outDir": "./out",
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
     "downlevelIteration": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
Remove `noEmit` and `allowImportingTsExtensions` which are already inherited from the parent dnb-design-system-portal tsconfig.

