### PR TITLE
fix(DatePicker): use focus color tokens for keyboard navigation

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2916,8 +2916,8 @@ html:not([data-whatintent=touch]) .dnb-date-picker__day--end-date:not(.dnb-date-
 }
 .dnb-date-picker__day--selectable .dnb-button:focus-visible:not([disabled]) {
   z-index: 2;
-  color: var(--token-color-component-button-text-action-hover);
-  background-color: var(--token-color-background-action-hover-subtle);
+  color: var(--token-color-text-action-focus);
+  background-color: var(--token-color-background-action-focus-subtle);
   --border-color: var(--token-color-stroke-action-focus);
   --border-width: var(--focus-ring-width);
   box-shadow: 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -489,8 +489,8 @@
     // Focus state for keyboard navigation (hover visual + focus outline)
     &--selectable .dnb-button:focus-visible:not([disabled]) {
       z-index: 2;
-      color: var(--token-color-component-button-text-action-hover);
-      background-color: var(--token-color-background-action-hover-subtle);
+      color: var(--token-color-text-action-focus);
+      background-color: var(--token-color-background-action-focus-subtle);
 
       @include utilities.fakeBorder(
         var(--token-color-stroke-action-focus),


### PR DESCRIPTION
Use proper focus color tokens for keyboard navigation in the calendar day buttons:

- `--token-color-component-button-text-action-hover` → `--token-color-text-action-focus`
- `--token-color-background-action-hover-subtle` → `--token-color-background-action-focus-subtle`

The focus-visible state should use focus tokens, not hover tokens.