### PR TITLE
fix(Accordion): prevent tertiary button from stretching when expanded

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -529,5 +529,8 @@ html:not([data-whatintent=touch]) .dnb-accordion__header--outlined:hover:not([di
   border: none;
   background: none;
   box-shadow: none;
+}
+.dnb-accordion__tertiary-button {
+  align-self: flex-start;
 }"
 `;

--- a/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
@@ -514,4 +514,7 @@
     background: none;
     box-shadow: none;
   }
+  &__tertiary-button {
+    align-self: flex-start;
+  }
 }


### PR DESCRIPTION
The tertiary accordion button stretches to match the width of its expanded content because the flex column container defaults to `align-items: stretch`. This is visually jarring — the button should keep its intrinsic width regardless of content size.

Adds `align-self: flex-start` to the tertiary button so it stays compact.

Motivation: https://github.com/dnbexperience/eufemia/pull/8366#issuecomment-4601146523
Preview: https://fix-accordion-tertiary-butto.eufemia-e25.pages.dev/uilib/components/accordion#variant-tertiary