### PR TITLE
feat(PortalRoot.Provider): add `translate` property

### DIFF
--- a/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
@@ -47,22 +47,36 @@ export type PortalRootProps = {
 } & SelectorOptions &
   Omit<HTMLProps<HTMLElement>, 'ref' | 'id'>
 
-type PortalRootContextValue = SelectorOptions
+type PortalRootContextValue = SelectorOptions & {
+  /**
+   * Set to `"no"` to prevent external translation tools (e.g. Google Translate)
+   * from mutating DOM inside portals, which can crash React.
+   */
+  translate?: 'no' | 'yes'
+}
 
 const PortalRootContext = createContext<PortalRootContextValue | null>(
   null
 )
 
-export type PortalRootProviderProps = PropsWithChildren<SelectorOptions>
+export type PortalRootProviderProps = PropsWithChildren<
+  SelectorOptions & {
+    /**
+     * Set to `"no"` to prevent external translation tools (e.g. Google Translate)
+     * from mutating DOM inside portals, which can crash React.
+     */
+    translate?: 'no' | 'yes'
+  }
+>
 
 export function PortalRootProvider(
   props: PortalRootProviderProps
 ): JSX.Element | null {
-  const { id, insideSelector, beforeSelector, children } = props
+  const { id, insideSelector, beforeSelector, translate, children } = props
 
   const value = useMemo(
-    () => ({ id, insideSelector, beforeSelector }),
-    [id, insideSelector, beforeSelector]
+    () => ({ id, insideSelector, beforeSelector, translate }),
+    [id, insideSelector, beforeSelector, translate]
   )
 
   return <PortalRootContext value={value}>{children}</PortalRootContext>
@@ -154,6 +168,7 @@ function PortalRootInstance(props: PortalRootProps = {}): ReactNode {
           className
         )}
         style={{ ...scopeStyle, ...style }}
+        translate={selectorContext?.translate}
         {...rest}
       >
         {children}

--- a/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
@@ -40,6 +40,32 @@ describe('PortalRoot', () => {
     expect(content).toHaveTextContent('Portal Content')
   })
 
+  it('should not have translate attribute by default', () => {
+    render(
+      <PortalRoot>
+        <div>Content</div>
+      </PortalRoot>
+    )
+
+    const portalWrapper = document.querySelector('.eufemia-portal-root')
+    expect(portalWrapper).toBeInTheDocument()
+    expect(portalWrapper).not.toHaveAttribute('translate')
+  })
+
+  it('should forward translate="no" from PortalRoot.Provider', () => {
+    render(
+      <PortalRoot.Provider translate="no">
+        <PortalRoot>
+          <div>Content</div>
+        </PortalRoot>
+      </PortalRoot.Provider>
+    )
+
+    const portalWrapper = document.querySelector('.eufemia-portal-root')
+    expect(portalWrapper).toBeInTheDocument()
+    expect(portalWrapper).toHaveAttribute('translate', 'no')
+  })
+
   it('should handle ref forwarding', () => {
     const ref: RefObject<HTMLElement | null> = { current: null }
     render(

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -26,6 +26,7 @@ import type { DrawerListContextValue } from '../DrawerListContext'
 import DrawerListContext from '../DrawerListContext'
 import { IsolatedStyleScope } from '../../../shared'
 import Dialog from '../../../components/dialog/Dialog'
+import PortalRoot from '../../../components/portal-root/PortalRoot'
 import {
   mockImplementationForDirectionObserver,
   testDirectionObserver,
@@ -114,6 +115,17 @@ describe('DrawerList component', () => {
         .querySelector('.dnb-drawer-list--open')
         .closest('#eufemia-portal-root')
     ).toBeInTheDocument()
+  })
+
+  it('should forward translate="no" from PortalRoot.Provider to portal content', () => {
+    render(
+      <PortalRoot.Provider translate="no">
+        <DrawerList {...props} data={mockData} />
+      </PortalRoot.Provider>
+    )
+    const portalRoot = document.querySelector('.eufemia-portal-root')
+    expect(portalRoot).toBeInTheDocument()
+    expect(portalRoot).toHaveAttribute('translate', 'no')
   })
 
   it('has correct state after changing prop to opened', () => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1780388191576599

Consumers who experience Google Translate crashing their app can now wrap their app in `<PortalRoot.Provider translate='no'>` to prevent translation tools from mutating DOM inside portals.

This is opt-in rather than a default, since I believe the crash depends on the apps code, like React version and specific translation tool behavior.

One could also add a `translate` prop or a `portalRootProps` prop to each component using a portalroot, but that could be excessive? Many translate properties in many components:
- Autocomplete
- Dropdown
- DatePicker
- Dialog
- Modal
- Popover
- Tooltip
- Drawer
