### PR TITLE
chore(NumberFormat.BankAccountNumber): remove unsupported types `decimals`, `rounding` & `signDisplay`

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/BankAccountNumber.tsx
@@ -4,7 +4,13 @@ import { withFormatter } from './withFormatter'
 
 export type NumberFormatBankAccountNumberProps = Omit<
   NumberFormatAllProps,
-  'currency' | 'currencyDisplay' | 'currencyPosition' | 'compact'
+  | 'currency'
+  | 'currencyDisplay'
+  | 'currencyPosition'
+  | 'compact'
+  | 'decimals'
+  | 'rounding'
+  | 'signDisplay'
 >
 
 const NumberFormatBankAccountNumber =


### PR DESCRIPTION
These props have no effect on BankAccountNumber since the formatter uses pure string manipulation, not Intl.NumberFormat. Omitting them from the type prevents confusion.

