### PR TITLE
chore(AGENTS.md): add commit message conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,5 @@ Follow the [Git convention style guide](packages/dnb-design-system-portal/src/do
 
 - `fix(Button): prevent double click submission`
 - `feat(DatePicker): add month-only mode`
-- `test(Field.Number): add edge case for negative values`
 
 For extensions/forms, use the compound name: `feat(Field.Date): ...`, `fix(Form.Section): ...`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,13 @@
 - Tests act as a contract to verify the intention of the functionality.
 - Write tests before implementing a fix - this ensures the test captures the expected behavior and verifies the fix works correctly.
 - Prefer document.querySelector over screen from @testing-library/react.
+
+## Commit Messages
+
+Follow the [Git convention style guide](packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx). Use Conventional Commits with imperative mood and a PascalCase scope when targeting a specific component:
+
+- `fix(Button): prevent double click submission`
+- `feat(DatePicker): add month-only mode`
+- `test(Field.Number): add edge case for negative values`
+
+For extensions/forms, use the compound name: `feat(Field.Date): ...`, `fix(Form.Section): ...`.


### PR DESCRIPTION
Motivation: I often find that agents do not follow the commit message conventions that we have in our codebase.