### PR TITLE
chore(PortalRoot): remove 'new' status

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root.mdx
@@ -5,7 +5,6 @@ showTabs: true
 theme: ['sbanken', 'carnegie']
 hideTabs:
   - title: Events
-status: 'new'
 ---
 
 import PortalRootInfo from 'Docs/uilib/components/portal-root/info'


### PR DESCRIPTION
PortalRoot was added in June 2025 and could be considered to not be new anymore.

