### PR TITLE
chore(Portal): show released version instead of 'Not released' in portal footer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 2
+          fetch-tags: true
 
       - name: Use Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -55,7 +55,30 @@ async function createReleaseNewVersion() {
   try {
     const file = path.resolve(__dirname, '../package.json')
     const packageJson = await fs.readJson(file)
-    const version = (await getNextReleaseVersion()) || 'Not released'
+    let version = await getNextReleaseVersion()
+
+    // Fallback: use the latest stable git tag.
+    // Uses `git tag` listing instead of `git describe` so it works in
+    // shallow clones (CI uses fetch-depth: 2).
+    if (!version) {
+      try {
+        const { execSync } = require('child_process')
+        const tags = execSync('git tag --sort=-v:refname -l "v*"', {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim()
+        const tag = tags
+          .split('\n')
+          .find((t) => /^v\d+\.\d+\.\d+$/.test(t))
+        if (tag) {
+          version = tag.replace(/^v/, '')
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
+    version = version || 'Not released'
     packageJson.releaseVersion = version
 
     // Update the extracted version of package.json with the build version

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/build-info.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/build-info.test.ts
@@ -17,13 +17,14 @@ describe('build-info plugin', () => {
   })
 
   describe('getBuildInfo', () => {
-    it('returns default values when files are missing', () => {
+    it('returns git tag version when files are missing', () => {
       const info = getBuildInfo({
         packageJsonPath: path.join(tmpDir, 'missing.json'),
         changelogPath: path.join(tmpDir, 'missing.mdx'),
       })
 
-      expect(info.releaseVersion).toBe('[LOCAL BUILD]')
+      // Falls back to git tag since we're running in the eufemia repo
+      expect(info.releaseVersion).toMatch(/^\d+\.\d+\.\d+/)
       expect(info.changelogVersion).toBe('[LOCAL BUILD]')
       expect(info.buildVersion).toMatch(/\d/)
     })
@@ -43,7 +44,7 @@ describe('build-info plugin', () => {
       expect(info.releaseVersion).toBe('11.0.4')
     })
 
-    it('falls back to [LOCAL BUILD] when releaseVersion is not set', () => {
+    it('falls back to git tag when releaseVersion is not set', () => {
       const pkgPath = path.join(tmpDir, 'package.json')
       fs.writeFileSync(
         pkgPath,
@@ -55,7 +56,25 @@ describe('build-info plugin', () => {
         changelogPath: path.join(tmpDir, 'missing.mdx'),
       })
 
-      expect(info.releaseVersion).toBe('[LOCAL BUILD]')
+      // Falls back to the latest git tag (e.g. "11.5.0") since we're in a git repo
+      expect(info.releaseVersion).toMatch(/^\d+\.\d+\.\d+/)
+    })
+
+    it('rejects "Not released" from package.json and falls back to git tag', () => {
+      const pkgPath = path.join(tmpDir, 'package.json')
+      fs.writeFileSync(
+        pkgPath,
+        JSON.stringify({ releaseVersion: 'Not released' })
+      )
+
+      const info = getBuildInfo({
+        packageJsonPath: pkgPath,
+        changelogPath: path.join(tmpDir, 'missing.mdx'),
+      })
+
+      // Should NOT be "Not released", should fall back to git tag
+      expect(info.releaseVersion).not.toBe('Not released')
+      expect(info.releaseVersion).toMatch(/^\d+\.\d+\.\d+/)
     })
 
     it('extracts changelogVersion from the first heading', () => {

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/build-info.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/build-info.test.ts
@@ -17,14 +17,16 @@ describe('build-info plugin', () => {
   })
 
   describe('getBuildInfo', () => {
-    it('returns git tag version when files are missing', () => {
+    it('returns git tag version or [LOCAL BUILD] when files are missing', () => {
       const info = getBuildInfo({
         packageJsonPath: path.join(tmpDir, 'missing.json'),
         changelogPath: path.join(tmpDir, 'missing.mdx'),
       })
 
-      // Falls back to git tag since we're running in the eufemia repo
-      expect(info.releaseVersion).toMatch(/^\d+\.\d+\.\d+/)
+      // Falls back to git tag when available, otherwise stays as [LOCAL BUILD]
+      expect(info.releaseVersion).toMatch(
+        /^(\d+\.\d+\.\d+|\[LOCAL BUILD\])/
+      )
       expect(info.changelogVersion).toBe('[LOCAL BUILD]')
       expect(info.buildVersion).toMatch(/\d/)
     })
@@ -56,11 +58,13 @@ describe('build-info plugin', () => {
         changelogPath: path.join(tmpDir, 'missing.mdx'),
       })
 
-      // Falls back to the latest git tag (e.g. "11.5.0") since we're in a git repo
-      expect(info.releaseVersion).toMatch(/^\d+\.\d+\.\d+/)
+      // Falls back to git tag when available, otherwise stays as [LOCAL BUILD]
+      expect(info.releaseVersion).toMatch(
+        /^(\d+\.\d+\.\d+|\[LOCAL BUILD\])/
+      )
     })
 
-    it('rejects "Not released" from package.json and falls back to git tag', () => {
+    it('rejects "Not released" from package.json', () => {
       const pkgPath = path.join(tmpDir, 'package.json')
       fs.writeFileSync(
         pkgPath,
@@ -72,9 +76,11 @@ describe('build-info plugin', () => {
         changelogPath: path.join(tmpDir, 'missing.mdx'),
       })
 
-      // Should NOT be "Not released", should fall back to git tag
+      // Should NOT be "Not released" — falls back to git tag or [LOCAL BUILD]
       expect(info.releaseVersion).not.toBe('Not released')
-      expect(info.releaseVersion).toMatch(/^\d+\.\d+\.\d+/)
+      expect(info.releaseVersion).toMatch(
+        /^(\d+\.\d+\.\d+|\[LOCAL BUILD\])/
+      )
     })
 
     it('extracts changelogVersion from the first heading', () => {

--- a/packages/dnb-design-system-portal/vite/client/plugins/build-info.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/build-info.ts
@@ -16,6 +16,7 @@
 import { type Plugin } from 'vite'
 import fs from 'node:fs'
 import path from 'node:path'
+import { execSync } from 'node:child_process'
 
 const VIRTUAL_MODULE_ID = 'virtual:build-info'
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
@@ -44,11 +45,33 @@ export function getBuildInfo({
   // Release version from package.json (set by build:version on CI)
   try {
     const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-    if (pkg.releaseVersion && pkg.releaseVersion !== '[LOCAL BUILD]') {
+    if (
+      pkg.releaseVersion &&
+      pkg.releaseVersion !== '[LOCAL BUILD]' &&
+      pkg.releaseVersion !== 'Not released'
+    ) {
       releaseVersion = pkg.releaseVersion
     }
   } catch {
     // Ignore — use default
+  }
+
+  // Fallback: use the latest stable git tag.
+  // Uses `git tag` listing instead of `git describe` so it works in
+  // shallow clones (CI uses fetch-depth: 2).
+  if (releaseVersion === '[LOCAL BUILD]') {
+    try {
+      const tags = execSync('git tag --sort=-v:refname -l "v*"', {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim()
+      const tag = tags.split('\n').find((t) => /^v\d+\.\d+\.\d+$/.test(t))
+      if (tag) {
+        releaseVersion = tag.replace(/^v/, '')
+      }
+    } catch {
+      // Ignore — use default
+    }
   }
 
   // Changelog version from the first heading in the changelog file


### PR DESCRIPTION
[Motivation](https://eufemia.dnb.no/uilib/):
<img width="290" height="70" alt="Screenshot 2026-06-03 at 14 03 29" src="https://github.com/user-attachments/assets/7ece4cfd-2b2a-4d0a-8978-eba272a3d3bb" />


When semantic-release --dry-run finds no unreleased commits, fall back to
the latest git tag to display the actual released version (e.g. 11.5.0).

- build-info.ts: reject 'Not released' from package.json, add git tag fallback
- version.js: add git tag fallback before defaulting to 'Not released'
- release.yml: add fetch-tags so tags are available in shallow CI clones
- build-info.test.ts: update tests for new fallback behavior

