### PR TITLE
feat(Accordion): rename standalone Content `id` prop to `connectedTo`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
@@ -32,6 +32,10 @@ $ yarn add @dnb/eufemia@12
 
 ## Component changes
 
+### [Accordion](/uilib/components/accordion/)
+
+- Replace `id` with `connectedTo` on `Accordion.Content` when connecting to a standalone tertiary button.
+
 ### [Modal](/uilib/components/modal/), [Dialog](/uilib/components/dialog/) and [Drawer](/uilib/components/drawer/)
 
 - Replace `closeButtonAttributes` with `closeButtonProps`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/Examples.tsx
@@ -342,7 +342,7 @@ export const AccordionTertiarySplitExample = () => (
       Text
     </P>
     <P>Other content between button and accordion content.</P>
-    <Accordion.Content id="accordion-tertiary">
+    <Accordion.Content connectedTo="accordion-tertiary">
       <P top>
         This content is placed separately from the button, connected via
         the id.

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -36,6 +36,10 @@ export type AccordionContentProps = Omit<
   SpacingProps & {
     instance?: RefObject<unknown>
     /**
+     * Connects this standalone `Accordion.Content` to an `Accordion` tertiary button using the same identifier.
+     */
+    connectedTo?: string
+    /**
      * If set to `true` the content will be present, even when the accordion is not expanded. In standalone tertiary mode, the content region stays mounted to preserve `aria-controls`.
      */
     keepInDOM?: boolean
@@ -54,11 +58,15 @@ export type AccordionContentProps = Omit<
 export default function AccordionContent(props: AccordionContentProps) {
   const context = useContext<AccordionContextValue>(AccordionContext)
 
-  // Standalone mode: when used outside an Accordion parent with an explicit id,
+  const connectionId = props.connectedTo ?? props.id
+
+  // Standalone mode: when used outside an Accordion parent with an explicit connectedTo (or legacy id),
   // subscribe to the shared state from an AccordionTertiary button.
-  const isStandalone = !context.id && props.id
+  const isStandalone = !context.id && connectionId
   if (isStandalone) {
-    return <AccordionContentStandalone {...props} />
+    return (
+      <AccordionContentStandalone {...props} connectionId={connectionId} />
+    )
   }
 
   return <AccordionContentInner {...props} />
@@ -66,10 +74,12 @@ export default function AccordionContent(props: AccordionContentProps) {
 
 function AccordionContentStandalone({
   ref: _ref,
+  connectionId,
   ...props
-}: AccordionContentProps) {
+}: AccordionContentProps & { connectionId: string }) {
   const {
-    id,
+    connectedTo: _connectedTo,
+    id: _id,
     className,
     children,
     title,
@@ -80,10 +90,10 @@ function AccordionContentStandalone({
 
   const contentRef = useRef<HTMLElement>(null)
   const { data: sharedData, set } =
-    useSharedState<AccordionTertiarySharedState>(id)
+    useSharedState<AccordionTertiarySharedState>(connectionId)
   const expanded = sharedData?.expanded ?? false
   const shouldFocusContent = sharedData?.shouldFocusContent ?? false
-  const contentId = `${id}-content`
+  const contentId = `${connectionId}-content`
   const content = processChildren(props) as ReactNode
 
   const wrapperParams = useSpacing(props, {

--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -129,10 +129,15 @@ export const AccordionProperties: PropertiesTableProps = {
 }
 
 export const AccordionContentProperties: PropertiesTableProps = {
-  id: {
-    doc: 'A unique `id` used to connect standalone `Accordion.Content` with an `Accordion` or `Accordion` tertiary button using the same `id`.',
+  connectedTo: {
+    doc: 'Connects this standalone `Accordion.Content` with an `Accordion` or `Accordion` tertiary button using the same identifier.',
     type: 'string',
     status: 'optional',
+  },
+  id: {
+    doc: 'Deprecated. Use `connectedTo` instead.',
+    type: 'string',
+    status: 'deprecated',
   },
   title: {
     doc: 'Provides a label for the content region in standalone tertiary mode. It is applied to both `aria-label` and `title`.',

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -758,7 +758,7 @@ describe('Accordion tertiary variant', () => {
           id="split-test"
           noAnimation
         />
-        <Accordion.Content id="split-test">
+        <Accordion.Content connectedTo="split-test">
           <p>Remote content</p>
         </Accordion.Content>
       </>
@@ -789,6 +789,29 @@ describe('Accordion tertiary variant', () => {
     // Click collapses again
     fireEvent.click(button)
     expect(button.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('supports deprecated id prop as fallback for connectedTo', () => {
+    render(
+      <>
+        <Accordion
+          variant="tertiary"
+          title="Toggle"
+          id="deprecated-id-test"
+          noAnimation
+        />
+        <Accordion.Content id="deprecated-id-test">
+          <p>Remote content</p>
+        </Accordion.Content>
+      </>
+    )
+
+    const button = document.querySelector(
+      '.dnb-accordion__tertiary-button'
+    )
+
+    fireEvent.click(button)
+    expect(button.getAttribute('aria-expanded')).toBe('true')
   })
 
   it('does not focus content on pointer click', () => {
@@ -898,7 +921,7 @@ describe('Accordion tertiary variant', () => {
           id="focus-split-mouse"
           noAnimation
         />
-        <Accordion.Content id="focus-split-mouse" title="Details">
+        <Accordion.Content connectedTo="focus-split-mouse" title="Details">
           <p>Remote content</p>
         </Accordion.Content>
       </>
@@ -926,7 +949,7 @@ describe('Accordion tertiary variant', () => {
           id="focus-split"
           noAnimation
         />
-        <Accordion.Content id="focus-split" title="Details">
+        <Accordion.Content connectedTo="focus-split" title="Details">
           <p>Remote content</p>
         </Accordion.Content>
       </>
@@ -970,7 +993,7 @@ describe('Accordion tertiary variant', () => {
           id="axe-split"
           noAnimation
         />
-        <Accordion.Content id="axe-split">
+        <Accordion.Content connectedTo="axe-split">
           <p>Content</p>
         </Accordion.Content>
       </>
@@ -988,7 +1011,7 @@ describe('Accordion tertiary variant', () => {
           id="section-test"
           noAnimation
         />
-        <Accordion.Content id="section-test" title="Details">
+        <Accordion.Content connectedTo="section-test" title="Details">
           <p>Content</p>
         </Accordion.Content>
       </>
@@ -1011,7 +1034,7 @@ describe('Accordion tertiary variant', () => {
           id="default-keep-test"
           noAnimation
         />
-        <Accordion.Content id="default-keep-test">
+        <Accordion.Content connectedTo="default-keep-test">
           <p>Content</p>
         </Accordion.Content>
       </>
@@ -1033,7 +1056,7 @@ describe('Accordion tertiary variant', () => {
           id="keep-test"
           noAnimation
         />
-        <Accordion.Content id="keep-test" keepInDOM={false}>
+        <Accordion.Content connectedTo="keep-test" keepInDOM={false}>
           <p>Content</p>
         </Accordion.Content>
       </>
@@ -1054,7 +1077,7 @@ describe('Accordion tertiary variant', () => {
           id="keep-in-dom-test"
           noAnimation
         />
-        <Accordion.Content id="keep-in-dom-test" keepInDOM>
+        <Accordion.Content connectedTo="keep-in-dom-test" keepInDOM>
           <p>Content</p>
         </Accordion.Content>
       </>
@@ -1073,7 +1096,7 @@ describe('Accordion tertiary variant', () => {
           title="Toggle"
           id="no-animation-test"
         />
-        <Accordion.Content id="no-animation-test" noAnimation>
+        <Accordion.Content connectedTo="no-animation-test" noAnimation>
           <p>Content</p>
         </Accordion.Content>
       </>
@@ -1102,7 +1125,7 @@ describe('Accordion tertiary variant', () => {
           id="function-child-test"
           noAnimation
         />
-        <Accordion.Content id="function-child-test">
+        <Accordion.Content connectedTo="function-child-test">
           {() => <p>Content</p>}
         </Accordion.Content>
       </>
@@ -1123,7 +1146,7 @@ describe('Accordion tertiary variant', () => {
     render(
       <>
         <Accordion variant="tertiary" title="Toggle" id="spacing-test" />
-        <Accordion.Content id="spacing-test" top="large">
+        <Accordion.Content connectedTo="spacing-test" top="large">
           <p>Content</p>
         </Accordion.Content>
       </>


### PR DESCRIPTION
The `id` prop on `Accordion.Content` is misleading — it doesn't set an HTML `id` attribute but connects the content to a remote tertiary button via shared state.

This renames it to `connectedTo` to better convey its purpose. The old `id` prop still works as a deprecated fallback so existing code won't break.

### Changes
- Add `connectedTo` prop to `AccordionContentProps`
- Fall back to `id` when `connectedTo` is not provided (with deprecation warning)
- Update docs, examples, and tests
- Add v12 migration entry