### PR TITLE
chore(List): update stale CSS variable name in example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
@@ -325,7 +325,7 @@ export const BackgroundColor = () => {
 
         <List.Item.Basic
           style={{
-            ['--item-background-color' as string]:
+            ['--list-item-background-color' as string]:
               'var(--color-mint-green-12)',
           }}
         >


### PR DESCRIPTION
Change --item-background-color to --list-item-background-color to match the scoped variable names introduced in the List component refactor.

