### PR TITLE
chore(Portal): handle nested **/* glob patterns in portal-query

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/shims/portal-query.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/portal-query.test.ts
@@ -35,6 +35,18 @@ vi.mock('virtual:portal-pages', () => ({
       fields: { slug: 'quickguide-designer' },
       frontmatter: { title: 'Design', hideInMenu: true, order: 5 },
     },
+    {
+      fields: { slug: 'uilib/about-the-lib/releases/eufemia/v11-info' },
+      frontmatter: { title: 'v11', order: 1 },
+    },
+    {
+      fields: { slug: 'uilib/about-the-lib/releases/eufemia/v10-info' },
+      frontmatter: { title: 'v10', order: 2 },
+    },
+    {
+      fields: { slug: 'uilib/about-the-lib/releases/dnb-ui-lib/v8-info' },
+      frontmatter: { title: 'v8' },
+    },
   ],
 }))
 
@@ -176,6 +188,27 @@ describe('portal-query', () => {
       for (const slug of slugs) {
         expect(slug).toMatch(/^uilib\/elements\//)
       }
+    })
+
+    it('filters by contentFilePath glob with nested **/* pattern', () => {
+      const query = `
+        query { allMdx(filter: { frontmatter: { title: { ne: null } }, internal: { contentFilePath: { glob: "**/uilib/about-the-lib/releases/eufemia/**/*" } } }) {
+          edges { node { fields { slug } frontmatter { title } } }
+        }}
+      `
+      const result = runQuery(query)
+      const slugs = result.allMdx.edges.map(
+        (e: { node: { fields: { slug: string } } }) => e.node.fields.slug
+      )
+      expect(slugs).toContain(
+        'uilib/about-the-lib/releases/eufemia/v11-info'
+      )
+      expect(slugs).toContain(
+        'uilib/about-the-lib/releases/eufemia/v10-info'
+      )
+      expect(slugs).not.toContain(
+        'uilib/about-the-lib/releases/dnb-ui-lib/v8-info'
+      )
     })
 
     it('filters by hideInMenu', () => {

--- a/packages/dnb-design-system-portal/vite/client/shims/portal-query.tsx
+++ b/packages/dnb-design-system-portal/vite/client/shims/portal-query.tsx
@@ -123,9 +123,13 @@ function buildFilteredEdges(
       // ignore invalid regex
     }
   } else if (globMatch) {
-    // Convert simple glob like "**/uilib/elements/*" to a slug prefix
+    // Convert glob like "**/uilib/elements/*" or
+    // "**/uilib/about-the-lib/releases/eufemia/**/*" to a slug prefix
     const globPattern = globMatch[1]
-    const prefix = globPattern.replace(/^\*\*\//, '').replace(/\/\*$/, '')
+    const prefix = globPattern
+      .replace(/^\*\*\//, '')
+      .replace(/\/\*\*\/\*$/, '')
+      .replace(/\/\*$/, '')
     filtered = filtered.filter((node) => {
       const slug = (node.fields as Record<string, unknown>)?.slug as string
       return slug && slug.startsWith(prefix + '/')


### PR DESCRIPTION
Motivation: https://eufemia.dnb.no/uilib/about-the-lib/releases#dnbeufemia

Versions should be listed here:

<img width="956" height="577" alt="image" src="https://github.com/user-attachments/assets/cae20636-2b6f-4f1f-92d7-274ade2d306c" />



The glob-to-prefix conversion in useStaticQuery only stripped **/ from the start and /* from the end. Patterns like
**/uilib/about-the-lib/releases/eufemia/**/* left a literal **/ in the prefix, causing no slugs to match.

Strip /**/* from the end before /*, so nested glob patterns correctly resolve to a prefix for slug matching.

Fixes empty release version lists on /uilib/about-the-lib/releases.

