### PR TITLE
chore(NumberFormat.NationalIdentityNumber): remove unsupported types `decimals`, `rounding` & `signDisplay`

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NationalIdentityNumber.tsx
@@ -4,7 +4,13 @@ import { withFormatter } from './withFormatter'
 
 export type NumberFormatNationalIdentityNumberProps = Omit<
   NumberFormatAllProps,
-  'currency' | 'currencyDisplay' | 'currencyPosition' | 'compact'
+  | 'currency'
+  | 'currencyDisplay'
+  | 'currencyPosition'
+  | 'compact'
+  | 'decimals'
+  | 'rounding'
+  | 'signDisplay'
 >
 
 const NumberFormatNationalIdentityNumber =


### PR DESCRIPTION
These props have no effect on NationalIdentityNumber since the formatter uses pure string manipulation, not Intl.NumberFormat. Omitting them from the type prevents confusion.

