### PR TITLE
chore(TermDefinition): remove 'new' status

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition.mdx
@@ -5,7 +5,6 @@ showTabs: true
 hideTabs:
   - title: Events
 theme: ['sbanken', 'carnegie']
-status: 'new'
 ---
 
 import TermDefinitionInfo from 'Docs/uilib/components/term-definition/info'


### PR DESCRIPTION
TermDefinition was added in November 2025 and could be considered to not be new anymore.

