### PR TITLE
chore: remove unused storybook-utils index.js

### DIFF
--- a/tools/storybook-utils/index.js
+++ b/tools/storybook-utils/index.js
@@ -1,1 +1,0 @@
-// have a nice day!

--- a/tools/storybook-utils/package.json
+++ b/tools/storybook-utils/package.json
@@ -5,7 +5,6 @@
   "license": "SEE LICENSE IN LICENSE FILE",
   "author": "DNB Team & Tobias Høegh",
   "version": "1.0.0",
-  "main": "index.js",
   "peerDependencies": {
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.0",


### PR DESCRIPTION
The file only contained a comment and exported nothing. All consumers import from storybook-utils/helpers directly. Also removed the now-unnecessary main field from package.json.

