### PR TITLE
chore(Form.Appearance): remove 'beta' status

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance.mdx
@@ -2,7 +2,6 @@
 title: 'Form.Appearance'
 description: '`Form.Appearance` is a provider for theming form fields.'
 showTabs: true
-status: 'beta'
 tabs:
   - title: Info
     key: '/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/info.mdx
@@ -17,8 +17,6 @@ For now, it only provides theming of sizes for [base fields](/uilib/extensions/f
 
 You can nest `Form.Appearance` to provide different themes for different parts of the form.
 
-**BETA:** The sizes are not 100% finalised and may change to be officially approved by UX through an RFC.
-
 ## Usage
 
 ```tsx


### PR DESCRIPTION
Form.Appearance has been in beta since November 2024 (18+ months). It has since undergone breaking changes, refactors, and design token updates, perhaps it's mature enough to drop the beta label?

