### PR TITLE
chore(NumberFormat.PhoneNumber): remove unsupported types `decimals`, `rounding` & `signDisplay`

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/PhoneNumber.tsx
@@ -8,7 +8,13 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type NumberFormatPhoneNumberProps = Omit<
   NumberFormatAllProps,
-  'currency' | 'currencyDisplay' | 'currencyPosition' | 'compact'
+  | 'currency'
+  | 'currencyDisplay'
+  | 'currencyPosition'
+  | 'compact'
+  | 'decimals'
+  | 'rounding'
+  | 'signDisplay'
 > & {
   /** Wraps the formatted phone value in a clickable link: `tel` (default) or `sms`. */
   link?: NumberFormatLink | true


### PR DESCRIPTION
These props have no effect on PhoneNumber since the formatter uses pure string manipulation, not Intl.NumberFormat. Omitting them from the type prevents confusion.

