### PR TITLE
fix(Textarea): add disabled placeholder color token to match input

### DIFF
--- a/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
@@ -377,6 +377,7 @@ button .dnb-form-status__text {
     --token-color-background-neutral-subtle
   );
   --textarea-color-text: var(--token-color-text-neutral-alternative);
+  --textarea-color-placeholder: var(--token-color-text-action-disabled);
   --textarea-color-border: var(--token-color-stroke-action-disabled);
 }
 .dnb-textarea--disabled .dnb-textarea__textarea, .dnb-textarea__textarea[disabled] {

--- a/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
+++ b/packages/dnb-eufemia/src/components/textarea/style/dnb-textarea.scss
@@ -218,6 +218,7 @@
       --token-color-background-neutral-subtle
     );
     --textarea-color-text: var(--token-color-text-neutral-alternative);
+    --textarea-color-placeholder: var(--token-color-text-action-disabled);
     --textarea-color-border: var(--token-color-stroke-action-disabled);
   }
 


### PR DESCRIPTION
Based on https://github.com/dnbexperience/eufemia/pull/8355

Add --textarea-color-placeholder override in disabled state using --token-color-text-action-disabled, matching input's --input-color-placeholder--disabled token.


Motviation:
Disabled placeholder does not look the same as the Input component's disabled placeholder:

<img width="257" height="79" alt="Screenshot 2026-06-01 at 12 57 05" src="https://github.com/user-attachments/assets/b09b042d-2177-43c2-a60a-cccf370f8809" />


From:


<img width="288" height="113" alt="Screenshot 2026-06-01 at 12 56 55" src="https://github.com/user-attachments/assets/55064aac-dc2f-493c-aeb2-04468eff7a6d" />


To:





<img width="297" height="112" alt="Screenshot 2026-06-01 at 12 57 00" src="https://github.com/user-attachments/assets/30016006-4148-4623-a1e1-6655fd45e022" />


