### PR TITLE
chore(Breadcrumb): remove redundant default translation props

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -154,10 +154,6 @@ export type BreadcrumbAllProps = BreadcrumbProps &
 
 const defaultProps: Partial<BreadcrumbAllProps> = {
   skeleton: false,
-  navText: 'Back',
-  goBackText: 'Back',
-  homeText: 'Home',
-  backToText: 'Gå til ...',
   collapsed: true,
   spacing: false,
 }


### PR DESCRIPTION
The default translations is already provided by the context