### PR TITLE
refactor: rename `status` to `statusMessage` and repurpose `status` to replace `statusState`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
@@ -13,6 +13,7 @@ draft: true
   - [CSS custom properties](#css-custom-properties)
   - [Component changes](#component-changes)
     - [Accordion](#accordion)
+    - [statusState → intent](#statusstate--intent)
     - [Modal, Dialog and Drawer](#modal-dialog-and-drawer)
     - [InfoCard](#infocard)
     - [Popover](#popover)
@@ -66,6 +67,23 @@ When removing these properties, also update the documentation in `classes.mdx` (
 ### [Accordion](/uilib/components/accordion/)
 
 - Replace `id` with `connectedTo` on `Accordion.Content` when connecting to a standalone tertiary button.
+
+### statusState → intent
+
+The `statusState` prop has been deprecated in favor of `intent`. Replace `statusState` with `intent` on all form components that support it.
+
+```diff
+-<Input status="Error message" statusState="error" />
++<Input status="Error message" intent="error" />
+```
+
+The `intent` prop also supports setting visual intent without a status message. When used this way, consider adding `aria-label` or `aria-labelledby` to convey the intent to assistive technologies:
+
+```jsx
+<Input intent="error" aria-label="Error in field" />
+```
+
+Affected components: Autocomplete, Button, Checkbox, DatePicker, Dropdown, Input, Radio, RadioGroup, SegmentedField, Slider, StepIndicator, Switch, Textarea, ToggleButton, ToggleButtonGroup.
 
 ### [Modal](/uilib/components/modal/), [Dialog](/uilib/components/dialog/) and [Drawer](/uilib/components/drawer/)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
@@ -13,7 +13,7 @@ draft: true
   - [CSS custom properties](#css-custom-properties)
   - [Component changes](#component-changes)
     - [Accordion](#accordion)
-    - [statusState → intent](#statusstate--intent)
+    - [statusState → status, status → statusMessage](#statusstate--status-status--statusmessage)
     - [Modal, Dialog and Drawer](#modal-dialog-and-drawer)
     - [InfoCard](#infocard)
     - [Popover](#popover)
@@ -68,19 +68,19 @@ When removing these properties, also update the documentation in `classes.mdx` (
 
 - Replace `id` with `connectedTo` on `Accordion.Content` when connecting to a standalone tertiary button.
 
-### statusState → intent
+### statusState → status, status → statusMessage
 
-The `statusState` prop has been deprecated in favor of `intent`. Replace `statusState` with `intent` on all form components that support it.
+The `statusState` prop has been deprecated in favor of `status`. The old `status` prop (which held the message text) has been renamed to `statusMessage`. Replace `statusState` with `status` and `status` with `statusMessage` on all form components that support it.
 
 ```diff
 -<Input status="Error message" statusState="error" />
-+<Input status="Error message" intent="error" />
++<Input statusMessage="Error message" status="error" />
 ```
 
-The `intent` prop also supports setting visual intent without a status message. When used this way, consider adding `aria-label` or `aria-labelledby` to convey the intent to assistive technologies:
+The `status` prop also supports setting visual status without a status message. When used this way, consider adding `aria-label` or `aria-labelledby` to convey the status to assistive technologies:
 
 ```jsx
-<Input intent="error" aria-label="Error in field" />
+<Input status="error" aria-label="Error in field" />
 ```
 
 Affected components: Autocomplete, Button, Checkbox, DatePicker, Dropdown, Input, Radio, RadioGroup, SegmentedField, Slider, StepIndicator, Switch, Textarea, ToggleButton, ToggleButtonGroup.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v12-info.mdx
@@ -77,6 +77,13 @@ The `statusState` prop has been deprecated in favor of `status`. The old `status
 +<Input statusMessage="Error message" status="error" />
 ```
 
+If you used `status={true}` to only get the status color without a message, replace it with the status state you want to show. Do not move `true` to `statusMessage`.
+
+```diff
+-<Input status={true} />
++<Input status="error" />
+```
+
 The `status` prop also supports setting visual status without a status message. When used this way, consider adding `aria-label` or `aria-labelledby` to convey the status to assistive technologies:
 
 ```jsx

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -48,8 +48,8 @@ export const AutocompleteStatusInfoExample = () => (
       <Autocomplete
         data={topMovies}
         label="Label"
-        status="You need to select a movie"
-        statusState="information"
+        statusMessage="You need to select a movie"
+        status="information"
         showSubmitButton
       />
     </ComponentBox>
@@ -65,8 +65,8 @@ export const AutocompleteStatusErrorExample = () => (
       <Autocomplete
         label="Status error"
         data={[topMovies[0]]}
-        status="Error"
-        statusState="error"
+        statusMessage="Error"
+        status="error"
         showSubmitButton
         open
         noAnimation

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/Examples.tsx
@@ -26,7 +26,7 @@ export const CheckboxChecked = () => (
 
 export const CheckboxWithError = () => (
   <ComponentBox data-visual-test="checkbox-error">
-    <Checkbox label="Checkbox" checked status="Error message" />
+    <Checkbox label="Checkbox" checked statusMessage="Error message" />
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
@@ -158,8 +158,8 @@ export const DatePickerStatusMessage = () => (
       label="DatePicker"
       date={new Date()}
       showInput
-      status="Please select a valid date"
-      statusState="information"
+      statusMessage="Please select a valid date"
+      status="information"
     />
   </ComponentBox>
 )
@@ -187,7 +187,7 @@ export const DatePickerNoInputStatus = () => (
       label="DatePicker"
       date="2019-05-05"
       hideNavigation
-      status="Please select a valid date"
+      statusMessage="Please select a valid date"
     />
   </ComponentBox>
 )
@@ -199,7 +199,7 @@ export const DatePickerErrorMessage = () => (
       date="2019-05-05"
       showInput
       showSubmitButton
-      status={
+      statusMessage={
         <span>
           Status message with <b>HTML</b> inside
         </span>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
@@ -467,7 +467,11 @@ export const DropdownStatusVertical = () => (
       data-visual-test="dropdown-status-error"
       scope={{ data }}
     >
-      <Dropdown data={data} label="Label" status="Message to the user" />
+      <Dropdown
+        data={data}
+        label="Label"
+        statusMessage="Message to the user"
+      />
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/Examples.tsx
@@ -69,7 +69,7 @@ export const FormStatusInput = () => (
   <ComponentBox>
     <Input
       label="Input with status"
-      status="You have to fill in this field"
+      statusMessage="You have to fill in this field"
       value="Input value"
     />
   </ComponentBox>
@@ -90,7 +90,7 @@ export const FormStatusAnimation = () => (
           <Provider formElement={{ vertical: false }}>
             <Input
               label="Input with status"
-              status={status}
+              statusMessage={status}
               value="Input value"
               right
             />
@@ -117,8 +117,8 @@ export const FormStatusCustom = () => (
       return (
         <Input
           label="Input with custom status"
-          status={<CustomStatus />}
-          statusState="information"
+          statusMessage={<CustomStatus />}
+          status="information"
           value="Input value"
         />
       )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/Examples.tsx
@@ -370,7 +370,7 @@ export const GlobalStatusInfoExample3 = () => (
     <Provider
       formElement={{ globalStatus: { id: 'other-global-status' } }}
     >
-      <Input status="Message" />
+      <Input statusMessage="Message" />
     </Provider>
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/Examples.tsx
@@ -78,14 +78,14 @@ export const InputExampleFormStatus = () => (
       <section data-visual-test="input-error">
         <Input
           label="With FormStatus"
-          status="You have to fill in this field"
+          statusMessage="You have to fill in this field"
           value="Input value with error"
         />
       </section>
       <section data-visual-test="input-error-button">
         <Input
           label="With button"
-          status="You have to fill in this field"
+          statusMessage="You have to fill in this field"
           value="Input value with error"
           type="search"
         />
@@ -122,8 +122,8 @@ export const InputExampleStretched = () => (
         id="input-id"
         value="I stretch ..."
         stretch
-        status="Status message"
-        statusState="warning"
+        statusMessage="Status message"
+        status="warning"
       />
     </FieldBlock>
   </ComponentBox>
@@ -135,8 +135,8 @@ export const InputExampleNumbers = () => (
       label="Label"
       autocomplete="on"
       placeholder="Placeholder text"
-      status="Numbers are using DNB Mono (monospace)"
-      statusState="information"
+      statusMessage="Numbers are using DNB Mono (monospace)"
+      status="information"
       value="1234567890"
       onChange={({ value }) => {
         console.log('onChange', value)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/Examples.tsx
@@ -67,13 +67,13 @@ export const RadioExampleGroupStatus = () => (
       }}
     >
       <Radio label="First" value="first" status="error" />
-      <Radio label="Second" value="second" status="Error message" />
+      <Radio label="Second" value="second" statusMessage="Error message" />
       <Radio
         label="Third"
         value="third"
         checked
-        status="Info message"
-        statusState="information"
+        statusMessage="Info message"
+        status="information"
       />
     </Radio.Group>
   </ComponentBox>
@@ -152,7 +152,7 @@ export const RadioExampleSuffix = () => (
       <Radio
         label="Third"
         value="third"
-        status="Error message"
+        statusMessage="Error message"
         suffix={<HelpButton title="Modal Title">Modal content</HelpButton>}
         checked
       />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/Examples.tsx
@@ -47,7 +47,7 @@ export const StepIndicatorStrict = () => (
           title: 'Bestill eller erstatt',
           onClick: ({ currentStep }) =>
             console.log('currentStep:', currentStep),
-          status:
+          statusMessage:
             'Du må velge bestill nytt kort eller erstatt kort for å kunne fullføre bestillingen din.',
         },
         {
@@ -223,18 +223,18 @@ export const StepIndicatorStatuses = () => (
         },
         {
           title: 'Warning',
-          status: 'Status message',
-          statusState: 'warning',
+          statusMessage: 'Status message',
+          status: 'warning',
         },
         {
           title: 'Error',
-          status: 'Status message',
-          statusState: 'error',
+          statusMessage: 'Status message',
+          status: 'error',
         },
         {
           title: 'Information',
-          status: 'Status message',
-          statusState: 'information',
+          statusMessage: 'Status message',
+          status: 'information',
         },
       ]}
     />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/Examples.tsx
@@ -25,7 +25,7 @@ export const SwitchExampleChecked = () => (
 
 export const SwitchExampleErrorMessage = () => (
   <ComponentBox data-visual-test="switch-error">
-    <Switch label="Switch" checked status="Error message" />
+    <Switch label="Switch" checked statusMessage="Error message" />
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/Examples.tsx
@@ -59,7 +59,7 @@ export const CharacterCounter = () => (
         label="Count characters"
         autoResize
         value="Textarea value\nNewline"
-        status="Message to the user"
+        statusMessage="Message to the user"
         characterCounter={40}
       />
     </ComponentBox>
@@ -105,7 +105,7 @@ export const FormStatus = () => (
         label="Error Message"
         cols="33"
         value="Nec litora inceptos vestibulum id interdum donec gravida."
-        status="Message to the user"
+        statusMessage="Message to the user"
       />
     </ComponentBox>
   </Wrapper>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.tsx
@@ -80,7 +80,7 @@ export const ToggleButtonStatus = () => (
   <ComponentBox>
     <ToggleButton.Group
       label="ToggleButton Group with status"
-      status="Error message"
+      statusMessage="Error message"
       multiselect={true}
       onChange={({ values }) => {
         console.log('onChange', values)
@@ -107,13 +107,13 @@ export const ToggleButtonStatusMessages = () => (
         text="Second"
         value="second"
         checked
-        status="Error message"
+        statusMessage="Error message"
       />
       <ToggleButton
         text="Third"
         value="third"
-        status="Info message"
-        statusState="information"
+        statusMessage="Info message"
+        status="information"
       />
     </ToggleButton.Group>
   </ComponentBox>
@@ -144,7 +144,7 @@ export const ToggleButtonSuffix = () => (
       <ToggleButton
         text="Second"
         value="second"
-        status="Error message"
+        statusMessage="Error message"
         suffix={
           <HelpButton title="Button suffix">Button suffix</HelpButton>
         }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Examples.tsx
@@ -194,7 +194,7 @@ export const CreateComposedFieldComponent = () => {
                     onChange={handleBirthYearChange}
                     onDragStart={handleFocus}
                     onDragEnd={handleBlur}
-                    status={hasError}
+                    status={hasError ? 'error' : undefined}
                     tooltip
                   />
                 </FieldBlock>

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -47,8 +47,8 @@ import {
   validateDOMAttributes,
   dispatchCustomElementEvent,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   escapeRegexChars,
   getClosestParent,
@@ -412,6 +412,7 @@ const autocompleteDefaultProps: Partial<AutocompleteAllProps> & {
   keepSelection: null,
   keepValueAndSelection: null,
   showClearButton: null,
+  statusMessage: null,
   status: null,
   statusState: 'error',
   statusProps: null,
@@ -567,8 +568,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     size,
     align,
     fixedPosition,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -2337,17 +2338,17 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   })
 
   // Render
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const { id, hidden, selectedItem, direction, open } = drawerList
 
@@ -2368,7 +2369,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
       visibleIndicator && 'dnb-autocomplete--show-indicator',
       size && `dnb-autocomplete--${size}`,
       stretch && `dnb-autocomplete--stretch`,
-      status && `dnb-autocomplete__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-autocomplete__status--${effectiveStatus}`,
       showStatus && 'dnb-autocomplete__form-status',
       'dnb-form-component',
       className
@@ -2431,7 +2432,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   const triggerParams = {
     id: id + '-submit-button',
     disabled,
-    status: status ? effectiveIntent : null,
+    status: effectiveStatus,
     onKeyDown: onTriggerKeyDownHandler,
     onSubmit: toggleVisible as any as InputSubmitButtonProps['onSubmit'],
     onMouseDown: reserveActivityHandler,
@@ -2465,8 +2466,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
         variant="secondary"
         size={size === 'default' ? 'medium' : (size as ButtonSize)}
         type="button"
-        status={status}
-        intent={effectiveIntent}
+        status={effectiveStatus}
         statusProps={statusProps}
         {...triggerParams}
       />
@@ -2542,8 +2542,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           globalStatus={globalStatus}
           label={label}
           textId={id + '-status'}
-          text={status}
-          state={effectiveIntent}
+          text={statusMessage}
+          state={effectiveStatus}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           widthSelector={innerId}
@@ -2569,8 +2569,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
                   iconSize || (size === 'large' ? 'medium' : 'default')
                 }
                 size={size}
-                status={status ? effectiveIntent : null}
-                intent={effectiveIntent}
+                status={effectiveStatus}
                 type={null}
                 innerElement={
                   currentDataItem?.suffixValue && (

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -47,6 +47,8 @@ import {
   validateDOMAttributes,
   dispatchCustomElementEvent,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   escapeRegexChars,
   getClosestParent,
@@ -565,7 +567,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     size,
     align,
     fixedPosition,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -2334,6 +2337,16 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   })
 
   // Render
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const showStatus = getStatusState(status)
 
   const { id, hidden, selectedItem, direction, open } = drawerList
@@ -2355,7 +2368,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
       visibleIndicator && 'dnb-autocomplete--show-indicator',
       size && `dnb-autocomplete--${size}`,
       stretch && `dnb-autocomplete--stretch`,
-      status && `dnb-autocomplete__status--${statusState}`,
+      status && `dnb-autocomplete__status--${effectiveIntent}`,
       showStatus && 'dnb-autocomplete__form-status',
       'dnb-form-component',
       className
@@ -2418,7 +2431,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   const triggerParams = {
     id: id + '-submit-button',
     disabled,
-    status: status ? statusState : null,
+    status: status ? effectiveIntent : null,
     onKeyDown: onTriggerKeyDownHandler,
     onSubmit: toggleVisible as any as InputSubmitButtonProps['onSubmit'],
     onMouseDown: reserveActivityHandler,
@@ -2453,7 +2466,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
         size={size === 'default' ? 'medium' : (size as ButtonSize)}
         type="button"
         status={status}
-        statusState={statusState}
+        intent={effectiveIntent}
         statusProps={statusProps}
         {...triggerParams}
       />
@@ -2530,7 +2543,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           label={label}
           textId={id + '-status'}
           text={status}
-          state={statusState}
+          state={effectiveIntent}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           widthSelector={innerId}
@@ -2556,8 +2569,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
                   iconSize || (size === 'large' ? 'medium' : 'default')
                 }
                 size={size}
-                status={status ? statusState : null}
-                statusState={statusState}
+                status={status ? effectiveIntent : null}
+                intent={effectiveIntent}
                 type={null}
                 innerElement={
                   currentDataItem?.suffixValue && (

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -186,10 +186,21 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -181,13 +181,13 @@ export const AutocompleteProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -182,7 +182,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -414,7 +414,7 @@ describe('Autocomplete component', () => {
         <Autocomplete
           data={mockData}
           {...mockProps}
-          status="status text"
+          statusMessage="status text"
           statusState="information"
           statusProps={{ stretch: true }}
           showSubmitButton
@@ -553,7 +553,7 @@ describe('Autocomplete component', () => {
       data: ['A', { content: 'B', suffixValue: 'suffix B' }, 'C'],
       showSubmitButton: true,
       value: 1,
-      status: 'status text',
+      statusMessage: 'status text',
       suffix: 'suffix text',
       label: 'Autocomplete label',
       noAnimation: true,
@@ -3326,7 +3326,7 @@ describe('Autocomplete component', () => {
       <Autocomplete
         data={mockData}
         {...mockProps}
-        status="status text"
+        statusMessage="status text"
         showSubmitButton
       />
     )
@@ -3351,7 +3351,7 @@ describe('Autocomplete component', () => {
       <Autocomplete
         data={mockData}
         {...mockProps}
-        status="status text"
+        statusMessage="status text"
         statusState="error"
         showSubmitButton
       />
@@ -3377,7 +3377,7 @@ describe('Autocomplete component', () => {
       <Autocomplete
         data={mockData}
         {...mockProps}
-        status="status text"
+        statusMessage="status text"
         statusState="information"
         showSubmitButton
       />
@@ -4624,7 +4624,7 @@ describe('Autocomplete markup', () => {
   it('should validate with ARIA rules', async () => {
     const snapshotProps: AutocompleteAllProps = {
       label: 'Autocomplete Label:',
-      status: 'status',
+      statusMessage: 'status',
       statusState: 'error',
       statusProps: null,
       value: 2,

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -3398,6 +3398,28 @@ describe('Autocomplete component', () => {
     ).toContain('dnb-button__status--information')
   })
 
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Autocomplete
+        data={mockData}
+        {...mockProps}
+        status="Legacy information message"
+        statusState="information"
+        showSubmitButton
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-autocomplete')).toHaveClass(
+      'dnb-autocomplete__status--information'
+    )
+    expect(document.querySelector('.dnb-input')).toHaveClass(
+      'dnb-input__status--information'
+    )
+  })
+
   it('should support spacing props', () => {
     render(<Autocomplete top="2rem" />)
 

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -24,8 +24,8 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
@@ -218,6 +218,7 @@ const buttonDefaultProps: Partial<ButtonProps> = {
   skeleton: null,
   disabled: null,
   tooltip: null,
+  statusMessage: null,
   status: null,
   statusState: 'error',
   statusProps: null,
@@ -248,7 +249,10 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
   // needs one for aria linking.
   const generatedId = useId(restProps.id)
   const resolvedId =
-    restProps.id || restProps.status || restProps.tooltip
+    restProps.id ||
+    restProps.status ||
+    restProps.statusMessage ||
+    restProps.tooltip
       ? generatedId
       : undefined
 
@@ -272,8 +276,8 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     title,
     customContent,
     tooltip,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -292,17 +296,17 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     ...attributes
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const { text } = props
   let { icon: usedIcon } = props
@@ -388,7 +392,7 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
       isIconOnly && 'dnb-button--icon-only',
       selected && 'dnb-button--selected',
       wrap && 'dnb-button--wrap',
-      status && `dnb-button__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-button__status--${effectiveStatus}`,
       createSkeletonClass(
         variant === 'tertiary' ? 'font' : 'shape',
         skeleton,
@@ -474,8 +478,8 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
         id={resolvedId + '-form-status'}
         globalStatus={globalStatus}
         label={text}
-        text={status}
-        state={effectiveIntent}
+        text={statusMessage}
+        state={effectiveStatus}
         textId={resolvedId + '-status'} // used for "aria-describedby"
         noAnimation={statusNoAnimation}
         skeleton={skeleton}

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -24,6 +24,8 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
@@ -270,7 +272,8 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     title,
     customContent,
     tooltip,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -288,6 +291,16 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     selected,
     ...attributes
   } = props
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
 
   const showStatus = getStatusState(status)
 
@@ -375,7 +388,7 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
       isIconOnly && 'dnb-button--icon-only',
       selected && 'dnb-button--selected',
       wrap && 'dnb-button--wrap',
-      status && `dnb-button__status--${statusState}`,
+      status && `dnb-button__status--${effectiveIntent}`,
       createSkeletonClass(
         variant === 'tertiary' ? 'font' : 'shape',
         skeleton,
@@ -462,7 +475,7 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
         globalStatus={globalStatus}
         label={text}
         text={status}
-        state={statusState}
+        state={effectiveIntent}
         textId={resolvedId + '-status'} // used for "aria-describedby"
         noAnimation={statusNoAnimation}
         skeleton={skeleton}

--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -111,10 +111,21 @@ export const ButtonProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -106,13 +106,13 @@ export const ButtonProperties: PropertiesTableProps = {
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  status: {
-    doc: 'Set it to either `status="error"` or a text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -107,7 +107,7 @@ export const ButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -501,6 +501,51 @@ describe('Button component', () => {
       ).toBeInTheDocument()
     })
   })
+
+  it('supports deprecated status message via status', () => {
+    render(<Button text="Button" status="Legacy error message" />)
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy error message')
+    expect(document.querySelector('.dnb-button')).toHaveClass(
+      'dnb-button__status--error'
+    )
+  })
+
+  it('supports deprecated statusState together with legacy status message', () => {
+    render(
+      <Button
+        text="Button"
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-button')).toHaveClass(
+      'dnb-button__status--information'
+    )
+  })
+
+  it('prioritizes statusMessage over deprecated legacy status string', () => {
+    render(
+      <Button
+        text="Button"
+        status="Legacy message"
+        statusMessage="Preferred message"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Preferred message')
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).not.toHaveTextContent('Legacy message')
+  })
 })
 
 // React's deprecated .defaultProps would convert undefined values to the

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -23,8 +23,8 @@ import { clsx } from 'clsx'
 import {
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   extendPropsWithContext,
 } from '../../shared/component-helper'
@@ -140,8 +140,8 @@ function Checkbox(localProps: CheckboxProps) {
 
   const {
     value,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -166,14 +166,14 @@ function Checkbox(localProps: CheckboxProps) {
     ...rest
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
   const [, forceUpdate] = useReducer(() => ({}), {})
@@ -273,7 +273,7 @@ function Checkbox(localProps: CheckboxProps) {
     [handleChange]
   )
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   /**
    * Adds aria attributes, calls validateDOMAttributes and skeletonDOMAttributes and returns the result
@@ -296,7 +296,7 @@ function Checkbox(localProps: CheckboxProps) {
     if (readOnly) {
       inputParams['aria-readonly'] = inputParams.readOnly = true
     }
-    if (effectiveIntent === 'error') {
+    if (effectiveStatus === 'error') {
       inputParams['aria-invalid'] = true
     }
 
@@ -308,7 +308,7 @@ function Checkbox(localProps: CheckboxProps) {
   }, [
     context,
     disabled,
-    effectiveIntent,
+    effectiveStatus,
     id,
     props,
     readOnly,
@@ -321,7 +321,7 @@ function Checkbox(localProps: CheckboxProps) {
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-checkbox',
-      status && `dnb-checkbox__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-checkbox__status--${effectiveStatus}`,
       size && `dnb-checkbox--${size}`,
       label && `dnb-checkbox--label-position-${labelPosition || 'right'}`,
       'dnb-form-component',
@@ -340,8 +340,8 @@ function Checkbox(localProps: CheckboxProps) {
       label={label}
       textId={id + '-status'} // used for "aria-describedby"
       widthSelector={id + ', ' + id + '-label'}
-      text={status}
-      state={effectiveIntent}
+      text={statusMessage}
+      state={effectiveStatus}
       noAnimation={statusNoAnimation}
       skeleton={skeleton}
       {...statusProps}

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -23,6 +23,8 @@ import { clsx } from 'clsx'
 import {
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   extendPropsWithContext,
 } from '../../shared/component-helper'
@@ -138,7 +140,8 @@ function Checkbox(localProps: CheckboxProps) {
 
   const {
     value,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -162,6 +165,16 @@ function Checkbox(localProps: CheckboxProps) {
     ref: refProp,
     ...rest
   } = props
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
 
   const [, forceUpdate] = useReducer(() => ({}), {})
   const id = useId(idProp)
@@ -283,6 +296,9 @@ function Checkbox(localProps: CheckboxProps) {
     if (readOnly) {
       inputParams['aria-readonly'] = inputParams.readOnly = true
     }
+    if (effectiveIntent === 'error') {
+      inputParams['aria-invalid'] = true
+    }
 
     // also used for code markup simulation
     return validateDOMAttributes(
@@ -292,6 +308,7 @@ function Checkbox(localProps: CheckboxProps) {
   }, [
     context,
     disabled,
+    effectiveIntent,
     id,
     props,
     readOnly,
@@ -304,7 +321,7 @@ function Checkbox(localProps: CheckboxProps) {
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-checkbox',
-      status && `dnb-checkbox__status--${statusState}`,
+      status && `dnb-checkbox__status--${effectiveIntent}`,
       size && `dnb-checkbox--${size}`,
       label && `dnb-checkbox--label-position-${labelPosition || 'right'}`,
       'dnb-form-component',
@@ -324,7 +341,7 @@ function Checkbox(localProps: CheckboxProps) {
       textId={id + '-status'} // used for "aria-describedby"
       widthSelector={id + ', ' + id + '-label'}
       text={status}
-      state={statusState}
+      state={effectiveIntent}
       noAnimation={statusNoAnimation}
       skeleton={skeleton}
       {...statusProps}

--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -41,10 +41,21 @@ export const CheckboxProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties. See [FormStatus](/uilib/components/form-status/properties/).',

--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -36,13 +36,13 @@ export const CheckboxProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
+++ b/packages/dnb-eufemia/src/components/checkbox/CheckboxDocs.ts
@@ -37,7 +37,7 @@ export const CheckboxProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -423,6 +423,23 @@ describe('Checkbox component', () => {
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Checkbox
+        label="Checkbox"
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-checkbox')).toHaveClass(
+      'dnb-checkbox__status--information'
+    )
+  })
+
   it('gets valid ref element', () => {
     let ref: RefObject<HTMLInputElement>
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -26,6 +26,8 @@ import {
   warn,
   extendPropsWithContext,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   validateDOMAttributes,
 } from '../../shared/component-helper'
@@ -588,7 +590,8 @@ function DatePicker(externalProps: DatePickerAllProps) {
     stretch,
     skeleton,
     size,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -621,6 +624,16 @@ function DatePicker(externalProps: DatePickerAllProps) {
     () => filterOutNonAttributes(restProps),
     [restProps]
   )
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
 
   const showStatus = getStatusState(status)
 
@@ -667,7 +680,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-date-picker',
-      status && `dnb-date-picker__status--${statusState}`,
+      status && `dnb-date-picker__status--${effectiveIntent}`,
       labelDirection && `dnb-date-picker--${labelDirection}`,
       open && 'dnb-date-picker--open',
       hidden && 'dnb-date-picker--hidden',
@@ -741,7 +754,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
             textId={id + '-status'} // used for "aria-describedby"
             widthSelector={id + '-shell'}
             text={status}
-            state={statusState}
+            state={effectiveIntent}
             noAnimation={statusNoAnimation}
             skeleton={skeleton}
             {...statusProps}
@@ -801,7 +814,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   hidden={hidden}
                   size={size}
                   status={status ? 'error' : null}
-                  statusState={statusState}
+                  intent={effectiveIntent}
                   lang={context.locale}
                   _omitInputShellClass={_omitInputShellClass}
                   {...attributes}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -26,8 +26,8 @@ import {
   warn,
   extendPropsWithContext,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   validateDOMAttributes,
 } from '../../shared/component-helper'
@@ -590,8 +590,8 @@ function DatePicker(externalProps: DatePickerAllProps) {
     stretch,
     skeleton,
     size,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -625,17 +625,17 @@ function DatePicker(externalProps: DatePickerAllProps) {
     [restProps]
   )
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const pickerParams = {} as HTMLProps<HTMLSpanElement>
 
@@ -680,7 +680,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-date-picker',
-      status && `dnb-date-picker__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-date-picker__status--${effectiveStatus}`,
       labelDirection && `dnb-date-picker--${labelDirection}`,
       open && 'dnb-date-picker--open',
       hidden && 'dnb-date-picker--hidden',
@@ -753,8 +753,8 @@ function DatePicker(externalProps: DatePickerAllProps) {
             label={String(label)}
             textId={id + '-status'} // used for "aria-describedby"
             widthSelector={id + '-shell'}
-            text={status}
-            state={effectiveIntent}
+            text={statusMessage}
+            state={effectiveStatus}
             noAnimation={statusNoAnimation}
             skeleton={skeleton}
             {...statusProps}
@@ -813,8 +813,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   open={open}
                   hidden={hidden}
                   size={size}
-                  status={status ? 'error' : null}
-                  intent={effectiveIntent}
+                  status={effectiveStatus}
                   lang={context.locale}
                   _omitInputShellClass={_omitInputShellClass}
                   {...attributes}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -244,7 +244,7 @@ export const DatePickerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -243,13 +243,13 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -248,10 +248,21 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -31,7 +31,7 @@ import type { InputElement, InputSize } from '../Input'
 import {
   warn,
   validateDOMAttributes,
-  resolveIntent,
+  resolveStatus,
 } from '../../shared/component-helper'
 import { convertStringToDate } from './DatePickerCalc'
 import DatePickerContext from './DatePickerContext'
@@ -149,8 +149,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     skeleton,
     open,
     size,
+    statusMessage,
     status,
-    intent,
     statusState,
     statusProps,
     triggerProps,
@@ -159,10 +159,10 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     ...attributes
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent,
-    statusState,
+  const effectiveStatus = resolveStatus({
     status,
+    statusState,
+    statusMessage,
   })
 
   const [focusState, setFocusState] = useState<string>('virgin')
@@ -792,8 +792,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           id={`${id}-start`}
           _omitInputShellClass
           size={size}
-          status={!open ? status : null}
-          intent={effectiveIntent}
+          statusMessage={!open ? statusMessage : null}
+          status={effectiveStatus}
           inputs={buildInputs('start')}
           values={getValues('start')}
           delimiter={delimiter}
@@ -834,8 +834,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             id={`${id}-end`}
             _omitInputShellClass
             size={size}
-            status={!open ? status : null}
-            intent={effectiveIntent}
+            statusMessage={!open ? statusMessage : null}
+            status={effectiveStatus}
             inputs={buildInputs('end')}
             values={getValues('end')}
             delimiter={delimiter}
@@ -878,8 +878,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     disabled,
     skeleton,
     open,
+    statusMessage,
     status,
-    intent,
     statusState,
     attributes,
     isRange,
@@ -923,8 +923,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         disabled={disabled || skeleton}
         skeleton={skeleton}
         size={size}
-        status={!open ? status : null}
-        intent={effectiveIntent}
+        statusMessage={!open ? statusMessage : null}
+        status={effectiveStatus}
         {...(statusProps as Record<string, unknown>)}
         submitElement={
           <SubmitElement
@@ -936,8 +936,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             aria-label={ariaLabel}
             title={title}
             size={size}
-            status={status}
-            intent={effectiveIntent}
+            statusMessage={statusMessage}
+            status={effectiveStatus}
             type="button"
             icon="calendar"
             variant="secondary"

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -28,7 +28,11 @@ import Button from '../button/Button'
 import type { ButtonProps } from '../Button'
 import Input, { SubmitButton } from '../input/Input'
 import type { InputElement, InputSize } from '../Input'
-import { warn, validateDOMAttributes } from '../../shared/component-helper'
+import {
+  warn,
+  validateDOMAttributes,
+  resolveIntent,
+} from '../../shared/component-helper'
 import { convertStringToDate } from './DatePickerCalc'
 import DatePickerContext from './DatePickerContext'
 
@@ -146,6 +150,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     open,
     size,
     status,
+    intent,
     statusState,
     statusProps,
     triggerProps,
@@ -153,6 +158,13 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
 
     ...attributes
   } = props
+
+  const effectiveIntent = resolveIntent({
+    intent,
+    statusState,
+    status,
+  })
+
   const [focusState, setFocusState] = useState<string>('virgin')
 
   const invalidDatesRef = useRef<DatePickerInvalidDates>({
@@ -781,7 +793,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
           _omitInputShellClass
           size={size}
           status={!open ? status : null}
-          statusState={statusState}
+          intent={effectiveIntent}
           inputs={buildInputs('start')}
           values={getValues('start')}
           delimiter={delimiter}
@@ -823,7 +835,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             _omitInputShellClass
             size={size}
             status={!open ? status : null}
-            statusState={statusState}
+            intent={effectiveIntent}
             inputs={buildInputs('end')}
             values={getValues('end')}
             delimiter={delimiter}
@@ -867,6 +879,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     skeleton,
     open,
     status,
+    intent,
     statusState,
     attributes,
     isRange,
@@ -911,7 +924,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         skeleton={skeleton}
         size={size}
         status={!open ? status : null}
-        statusState={statusState}
+        intent={effectiveIntent}
         {...(statusProps as Record<string, unknown>)}
         submitElement={
           <SubmitElement
@@ -924,7 +937,7 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
             title={title}
             size={size}
             status={status}
-            statusState={statusState}
+            intent={effectiveIntent}
             type="button"
             icon="calendar"
             variant="secondary"

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5128,6 +5128,76 @@ describe('DatePicker component', () => {
       calendar.querySelector('.dnb-date-picker__labels')
     ).not.toBeInTheDocument()
   })
+
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <DatePicker
+        showInput
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-date-picker')).toHaveClass(
+      'dnb-date-picker__status--information'
+    )
+  })
+
+  it('supports deprecated status message via status when passing a React element', () => {
+    const statusElement = (
+      <span>
+        Status message with <b>HTML</b> inside
+      </span>
+    )
+
+    const { rerender } = render(
+      <DatePicker
+        label="DatePicker"
+        date="2019-05-05"
+        showInput
+        showSubmitButton
+        statusMessage={statusElement}
+      />
+    )
+
+    const statusWithStatusMessage = document.querySelector(
+      '.dnb-form-status__text'
+    ) as HTMLElement
+
+    expect(statusWithStatusMessage).toHaveTextContent(
+      'Status message with HTML inside'
+    )
+    expect(statusWithStatusMessage.querySelector('b')).toHaveTextContent(
+      'HTML'
+    )
+
+    const expectedStatusMarkup = statusWithStatusMessage.innerHTML
+
+    rerender(
+      <DatePicker
+        label="DatePicker"
+        date="2019-05-05"
+        showInput
+        showSubmitButton
+        status={statusElement}
+      />
+    )
+
+    const statusWithLegacyStatus = document.querySelector(
+      '.dnb-form-status__text'
+    ) as HTMLElement
+
+    expect(statusWithLegacyStatus).toHaveTextContent(
+      'Status message with HTML inside'
+    )
+    expect(statusWithLegacyStatus.querySelector('b')).toHaveTextContent(
+      'HTML'
+    )
+    expect(statusWithLegacyStatus.innerHTML).toBe(expectedStatusMarkup)
+  })
 })
 
 // for the unit calc tests

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -22,6 +22,8 @@ import { clsx } from 'clsx'
 import {
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -421,7 +423,8 @@ const DropdownInstance = memo(function DropdownInstance({
     size,
     fixedPosition,
     enableBodyLock,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -502,6 +505,17 @@ const DropdownInstance = memo(function DropdownInstance({
   }
 
   const { id, selectedItem, direction, open } = context.drawerList
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const showStatus = getStatusState(status)
 
   Object.assign(
@@ -521,7 +535,7 @@ const DropdownInstance = memo(function DropdownInstance({
       size && `dnb-dropdown--${size}`,
       stretch && `dnb-dropdown--stretch`,
       `dnb-dropdown--${align || 'right'}`,
-      status && `dnb-dropdown__status--${statusState}`,
+      status && `dnb-dropdown__status--${effectiveIntent}`,
       showStatus && 'dnb-dropdown__form-status',
       'dnb-form-component',
       className
@@ -563,6 +577,9 @@ const DropdownInstance = memo(function DropdownInstance({
       id // used to read the current value
     )
   }
+  if (effectiveIntent === 'error') {
+    triggerParams['aria-invalid'] = true
+  }
 
   // also used for code markup simulation
   validateDOMAttributes(null, mainParams)
@@ -596,7 +613,7 @@ const DropdownInstance = memo(function DropdownInstance({
           label={label}
           textId={id + '-status'} // used for "aria-describedby"
           text={status}
-          state={statusState}
+          state={effectiveIntent}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}
@@ -609,8 +626,8 @@ const DropdownInstance = memo(function DropdownInstance({
             ) : (
               <Button
                 variant={variant}
-                status={status ? statusState : null}
-                statusState={statusState}
+                status={status ? effectiveIntent : null}
+                intent={effectiveIntent}
                 icon={false} // only to suppress the warning about the icon when tertiary variant is used
                 size={(size === 'default' ? 'medium' : size) as ButtonSize}
                 ref={setButtonRef}

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -22,8 +22,8 @@ import { clsx } from 'clsx'
 import {
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -423,8 +423,8 @@ const DropdownInstance = memo(function DropdownInstance({
     size,
     fixedPosition,
     enableBodyLock,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -506,17 +506,17 @@ const DropdownInstance = memo(function DropdownInstance({
 
   const { id, selectedItem, direction, open } = context.drawerList
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   Object.assign(
     context.drawerList.attributes,
@@ -535,7 +535,7 @@ const DropdownInstance = memo(function DropdownInstance({
       size && `dnb-dropdown--${size}`,
       stretch && `dnb-dropdown--stretch`,
       `dnb-dropdown--${align || 'right'}`,
-      status && `dnb-dropdown__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-dropdown__status--${effectiveStatus}`,
       showStatus && 'dnb-dropdown__form-status',
       'dnb-form-component',
       className
@@ -577,7 +577,7 @@ const DropdownInstance = memo(function DropdownInstance({
       id // used to read the current value
     )
   }
-  if (effectiveIntent === 'error') {
+  if (effectiveStatus === 'error') {
     triggerParams['aria-invalid'] = true
   }
 
@@ -612,8 +612,8 @@ const DropdownInstance = memo(function DropdownInstance({
           globalStatus={globalStatus}
           label={label}
           textId={id + '-status'} // used for "aria-describedby"
-          text={status}
-          state={effectiveIntent}
+          text={statusMessage}
+          state={effectiveStatus}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}
@@ -626,8 +626,7 @@ const DropdownInstance = memo(function DropdownInstance({
             ) : (
               <Button
                 variant={variant}
-                status={status ? effectiveIntent : null}
-                intent={effectiveIntent}
+                status={effectiveStatus}
                 icon={false} // only to suppress the warning about the icon when tertiary variant is used
                 size={(size === 'default' ? 'medium' : size) as ButtonSize}
                 ref={setButtonRef}

--- a/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
@@ -104,13 +104,13 @@ export const DropdownProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
@@ -105,7 +105,7 @@ export const DropdownProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/DropdownDocs.ts
@@ -109,10 +109,21 @@ export const DropdownProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -240,6 +240,25 @@ describe('Dropdown component', () => {
     )
   })
 
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Dropdown
+        skipPortal
+        noAnimation
+        data={mockData}
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-dropdown')).toHaveClass(
+      'dnb-dropdown__status--information'
+    )
+  })
+
   it('will stay open when keepOpen and a selection is made', () => {
     const onChange = vi.fn()
     render(

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -213,7 +213,7 @@ describe('Dropdown component', () => {
         skipPortal
         noAnimation
         data={mockData}
-        status="status text"
+        statusMessage="status text"
         statusState="warning"
         statusProps={{ stretch: true }}
       />
@@ -230,7 +230,7 @@ describe('Dropdown component', () => {
         skipPortal
         noAnimation
         data={mockData}
-        status="status text"
+        statusMessage="status text"
         statusState="error"
       />
     )
@@ -2087,7 +2087,7 @@ describe('Dropdown markup', () => {
       title: 'title',
       label: 'label',
       id: 'dropdown-id',
-      status: 'status',
+      statusMessage: 'status',
       statusState: 'error',
       value: 2,
       open: true,

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -68,7 +68,14 @@ export type FormStatusBaseProps = {
    */
   status?: FormStatusText
   /**
-   * Defines the state of the status. Valid states are `error`, `warning`, `information`, `success` and `marketing`. Defaults to `error`.
+   * Visual intent of the component. Valid values are `error`, `warning`, `information`, `success` and `marketing`.
+   * When set, applies the corresponding visual styling (e.g. red border for error) even without a status message.
+   * When set to `error`, `aria-invalid` is automatically applied.
+   *
+   */
+  intent?: FormStatusState
+  /**
+   * @deprecated Use `intent` instead. Defines the state of the status. Defaults to `error`.
    */
   statusState?: FormStatusState
   /**

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -6,7 +6,6 @@ import { memo, useCallback, useContext, useEffect, useRef } from 'react'
 import type {
   HTMLProps,
   MemoExoticComponent,
-  ReactElement,
   ReactNode,
   Ref,
   SVGProps,
@@ -45,10 +44,9 @@ import type { SpacingProps, SpaceTypeAll } from '../../shared/types'
 const properties = { ui, sbanken }
 
 export type FormStatusText =
-  | string
-  | boolean
+  | Exclude<ReactNode, boolean>
   | (() => ReactNode)
-  | ReactNode
+type FormStatusLegacyText = FormStatusText | boolean
 export type FormStatusState =
   | 'error'
   | 'warning'
@@ -73,9 +71,9 @@ export type FormStatusBaseProps = {
    * When set, applies the corresponding visual styling (e.g. red border for error) even without a status message.
    * When set to `error`, `aria-invalid` is automatically applied.
    * When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.
-    * Passing a message value (such as string or React element) is supported for backwards compatibility but deprecated — use `statusMessage` instead.
+   * Passing a message value or boolean is supported for backwards compatibility but deprecated — use `statusMessage` instead.
    */
-    status?: FormStatusState | string | ReactElement
+  status?: FormStatusState | FormStatusLegacyText
   /**
    * @deprecated Use `status` instead. Defines the state of the status. Defaults to `error`.
    */
@@ -108,7 +106,7 @@ export type FormStatusProps = {
   /**
    * The `text` appears as the status message. Besides plain text, you can send in a React component as well.
    */
-  text?: FormStatusText
+  text?: FormStatusLegacyText
   /**
    * The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).
    */

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -64,18 +64,18 @@ export type FormStatusChildren = string | (() => ReactNode) | ReactNode
  */
 export type FormStatusBaseProps = {
   /**
-   * Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.
+   * Text with a status message. The style defaults to an error message.
    */
-  status?: FormStatusText
+  statusMessage?: FormStatusText
   /**
-   * Visual intent of the component. Valid values are `error`, `warning`, `information`, `success` and `marketing`.
+   * Visual status of the component. Valid values are `error`, `warning`, `information`, `success` and `marketing`.
    * When set, applies the corresponding visual styling (e.g. red border for error) even without a status message.
    * When set to `error`, `aria-invalid` is automatically applied.
-   *
+   * When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.
    */
-  intent?: FormStatusState
+  status?: FormStatusState
   /**
-   * @deprecated Use `intent` instead. Defines the state of the status. Defaults to `error`.
+   * @deprecated Use `status` instead. Defines the state of the status. Defaults to `error`.
    */
   statusState?: FormStatusState
   /**
@@ -454,9 +454,12 @@ function FormStatusComponent(
 
       if (state === 'error') {
         const content = getContent(restOwnProps)
+        const prevContent = getContent(prevProps)
 
         if (!content) {
-          globalStatusRef.current?.remove(statusId)
+          if (prevContent) {
+            globalStatusRef.current?.remove(statusId)
+          }
         } else if (show) {
           globalStatusRef.current?.update(
             statusId,

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback, useContext, useEffect, useRef } from 'react'
 import type {
   HTMLProps,
   MemoExoticComponent,
+  ReactElement,
   ReactNode,
   Ref,
   SVGProps,
@@ -64,7 +65,7 @@ export type FormStatusChildren = string | (() => ReactNode) | ReactNode
  */
 export type FormStatusBaseProps = {
   /**
-   * Text with a status message. The style defaults to an error message.
+   * Text with a status message. Use `status` to set the visual style.
    */
   statusMessage?: FormStatusText
   /**
@@ -72,8 +73,9 @@ export type FormStatusBaseProps = {
    * When set, applies the corresponding visual styling (e.g. red border for error) even without a status message.
    * When set to `error`, `aria-invalid` is automatically applied.
    * When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.
+    * Passing a message value (such as string or React element) is supported for backwards compatibility but deprecated — use `statusMessage` instead.
    */
-  status?: FormStatusState
+    status?: FormStatusState | string | ReactElement
   /**
    * @deprecated Use `status` instead. Defines the state of the status. Defaults to `error`.
    */

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
@@ -29,7 +29,7 @@ describe('FormStatus component', () => {
     render(
       <Input
         style={{ width: '10rem' }}
-        status="Long status pulvinar per ad varius nostra faucibus enim ante posuere in"
+        statusMessage="Long status pulvinar per ad varius nostra faucibus enim ante posuere in"
       />
     )
 
@@ -42,7 +42,7 @@ describe('FormStatus component', () => {
   })
 
   it('should have correct icon label', () => {
-    render(<Input status="Error message" statusState="error" />)
+    render(<Input statusMessage="Error message" statusState="error" />)
     expect(
       document.querySelector('[role="presentation"]')
     ).toHaveAttribute('data-testid', 'ErrorIcon icon')
@@ -53,7 +53,7 @@ describe('FormStatus component', () => {
 
   it('should re-calculate max-width', () => {
     const { rerender } = render(
-      <Input style={{ width: '10rem' }} status="status message" />
+      <Input style={{ width: '10rem' }} statusMessage="status message" />
     )
 
     expect(
@@ -62,7 +62,7 @@ describe('FormStatus component', () => {
 
     rerender(
       <Input
-        status="status message"
+        statusMessage="status message"
         statusProps={{ text: 'change width to 35rem' }}
         style={{ width: '35rem' }}
       />
@@ -74,7 +74,7 @@ describe('FormStatus component', () => {
 
     rerender(
       <Input
-        status="status message"
+        statusMessage="status message"
         statusProps={{ text: 'change width to 40rem' }}
         style={{ width: '40rem' }}
       />
@@ -86,7 +86,7 @@ describe('FormStatus component', () => {
 
     rerender(
       <Input
-        status="status message"
+        statusMessage="status message"
         statusProps={{ text: 'change width to 10rem' }}
         style={{ width: '10rem' }}
       />
@@ -100,7 +100,7 @@ describe('FormStatus component', () => {
   })
 
   it('should set correct id', () => {
-    render(<Input id="custom-id" status="status text" />)
+    render(<Input id="custom-id" statusMessage="status text" />)
 
     expect(
       document.querySelector('.dnb-form-status').getAttribute('id')
@@ -113,7 +113,7 @@ describe('FormStatus component', () => {
   it('should be modifiable with status_prop', () => {
     render(
       <Input
-        status="status message"
+        statusMessage="status message"
         statusProps={{
           variant: 'outlined',
         }}

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -443,7 +443,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'scroll-to-test' }}
           onChange={({ checked }) => {
@@ -512,7 +512,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch-no-scroll"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'no-scroll-test' }}
           onChange={({ checked }) => {
@@ -546,7 +546,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch-scroll"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'scroll-test' }}
           onChange={({ checked }) => {
@@ -582,7 +582,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'esc-test' }}
           onChange={({ checked }) => {
@@ -640,7 +640,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch-escape-key"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'escape-name-test' }}
           onChange={({ checked }) => {
@@ -694,7 +694,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'height-test' }}
           onChange={({ checked }) => {
@@ -729,7 +729,7 @@ describe('GlobalStatus component', () => {
       return (
         <Switch
           id="switch"
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'main-to-be-empty' }}
           onChange={({ checked }) => {
@@ -838,7 +838,7 @@ describe('GlobalStatus component', () => {
         <Switch
           id="switch"
           label={<LabelAsComponent />}
-          status={status}
+          statusMessage={status}
           statusNoAnimation={true}
           globalStatus={{ id: 'main-to-be-empty' }}
           onChange={({ checked }) => {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -316,45 +316,45 @@ describe('GlobalStatus component', () => {
 
   it('should handle delayed interactions', async () => {
     const FormField1 = () => {
-      const [status, setStatus] = useState(null)
+      const [statusMsg, setStatusMsg] = useState(null)
       return (
         <Switch
           id="switch-1"
-          status={status}
+          statusMessage={statusMsg}
           statusNoAnimation={true}
           onChange={({ checked }) => {
-            setStatus(checked ? 'error-message-1' : null)
+            setStatusMsg(checked ? 'error-message-1' : null)
           }}
         />
       )
     }
 
     const FormField2 = () => {
-      const [status, setStatus] = useState(null)
+      const [statusMsg, setStatusMsg] = useState(null)
       return (
         <Switch
           id="switch-2"
-          status={status}
+          statusMessage={statusMsg}
           statusNoAnimation={true}
           onChange={({ checked }) => {
-            setStatus(checked ? 'error-message-2' : null)
+            setStatusMsg(checked ? 'error-message-2' : null)
           }}
         />
       )
     }
 
     const FormField3 = () => {
-      const [status, setStatus] = useState(null)
+      const [statusMsg, setStatusMsg] = useState(null)
       return (
         <Autocomplete
           id="autocomplete-3"
-          status={status}
+          statusMessage={statusMsg}
           statusNoAnimation={true}
           onFocus={() => {
-            setStatus('error-message-3')
+            setStatusMsg('error-message-3')
           }}
           onBlur={() => {
-            setStatus(null)
+            setStatusMsg(null)
           }}
         />
       )

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/SegmentedField.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/SegmentedField.test.tsx
@@ -223,7 +223,7 @@ describe('SegmentedField', () => {
     })
 
     it('should render status', () => {
-      renderSegmentedField({ status: 'error', statusState: 'error' })
+      renderSegmentedField({ statusMessage: 'error', status: 'error' })
 
       const input = document.querySelector('.dnb-input')
       expect(input.classList).toContain('dnb-input__status--error')

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/SegmentedField.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/SegmentedField.test.tsx
@@ -228,6 +228,31 @@ describe('SegmentedField', () => {
       const input = document.querySelector('.dnb-input')
       expect(input.classList).toContain('dnb-input__status--error')
     })
+
+    it('should support deprecated status message via status', () => {
+      renderSegmentedField({ status: 'Legacy error message' })
+
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent('Legacy error message')
+      expect(document.querySelector('.dnb-input')).toHaveClass(
+        'dnb-input__status--error'
+      )
+    })
+
+    it('should support deprecated statusState with statusMessage', () => {
+      renderSegmentedField({
+        statusMessage: 'Information message',
+        statusState: 'information',
+      })
+
+      expect(
+        document.querySelector('.dnb-form-status__text')
+      ).toHaveTextContent('Information message')
+      expect(document.querySelector('.dnb-input')).toHaveClass(
+        'dnb-input__status--information'
+      )
+    })
   })
 
   describe('typing', () => {

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
@@ -3,6 +3,7 @@ import type { FocusEvent, RefObject } from 'react'
 import { flushSync } from 'react-dom'
 import { clsx } from 'clsx'
 import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
+import { resolveIntent } from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
 import Input from '../../Input'
 import FormLabel from '../../FormLabel'
@@ -38,6 +39,7 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
     onChange: onChangeExternal,
     disabled,
     status,
+    intent,
     statusState,
     values: defaultValues,
     className,
@@ -53,6 +55,12 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
     ...rest
   } = props
   const hasExternalScopeRef = Boolean(props.scopeRef)
+
+  const effectiveIntent = resolveIntent({
+    intent,
+    statusState,
+    status,
+  })
 
   const [values, onChangeBase] = useSegmentedFieldValues({
     inputs,
@@ -394,7 +402,7 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
         labelDirection={labelDirection}
         disabled={disabled}
         status={status}
-        statusState={statusState}
+        intent={effectiveIntent}
         suffix={suffix}
         stretch={stretch}
         inputElement={inputElement}

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
@@ -3,7 +3,10 @@ import type { FocusEvent, RefObject } from 'react'
 import { flushSync } from 'react-dom'
 import { clsx } from 'clsx'
 import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
-import { resolveStatus } from '../../../shared/component-helper'
+import {
+  resolveStatus,
+  resolveStatusMessage,
+} from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
 import Input from '../../Input'
 import FormLabel from '../../FormLabel'
@@ -59,6 +62,10 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
   const effectiveStatus = resolveStatus({
     status,
     statusState,
+    statusMessage,
+  })
+  const effectiveStatusMessage = resolveStatusMessage({
+    status,
     statusMessage,
   })
 
@@ -401,7 +408,7 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
         size={size}
         labelDirection={labelDirection}
         disabled={disabled}
-        statusMessage={statusMessage}
+        statusMessage={effectiveStatusMessage}
         status={effectiveStatus}
         suffix={suffix}
         stretch={stretch}

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
@@ -3,7 +3,7 @@ import type { FocusEvent, RefObject } from 'react'
 import { flushSync } from 'react-dom'
 import { clsx } from 'clsx'
 import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
-import { resolveIntent } from '../../../shared/component-helper'
+import { resolveStatus } from '../../../shared/component-helper'
 import useId from '../../../shared/helpers/useId'
 import Input from '../../Input'
 import FormLabel from '../../FormLabel'
@@ -38,8 +38,8 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
     delimiter,
     onChange: onChangeExternal,
     disabled,
+    statusMessage,
     status,
-    intent,
     statusState,
     values: defaultValues,
     className,
@@ -56,10 +56,10 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
   } = props
   const hasExternalScopeRef = Boolean(props.scopeRef)
 
-  const effectiveIntent = resolveIntent({
-    intent,
-    statusState,
+  const effectiveStatus = resolveStatus({
     status,
+    statusState,
+    statusMessage,
   })
 
   const [values, onChangeBase] = useSegmentedFieldValues({
@@ -401,8 +401,8 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
         size={size}
         labelDirection={labelDirection}
         disabled={disabled}
-        status={status}
-        intent={effectiveIntent}
+        statusMessage={statusMessage}
+        status={effectiveStatus}
         suffix={suffix}
         stretch={stretch}
         inputElement={inputElement}

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldDocs.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldDocs.ts
@@ -31,13 +31,13 @@ export const SegmentedFieldProperties: PropertiesTableProps = {
     type: ['"replace"', '"shift"'],
     status: 'optional',
   },
-  status: {
-    doc: 'Status message shown below the field. You can also use `true` to show only the state styling.',
-    type: 'React.ReactNode',
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldDocs.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldDocs.ts
@@ -36,10 +36,21 @@ export const SegmentedFieldProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Visual status state passed to the wrapped `Input` component.',
     type: ['"error"', '"information"', '"warning"', '"disabled"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   stretch: {
     doc: 'Set to `true` to stretch the wrapped `Input` to the available width.',

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldDocs.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldDocs.ts
@@ -32,7 +32,7 @@ export const SegmentedFieldProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
@@ -36,8 +36,8 @@ export type SegmentedFieldProps<T extends string> = {
   onChange?: (values: SegmentedFieldValue<T>) => void
   onFocus?: (values: SegmentedFieldValue<T>) => void
   onBlur?: (values: SegmentedFieldValue<T>) => void
-  status?: FormStatusText
-  intent?: FormStatusState
+  statusMessage?: FormStatusText
+  status?: FormStatusState
   statusState?: FormStatusState
   stretch?: boolean
   suffix?: ReactNode

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
@@ -37,7 +37,7 @@ export type SegmentedFieldProps<T extends string> = {
   onFocus?: (values: SegmentedFieldValue<T>) => void
   onBlur?: (values: SegmentedFieldValue<T>) => void
   statusMessage?: FormStatusText
-  status?: FormStatusState
+  status?: FormStatusState | string
   statusState?: FormStatusState
   stretch?: boolean
   suffix?: ReactNode

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
@@ -37,6 +37,7 @@ export type SegmentedFieldProps<T extends string> = {
   onFocus?: (values: SegmentedFieldValue<T>) => void
   onBlur?: (values: SegmentedFieldValue<T>) => void
   status?: FormStatusText
+  intent?: FormStatusState
   statusState?: FormStatusState
   stretch?: boolean
   suffix?: ReactNode

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -43,6 +43,8 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   dispatchCustomElementEvent,
   convertJsxToString,
@@ -520,8 +522,9 @@ function InputComponent({ ref, ...restProps }: InputProps) {
     label,
     labelDirection,
     labelSrOnly,
-    status,
+    status: statusProp,
     globalStatus,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -576,6 +579,16 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   }
   const sizeIsNumber = parseFloat(size) > 0
 
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const id = _id
   const showStatus = getStatusState(status)
   const hasSubmitButton =
@@ -597,7 +610,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
       innerElement && 'dnb-input--has-inner-element',
       showClearButton && 'dnb-input--has-clear-button',
       align && `dnb-input__align--${align}`,
-      status && `dnb-input__status--${statusState}`,
+      status && `dnb-input__status--${effectiveIntent}`,
       disabled && 'dnb-input--disabled',
       icon && `dnb-input--icon-position-${iconPosition}`,
       icon && 'dnb-input--has-icon',
@@ -668,6 +681,9 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   if (readOnly) {
     inputParams['aria-readonly'] = inputParams.readOnly = true
   }
+  if (effectiveIntent === 'error') {
+    inputParams['aria-invalid'] = true
+  }
 
   const shellParams = {
     className: clsx(
@@ -717,7 +733,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
           globalStatus={globalStatus}
           label={label}
           text={status}
-          state={statusState}
+          state={effectiveIntent}
           textId={id + '-status'} // used for "aria-describedby"
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
@@ -789,10 +805,14 @@ function InputComponent({ ref, ...restProps }: InputProps) {
                   value={hasVal ? value : ''}
                   icon={submitButtonIcon}
                   status={
-                    submitButtonStatus || status ? statusState : null
+                    submitButtonStatus || status ? effectiveIntent : null
                   }
-                  statusState={statusState}
-                  iconSize={size === 'large' ? 'medium' : 'default'}
+                  intent={effectiveIntent}
+                  iconSize={
+                    size === 'medium' || size === 'large'
+                      ? 'medium'
+                      : 'default'
+                  }
                   title={submitButtonTitle}
                   variant={submitButtonVariant}
                   disabled={disabled}
@@ -905,6 +925,7 @@ function InputSubmitButton({
     icon,
     iconSize,
     status,
+    intent,
     statusState,
     statusProps,
     className,
@@ -947,7 +968,7 @@ function InputSubmitButton({
         icon={icon}
         iconSize={iconSize}
         status={status}
-        statusState={statusState}
+        intent={intent}
         onClick={onSubmitHandler}
         onFocus={onSubmitFocusHandler}
         onBlur={onSubmitBlurHandler}

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -43,8 +43,8 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   dispatchCustomElementEvent,
   convertJsxToString,
@@ -522,9 +522,9 @@ function InputComponent({ ref, ...restProps }: InputProps) {
     label,
     labelDirection,
     labelSrOnly,
+    statusMessage: statusMessageProp,
     status: statusProp,
     globalStatus,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -579,18 +579,18 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   }
   const sizeIsNumber = parseFloat(size) > 0
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
   const id = _id
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
   const hasSubmitButton =
     submitElement || (submitElement !== false && type === 'search')
   const hasVal = hasValue(value)
@@ -610,7 +610,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
       innerElement && 'dnb-input--has-inner-element',
       showClearButton && 'dnb-input--has-clear-button',
       align && `dnb-input__align--${align}`,
-      status && `dnb-input__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-input__status--${effectiveStatus}`,
       disabled && 'dnb-input--disabled',
       icon && `dnb-input--icon-position-${iconPosition}`,
       icon && 'dnb-input--has-icon',
@@ -681,7 +681,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   if (readOnly) {
     inputParams['aria-readonly'] = inputParams.readOnly = true
   }
-  if (effectiveIntent === 'error') {
+  if (effectiveStatus === 'error') {
     inputParams['aria-invalid'] = true
   }
 
@@ -732,8 +732,8 @@ function InputComponent({ ref, ...restProps }: InputProps) {
           id={id + '-form-status'}
           globalStatus={globalStatus}
           label={label}
-          text={status}
-          state={effectiveIntent}
+          text={statusMessage}
+          state={effectiveStatus}
           textId={id + '-status'} // used for "aria-describedby"
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
@@ -805,14 +805,12 @@ function InputComponent({ ref, ...restProps }: InputProps) {
                   value={hasVal ? value : ''}
                   icon={submitButtonIcon}
                   status={
-                    submitButtonStatus || status ? effectiveIntent : null
+                    submitButtonStatus || statusMessage
+                      ? effectiveStatus
+                      : null
                   }
-                  intent={effectiveIntent}
-                  iconSize={
-                    size === 'medium' || size === 'large'
-                      ? 'medium'
-                      : 'default'
-                  }
+                  statusState={effectiveStatus}
+                  iconSize={size === 'large' ? 'medium' : 'default'}
                   title={submitButtonTitle}
                   variant={submitButtonVariant}
                   disabled={disabled}
@@ -925,7 +923,6 @@ function InputSubmitButton({
     icon,
     iconSize,
     status,
-    intent,
     statusState,
     statusProps,
     className,
@@ -968,7 +965,7 @@ function InputSubmitButton({
         icon={icon}
         iconSize={iconSize}
         status={status}
-        intent={intent}
+        statusState={statusState}
         onClick={onSubmitHandler}
         onFocus={onSubmitFocusHandler}
         onBlur={onSubmitBlurHandler}

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -31,10 +31,21 @@ export const InputProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -27,7 +27,7 @@ export const InputProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/input/InputDocs.ts
+++ b/packages/dnb-eufemia/src/components/input/InputDocs.ts
@@ -26,13 +26,13 @@ export const InputProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -447,7 +447,7 @@ describe('Input component', () => {
   })
 
   it('has to have a status value as defined in the prop', () => {
-    render(<Input {...props} status="status" statusState="error" />)
+    render(<Input {...props} statusMessage="status" statusState="error" />)
     expect(
       document.querySelector('.dnb-form-status__text').textContent
     ).toBe('status')
@@ -457,7 +457,7 @@ describe('Input component', () => {
     render(
       <Input
         value="value"
-        status="status text"
+        statusMessage="status text"
         statusState="warning"
         statusProps={{ stretch: true }}
       />
@@ -969,30 +969,34 @@ describe('Input scss', () => {
   })
 })
 
-describe('Input intent prop', () => {
-  it('applies aria-invalid when intent is error', () => {
-    render(<Input intent="error" />)
+describe('Input status prop', () => {
+  it('applies aria-invalid when status is error', () => {
+    render(<Input status="error" />)
     const input = document.querySelector('.dnb-input__input')
     expect(input.getAttribute('aria-invalid')).toBe('true')
   })
 
-  it('does not apply aria-invalid for non-error intents', () => {
-    render(<Input intent="warning" />)
+  it('does not apply aria-invalid for non-error status', () => {
+    render(<Input status="warning" />)
     const input = document.querySelector('.dnb-input__input')
     expect(input.getAttribute('aria-invalid')).toBeNull()
   })
 
-  it('applies status class from intent', () => {
-    render(<Input intent="warning" status="Some warning" />)
+  it('applies status class from status', () => {
+    render(<Input status="warning" statusMessage="Some warning" />)
     const element = document.querySelector('.dnb-input')
     expect(element.classList.contains('dnb-input__status--warning')).toBe(
       true
     )
   })
 
-  it('intent takes priority over statusState', () => {
+  it('status takes priority over statusState', () => {
     render(
-      <Input intent="warning" statusState="error" status="A message" />
+      <Input
+        status="warning"
+        statusState="error"
+        statusMessage="A message"
+      />
     )
     const element = document.querySelector('.dnb-input')
     expect(element.classList.contains('dnb-input__status--warning')).toBe(
@@ -1004,7 +1008,7 @@ describe('Input intent prop', () => {
   })
 
   it('shows visual styling without a status message', () => {
-    render(<Input intent="error" />)
+    render(<Input status="error" />)
     const input = document.querySelector('.dnb-input__input')
     expect(input.getAttribute('aria-invalid')).toBe('true')
   })

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -968,3 +968,44 @@ describe('Input scss', () => {
     expect(css).toMatchSnapshot()
   })
 })
+
+describe('Input intent prop', () => {
+  it('applies aria-invalid when intent is error', () => {
+    render(<Input intent="error" />)
+    const input = document.querySelector('.dnb-input__input')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+  })
+
+  it('does not apply aria-invalid for non-error intents', () => {
+    render(<Input intent="warning" />)
+    const input = document.querySelector('.dnb-input__input')
+    expect(input.getAttribute('aria-invalid')).toBeNull()
+  })
+
+  it('applies status class from intent', () => {
+    render(<Input intent="warning" status="Some warning" />)
+    const element = document.querySelector('.dnb-input')
+    expect(element.classList.contains('dnb-input__status--warning')).toBe(
+      true
+    )
+  })
+
+  it('intent takes priority over statusState', () => {
+    render(
+      <Input intent="warning" statusState="error" status="A message" />
+    )
+    const element = document.querySelector('.dnb-input')
+    expect(element.classList.contains('dnb-input__status--warning')).toBe(
+      true
+    )
+    expect(element.classList.contains('dnb-input__status--error')).toBe(
+      false
+    )
+  })
+
+  it('shows visual styling without a status message', () => {
+    render(<Input intent="error" />)
+    const input = document.querySelector('.dnb-input__input')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+  })
+})

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -1012,4 +1012,48 @@ describe('Input status prop', () => {
     const input = document.querySelector('.dnb-input__input')
     expect(input.getAttribute('aria-invalid')).toBe('true')
   })
+
+  it('defaults to error when only statusMessage is set (via statusState default)', () => {
+    render(<Input statusMessage="A message" />)
+    const element = document.querySelector('.dnb-input')
+    expect(element.classList.contains('dnb-input__status--error')).toBe(
+      true
+    )
+  })
+
+  it('supports legacy string message in status with deprecation warning', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => null)
+
+    render(<Input status="Legacy error message" />)
+
+    expect(
+      document.querySelector('.dnb-form-status__text').textContent
+    ).toBe('Legacy error message')
+    expect(document.querySelector('.dnb-form-status').classList).toContain(
+      'dnb-form-status--error'
+    )
+
+    expect(log).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining(
+        'Passing a message to `status` is deprecated'
+      )
+    )
+
+    log.mockRestore()
+  })
+
+  it('uses statusMessage over legacy string status', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => null)
+
+    render(
+      <Input status="do not show this" statusMessage="show this instead" />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text').textContent
+    ).toBe('show this instead')
+
+    log.mockRestore()
+  })
 })

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -21,6 +21,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
@@ -332,7 +334,8 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   )
 
   const {
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -357,6 +360,16 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
 
     ...rest
   } = props
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
 
   // Re-apply any explicitly-passed extra props from ownProps that aren't
   // part of radioDefaultProps (e.g. role: undefined, type: undefined from
@@ -393,7 +406,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-radio',
-      status && `dnb-radio__status--${statusState}`,
+      status && `dnb-radio__status--${effectiveIntent}`,
       size && `dnb-radio--${size}`,
       label && `dnb-radio--label-position-${labelPosition || 'right'}`,
       className
@@ -419,6 +432,9 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   }
   if (readOnly) {
     inputParams['aria-readonly'] = inputParams.readOnly = true
+  }
+  if (effectiveIntent === 'error') {
+    inputParams['aria-invalid'] = true
   }
 
   inputParams = Object.assign(inputParams, rest)
@@ -461,7 +477,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
             textId={id + '-status'} // used for "aria-describedby"
             widthSelector={id + ', ' + id + '-label'}
             text={status}
-            state={statusState}
+            state={effectiveIntent}
             noAnimation={statusNoAnimation}
             skeleton={skeleton}
             {...statusProps}

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -21,8 +21,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
@@ -334,8 +334,8 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   )
 
   const {
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -361,14 +361,14 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
     ...rest
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
   // Re-apply any explicitly-passed extra props from ownProps that aren't
@@ -401,12 +401,12 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
     group = rest.name
   }
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-radio',
-      status && `dnb-radio__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-radio__status--${effectiveStatus}`,
       size && `dnb-radio--${size}`,
       label && `dnb-radio--label-position-${labelPosition || 'right'}`,
       className
@@ -433,7 +433,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   if (readOnly) {
     inputParams['aria-readonly'] = inputParams.readOnly = true
   }
-  if (effectiveIntent === 'error') {
+  if (effectiveStatus === 'error') {
     inputParams['aria-invalid'] = true
   }
 
@@ -476,8 +476,8 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
             label={label as ReactNode}
             textId={id + '-status'} // used for "aria-describedby"
             widthSelector={id + ', ' + id + '-label'}
-            text={status}
-            state={effectiveIntent}
+            text={statusMessage}
+            state={effectiveStatus}
             noAnimation={statusNoAnimation}
             skeleton={skeleton}
             {...statusProps}

--- a/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
@@ -41,10 +41,21 @@ export const RadioProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',
@@ -89,10 +100,21 @@ export const RadioGroupProperties: PropertiesTableProps = {
     type: ['string', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
@@ -37,7 +37,7 @@ export const RadioProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
@@ -96,7 +96,7 @@ export const RadioGroupProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
+++ b/packages/dnb-eufemia/src/components/radio/RadioDocs.ts
@@ -36,13 +36,13 @@ export const RadioProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',
@@ -95,13 +95,13 @@ export const RadioGroupProperties: PropertiesTableProps = {
     type: ['"default"', '"medium"', '"large"'],
     status: 'optional',
   },
-  status: {
-    doc: 'Uses the `form-status` component to show failure messages.',
-    type: ['string', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -10,8 +10,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -78,6 +78,7 @@ const radioGroupDefaultProps: Partial<RadioGroupProps> = {
   id: null,
   name: null,
   size: null,
+  statusMessage: null,
   status: null,
   statusState: 'error',
   statusProps: null,
@@ -163,8 +164,8 @@ function RadioGroup(ownProps: RadioGroupProps) {
   )
 
   const {
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -190,22 +191,22 @@ function RadioGroup(ownProps: RadioGroupProps) {
     ...rest
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const rootProps = useSpacing(props, {
     className: clsx(
       'dnb-radio-group',
-      status && `dnb-radio-group__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-radio-group__status--${effectiveStatus}`,
       `dnb-radio-group--${layoutDirection}`,
       'dnb-form-component',
       className
@@ -292,8 +293,8 @@ function RadioGroup(ownProps: RadioGroupProps) {
                 id={id + '-form-status'}
                 globalStatus={globalStatus}
                 label={label}
-                text={status}
-                state={effectiveIntent}
+                text={statusMessage}
+                state={effectiveStatus}
                 textId={id + '-status'} // used for "aria-describedby"
                 widthSelector={id + ', ' + legendId}
                 noAnimation={statusNoAnimation}

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -10,6 +10,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -25,11 +27,7 @@ import Flex from '../Flex'
 import Context from '../../shared/Context'
 import Suffix from '../../shared/helpers/Suffix'
 import RadioGroupContext from './RadioGroupContext'
-import type {
-  FormStatusBaseProps,
-  FormStatusText,
-  FormStatusState,
-} from '../FormStatus'
+import type { FormStatusBaseProps } from '../FormStatus'
 import type { SkeletonShow } from '../Skeleton'
 import type { SpacingProps } from '../../shared/types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
@@ -57,11 +55,6 @@ export type RadioGroupProps = {
   id?: string
   name?: string
   size?: RadioGroupSize
-  status?: FormStatusText
-  statusState?: FormStatusState
-  statusProps?: FormStatusBaseProps
-  statusNoAnimation?: boolean
-  globalStatus?: FormStatusBaseProps['globalStatus']
   suffix?: RadioGroupSuffix
   vertical?: boolean
   layoutDirection?: RadioGroupLayoutDirection
@@ -71,7 +64,8 @@ export type RadioGroupProps = {
   className?: string
   children?: RadioGroupChildren
   onChange?: (event: RadioGroupChangeEvent) => void
-} & SpacingProps
+} & FormStatusBaseProps &
+  SpacingProps
 
 const radioGroupDefaultProps: Partial<RadioGroupProps> = {
   label: null,
@@ -169,7 +163,8 @@ function RadioGroup(ownProps: RadioGroupProps) {
   )
 
   const {
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -195,12 +190,22 @@ function RadioGroup(ownProps: RadioGroupProps) {
     ...rest
   } = props
 
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const showStatus = getStatusState(status)
 
   const rootProps = useSpacing(props, {
     className: clsx(
       'dnb-radio-group',
-      status && `dnb-radio-group__status--${statusState}`,
+      status && `dnb-radio-group__status--${effectiveIntent}`,
       `dnb-radio-group--${layoutDirection}`,
       'dnb-form-component',
       className
@@ -288,7 +293,7 @@ function RadioGroup(ownProps: RadioGroupProps) {
                 globalStatus={globalStatus}
                 label={label}
                 text={status}
-                state={statusState}
+                state={effectiveIntent}
                 textId={id + '-status'} // used for "aria-describedby"
                 widthSelector={id + ', ' + legendId}
                 noAnimation={statusNoAnimation}

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -165,6 +165,23 @@ describe('Radio component', () => {
       { exact: true }
     )
   })
+
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Radio
+        label="Radio"
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-radio')).toHaveClass(
+      'dnb-radio__status--information'
+    )
+  })
 })
 
 describe('Radio ARIA', () => {

--- a/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
@@ -243,6 +243,26 @@ describe('Radio group component', () => {
       expect(shell).not.toHaveAttribute('role')
     })
   })
+
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Radio.Group
+        label="Label"
+        status="Legacy information message"
+        statusState="information"
+      >
+        <Radio label="First" value="first" />
+        <Radio label="Second" value="second" />
+      </Radio.Group>
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-radio-group')).toHaveClass(
+      'dnb-radio-group__status--information'
+    )
+  })
 })
 
 describe('Radio ARIA', () => {

--- a/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
+++ b/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
@@ -96,10 +96,21 @@ export const SliderProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
+++ b/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
@@ -91,13 +91,13 @@ export const SliderProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
+++ b/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
@@ -92,7 +92,7 @@ export const SliderProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
@@ -37,6 +37,8 @@ export function SliderInstance() {
     isVertical,
     showButtons,
     showStatus,
+    effectiveIntent,
+    status,
     shouldAnimate,
     allProps,
   } = useSliderProps()
@@ -46,9 +48,7 @@ export function SliderInstance() {
     label,
     labelSrOnly,
     labelDirection,
-    status,
     statusProps,
-    statusState,
     statusNoAnimation,
     globalStatus,
     stretch,
@@ -68,7 +68,7 @@ export function SliderInstance() {
       stretch && 'dnb-slider--stretch',
       label && labelDirection && `dnb-slider__label--${labelDirection}`,
       showStatus && 'dnb-slider__form-status',
-      status && `dnb-slider__status--${statusState}`,
+      status && `dnb-slider__status--${effectiveIntent}`,
       'dnb-form-component',
       createSkeletonClass(null, skeleton),
       className
@@ -103,7 +103,7 @@ export function SliderInstance() {
           globalStatus={globalStatus}
           textId={id + '-status'} // used for "aria-describedby"
           text={status}
-          state={statusState}
+          state={effectiveIntent}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}

--- a/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderInstance.tsx
@@ -37,8 +37,8 @@ export function SliderInstance() {
     isVertical,
     showButtons,
     showStatus,
-    effectiveIntent,
-    status,
+    effectiveStatus,
+    statusMessage,
     shouldAnimate,
     allProps,
   } = useSliderProps()
@@ -68,7 +68,7 @@ export function SliderInstance() {
       stretch && 'dnb-slider--stretch',
       label && labelDirection && `dnb-slider__label--${labelDirection}`,
       showStatus && 'dnb-slider__form-status',
-      status && `dnb-slider__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-slider__status--${effectiveStatus}`,
       'dnb-form-component',
       createSkeletonClass(null, skeleton),
       className
@@ -102,8 +102,8 @@ export function SliderInstance() {
           id={id + '-form-status'}
           globalStatus={globalStatus}
           textId={id + '-status'} // used for "aria-describedby"
-          text={status}
-          state={effectiveIntent}
+          text={statusMessage}
+          state={effectiveStatus}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}

--- a/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
@@ -9,8 +9,8 @@ import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import {
   dispatchCustomElementEvent,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
@@ -63,8 +63,8 @@ export function SliderProvider(localProps: SliderAllProps) {
     label,
     labelDirection,
     labelSrOnly,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -231,17 +231,17 @@ export function SliderProvider(localProps: SliderAllProps) {
     }
   }
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
   const showButtons = !isMulti && !hideButtons
   const values = (isMulti ? value : [value]) as Array<number>
 
@@ -258,8 +258,8 @@ export function SliderProvider(localProps: SliderAllProps) {
         attributes,
         showStatus,
         showButtons,
-        effectiveIntent,
-        status,
+        effectiveStatus,
+        statusMessage,
         thumbState,
         setThumbState,
         thumbIndex,

--- a/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
@@ -9,6 +9,8 @@ import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import {
   dispatchCustomElementEvent,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
@@ -61,7 +63,8 @@ export function SliderProvider(localProps: SliderAllProps) {
     label,
     labelDirection,
     labelSrOnly,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -228,6 +231,16 @@ export function SliderProvider(localProps: SliderAllProps) {
     }
   }
 
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const showStatus = getStatusState(status)
   const showButtons = !isMulti && !hideButtons
   const values = (isMulti ? value : [value]) as Array<number>
@@ -245,6 +258,8 @@ export function SliderProvider(localProps: SliderAllProps) {
         attributes,
         showStatus,
         showButtons,
+        effectiveIntent,
+        status,
         thumbState,
         setThumbState,
         thumbIndex,

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -34,6 +34,7 @@ function Thumb({ value, currentIndex }: ThumbProps) {
     isVertical,
     isReverse,
     showStatus,
+    effectiveIntent,
     attributes,
     allProps,
     shouldAnimate,
@@ -89,6 +90,9 @@ function Thumb({ value, currentIndex }: ThumbProps) {
       showStatus ? id + '-status' : null,
       suffix ? id + '-suffix' : null
     )
+  }
+  if (effectiveIntent === 'error') {
+    helperParams['aria-invalid'] = true
   }
 
   const thumbParams = attributes as Record<string, unknown>

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -34,7 +34,7 @@ function Thumb({ value, currentIndex }: ThumbProps) {
     isVertical,
     isReverse,
     showStatus,
-    effectiveIntent,
+    effectiveStatus,
     attributes,
     allProps,
     shouldAnimate,
@@ -91,7 +91,7 @@ function Thumb({ value, currentIndex }: ThumbProps) {
       suffix ? id + '-suffix' : null
     )
   }
-  if (effectiveIntent === 'error') {
+  if (effectiveStatus === 'error') {
     helperParams['aria-invalid'] = true
   }
 

--- a/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
@@ -923,6 +923,23 @@ describe('Slider component', () => {
     const Component = render(<Slider {...props} />)
     expect(await axeComponent(Component)).toHaveNoViolations()
   })
+
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Slider
+        {...props}
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-slider')).toHaveClass(
+      'dnb-slider__status--information'
+    )
+  })
 })
 
 describe('Slider scss', () => {

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -23,87 +23,144 @@ export type SliderExtensions = Record<
 >
 
 export type SliderProps = {
-  /** prepends the Form Label component. If no ID is provided, a random ID is created. */
+  /**
+   * Prepends the Form Label component. If no ID is provided, a random ID is created.
+   */
   label?: ReactNode
 
-  /** use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`. */
+  /**
+   * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
+   */
   labelDirection?: 'vertical' | 'horizontal'
 
-  /** use `true` to make the label only readable by screen readers. */
+  /**
+   * Use `true` to make the label only readable by screen readers.
+   */
   labelSrOnly?: boolean
 
-  /** text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message. */
+  /**
+   * Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.
+   */
   status?: string | boolean
 
-  /** defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`. */
+  /**
+   * Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied.
+   */
+  intent?: 'error' | 'warning' | 'information' | 'success' | 'marketing'
+
+  /**
+   * @deprecated Use `intent` instead. Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.
+   */
   statusState?: 'error' | 'information'
 
-  /** use an object to define additional FormStatus properties. */
+  /**
+   * Use an object to define additional FormStatus properties.
+   */
   statusProps?: Record<string, unknown>
   statusNoAnimation?: boolean
 
-  /** the `statusId` used for the target [GlobalStatus](/uilib/components/global-status). */
+  /**
+   * The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).
+   */
   globalStatus?: GlobalStatusConfigObject
 
-  /** text describing the content of the Slider more than the label. You can also send in a React component, so it gets wrapped inside the Slider component. */
+  /**
+   * Text describing the content of the Slider more than the label. You can also send in a React component, so it gets wrapped inside the Slider component.
+   */
   suffix?: SuffixChildren
 
-  /** give the slider thumb button a title for accessibility reasons. Defaults to `null`. */
+  /**
+   * Give the slider thumb button a title for accessibility reasons. Defaults to `null`.
+   */
   thumbTitle?: string
 
-  /** give the add button a title for accessibility reasons. Defaults to `Increase (%s)`. */
+  /**
+   * Give the add button a title for accessibility reasons. Defaults to `Increase (%s)`.
+   */
   addTitle?: string
 
-  /** give the subtract button a title for accessibility reasons. Defaults to `Decrease (%s)`. */
+  /**
+   * Give the subtract button a title for accessibility reasons. Defaults to `Decrease (%s)`.
+   */
   subtractTitle?: string
 
-  /** the minimum value. Defaults to `0`. */
+  /**
+   * The minimum value. Can be a negative number as well. Defaults to `0`.
+   */
   min?: number
 
-  /** the maximum value. Defaults to `100`. */
+  /**
+   * The maximum value. Defaults to `100`.
+   */
   max?: number
 
-  /** the `value` of the slider as a number. If an array with numbers is provided, each number will represent a thumb button (the `+` and `-` button will be hidden on multiple thumbs). */
+  /**
+   * The `value` of the slider as a number or an array. If an array with numbers is provided, each number will represent a thumb button (the `+` and `-` button will be hidden on multiple thumbs).
+   */
   value?: SliderValue
 
-  /** the steps the slider takes on changing the value. Defaults to `null`. */
+  /**
+   * The steps the slider takes on changing the value. Defaults to `null`.
+   */
   step?: number
 
-  /** makes it possible to display overlays with other functionality such as a marker on the slider marking a given value. */
+  /**
+   * Makes it possible to display overlays with other functionality such as a marker on the slider marking a given value.
+   */
   extensions?: SliderExtensions
 
-  /** show the slider vertically. Defaults to `false`. */
+  /**
+   * Show the slider vertically. Defaults to `false`.
+   */
   vertical?: boolean
 
-  /** show the slider reversed. Defaults to `false`. */
+  /**
+   * Show the slider reversed. Defaults to `false`.
+   */
   reverse?: boolean
 
-  /** if set to `true`, then the slider will be 100% in `width`. */
+  /**
+   * If set to `true`, then the slider will be 100% in `width`.
+   */
   stretch?: boolean
 
-  /** provide a function callback or use the options from the [NumberFormat](/uilib/components/number-format/properties) component. It will show a formatted number in the Tooltip (`tooltip={true}`) and enhance the screen reader UX. It will also extend the `onChange` event return object with a formatted `number` property. */
+  /**
+   * Will extend the return object with a `number` property (from `onChange` event). You can use all the options from the [NumberFormat](/uilib/components/number-format/properties) component. It also will use that formatted number in the increase/decrease buttons. If it has to represent a currency, then use e.g. `numberFormat={{ currency: true, decimals: 0 }}`.
+   */
   numberFormat?: SliderNumberFormat
 
-  /** use `true` to show a tooltip on `mouseOver`, `touchStart` and `focus`, showing the current number (if `numberFormat` is given) or the raw value. Defaults to `null`. */
+  /**
+   * Use `true` to show a tooltip on `mouseOver`, `touchStart` and `focus`, showing the current number (if `numberFormat` is given) or the raw value.
+   */
   tooltip?: boolean
 
-  /** use `true` to always show the tooltip, in addition to the `tooltip` property.  */
+  /**
+   * Use `true` to always show the tooltip, in addition to the `tooltip` property.
+   */
   alwaysShowTooltip?: boolean
 
-  /** removes the helper buttons. Defaults to `false`. */
+  /**
+   * Removes the helper buttons. Defaults to `false`.
+   */
   hideButtons?: boolean
 
-  /** use either `omit`, `push` or `swap`. This property only works for two (range) or more thumb buttons, while `omit` will stop the thumb from swapping, `push` will push its nearest thumb along. Defaults to `swap`. */
+  /**
+   * Use either `omit`, `push` or `swap`. This property only works for two (range) or more thumb buttons, while `omit` will stop the thumb from swapping, `push` will push its nearest thumb along. Defaults to `swap`.
+   */
   multiThumbBehavior?: 'swap' | 'omit' | 'push'
 
-  /** if set to `true`, an overlaying skeleton with animation will be shown. */
+  /**
+   * If set to `true`, an overlaying skeleton with animation will be shown.
+   */
   skeleton?: SkeletonShow
 
   id?: string
   disabled?: boolean
   className?: string
 
-  /** Will be called on state changes made by the user. The callback `value` and `rawValue` is a number `{ value, rawValue, event }`. But if the prop `numberFormat` is given, then it will return an additional `number` with the given format `{ value, number, rawValue, event }`. */
+  /**
+   * Will be called on state changes made by the user. The callback `value` and `rawValue` is a number `{ value, rawValue, event }`. But if the `numberFormat` property is given, then it will return an additional `number` with the given format `{ value, number, rawValue, event }`.
+   */
   onChange?: (props: SliderOnChangeParams) => void
 
   /** Will be called once the user starts dragging. Returns `{ event }`. */
@@ -134,6 +191,13 @@ export type SliderContextValue = {
   thumbIndex: RefObject<number>
   showStatus: boolean
   showButtons: boolean
+  effectiveIntent:
+    | 'error'
+    | 'warning'
+    | 'information'
+    | 'success'
+    | 'marketing'
+  status: string | boolean | (() => ReactNode) | ReactNode
   attributes: unknown
   allProps: SliderProps
   value: SliderValue

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -45,8 +45,15 @@ export type SliderProps = {
 
   /**
    * Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied.
+   * Passing a message string is supported for backwards compatibility but deprecated — use `statusMessage` instead.
    */
-  status?: 'error' | 'warning' | 'information' | 'success' | 'marketing'
+  status?:
+    | 'error'
+    | 'warning'
+    | 'information'
+    | 'success'
+    | 'marketing'
+    | string
 
   /**
    * @deprecated Use `status` instead. Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -39,17 +39,17 @@ export type SliderProps = {
   labelSrOnly?: boolean
 
   /**
-   * Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.
+   * Text with a status message. The style defaults to an error message.
    */
-  status?: string | boolean
+  statusMessage?: string | boolean
 
   /**
-   * Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied.
+   * Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied.
    */
-  intent?: 'error' | 'warning' | 'information' | 'success' | 'marketing'
+  status?: 'error' | 'warning' | 'information' | 'success' | 'marketing'
 
   /**
-   * @deprecated Use `intent` instead. Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.
+   * @deprecated Use `status` instead. Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.
    */
   statusState?: 'error' | 'information'
 
@@ -191,13 +191,13 @@ export type SliderContextValue = {
   thumbIndex: RefObject<number>
   showStatus: boolean
   showButtons: boolean
-  effectiveIntent:
+  effectiveStatus:
     | 'error'
     | 'warning'
     | 'information'
     | 'success'
     | 'marketing'
-  status: string | boolean | (() => ReactNode) | ReactNode
+  statusMessage: string | boolean | (() => ReactNode) | ReactNode
   attributes: unknown
   allProps: SliderProps
   value: SliderValue

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -23,7 +23,10 @@ import type {
   FormStatusText,
 } from '../form-status/FormStatus'
 import FormStatus from '../form-status/FormStatus'
-import { resolveStatus } from '../../shared/component-helper'
+import {
+  resolveStatus,
+  resolveStatusMessage,
+} from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type StepIndicatorMode = 'static' | 'strict' | 'loose'
@@ -102,8 +105,9 @@ export type StepIndicatorProps = Omit<
     statusMessage?: FormStatusText
     /**
      * Visual status.
+     * Passing a message string is supported for backwards compatibility, but deprecated. Use `statusMessage` instead.
      */
-    status?: FormStatusState
+    status?: FormStatusState | string
     /**
      * The type of status for the `statusMessage` prop. Is either `information`, `error` or `warning`.
      * Defaults to `warning`.
@@ -149,6 +153,16 @@ function StepIndicator({
     ...restOfProps,
   }
 
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
+    statusState,
+    statusMessage,
+  })
+  const effectiveStatusMessage = resolveStatusMessage({
+    status: statusProp,
+    statusMessage,
+  })
+
   return (
     <StepIndicatorProvider {...props}>
       <div className="dnb-step-indicator-wrapper">
@@ -166,12 +180,8 @@ function StepIndicator({
           <StepIndicatorList />
         </Card>
         <StepIndicatorStatus
-          status={statusMessage}
-          effectiveStatus={resolveStatus({
-            status: statusProp,
-            statusState,
-            statusMessage,
-          })}
+          status={effectiveStatusMessage}
+          effectiveStatus={effectiveStatus}
         />
       </div>
     </StepIndicatorProvider>

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -23,6 +23,7 @@ import type {
   FormStatusText,
 } from '../form-status/FormStatus'
 import FormStatus from '../form-status/FormStatus'
+import { resolveIntent } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type StepIndicatorMode = 'static' | 'strict' | 'loose'
@@ -33,6 +34,7 @@ export type StepIndicatorDataItem = Pick<
   | 'inactive'
   | 'disabled'
   | 'status'
+  | 'intent'
   | 'statusState'
   | 'onClick'
 >
@@ -99,8 +101,13 @@ export type StepIndicatorProps = Omit<
      */
     status?: FormStatusText
     /**
+     * Visual intent of the status.
+     */
+    intent?: FormStatusState
+    /**
      * The type of status for the `status` prop. Is either `information`, `error` or `warning`.
      * Defaults to `warning`.
+     * @deprecated Use `intent` instead.
      */
     statusState?: FormStatusState
     /**
@@ -122,6 +129,7 @@ export type StepIndicatorProps = Omit<
 
 function StepIndicator({
   status,
+  intent: intentProp,
   statusState = 'warning',
   data = stepIndicatorDefaultProps.data,
   skeleton = stepIndicatorDefaultProps.skeleton,
@@ -157,20 +165,27 @@ function StepIndicator({
           />
           <StepIndicatorList />
         </Card>
-        <StepIndicatorStatus status={status} statusState={statusState} />
+        <StepIndicatorStatus
+          status={status}
+          effectiveIntent={resolveIntent({
+            intent: intentProp,
+            statusState,
+            status,
+          })}
+        />
       </div>
     </StepIndicatorProvider>
   )
 }
 
-function StepIndicatorStatus({ status, statusState }) {
+function StepIndicatorStatus({ status, effectiveIntent }) {
   const { open, noAnimation } = useContext(StepIndicatorContext)
   const show = !open && !!status
   return (
     <FormStatus
       show={show}
       noAnimation={noAnimation}
-      state={status && statusState}
+      state={status && effectiveIntent}
     >
       {status}
     </FormStatus>

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -23,7 +23,7 @@ import type {
   FormStatusText,
 } from '../form-status/FormStatus'
 import FormStatus from '../form-status/FormStatus'
-import { resolveIntent } from '../../shared/component-helper'
+import { resolveStatus } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type StepIndicatorMode = 'static' | 'strict' | 'loose'
@@ -33,8 +33,8 @@ export type StepIndicatorDataItem = Pick<
   | 'isCurrent'
   | 'inactive'
   | 'disabled'
+  | 'statusMessage'
   | 'status'
-  | 'intent'
   | 'statusState'
   | 'onClick'
 >
@@ -99,15 +99,15 @@ export type StepIndicatorProps = Omit<
     /**
      * Status text. Status is only shown if this prop has text. Defaults to `undefined`
      */
-    status?: FormStatusText
+    statusMessage?: FormStatusText
     /**
-     * Visual intent of the status.
+     * Visual status.
      */
-    intent?: FormStatusState
+    status?: FormStatusState
     /**
-     * The type of status for the `status` prop. Is either `information`, `error` or `warning`.
+     * The type of status for the `statusMessage` prop. Is either `information`, `error` or `warning`.
      * Defaults to `warning`.
-     * @deprecated Use `intent` instead.
+     * @deprecated Use `status` instead.
      */
     statusState?: FormStatusState
     /**
@@ -128,8 +128,8 @@ export type StepIndicatorProps = Omit<
   }
 
 function StepIndicator({
-  status,
-  intent: intentProp,
+  statusMessage,
+  status: statusProp,
   statusState = 'warning',
   data = stepIndicatorDefaultProps.data,
   skeleton = stepIndicatorDefaultProps.skeleton,
@@ -166,11 +166,11 @@ function StepIndicator({
           <StepIndicatorList />
         </Card>
         <StepIndicatorStatus
-          status={status}
-          effectiveIntent={resolveIntent({
-            intent: intentProp,
+          status={statusMessage}
+          effectiveStatus={resolveStatus({
+            status: statusProp,
             statusState,
-            status,
+            statusMessage,
           })}
         />
       </div>
@@ -178,14 +178,14 @@ function StepIndicator({
   )
 }
 
-function StepIndicatorStatus({ status, effectiveIntent }) {
+function StepIndicatorStatus({ status, effectiveStatus }) {
   const { open, noAnimation } = useContext(StepIndicatorContext)
   const show = !open && !!status
   return (
     <FormStatus
       show={show}
       noAnimation={noAnimation}
-      state={status && effectiveIntent}
+      state={status && effectiveStatus}
     >
       {status}
     </FormStatus>

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -47,7 +47,7 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
@@ -114,7 +114,7 @@ export const StepIndicatorStepProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -51,10 +51,21 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'The type of status shown when the `status` property is set. Defaults to `warning`.',
     type: ['"warning"', '"information"', '"error"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   skeleton: {
     doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
@@ -107,10 +118,21 @@ export const StepIndicatorStepProperties: PropertiesTableProps = {
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the step. When set, applies the corresponding visual styling even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'In case the status state should be `information` or `error`. Defaults to `warning`.',
     type: ['"warning"', '"information"', '"error"'],
-    status: 'optional',
+    status: 'deprecated',
   },
 }
 

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -46,13 +46,13 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Text for status shown below the step indicator when it is not expanded. Defaults to `undefined`.',
-    type: 'string',
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',
@@ -113,13 +113,13 @@ export const StepIndicatorStepProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  status: {
-    doc: 'Is used to set the status text.',
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the step. When set, applies the corresponding visual styling even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -7,7 +7,10 @@ import { useCallback, useContext, useMemo } from 'react'
 import type { HTMLProps, ReactNode } from 'react'
 
 import { clsx } from 'clsx'
-import { dispatchCustomElementEvent } from '../../shared/component-helper'
+import {
+  dispatchCustomElementEvent,
+  resolveIntent,
+} from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import type { AnchorAllProps } from '../anchor/Anchor'
 import Anchor from '../anchor/Anchor'
@@ -50,8 +53,13 @@ export type StepIndicatorItemProps = Omit<
    */
   status?: string | ReactNode
   /**
+   * Visual intent of the step status.
+   */
+  intent?: StepIndicatorStatusState
+  /**
    * Used to set the status state to be either `information`, `error` or `warning`.
    * Defaults to `warning`.
+   * @deprecated Use `intent` instead.
    */
   statusState?: StepIndicatorStatusState
   /**
@@ -62,6 +70,7 @@ export type StepIndicatorItemProps = Omit<
 }
 
 function StepIndicatorItem({
+  intent: intentDefault,
   statusState: statusStateDefault = 'warning',
   inactive: inactiveDefault = false,
   disabled: disabledDefault = false,
@@ -71,6 +80,7 @@ function StepIndicatorItem({
 
   const props: StepIndicatorItemProps = useMemo(() => {
     return {
+      intent: intentDefault,
       statusState: statusStateDefault,
       inactive: inactiveDefault,
       disabled: globalContext?.formElement?.disabled ?? disabledDefault,
@@ -79,6 +89,7 @@ function StepIndicatorItem({
   }, [
     disabledDefault,
     inactiveDefault,
+    intentDefault,
     restOfProps,
     statusStateDefault,
     globalContext?.formElement?.disabled,
@@ -141,10 +152,13 @@ function StepIndicatorItem({
     inactive,
     disabled,
     status,
+    intent,
     statusState = 'warning',
 
     onClick, // eslint-disable-line
   } = props
+
+  const effectiveIntent = resolveIntent({ intent, statusState, status })
 
   const hasPassedAndIsCurrent =
     mode === 'loose' ||
@@ -170,7 +184,7 @@ function StepIndicatorItem({
   const itemParams = {} as HTMLProps<HTMLLIElement>
   const buttonParams = {
     status,
-    statusState,
+    effectiveIntent,
     'aria-describedby': id,
   } as StepItemButtonProps
 
@@ -235,7 +249,7 @@ function StepIndicatorItem({
         >
           {status && !usedIsCurrent ? (
             <Icon
-              icon={stateIcons[statusState] || stateIcons.warning}
+              icon={stateIcons[effectiveIntent] || stateIcons.warning}
               className="dnb-step-indicator__item__icon"
               size="medium"
               inheritColor={false}
@@ -270,7 +284,7 @@ function StepIndicatorItem({
             <FormStatus
               shellSpace={{ top: '1rem' }}
               noAnimation={noAnimation}
-              state={status ? statusState : undefined}
+              state={status ? effectiveIntent : undefined}
               variant="outlined"
               className="dnb-step-indicator__item-content__status"
               text={status}
@@ -285,14 +299,16 @@ function StepIndicatorItem({
   )
 }
 
-type StepItemButtonProps = AnchorAllProps &
-  Pick<StepIndicatorItemProps, 'status' | 'statusState'>
+type StepItemButtonProps = AnchorAllProps & {
+  status?: StepIndicatorItemProps['status']
+  effectiveIntent?: StepIndicatorStatusState
+}
 
 export function StepItemButton({
   children,
   className,
   status,
-  statusState = 'warning',
+  effectiveIntent = 'warning',
   ref,
   ...props
 }: StepItemButtonProps) {
@@ -306,7 +322,7 @@ export function StepItemButton({
         className,
         'dnb-step-indicator__button',
         status &&
-          `dnb-step-indicator__button--has-status dnb-step-indicator__button--${statusState}`
+          `dnb-step-indicator__button--has-status dnb-step-indicator__button--${effectiveIntent}`
       )}
       noStyle={notClickable}
       ref={ref}

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -9,7 +9,7 @@ import type { HTMLProps, ReactNode } from 'react'
 import { clsx } from 'clsx'
 import {
   dispatchCustomElementEvent,
-  resolveIntent,
+  resolveStatus,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import type { AnchorAllProps } from '../anchor/Anchor'
@@ -51,15 +51,15 @@ export type StepIndicatorItemProps = Omit<
   /**
    * Is used to set the status text.
    */
-  status?: string | ReactNode
+  statusMessage?: string | ReactNode
   /**
-   * Visual intent of the step status.
+   * Visual status of the step.
    */
-  intent?: StepIndicatorStatusState
+  status?: StepIndicatorStatusState
   /**
    * Used to set the status state to be either `information`, `error` or `warning`.
    * Defaults to `warning`.
-   * @deprecated Use `intent` instead.
+   * @deprecated Use `status` instead.
    */
   statusState?: StepIndicatorStatusState
   /**
@@ -70,7 +70,7 @@ export type StepIndicatorItemProps = Omit<
 }
 
 function StepIndicatorItem({
-  intent: intentDefault,
+  status: statusDefault,
   statusState: statusStateDefault = 'warning',
   inactive: inactiveDefault = false,
   disabled: disabledDefault = false,
@@ -80,7 +80,7 @@ function StepIndicatorItem({
 
   const props: StepIndicatorItemProps = useMemo(() => {
     return {
-      intent: intentDefault,
+      status: statusDefault,
       statusState: statusStateDefault,
       inactive: inactiveDefault,
       disabled: globalContext?.formElement?.disabled ?? disabledDefault,
@@ -89,7 +89,7 @@ function StepIndicatorItem({
   }, [
     disabledDefault,
     inactiveDefault,
-    intentDefault,
+    statusDefault,
     restOfProps,
     statusStateDefault,
     globalContext?.formElement?.disabled,
@@ -151,14 +151,18 @@ function StepIndicatorItem({
     isCurrent, // eslint-disable-line
     inactive,
     disabled,
+    statusMessage,
     status,
-    intent,
     statusState = 'warning',
 
     onClick, // eslint-disable-line
   } = props
 
-  const effectiveIntent = resolveIntent({ intent, statusState, status })
+  const effectiveStatus = resolveStatus({
+    status,
+    statusState,
+    statusMessage,
+  })
 
   const hasPassedAndIsCurrent =
     mode === 'loose' ||
@@ -183,8 +187,8 @@ function StepIndicatorItem({
 
   const itemParams = {} as HTMLProps<HTMLLIElement>
   const buttonParams = {
-    status,
-    effectiveIntent,
+    status: statusMessage,
+    effectiveStatus,
     'aria-describedby': id,
   } as StepItemButtonProps
 
@@ -230,7 +234,7 @@ function StepIndicatorItem({
       <div
         className={clsx(
           'dnb-step-indicator__item__wrapper',
-          !status &&
+          !statusMessage &&
             isVisited &&
             'dnb-step-indicator__item__wrapper--check'
         )}
@@ -240,16 +244,16 @@ function StepIndicatorItem({
             'dnb-step-indicator__item__bullet',
             usedIsCurrent
               ? 'dnb-step-indicator__item__bullet--current'
-              : !status &&
+              : !statusMessage &&
                   (isVisited
                     ? 'dnb-step-indicator__item__bullet--check'
                     : 'dnb-step-indicator__item__bullet--empty'),
             createSkeletonClass('shape', skeleton)
           )}
         >
-          {status && !usedIsCurrent ? (
+          {statusMessage && !usedIsCurrent ? (
             <Icon
-              icon={stateIcons[effectiveIntent] || stateIcons.warning}
+              icon={stateIcons[effectiveStatus] || stateIcons.warning}
               className="dnb-step-indicator__item__icon"
               size="medium"
               inheritColor={false}
@@ -284,10 +288,10 @@ function StepIndicatorItem({
             <FormStatus
               shellSpace={{ top: '1rem' }}
               noAnimation={noAnimation}
-              state={status ? effectiveIntent : undefined}
+              state={statusMessage ? effectiveStatus : undefined}
               variant="outlined"
               className="dnb-step-indicator__item-content__status"
-              text={status}
+              text={statusMessage}
             />
           </div>
         </div>
@@ -301,14 +305,14 @@ function StepIndicatorItem({
 
 type StepItemButtonProps = AnchorAllProps & {
   status?: StepIndicatorItemProps['status']
-  effectiveIntent?: StepIndicatorStatusState
+  effectiveStatus?: StepIndicatorStatusState
 }
 
 export function StepItemButton({
   children,
   className,
   status,
-  effectiveIntent = 'warning',
+  effectiveStatus = 'warning',
   ref,
   ...props
 }: StepItemButtonProps) {
@@ -322,7 +326,7 @@ export function StepItemButton({
         className,
         'dnb-step-indicator__button',
         status &&
-          `dnb-step-indicator__button--has-status dnb-step-indicator__button--${effectiveIntent}`
+          `dnb-step-indicator__button--has-status dnb-step-indicator__button--${effectiveStatus}`
       )}
       noStyle={notClickable}
       ref={ref}

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -10,6 +10,7 @@ import { clsx } from 'clsx'
 import {
   dispatchCustomElementEvent,
   resolveStatus,
+  resolveStatusMessage,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import type { AnchorAllProps } from '../anchor/Anchor'
@@ -54,8 +55,9 @@ export type StepIndicatorItemProps = Omit<
   statusMessage?: string | ReactNode
   /**
    * Visual status of the step.
+   * Passing a message string is supported for backwards compatibility, but deprecated. Use `statusMessage` instead.
    */
-  status?: StepIndicatorStatusState
+  status?: StepIndicatorStatusState | string
   /**
    * Used to set the status state to be either `information`, `error` or `warning`.
    * Defaults to `warning`.
@@ -163,6 +165,10 @@ function StepIndicatorItem({
     statusState,
     statusMessage,
   })
+  const effectiveStatusMessage = resolveStatusMessage({
+    status,
+    statusMessage,
+  })
 
   const hasPassedAndIsCurrent =
     mode === 'loose' ||
@@ -187,7 +193,7 @@ function StepIndicatorItem({
 
   const itemParams = {} as HTMLProps<HTMLLIElement>
   const buttonParams = {
-    status: statusMessage,
+    status: effectiveStatusMessage,
     effectiveStatus,
     'aria-describedby': id,
   } as StepItemButtonProps
@@ -234,7 +240,7 @@ function StepIndicatorItem({
       <div
         className={clsx(
           'dnb-step-indicator__item__wrapper',
-          !statusMessage &&
+          !effectiveStatusMessage &&
             isVisited &&
             'dnb-step-indicator__item__wrapper--check'
         )}
@@ -244,14 +250,14 @@ function StepIndicatorItem({
             'dnb-step-indicator__item__bullet',
             usedIsCurrent
               ? 'dnb-step-indicator__item__bullet--current'
-              : !statusMessage &&
+              : !effectiveStatusMessage &&
                   (isVisited
                     ? 'dnb-step-indicator__item__bullet--check'
                     : 'dnb-step-indicator__item__bullet--empty'),
             createSkeletonClass('shape', skeleton)
           )}
         >
-          {statusMessage && !usedIsCurrent ? (
+          {effectiveStatusMessage && !usedIsCurrent ? (
             <Icon
               icon={stateIcons[effectiveStatus] || stateIcons.warning}
               className="dnb-step-indicator__item__icon"
@@ -288,10 +294,10 @@ function StepIndicatorItem({
             <FormStatus
               shellSpace={{ top: '1rem' }}
               noAnimation={noAnimation}
-              state={statusMessage ? effectiveStatus : undefined}
+              state={effectiveStatusMessage ? effectiveStatus : undefined}
               variant="outlined"
               className="dnb-step-indicator__item-content__status"
-              text={statusMessage}
+              text={effectiveStatusMessage}
             />
           </div>
         </div>

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -718,6 +718,62 @@ describe('StepIndicator ARIA', () => {
   })
 })
 
+describe('StepIndicator deprecated status compatibility', () => {
+  it('supports deprecated status message on the component via status', () => {
+    render(
+      <StepIndicator
+        mode="loose"
+        data={stepIndicatorListData}
+        status="Legacy status message"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy status message')
+  })
+
+  it('supports deprecated status message on items via status', () => {
+    render(
+      <StepIndicator
+        mode="loose"
+        expandedInitially
+        data={[
+          {
+            title: 'Step A',
+            status: 'Legacy item message',
+          },
+          {
+            title: 'Step B',
+          },
+        ]}
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-step-indicator__item-content__status')
+    ).toHaveTextContent('Legacy item message')
+  })
+
+  it('supports deprecated statusState with statusMessage', () => {
+    render(
+      <StepIndicator
+        mode="loose"
+        data={stepIndicatorListData}
+        statusMessage="Information message"
+        statusState="information"
+      />
+    )
+
+    expect(document.querySelector('.dnb-form-status')).toHaveClass(
+      'dnb-form-status--information'
+    )
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Information message')
+  })
+})
+
 describe('StepIndicator scss', () => {
   it('should match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -19,8 +19,8 @@ import { clsx } from 'clsx'
 import {
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   extendPropsWithContext,
 } from '../../shared/component-helper'
@@ -129,8 +129,8 @@ function Switch(props: SwitchProps) {
   const {
     value,
     size,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     globalStatus,
@@ -153,14 +153,14 @@ function Switch(props: SwitchProps) {
     ...rest
   } = allProps
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
   const [, forceUpdate] = useReducer(() => ({}), {})
@@ -263,13 +263,16 @@ function Switch(props: SwitchProps) {
     [onChangeHandler]
   )
 
-  const showStatus = useMemo(() => getStatusState(status), [status])
+  const showStatus = useMemo(
+    () => getStatusState(statusMessage),
+    [statusMessage]
+  )
 
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-switch',
       size && `dnb-switch--${size}`,
-      status && `dnb-switch__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-switch__status--${effectiveStatus}`,
       `dnb-switch--label-position-${labelPosition || 'right'}`,
       'dnb-form-component',
       createSkeletonClass(null, skeleton),
@@ -293,7 +296,7 @@ function Switch(props: SwitchProps) {
   if (readOnly) {
     inputParams['aria-readonly'] = readOnly
   }
-  if (effectiveIntent === 'error') {
+  if (effectiveStatus === 'error') {
     inputParams['aria-invalid'] = true
   }
 
@@ -337,8 +340,8 @@ function Switch(props: SwitchProps) {
             globalStatus={globalStatus}
             label={label}
             widthSelector={id + ', ' + id + '-label'}
-            text={status}
-            state={effectiveIntent}
+            text={statusMessage}
+            state={effectiveStatus}
             skeleton={skeleton}
             noAnimation={statusNoAnimation}
             {...statusProps}

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -19,6 +19,8 @@ import { clsx } from 'clsx'
 import {
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   extendPropsWithContext,
 } from '../../shared/component-helper'
@@ -127,7 +129,8 @@ function Switch(props: SwitchProps) {
   const {
     value,
     size,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     globalStatus,
@@ -149,6 +152,16 @@ function Switch(props: SwitchProps) {
     ref: refProp,
     ...rest
   } = allProps
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
 
   const [, forceUpdate] = useReducer(() => ({}), {})
   const id = useId(idProp)
@@ -256,7 +269,7 @@ function Switch(props: SwitchProps) {
     className: clsx(
       'dnb-switch',
       size && `dnb-switch--${size}`,
-      status && `dnb-switch__status--${statusState}`,
+      status && `dnb-switch__status--${effectiveIntent}`,
       `dnb-switch--label-position-${labelPosition || 'right'}`,
       'dnb-form-component',
       createSkeletonClass(null, skeleton),
@@ -279,6 +292,9 @@ function Switch(props: SwitchProps) {
   }
   if (readOnly) {
     inputParams['aria-readonly'] = readOnly
+  }
+  if (effectiveIntent === 'error') {
+    inputParams['aria-invalid'] = true
   }
 
   skeletonDOMAttributes(inputParams, skeleton, context)
@@ -322,7 +338,7 @@ function Switch(props: SwitchProps) {
             label={label}
             widthSelector={id + ', ' + id + '-label'}
             text={status}
-            state={statusState}
+            state={effectiveIntent}
             skeleton={skeleton}
             noAnimation={statusNoAnimation}
             {...statusProps}

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -31,13 +31,13 @@ export const SwitchProperties: PropertiesTableProps = {
     type: ['"default"', '"medium"', '"large"'],
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -32,7 +32,7 @@ export const SwitchProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
+++ b/packages/dnb-eufemia/src/components/switch/SwitchDocs.ts
@@ -36,6 +36,17 @@ export const SwitchProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Defaults to `error`.',
     type: [
@@ -45,7 +56,7 @@ export const SwitchProperties: PropertiesTableProps = {
       '"success"',
       '"marketing"',
     ],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional [FormStatus](/uilib/components/form-status/properties/) properties.',

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -259,6 +259,23 @@ describe('Switch component', () => {
     expect(input.getAttribute('aria-checked')).toBe('true')
     expect(onChange).toHaveBeenCalledWith(true)
   })
+
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Switch
+        label="Switch"
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-switch')).toHaveClass(
+      'dnb-switch__status--information'
+    )
+  })
 })
 
 describe('Switch scss', () => {

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -29,8 +29,8 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   warn,
   dispatchCustomElementEvent,
@@ -231,8 +231,8 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     label,
     labelDirection,
     labelSrOnly,
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -259,14 +259,14 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     ...attributes
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -471,7 +471,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     }
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
   const currentHasValue = hasValue(value)
 
   let TextareaElement: TextareaElement = props.textareaElement
@@ -511,7 +511,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
   if (readOnly) {
     textareaParams['aria-readonly'] = textareaParams.readOnly = true
   }
-  if (effectiveIntent === 'error') {
+  if (effectiveStatus === 'error') {
     textareaParams['aria-invalid'] = true
   }
 
@@ -523,7 +523,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
       currentHasValue && 'dnb-textarea--has-content',
       align && `dnb-textarea__align--${align}`,
       typeof size === 'string' && `dnb-textarea__size--${size}`,
-      status && `dnb-textarea__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-textarea__status--${effectiveStatus}`,
       autoResize && 'dnb-textarea__autoresize',
       labelDirection && `dnb-textarea--${labelDirection}`,
       stretch && `dnb-textarea--stretch`,
@@ -591,8 +591,8 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
           globalStatus={globalStatus}
           label={label}
           textId={id + '-status'}
-          text={status}
-          state={effectiveIntent}
+          text={statusMessage}
+          state={effectiveStatus}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -29,6 +29,8 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   warn,
   dispatchCustomElementEvent,
@@ -229,7 +231,8 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     label,
     labelDirection,
     labelSrOnly,
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -255,6 +258,16 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     ref: _ref,
     ...attributes
   } = props
+
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const combinedRef = useCombinedRef(ref, textareaRef)
@@ -498,6 +511,9 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
   if (readOnly) {
     textareaParams['aria-readonly'] = textareaParams.readOnly = true
   }
+  if (effectiveIntent === 'error') {
+    textareaParams['aria-invalid'] = true
+  }
 
   const mainParams = useSpacing(props, {
     className: clsx(
@@ -507,7 +523,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
       currentHasValue && 'dnb-textarea--has-content',
       align && `dnb-textarea__align--${align}`,
       typeof size === 'string' && `dnb-textarea__size--${size}`,
-      status && `dnb-textarea__status--${statusState}`,
+      status && `dnb-textarea__status--${effectiveIntent}`,
       autoResize && 'dnb-textarea__autoresize',
       labelDirection && `dnb-textarea--${labelDirection}`,
       stretch && `dnb-textarea--stretch`,
@@ -576,7 +592,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
           label={label}
           textId={id + '-status'}
           text={status}
-          state={statusState}
+          state={effectiveIntent}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}

--- a/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
+++ b/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
@@ -66,13 +66,13 @@ export const TextareaProperties: PropertiesTableProps = {
     type: ['"small"', '"medium"', '"large"'],
     status: 'optional',
   },
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
+++ b/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
@@ -71,6 +71,17 @@ export const TextareaProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Defaults to `error`.',
     type: [
@@ -80,7 +91,7 @@ export const TextareaProperties: PropertiesTableProps = {
       '"success"',
       '"marketing"',
     ],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
+++ b/packages/dnb-eufemia/src/components/textarea/TextareaDocs.ts
@@ -67,7 +67,7 @@ export const TextareaProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
@@ -223,7 +223,9 @@ describe('Textarea component', () => {
   })
 
   it('has to have a status value as defined in the prop', () => {
-    render(<Textarea {...props} status="status" statusState="error" />)
+    render(
+      <Textarea {...props} statusMessage="status" statusState="error" />
+    )
     expect(
       document.querySelector('.dnb-form-status__text').textContent
     ).toBe('status')

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
@@ -231,6 +231,23 @@ describe('Textarea component', () => {
     ).toBe('status')
   })
 
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <Textarea
+        {...props}
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-textarea')).toHaveClass(
+      'dnb-textarea__status--information'
+    )
+  })
+
   it('has a disabled attribute, once we set disabled to true', () => {
     const { rerender } = render(<Textarea />)
     rerender(<Textarea disabled={true} />)

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -25,8 +25,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
@@ -268,8 +268,8 @@ function ToggleButton(ownProps: ToggleButtonProps) {
   )
 
   const {
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -320,22 +320,22 @@ function ToggleButton(ownProps: ToggleButtonProps) {
     }
   }
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-toggle-button',
-      status && `dnb-toggle-button__status--${effectiveIntent}`,
+      effectiveStatus && `dnb-toggle-button__status--${effectiveStatus}`,
       resolvedChecked && `dnb-toggle-button--checked`,
       labelDirection && `dnb-toggle-button--${labelDirection}`,
       className
@@ -373,10 +373,10 @@ function ToggleButton(ownProps: ToggleButtonProps) {
     title: null,
   }
 
-  if (status) {
+  if (effectiveStatus) {
     // do not send along the message, but only the status states
-    if (effectiveIntent === 'information') {
-      componentParams.intent = 'information'
+    if (effectiveStatus === 'information') {
+      componentParams.status = 'information'
     } else {
       componentParams.status = 'error'
     }
@@ -432,8 +432,8 @@ function ToggleButton(ownProps: ToggleButtonProps) {
           globalStatus={globalStatus}
           label={label}
           textId={id + '-status'} // used for "aria-describedby"
-          text={status}
-          state={effectiveIntent}
+          text={statusMessage}
+          state={effectiveStatus}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -25,6 +25,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
@@ -266,7 +268,8 @@ function ToggleButton(ownProps: ToggleButtonProps) {
   )
 
   const {
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -317,12 +320,22 @@ function ToggleButton(ownProps: ToggleButtonProps) {
     }
   }
 
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const showStatus = getStatusState(status)
 
   const mainParams = useSpacing(props, {
     className: clsx(
       'dnb-toggle-button',
-      status && `dnb-toggle-button__status--${statusState}`,
+      status && `dnb-toggle-button__status--${effectiveIntent}`,
       resolvedChecked && `dnb-toggle-button--checked`,
       labelDirection && `dnb-toggle-button--${labelDirection}`,
       className
@@ -362,8 +375,8 @@ function ToggleButton(ownProps: ToggleButtonProps) {
 
   if (status) {
     // do not send along the message, but only the status states
-    if (statusState === 'information') {
-      componentParams.statusState = 'information'
+    if (effectiveIntent === 'information') {
+      componentParams.intent = 'information'
     } else {
       componentParams.status = 'error'
     }
@@ -420,7 +433,7 @@ function ToggleButton(ownProps: ToggleButtonProps) {
           label={label}
           textId={id + '-status'} // used for "aria-describedby"
           text={status}
-          state={statusState}
+          state={effectiveIntent}
           noAnimation={statusNoAnimation}
           skeleton={skeleton}
           {...statusProps}

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
@@ -44,13 +44,13 @@ export const ToggleButtonProperties: PropertiesTableProps = {
   },
   tooltip: ButtonProperties.tooltip,
   size: ButtonProperties.size,
-  status: {
-    doc: 'Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
@@ -45,7 +45,7 @@ export const ToggleButtonProperties: PropertiesTableProps = {
   tooltip: ButtonProperties.tooltip,
   size: ButtonProperties.size,
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonDocs.ts
@@ -49,10 +49,21 @@ export const ToggleButtonProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
+    status: 'optional',
+  },
   statusState: {
     doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
     type: ['"error"', '"information"'],
-    status: 'optional',
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -11,8 +11,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -42,6 +42,7 @@ const toggleButtonGroupDefaultProps: Partial<ToggleButtonGroupProps> = {
   id: null,
   name: null,
   size: null,
+  statusMessage: null,
   status: null,
   statusState: 'error',
   statusProps: null,
@@ -164,8 +165,8 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
   )
 
   const {
+    statusMessage: statusMessageProp,
     status: statusProp,
-    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -194,22 +195,23 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
     ...rest
   } = props
 
-  const effectiveIntent = resolveIntent({
-    intent: intentProp,
+  const effectiveStatus = resolveStatus({
+    status: statusProp,
     statusState,
-    status: statusProp,
+    statusMessage: statusMessageProp,
   })
-  const status = resolveStatusForIntent({
-    intent: intentProp,
+  const statusMessage = resolveStatusMessage({
     status: statusProp,
+    statusMessage: statusMessageProp,
   })
 
-  const showStatus = getStatusState(status)
+  const showStatus = getStatusState(statusMessage)
 
   const rootProps = useSpacing(props, {
     className: clsx(
       'dnb-toggle-button-group',
-      status && `dnb-toggle-button-group__status--${effectiveIntent}`,
+      statusMessage &&
+        `dnb-toggle-button-group__status--${effectiveStatus}`,
       !label && 'dnb-toggle-button-group--no-label',
       `dnb-toggle-button-group--${layoutDirection}`,
       'dnb-form-component',
@@ -317,8 +319,8 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
                 globalStatus={globalStatus}
                 label={label}
                 textId={id + '-status'} // used for "aria-describedby"
-                text={status}
-                state={effectiveIntent}
+                text={statusMessage}
+                state={effectiveStatus}
                 noAnimation={statusNoAnimation}
                 skeleton={skeleton}
                 {...statusProps}

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -11,6 +11,8 @@ import {
   extendExistingPropsWithContext,
   validateDOMAttributes,
   getStatusState,
+  resolveIntent,
+  resolveStatusForIntent,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
@@ -162,7 +164,8 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
   )
 
   const {
-    status,
+    status: statusProp,
+    intent: intentProp,
     statusState,
     statusProps,
     statusNoAnimation,
@@ -191,12 +194,22 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
     ...rest
   } = props
 
+  const effectiveIntent = resolveIntent({
+    intent: intentProp,
+    statusState,
+    status: statusProp,
+  })
+  const status = resolveStatusForIntent({
+    intent: intentProp,
+    status: statusProp,
+  })
+
   const showStatus = getStatusState(status)
 
   const rootProps = useSpacing(props, {
     className: clsx(
       'dnb-toggle-button-group',
-      status && `dnb-toggle-button-group__status--${statusState}`,
+      status && `dnb-toggle-button-group__status--${effectiveIntent}`,
       !label && 'dnb-toggle-button-group--no-label',
       `dnb-toggle-button-group--${layoutDirection}`,
       'dnb-form-component',
@@ -305,7 +318,7 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
                 label={label}
                 textId={id + '-status'} // used for "aria-describedby"
                 text={status}
-                state={statusState}
+                state={effectiveIntent}
                 noAnimation={statusNoAnimation}
                 skeleton={skeleton}
                 {...statusProps}

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
@@ -26,13 +26,13 @@ export const ToggleButtonGroupProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
-  status: {
-    doc: 'Uses the `form-status` component to show failure messages.',
-    type: ['"error"', '"information"', 'boolean'],
+  statusMessage: {
+    doc: 'Text with a status message. The style defaults to an error message.',
+    type: ['string', 'React.ReactNode'],
     status: 'optional',
   },
-  intent: {
-    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+  status: {
+    doc: 'Visual status of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `statusMessage`, add an `aria-label` or `aria-labelledby` to convey the status to assistive technologies.',
     type: [
       '"error"',
       '"warning"',

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
@@ -31,10 +31,21 @@ export const ToggleButtonGroupProperties: PropertiesTableProps = {
     type: ['"error"', '"information"', 'boolean'],
     status: 'optional',
   },
-  statusState: {
-    doc: 'Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.',
-    type: ['"error"', '"information"'],
+  intent: {
+    doc: 'Visual intent of the component. When set, applies the corresponding visual styling (e.g. red border for error) even without a status message. When set to `error`, `aria-invalid` is automatically applied. When used without a `status` message, add a `aria-label` or `aria-labelledby` to convey the intent to assistive technologies.',
+    type: [
+      '"error"',
+      '"warning"',
+      '"information"',
+      '"success"',
+      '"marketing"',
+    ],
     status: 'optional',
+  },
+  statusState: {
+    doc: 'Defines the state of the status. Currently there are two statuses `[error, information]`. Defaults to `error`.',
+    type: ['"error"', '"information"'],
+    status: 'deprecated',
   },
   statusProps: {
     doc: 'Use an object to define additional FormStatus properties.',

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroupDocs.ts
@@ -27,7 +27,7 @@ export const ToggleButtonGroupProperties: PropertiesTableProps = {
     status: 'optional',
   },
   statusMessage: {
-    doc: 'Text with a status message. The style defaults to an error message.',
+    doc: 'Text with a status message. Use `status` to set the visual style.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButton.test.tsx
@@ -391,6 +391,23 @@ describe('ToggleButton component', () => {
 
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
+
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <ToggleButton
+        text="Toggle"
+        status="Legacy information message"
+        statusState="information"
+      />
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-toggle-button')).toHaveClass(
+      'dnb-toggle-button__status--information'
+    )
+  })
 })
 
 describe('ToggleButton scss', () => {

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
@@ -526,6 +526,27 @@ describe('ToggleButton group component', () => {
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 
+  it('supports deprecated status message via status and statusState', () => {
+    render(
+      <ToggleButton.Group
+        id="group"
+        label="Label"
+        status="Legacy information message"
+        statusState="information"
+      >
+        <ToggleButton text="First" value="first" />
+        <ToggleButton text="Second" value="second" />
+      </ToggleButton.Group>
+    )
+
+    expect(
+      document.querySelector('.dnb-form-status__text')
+    ).toHaveTextContent('Legacy information message')
+    expect(document.querySelector('.dnb-toggle-button-group')).toHaveClass(
+      'dnb-toggle-button-group__status--information'
+    )
+  })
+
   it('should validate with ARIA rules for group variant', async () => {
     const Comp = render(
       <ToggleButton.Group label="Label" id="group">

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -209,8 +209,8 @@ function Expiry(props: ExpiryProps = {}) {
     className,
     label = expiryLabel,
     hasError,
-    info,
-    warning,
+    info: _info,
+    warning: _warning,
     disabled,
     size,
     value = '',
@@ -236,14 +236,6 @@ function Expiry(props: ExpiryProps = {}) {
     }
   }, [expiry.month, expiry.year, itemPath, path, setDisplayValue])
 
-  const status = hasError
-    ? 'error'
-    : warning
-      ? 'warning'
-      : info
-        ? 'information'
-        : null
-
   const fieldBlockProps: FieldBlockProps = {
     id,
     forId: `${id}-input`,
@@ -258,7 +250,7 @@ function Expiry(props: ExpiryProps = {}) {
         stretch
         id={`${id}-input`}
         values={expiry}
-        status={status === 'error'}
+        status={hasError ? 'error' : undefined}
         disabled={disabled}
         size={size}
         onChange={handleChange}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -603,7 +603,7 @@ function NumberComponent(props: FieldNumberProps) {
     },
     onChange: onChangeHandler,
     disabled,
-    status: hasError ? 'error' : undefined,
+    status: hasError ? ('error' as const) : undefined,
     stretch: Boolean(width),
     ...maskProps,
     ...htmlAttributes,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -306,7 +306,7 @@ function StringComponent(props: FieldStringProps) {
     ...htmlAttributes,
     stretch: Boolean(width),
     ref: inputRef as any,
-    status: hasError ? 'error' : undefined,
+    status: hasError ? ('error' as const) : undefined,
     value: transformInstantly(value?.toString() ?? ''),
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Time/Time.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Time/Time.tsx
@@ -198,8 +198,8 @@ function Time(props: TimeProps = {}) {
     className,
     label = timeLabel,
     hasError,
-    info,
-    warning,
+    info: _info,
+    warning: _warning,
     disabled,
     size,
     value = '',
@@ -237,14 +237,6 @@ function Time(props: TimeProps = {}) {
     setDisplayValue,
   ])
 
-  const status = hasError
-    ? 'error'
-    : warning
-      ? 'warning'
-      : info
-        ? 'information'
-        : null
-
   const fieldBlockProps: FieldBlockProps = {
     id,
     forId: `${id}-input`,
@@ -259,7 +251,7 @@ function Time(props: TimeProps = {}) {
         stretch
         id={`${id}-input`}
         values={time}
-        status={status === 'error'}
+        status={hasError ? 'error' : undefined}
         disabled={disabled}
         size={size}
         onChange={handleChange}

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/DisplaySteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/DisplaySteps.tsx
@@ -31,8 +31,8 @@ export function DisplaySteps({
     if (hasInvalidStepsState(undefined, ['error'])) {
       return {
         // Show FormStatus inside the StepIndicator
-        status: translations.Step.stepHasError,
-        statusState: 'error',
+        statusMessage: translations.Step.stepHasError,
+        status: 'error',
       } satisfies Omit<StepIndicatorItemProps, 'title' | 'currentItemNum'>
     }
     return {}
@@ -42,7 +42,7 @@ export function DisplaySteps({
     translations.Step.stepHasError,
   ])
 
-  const { status, statusState } = getStepIndicatorStatus() ?? {}
+  const { statusMessage, status } = getStepIndicatorStatus() ?? {}
 
   return (
     <div className="dnb-forms-wizard-layout__indicator">
@@ -50,12 +50,18 @@ export function DisplaySteps({
         bottom
         currentStep={activeIndexRef.current}
         data={Array.from(stepsRef.current.values()).map(
-          ({ stringifiedTitle, title, inactive, status, statusState }) =>
+          ({
+            stringifiedTitle,
+            title,
+            inactive,
+            status: statusMessage,
+            statusState: status,
+          }) =>
             ({
               title: stringifiedTitle || title,
               inactive,
+              statusMessage,
               status,
-              statusState: statusState,
             }) satisfies Omit<StepIndicatorItemProps, 'currentItemNum'>
         )}
         mode={mode}
@@ -63,8 +69,8 @@ export function DisplaySteps({
         expandedInitially={expandedInitially}
         onChange={handleChange}
         outset={outset}
+        statusMessage={statusMessage}
         status={status}
-        statusState={statusState}
       />
     </div>
   )

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -25,6 +25,8 @@ import {
   convertJsxToString,
   escapeRegexChars,
   removeUndefinedProps,
+  resolveIntent,
+  resolveStatusForIntent,
 } from '../component-helper'
 import userEvent from '@testing-library/user-event'
 
@@ -663,5 +665,66 @@ describe('"removeUndefinedProps" should', () => {
 
   it('remove support undefined as data', () => {
     expect(removeUndefinedProps(undefined)).toBeUndefined()
+  })
+})
+
+describe('resolveIntent', () => {
+  it('returns intent when provided', () => {
+    expect(resolveIntent({ intent: 'warning' })).toBe('warning')
+  })
+
+  it('returns intent over statusState', () => {
+    expect(
+      resolveIntent({ intent: 'information', statusState: 'error' })
+    ).toBe('information')
+  })
+
+  it('returns statusState when status is truthy', () => {
+    expect(
+      resolveIntent({ statusState: 'warning', status: 'Some message' })
+    ).toBe('warning')
+  })
+
+  it('does not return statusState without status', () => {
+    expect(resolveIntent({ statusState: 'warning' })).toBeUndefined()
+  })
+
+  it('returns status value when it is a known state string', () => {
+    expect(resolveIntent({ status: 'error' })).toBe('error')
+    expect(resolveIntent({ status: 'warning' })).toBe('warning')
+    expect(resolveIntent({ status: 'information' })).toBe('information')
+  })
+
+  it('falls back to error when status is a non-state truthy value', () => {
+    expect(resolveIntent({ status: 'Some error message' })).toBe('error')
+    expect(resolveIntent({ status: true })).toBe('error')
+  })
+
+  it('returns undefined when nothing is set', () => {
+    expect(resolveIntent({})).toBeUndefined()
+  })
+})
+
+describe('resolveStatusForIntent', () => {
+  it('returns true when intent is set and status is undefined', () => {
+    expect(
+      resolveStatusForIntent({ intent: 'error', status: undefined })
+    ).toBe(true)
+  })
+
+  it('returns status when it is provided', () => {
+    expect(
+      resolveStatusForIntent({ intent: 'error', status: 'A message' })
+    ).toBe('A message')
+  })
+
+  it('returns status when intent is not set', () => {
+    expect(resolveStatusForIntent({ status: 'A message' })).toBe(
+      'A message'
+    )
+  })
+
+  it('returns undefined when neither intent nor status is set', () => {
+    expect(resolveStatusForIntent({})).toBeUndefined()
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -708,14 +708,24 @@ describe('resolveStatus', () => {
     ).toBe('error')
   })
 
-  it('returns undefined when status is boolean true without statusMessage', () => {
-    expect(resolveStatus({ status: true })).toBeUndefined()
+  it('falls back to error when status is boolean true', () => {
+    expect(resolveStatus({ status: true })).toBe('error')
   })
 
-  it('returns undefined when status is boolean true with statusMessage', () => {
+  it('returns statusState when status is boolean true', () => {
+    expect(resolveStatus({ status: true, statusState: 'warning' })).toBe(
+      'warning'
+    )
+  })
+
+  it('falls back to error when status is boolean true with statusMessage', () => {
     expect(
       resolveStatus({ status: true, statusMessage: 'A message' })
-    ).toBeUndefined()
+    ).toBe('error')
+  })
+
+  it('returns undefined when status is boolean false', () => {
+    expect(resolveStatus({ status: false })).toBeUndefined()
   })
 
   it('returns undefined when only statusMessage is set', () => {
@@ -786,5 +796,18 @@ describe('resolveStatusMessage', () => {
 
   it('returns undefined when status is boolean true', () => {
     expect(resolveStatusMessage({ status: true })).toBeUndefined()
+  })
+
+  it('returns undefined when statusMessage is boolean true', () => {
+    expect(resolveStatusMessage({ statusMessage: true })).toBeUndefined()
+  })
+
+  it('falls back to legacy status when statusMessage is boolean true', () => {
+    expect(
+      resolveStatusMessage({
+        status: 'legacy message',
+        statusMessage: true,
+      })
+    ).toBe('legacy message')
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -25,8 +25,8 @@ import {
   convertJsxToString,
   escapeRegexChars,
   removeUndefinedProps,
-  resolveIntent,
-  resolveStatusForIntent,
+  resolveStatus,
+  resolveStatusMessage,
 } from '../component-helper'
 import userEvent from '@testing-library/user-event'
 
@@ -668,63 +668,66 @@ describe('"removeUndefinedProps" should', () => {
   })
 })
 
-describe('resolveIntent', () => {
-  it('returns intent when provided', () => {
-    expect(resolveIntent({ intent: 'warning' })).toBe('warning')
+describe('resolveStatus', () => {
+  it('returns status when provided', () => {
+    expect(resolveStatus({ status: 'warning' })).toBe('warning')
   })
 
-  it('returns intent over statusState', () => {
+  it('returns status over statusState', () => {
     expect(
-      resolveIntent({ intent: 'information', statusState: 'error' })
+      resolveStatus({ status: 'information', statusState: 'error' })
     ).toBe('information')
   })
 
-  it('returns statusState when status is truthy', () => {
+  it('returns statusState when statusMessage is truthy', () => {
     expect(
-      resolveIntent({ statusState: 'warning', status: 'Some message' })
+      resolveStatus({
+        statusState: 'warning',
+        statusMessage: 'Some message',
+      })
     ).toBe('warning')
   })
 
-  it('does not return statusState without status', () => {
-    expect(resolveIntent({ statusState: 'warning' })).toBeUndefined()
+  it('does not return statusState without statusMessage', () => {
+    expect(resolveStatus({ statusState: 'warning' })).toBeUndefined()
   })
 
   it('returns status value when it is a known state string', () => {
-    expect(resolveIntent({ status: 'error' })).toBe('error')
-    expect(resolveIntent({ status: 'warning' })).toBe('warning')
-    expect(resolveIntent({ status: 'information' })).toBe('information')
+    expect(resolveStatus({ status: 'error' })).toBe('error')
+    expect(resolveStatus({ status: 'warning' })).toBe('warning')
+    expect(resolveStatus({ status: 'information' })).toBe('information')
   })
 
   it('falls back to error when status is a non-state truthy value', () => {
-    expect(resolveIntent({ status: 'Some error message' })).toBe('error')
-    expect(resolveIntent({ status: true })).toBe('error')
+    expect(resolveStatus({ status: 'Some error message' })).toBe('error')
+    expect(resolveStatus({ status: true })).toBe('error')
   })
 
   it('returns undefined when nothing is set', () => {
-    expect(resolveIntent({})).toBeUndefined()
+    expect(resolveStatus({})).toBeUndefined()
   })
 })
 
-describe('resolveStatusForIntent', () => {
-  it('returns true when intent is set and status is undefined', () => {
+describe('resolveStatusMessage', () => {
+  it('returns undefined when status is a FormStatusState and statusMessage is undefined', () => {
     expect(
-      resolveStatusForIntent({ intent: 'error', status: undefined })
-    ).toBe(true)
+      resolveStatusMessage({ status: 'error', statusMessage: undefined })
+    ).toBeUndefined()
   })
 
-  it('returns status when it is provided', () => {
+  it('returns statusMessage when it is provided', () => {
     expect(
-      resolveStatusForIntent({ intent: 'error', status: 'A message' })
+      resolveStatusMessage({ status: 'error', statusMessage: 'A message' })
     ).toBe('A message')
   })
 
-  it('returns status when intent is not set', () => {
-    expect(resolveStatusForIntent({ status: 'A message' })).toBe(
+  it('returns statusMessage when status is not set', () => {
+    expect(resolveStatusMessage({ statusMessage: 'A message' })).toBe(
       'A message'
     )
   })
 
-  it('returns undefined when neither intent nor status is set', () => {
-    expect(resolveStatusForIntent({})).toBeUndefined()
+  it('returns undefined when neither status nor statusMessage is set', () => {
+    expect(resolveStatusMessage({})).toBeUndefined()
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -698,9 +698,28 @@ describe('resolveStatus', () => {
     expect(resolveStatus({ status: 'information' })).toBe('information')
   })
 
-  it('falls back to error when status is a non-state truthy value', () => {
+  it('falls back to error when status is a non-state string', () => {
     expect(resolveStatus({ status: 'Some error message' })).toBe('error')
-    expect(resolveStatus({ status: true })).toBe('error')
+  })
+
+  it('falls back to error when status is a non-state React element', () => {
+    expect(
+      resolveStatus({ status: <span>Some error message</span> })
+    ).toBe('error')
+  })
+
+  it('returns undefined when status is boolean true without statusMessage', () => {
+    expect(resolveStatus({ status: true })).toBeUndefined()
+  })
+
+  it('returns undefined when status is boolean true with statusMessage', () => {
+    expect(
+      resolveStatus({ status: true, statusMessage: 'A message' })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when only statusMessage is set', () => {
+    expect(resolveStatus({ statusMessage: 'A message' })).toBeUndefined()
   })
 
   it('returns undefined when nothing is set', () => {
@@ -729,5 +748,43 @@ describe('resolveStatusMessage', () => {
 
   it('returns undefined when neither status nor statusMessage is set', () => {
     expect(resolveStatusMessage({})).toBeUndefined()
+  })
+
+  it('returns status as message when status is a non-state string (backwards compat)', () => {
+    expect(resolveStatusMessage({ status: 'Some error message' })).toBe(
+      'Some error message'
+    )
+  })
+
+  it('returns status as message when status is a non-state React element (backwards compat)', () => {
+    const message = (
+      <span>
+        Status message with <b>HTML</b> inside
+      </span>
+    )
+
+    expect(resolveStatusMessage({ status: message })).toBe(message)
+  })
+
+  it('returns statusMessage over legacy string status', () => {
+    expect(
+      resolveStatusMessage({
+        status: 'legacy message',
+        statusMessage: 'preferred message',
+      })
+    ).toBe('preferred message')
+  })
+
+  it('falls back to legacy string status when statusMessage is null', () => {
+    expect(
+      resolveStatusMessage({
+        status: 'legacy message',
+        statusMessage: null,
+      })
+    ).toBe('legacy message')
+  })
+
+  it('returns undefined when status is boolean true', () => {
+    expect(resolveStatusMessage({ status: true })).toBeUndefined()
   })
 })

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -346,6 +346,8 @@ export function getStatusState(status) {
  * - Defaults to `undefined` when no status is specified.
  * - Handles backwards compatibility: if `status` receives a non-FormStatusState
  *   message value (old `status` message pattern), falls back to `statusState` or `'error'`.
+ *
+ * @deprecated should be removed in favor of using `status` and `statusMessage` directly without the need for a helper function.
  */
 export function resolveStatus({
   status,
@@ -360,6 +362,10 @@ export function resolveStatus({
     return status
   }
 
+  if (status === true) {
+    return statusState || 'error'
+  }
+
   // Backwards compat: status used as a message (old API)
   if (isLegacyStatusMessage(status)) {
     warn(
@@ -368,7 +374,7 @@ export function resolveStatus({
     return statusState || 'error'
   }
 
-  if (statusState && statusMessage) {
+  if (statusState && isStatusMessageValue(statusMessage)) {
     return statusState
   }
 
@@ -402,7 +408,7 @@ export function resolveStatusMessage<T>({
   statusMessage?: T
 }): T | undefined {
   // statusMessage takes priority over legacy status message
-  if (statusMessage !== undefined && statusMessage !== null) {
+  if (isStatusMessageValue(statusMessage)) {
     return statusMessage
   }
 
@@ -424,6 +430,12 @@ function isLegacyStatusMessage(status: unknown): boolean {
   }
 
   return !isFormStatusState(status)
+}
+
+function isStatusMessageValue(value: unknown): boolean {
+  return (
+    value !== undefined && value !== null && typeof value !== 'boolean'
+  )
 }
 
 export function combineLabelledBy(...params) {

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -8,6 +8,7 @@ import type { ReactElement, ReactNode } from 'react'
 
 import whatInput from './helpers/whatInput'
 import { warn } from './helpers'
+import type { FormStatusState } from '../components/form-status/FormStatus'
 import { getClosestParent } from './helpers/getClosest'
 import { init } from './Eufemia'
 import { defineNavigator } from './legacy/component-helper-legacy'
@@ -336,6 +337,65 @@ export function getStatusState(status) {
     status !== 'warning' &&
     status !== 'information'
   )
+}
+
+/**
+ * Resolves the effective intent from `intent`, `statusState`, and `status`.
+ *
+ * - `intent` takes priority over `statusState` (which is deprecated).
+ * - If `status` is a known state string ("error", "warn", etc.) and no explicit
+ *   intent/statusState is set, the status value is used as the intent.
+ * - Falls back to `'error'` when a status message is present but no intent is specified.
+ */
+export function resolveIntent({
+  intent,
+  statusState,
+  status,
+}: {
+  intent?: FormStatusState
+  statusState?: FormStatusState
+  status?: unknown
+}): FormStatusState | undefined {
+  if (intent) {
+    return intent
+  }
+
+  if (statusState && status) {
+    return statusState
+  }
+
+  if (
+    typeof status === 'string' &&
+    (status === 'error' ||
+      status === 'warning' ||
+      status === 'information')
+  ) {
+    return status
+  }
+
+  if (status) {
+    return 'error'
+  }
+
+  return undefined
+}
+
+/**
+ * Returns the effective status value when `intent` is set.
+ * If `intent` is provided but `status` is not, returns `true`
+ * so the component applies visual styling without a message.
+ */
+export function resolveStatusForIntent<T>({
+  intent,
+  status,
+}: {
+  intent?: FormStatusState
+  status?: T
+}): T | true {
+  if (intent && status === undefined) {
+    return true
+  }
+  return status as T
 }
 
 export function combineLabelledBy(...params) {

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -343,9 +343,9 @@ export function getStatusState(status) {
  * Resolves the effective status from `status`, `statusState`, and `statusMessage`.
  *
  * - `status` takes priority over `statusState` (which is deprecated).
- * - Falls back to `'error'` when a status message is present but no status is specified.
+ * - Defaults to `undefined` when no status is specified.
  * - Handles backwards compatibility: if `status` receives a non-FormStatusState
- *   string (old `status` message pattern), falls back to `statusState` or `'error'`.
+ *   message value (old `status` message pattern), falls back to `statusState` or `'error'`.
  */
 export function resolveStatus({
   status,
@@ -361,7 +361,7 @@ export function resolveStatus({
   }
 
   // Backwards compat: status used as a message (old API)
-  if (status && !isFormStatusState(status)) {
+  if (isLegacyStatusMessage(status)) {
     warn(
       'Passing a message to `status` is deprecated. Use `statusMessage` instead.'
     )
@@ -370,10 +370,6 @@ export function resolveStatus({
 
   if (statusState && statusMessage) {
     return statusState
-  }
-
-  if (statusMessage) {
-    return 'error'
   }
 
   return undefined
@@ -394,10 +390,9 @@ function isFormStatusState(value: unknown): value is FormStatusState {
 /**
  * Resolves the effective status message.
  *
- * - If `status` is set but `statusMessage` is not, returns `true`
- *   so the component applies visual styling without a message.
+ * - `statusMessage` takes precedence whenever provided.
  * - Handles backwards compatibility: if `status` receives a non-FormStatusState
- *   value (old API pattern), that value is used as the message.
+ *   message value (old API pattern), that value is used as the message.
  */
 export function resolveStatusMessage<T>({
   status,
@@ -406,12 +401,29 @@ export function resolveStatusMessage<T>({
   status?: unknown
   statusMessage?: T
 }): T | undefined {
+  // statusMessage takes priority over legacy status message
+  if (statusMessage !== undefined && statusMessage !== null) {
+    return statusMessage
+  }
+
   // Backwards compat: status used as a message (old API)
-  if (status && !isFormStatusState(status)) {
+  if (isLegacyStatusMessage(status)) {
     return status as unknown as T
   }
 
-  return statusMessage
+  return undefined
+}
+
+function isLegacyStatusMessage(status: unknown): boolean {
+  if (status === undefined || status === null) {
+    return false
+  }
+
+  if (typeof status === 'boolean') {
+    return false
+  }
+
+  return !isFormStatusState(status)
 }
 
 export function combineLabelledBy(...params) {

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -340,62 +340,78 @@ export function getStatusState(status) {
 }
 
 /**
- * Resolves the effective intent from `intent`, `statusState`, and `status`.
+ * Resolves the effective status from `status`, `statusState`, and `statusMessage`.
  *
- * - `intent` takes priority over `statusState` (which is deprecated).
- * - If `status` is a known state string ("error", "warn", etc.) and no explicit
- *   intent/statusState is set, the status value is used as the intent.
- * - Falls back to `'error'` when a status message is present but no intent is specified.
+ * - `status` takes priority over `statusState` (which is deprecated).
+ * - Falls back to `'error'` when a status message is present but no status is specified.
+ * - Handles backwards compatibility: if `status` receives a non-FormStatusState
+ *   string (old `status` message pattern), falls back to `statusState` or `'error'`.
  */
-export function resolveIntent({
-  intent,
-  statusState,
+export function resolveStatus({
   status,
+  statusState,
+  statusMessage,
 }: {
-  intent?: FormStatusState
+  status?: FormStatusState | unknown
   statusState?: FormStatusState
-  status?: unknown
+  statusMessage?: unknown
 }): FormStatusState | undefined {
-  if (intent) {
-    return intent
-  }
-
-  if (statusState && status) {
-    return statusState
-  }
-
-  if (
-    typeof status === 'string' &&
-    (status === 'error' ||
-      status === 'warning' ||
-      status === 'information')
-  ) {
+  if (isFormStatusState(status)) {
     return status
   }
 
-  if (status) {
+  // Backwards compat: status used as a message (old API)
+  if (status && !isFormStatusState(status)) {
+    warn(
+      'Passing a message to `status` is deprecated. Use `statusMessage` instead.'
+    )
+    return statusState || 'error'
+  }
+
+  if (statusState && statusMessage) {
+    return statusState
+  }
+
+  if (statusMessage) {
     return 'error'
   }
 
   return undefined
 }
 
+const VALID_STATUS_STATES = new Set([
+  'error',
+  'warning',
+  'information',
+  'success',
+  'marketing',
+])
+
+function isFormStatusState(value: unknown): value is FormStatusState {
+  return typeof value === 'string' && VALID_STATUS_STATES.has(value)
+}
+
 /**
- * Returns the effective status value when `intent` is set.
- * If `intent` is provided but `status` is not, returns `true`
- * so the component applies visual styling without a message.
+ * Resolves the effective status message.
+ *
+ * - If `status` is set but `statusMessage` is not, returns `true`
+ *   so the component applies visual styling without a message.
+ * - Handles backwards compatibility: if `status` receives a non-FormStatusState
+ *   value (old API pattern), that value is used as the message.
  */
-export function resolveStatusForIntent<T>({
-  intent,
+export function resolveStatusMessage<T>({
   status,
+  statusMessage,
 }: {
-  intent?: FormStatusState
-  status?: T
-}): T | true {
-  if (intent && status === undefined) {
-    return true
+  status?: unknown
+  statusMessage?: T
+}): T | undefined {
+  // Backwards compat: status used as a message (old API)
+  if (status && !isFormStatusState(status)) {
+    return status as unknown as T
   }
-  return status as T
+
+  return statusMessage
 }
 
 export function combineLabelledBy(...params) {


### PR DESCRIPTION
## Motivation

https://dnb-it.slack.com/archives/CMXABCHEY/p1779868765841559?thread_ts=1779784812.244889&cid=CMXABCHEY

## Why

The existing `status` / `statusState` API is confusing: `status` holds the *message text*, while `statusState` holds the *actual status*. This is counterintuitive — most developers expect `status` to describe the state, not the message.

This PR fixes the naming so each prop means what its name says:

| Before | After | Purpose |
|---|---|---|
| `status` | `statusMessage` | The status message text |
| `statusState` | `status` | The visual status state (`error`, `warning`, etc.) |

The rename also enables setting a visual status (e.g. error border) *without* requiring a message — something the old API couldn't express cleanly.

## Changes

- **`statusMessage` prop** – replaces the old `status` prop for providing status message text.
- **`status` prop repurposed** – now accepts a status state value (`"error"`, `"warning"`, `"information"`, `"success"`, `"marketing"`).
- **`statusState` deprecated** – falls back to `statusState` when the new `status` is not set. Runtime deprecation warning in dev mode.
- **`aria-invalid`** – automatically set when `status="error"`.
- **v12 migration entry** – documents the rename in v12-info.mdx.

## Affected components

Autocomplete, Button, Checkbox, DatePicker, Dropdown, Input, Radio, RadioGroup, SegmentedField, Slider, StepIndicator, Switch, Textarea, ToggleButton, ToggleButtonGroup.

## Migration

```diff
-<Input status="Error message" statusState="error" />
+<Input statusMessage="Error message" status="error" />
```

## Preview:

Button: https://feat-intent-prop.eufemia-e25.pages.dev/uilib/components/button/demos
Input: https://feat-intent-prop.eufemia-e25.pages.dev/uilib/components/input/demos


```tsx
<Input label="Label" status="warning" statusMessage="Message" />
```