### PR TITLE
chore: use Eufemia Table sub-components and border/outline for card products table

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/CardProductsTable.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/CardProductsTable.tsx
@@ -4,42 +4,46 @@ import { Table } from '@dnb/eufemia/src/components'
 export default function CardProductsTable() {
   return (
     <Table.ScrollView>
-      <Table>
+      <Table border outline>
         <thead>
-          <tr>
-            <th>Product Id</th>
-            <th>Product name cards</th>
-            <th>Card name to show in app</th>
-            <th>Design</th>
-            <th>Bank Logo</th>
-            <th>Product Logo</th>
-            <th>Product Logo Variant</th>
-            <th>Type of Card</th>
-            <th>Type of Card Variant</th>
-          </tr>
+          <Table.Tr>
+            <Table.Th>Product Id</Table.Th>
+            <Table.Th>Product name cards</Table.Th>
+            <Table.Th>Card name to show in app</Table.Th>
+            <Table.Th>Design</Table.Th>
+            <Table.Th>Bank Logo</Table.Th>
+            <Table.Th>Product Logo</Table.Th>
+            <Table.Th>Product Logo Variant</Table.Th>
+            <Table.Th>Type of Card</Table.Th>
+            <Table.Th>Type of Card Variant</Table.Th>
+          </Table.Tr>
         </thead>
         <tbody>
           {data.map((card) => {
             return (
-              <tr key={card.productCode}>
-                <td>{card.productCode}</td>
-                <td>{card.productName}</td>
-                <td>{card.displayName}</td>
-                <td>{card.cardDesign.name}</td>
-                <td>{getProductLogo(card.cardDesign.bankLogo)}</td>
-                <td>
+              <Table.Tr key={card.productCode}>
+                <Table.Td>{card.productCode}</Table.Td>
+                <Table.Td>{card.productName}</Table.Td>
+                <Table.Td>{card.displayName}</Table.Td>
+                <Table.Td>{card.cardDesign.name}</Table.Td>
+                <Table.Td>
+                  {getProductLogo(card.cardDesign.bankLogo)}
+                </Table.Td>
+                <Table.Td>
                   {card.productType.tag === 'None'
                     ? '-'
                     : card.productType.tag}
-                </td>
-                <td>
+                </Table.Td>
+                <Table.Td>
                   {getProductVariant(card.productType, card.cardDesign)}
-                </td>
-                <td>
+                </Table.Td>
+                <Table.Td>
                   {card.cardType.tag === 'None' ? '-' : card.cardType.tag}
-                </td>
-                <td>{getTypeVariant(card.cardType, card.cardDesign)}</td>
-              </tr>
+                </Table.Td>
+                <Table.Td>
+                  {getTypeVariant(card.cardType, card.cardDesign)}
+                </Table.Td>
+              </Table.Tr>
             )
           })}
         </tbody>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/CardProductsTable.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/CardProductsTable.tsx
@@ -1,49 +1,45 @@
 import data from '@dnb/eufemia/src/extensions/payment-card/utils/cardProducts'
-import { Table } from '@dnb/eufemia/src/components'
+import { Table, Td, Th, Tr } from '@dnb/eufemia/src'
 
 export default function CardProductsTable() {
   return (
     <Table.ScrollView>
       <Table border outline>
         <thead>
-          <Table.Tr>
-            <Table.Th>Product Id</Table.Th>
-            <Table.Th>Product name cards</Table.Th>
-            <Table.Th>Card name to show in app</Table.Th>
-            <Table.Th>Design</Table.Th>
-            <Table.Th>Bank Logo</Table.Th>
-            <Table.Th>Product Logo</Table.Th>
-            <Table.Th>Product Logo Variant</Table.Th>
-            <Table.Th>Type of Card</Table.Th>
-            <Table.Th>Type of Card Variant</Table.Th>
-          </Table.Tr>
+          <Tr>
+            <Th>Product Id</Th>
+            <Th>Product name cards</Th>
+            <Th>Card name to show in app</Th>
+            <Th>Design</Th>
+            <Th>Bank Logo</Th>
+            <Th>Product Logo</Th>
+            <Th>Product Logo Variant</Th>
+            <Th>Type of Card</Th>
+            <Th>Type of Card Variant</Th>
+          </Tr>
         </thead>
         <tbody>
           {data.map((card) => {
             return (
-              <Table.Tr key={card.productCode}>
-                <Table.Td>{card.productCode}</Table.Td>
-                <Table.Td>{card.productName}</Table.Td>
-                <Table.Td>{card.displayName}</Table.Td>
-                <Table.Td>{card.cardDesign.name}</Table.Td>
-                <Table.Td>
-                  {getProductLogo(card.cardDesign.bankLogo)}
-                </Table.Td>
-                <Table.Td>
+              <Tr key={card.productCode}>
+                <Td>{card.productCode}</Td>
+                <Td>{card.productName}</Td>
+                <Td>{card.displayName}</Td>
+                <Td>{card.cardDesign.name}</Td>
+                <Td>{getProductLogo(card.cardDesign.bankLogo)}</Td>
+                <Td>
                   {card.productType.tag === 'None'
                     ? '-'
                     : card.productType.tag}
-                </Table.Td>
-                <Table.Td>
+                </Td>
+                <Td>
                   {getProductVariant(card.productType, card.cardDesign)}
-                </Table.Td>
-                <Table.Td>
+                </Td>
+                <Td>
                   {card.cardType.tag === 'None' ? '-' : card.cardType.tag}
-                </Table.Td>
-                <Table.Td>
-                  {getTypeVariant(card.cardType, card.cardDesign)}
-                </Table.Td>
-              </Table.Tr>
+                </Td>
+                <Td>{getTypeVariant(card.cardType, card.cardDesign)}</Td>
+              </Tr>
             )
           })}
         </tbody>


### PR DESCRIPTION
[From](https://eufemia.dnb.no/uilib/extensions/payment-card/products):

<img width="1218" height="1018" alt="Screenshot 2026-06-03 at 13 52 51" src="https://github.com/user-attachments/assets/82dbe6fe-b7d0-4b8a-add2-fb8c7f220a92" />


[To](https://fix-payment-card-products-ta.eufemia-e25.pages.dev/uilib/extensions/payment-card/products#list-of-all-card-products):

<img width="1232" height="1194" alt="image" src="https://github.com/user-attachments/assets/5c2e2843-4335-4a1c-8bc1-2c9f0d745400" />

