### PR TITLE
chore(NumberFormat): remove unsupported types and docs `decimals`, `rounding` & `signDisplay` from identifier props

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
@@ -159,6 +159,15 @@ const commonProps: PropertiesTableProps = {
   ...presentationProps,
 }
 
+const commonIdentifierProps: PropertiesTableProps = {
+  ...valueProp,
+  ...localeProp,
+  clean: decimalsAndFormattingProps.clean,
+  ...affixProps,
+  ...interactionProps,
+  ...presentationProps,
+}
+
 export const NumberFormatNumberProperties: PropertiesTableProps = {
   ...commonProps,
   ...compactProp,
@@ -183,24 +192,24 @@ export const NumberFormatPercentProperties: PropertiesTableProps = {
 }
 
 export const NumberFormatPhoneNumberProperties: PropertiesTableProps = {
-  ...commonProps,
+  ...commonIdentifierProps,
   ...linkProp,
   ...spacingProps,
 }
 
 export const NumberFormatBankAccountNumberProperties: PropertiesTableProps =
   {
-    ...commonProps,
+    ...commonIdentifierProps,
     ...spacingProps,
   }
 
 export const NumberFormatNationalIdentityNumberProperties: PropertiesTableProps =
   {
-    ...commonProps,
+    ...commonIdentifierProps,
     ...spacingProps,
   }
 
 export const NumberFormatOrganizationProperties: PropertiesTableProps = {
-  ...commonProps,
+  ...commonIdentifierProps,
   ...spacingProps,
 }


### PR DESCRIPTION
Create commonIdentifierProps that excludes decimals, rounding, and signDisplay from the prop tables of BankAccountNumber, NationalIdentityNumber, OrganizationNumber, and PhoneNumber. The clean prop is retained as it is functional for these variants.

Documenting the removal of the following properties:
- https://github.com/dnbexperience/eufemia/pull/8350
- https://github.com/dnbexperience/eufemia/pull/8352
- https://github.com/dnbexperience/eufemia/pull/8353
- https://github.com/dnbexperience/eufemia/pull/8354

