### PR TITLE
chore(NumberFormat.OrganizationNumber): remove unsupported types `decimals`, `rounding` & `signDisplay`

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/OrganizationNumber.tsx
@@ -4,7 +4,13 @@ import { withFormatter } from './withFormatter'
 
 export type NumberFormatOrganizationNumberProps = Omit<
   NumberFormatAllProps,
-  'currency' | 'currencyDisplay' | 'currencyPosition' | 'compact'
+  | 'currency'
+  | 'currencyDisplay'
+  | 'currencyPosition'
+  | 'compact'
+  | 'decimals'
+  | 'rounding'
+  | 'signDisplay'
 >
 
 const NumberFormatOrganizationNumber =


### PR DESCRIPTION
These props have no effect on OrganizationNumber since the formatter uses pure string manipulation, not Intl.NumberFormat. Omitting them from the type prevents confusion.

