### PR TITLE
chore: match screenshot test filters against file names, not just directories

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/vitest/renewScreenshotsLib.ts
+++ b/packages/dnb-eufemia/scripts/tools/vitest/renewScreenshotsLib.ts
@@ -48,7 +48,10 @@ export function collectRenewScreenshotMatches(filters: string[]) {
         }
       ),
       testFiles: globby.sync(
-        `src/**/*${filter}*/**/*.screenshot.test.{ts,tsx}`,
+        [
+          `src/**/*${filter}*/**/*.screenshot.test.{ts,tsx}`,
+          `src/**/*${filter}*.screenshot.test.{ts,tsx}`,
+        ],
         {
           caseSensitiveMatch: false,
         }


### PR DESCRIPTION
The screenshot test glob only matched the filter against directory names (`src/**/*filter*/**/*.screenshot.test.*`), so filters like `DatePicker` wouldn't find `DatePicker.screenshot.test.ts` inside `date-picker/`. An additional glob pattern now also matches the filter against the test file name itself.