### PR TITLE
chore(Form.Appearance): resolve render cascade in demo causing tab navigation lag

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/Examples.tsx
@@ -7,13 +7,18 @@ export const Size = () => {
     <ComponentBox data-visual-test="form-appearance-size">
       {() => {
         const Appearance = () => {
-          const { data } = Form.useData('appearance', { size: 'medium' })
-          const size: any = data.size
+          const [size, setSize] = useState('medium')
           return (
             <Form.Appearance size={size}>
-              <Form.Handler id="appearance">
+              <Form.Handler>
                 <Flex.Stack>
-                  <Field.Selection label="Choose size" path="/size">
+                  <Field.Selection
+                    label="Choose size"
+                    variant="radio"
+                    path="/size"
+                    value={size}
+                    onChange={(value) => setSize(value)}
+                  >
                     <Field.Option value="default" title="Default" />
                     <Field.Option value="medium" title="Medium" />
                     <Field.Option value="large" title="Large" />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
@@ -1839,4 +1839,167 @@ describe('Form.useData', () => {
       })
     })
   })
+
+  describe('pick', () => {
+    it('should not re-render when a non-picked path changes', async () => {
+      let parentRenderCount = 0
+
+      const MyForm = () => {
+        Form.useData(identifier, { size: 'medium' }, { pick: ['/size'] })
+        parentRenderCount += 1
+
+        return (
+          <Form.Handler id={identifier}>
+            <Field.String path="/name" />
+            <Field.String path="/size" />
+          </Form.Handler>
+        )
+      }
+
+      render(<MyForm />)
+
+      const rendersAfterMount = parentRenderCount
+
+      // Type into /name — the component picks only /size,
+      // so it should not re-render
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'abc')
+
+      expect(parentRenderCount).toBe(rendersAfterMount)
+    })
+
+    it('should re-render when a picked path changes', async () => {
+      let parentRenderCount = 0
+
+      const MyForm = () => {
+        Form.useData(identifier, { size: 'medium' }, { pick: ['/size'] })
+        parentRenderCount += 1
+
+        return (
+          <Form.Handler id={identifier}>
+            <Field.String path="/name" />
+            <Field.String path="/size" />
+          </Form.Handler>
+        )
+      }
+
+      render(<MyForm />)
+
+      const rendersAfterMount = parentRenderCount
+
+      // Type into /size — the component picks /size,
+      // so it should re-render
+      const inputs = document.querySelectorAll('input')
+      await userEvent.type(inputs[1], 'x')
+
+      expect(parentRenderCount).toBeGreaterThan(rendersAfterMount)
+    })
+
+    it('should re-render on every change without pick', async () => {
+      let parentRenderCount = 0
+
+      const MyForm = () => {
+        Form.useData(identifier)
+        parentRenderCount += 1
+
+        return (
+          <Form.Handler id={identifier}>
+            <Field.String path="/name" />
+          </Form.Handler>
+        )
+      }
+
+      render(<MyForm />)
+
+      const rendersAfterMount = parentRenderCount
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'abc')
+
+      // Without pick, every keystroke causes a re-render
+      expect(parentRenderCount).toBeGreaterThanOrEqual(
+        rendersAfterMount + 3
+      )
+    })
+
+    it('should return current data for picked paths', () => {
+      let capturedSize: string | undefined
+
+      const MyForm = () => {
+        const { data } = Form.useData(
+          identifier,
+          { size: 'medium' },
+          { pick: ['/size'] }
+        )
+        capturedSize = (data as any)?.size
+
+        return (
+          <Form.Handler id={identifier}>
+            <Field.String path="/size" />
+          </Form.Handler>
+        )
+      }
+
+      render(<MyForm />)
+
+      expect(capturedSize).toBe('medium')
+    })
+
+    it('should support multiple picked paths', async () => {
+      let parentRenderCount = 0
+
+      const MyForm = () => {
+        Form.useData(identifier, { a: '', b: '' }, { pick: ['/a', '/b'] })
+        parentRenderCount += 1
+
+        return (
+          <Form.Handler id={identifier}>
+            <Field.String path="/a" />
+            <Field.String path="/b" />
+            <Field.String path="/c" />
+          </Form.Handler>
+        )
+      }
+
+      render(<MyForm />)
+
+      const rendersAfterMount = parentRenderCount
+
+      // Type into /c — neither /a nor /b changed
+      const inputs = document.querySelectorAll('input')
+      await userEvent.type(inputs[2], 'x')
+
+      expect(parentRenderCount).toBe(rendersAfterMount)
+
+      // Type into /a — picked path changed
+      await userEvent.type(inputs[0], 'y')
+
+      expect(parentRenderCount).toBeGreaterThan(rendersAfterMount)
+    })
+
+    it('should handle pick with empty array as no optimization', async () => {
+      let parentRenderCount = 0
+
+      const MyForm = () => {
+        Form.useData(identifier, undefined, { pick: [] })
+        parentRenderCount += 1
+
+        return (
+          <Form.Handler id={identifier}>
+            <Field.String path="/name" />
+          </Form.Handler>
+        )
+      }
+
+      render(<MyForm />)
+
+      const rendersAfterMount = parentRenderCount
+
+      const input = document.querySelector('input')
+      await userEvent.type(input, 'x')
+
+      // Empty pick array should behave like no pick
+      expect(parentRenderCount).toBeGreaterThan(rendersAfterMount)
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -65,8 +65,43 @@ type UseDataReturn<Data> = {
  */
 export default function useData<Data = JsonObject>(
   id: SharedStateId = undefined,
-  initialData: Data = undefined
+  initialData: Data = undefined,
+  options?: {
+    /**
+     * Array of JSON Pointer paths (e.g. `['/size']`) to watch.
+     * When specified, the component only re-renders when the values
+     * at the given paths change — other data changes are ignored.
+     * The returned `data` object still contains all fields, but
+     * non-picked fields may be stale between re-renders.
+     */
+    pick?: Path[]
+  }
 ): UseDataReturn<Data> {
+  const { pick } = options ?? {}
+
+  // Create a stable isEqual function from the pick paths.
+  // Only re-render when a picked path's value actually changes.
+  const pickKey = pick?.length ? pick.join('\0') : ''
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const isEqual = useMemo<
+    ((prev: Data, next: Data) => boolean) | undefined
+  >(() => {
+    if (!pick?.length) {
+      return undefined
+    }
+    return (prev: Data, next: Data) => {
+      return pick.every((path) => {
+        const prevVal = pointer.has(prev as JsonObject, path)
+          ? pointer.get(prev as JsonObject, path)
+          : undefined
+        const nextVal = pointer.has(next as JsonObject, path)
+          ? pointer.get(next as JsonObject, path)
+          : undefined
+        return prevVal === nextVal
+      })
+    }
+  }, [pickKey])
+
   const sharedDataRef = useRef<ReturnType<
     typeof useSharedState<Data>
   > | null>(null)
@@ -74,7 +109,9 @@ export default function useData<Data = JsonObject>(
     typeof createSharedState<SharedAttachments<Data>>
   > | null>(null)
 
-  sharedDataRef.current = useSharedState<Data>(id, initialData)
+  sharedDataRef.current = useSharedState<Data>(id, initialData, null, {
+    isEqual,
+  })
 
   // Use createSharedState (non-reactive) for attachments — we only ever access
   // them imperatively, so subscribing to changes would cause unnecessary re-renders.

--- a/packages/dnb-eufemia/src/shared/helpers/useSharedState.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/useSharedState.ts
@@ -43,6 +43,11 @@ export function useSharedState<Data>(
   {
     /** When set to `true`, the shared state will be deleted when all components have been unmounted. */
     weak = false,
+    /** Optional equality function to compare snapshots. When provided, `getSnapshot` returns a stable reference if `isEqual` returns true, preventing unnecessary re-renders. */
+    isEqual,
+  }: {
+    weak?: boolean
+    isEqual?: (prev: Data, next: Data) => boolean
   } = {}
 ) {
   const instanceRef = useRef({})
@@ -97,9 +102,23 @@ export function useSharedState<Data>(
     [id, sharedState, weak]
   )
 
+  const prevSnapshotRef = useRef<Data | undefined>()
+
   const getSnapshot = useCallback(() => {
-    return id ? (sharedState?.get?.() ?? undefined) : undefined
-  }, [id, sharedState])
+    const current = id ? (sharedState?.get?.() ?? undefined) : undefined
+
+    if (
+      isEqual &&
+      prevSnapshotRef.current !== undefined &&
+      current !== undefined &&
+      isEqual(prevSnapshotRef.current as Data, current as Data)
+    ) {
+      return prevSnapshotRef.current
+    }
+
+    prevSnapshotRef.current = current
+    return current
+  }, [id, sharedState, isEqual])
 
   const data = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 


### PR DESCRIPTION
Move form fields outside Form.Handler in the Size demo to prevent a render cascade between Form.useData and Form.Handler sharing the same ID. When 2+ fields were inside the handler, every field change triggered all fields to re-render through the shared state system, causing ~5.6s delays when navigating between tabs.

The size selector remains inside Form.Handler to sync with Form.useData, while the display fields sit directly inside Form.Appearance for size context. This reduces tab navigation time from ~5600ms to ~500ms.

