### PR TITLE
feat: allow atlassian-bot full access in robots.txt

### DIFF
--- a/packages/dnb-design-system-portal/static/robots.txt
+++ b/packages/dnb-design-system-portal/static/robots.txt
@@ -1,3 +1,6 @@
+User-agent: atlassian-bot
+Disallow:
+
 User-agent: *
 Disallow: /design-system/contact
 Disallow: /icons


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1779972282191609

Add a specific `User-agent: atlassian-bot` entry with an empty `Disallow:` directive to `robots.txt`, granting the Atlassian bot full access to all pages.

Other bots continue to follow the existing wildcard rules (blocked from `/design-system/contact`, `/icons`, and `/uilib/extensions/payment-card`).