### PR TITLE
chore(DateFormat): remove outdated 'new' status

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-format.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-format.mdx
@@ -2,7 +2,6 @@
 title: 'DateFormat'
 description: 'A ready-to-use DNB date formatter.'
 showTabs: true
-status: 'new'
 theme: ['sbanken', 'carnegie']
 tabs:
   - title: Info


### PR DESCRIPTION
DateFormat was added in June 2025 and could be considered to not be new anymore.
