### PR TITLE
fix(DatePicker): support responsive range calendars and use transparent background color when `inline`

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2601,11 +2601,13 @@ html:not([data-whatinput=touch]) .dnb-toggle-button__button:focus-visible:not([d
   height: inherit;
 }
 .dnb-date-picker__container {
-  width: min-content;
   border-radius: var(--token-radius-sm);
   background-color: var(--token-color-background-neutral);
   position: relative;
   top: auto;
+}
+.dnb-date-picker--inline .dnb-date-picker__container {
+  background-color: transparent;
 }
 .dnb-date-picker__container table {
   position: relative;
@@ -2701,6 +2703,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 }
 .dnb-date-picker__views {
   display: flex;
+  flex-wrap: wrap;
   user-select: none;
 }
 @media screen and (max-width: 60em) {

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -44,7 +44,6 @@
   }
 
   &__container {
-    width: min-content;
     border-radius: var(--token-radius-sm);
     background-color: var(--token-color-background-neutral);
 
@@ -52,6 +51,10 @@
     // where both unscoped and scoped styles are imported together (both position and top).
     position: relative;
     top: auto;
+
+    .dnb-date-picker--inline & {
+      background-color: transparent;
+    }
 
     table {
       position: relative;
@@ -167,6 +170,7 @@
 
   &__views {
     display: flex;
+    flex-wrap: wrap;
     user-select: none;
 
     // Wrap already on "medium", because "small" is too narrow in range mode


### PR DESCRIPTION
This ensures inline DatePicker calendars display side-by-side when there's room and stack vertically when the container is narrow — based on the actual available space rather than viewport width.

Preview: https://fix-datepicker-inline-style.eufemia-e25.pages.dev/uilib/components/date-picker#inline-datepicker

<img width="742" height="479" alt="Screenshot 2026-06-01 at 09 19 38" src="https://github.com/user-attachments/assets/e127d73c-79eb-40bb-b011-cc31ca17d843" />
