### PR TITLE
fix(Dropdown, Autocomplete, DrawerList): remove outline around divider on selected focused item

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -381,13 +381,6 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled])
     background-color: var(--drawer-list-option-color-bg);
   }
 }
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
-  visibility: visible;
-  --border-color: var(--token-color-stroke-action-hover-inverse);
-  --border-width: var(--drawer-list-option-border-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
-}
 .dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
   content: none;
 }
@@ -951,13 +944,6 @@ html:not([data-whatintent=touch]) .dnb-drawer-list__option:hover:not([disabled])
     z-index: 0;
     background-color: var(--drawer-list-option-color-bg);
   }
-}
-html[data-whatinput=keyboard] .dnb-drawer-list__option--selected.dnb-drawer-list__option--focus .dnb-drawer-list__option__inner::before {
-  visibility: visible;
-  --border-color: var(--token-color-stroke-action-hover-inverse);
-  --border-width: var(--drawer-list-option-border-width);
-  box-shadow: 0 0 0 var(--border-width) var(--border-color);
-  border-color: transparent;
 }
 .dnb-drawer-list__option.last-of-type:not(.dnb-drawer-list__option--focus) .dnb-drawer-list__option__inner::before {
   content: none;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -498,18 +498,6 @@
       }
     }
 
-    // show focus border when using keyboard
-    html[data-whatinput='keyboard']
-      &--selected#{&}--focus
-      &__inner::before {
-      visibility: visible;
-
-      @include utilities.fakeBorder(
-        var(--token-color-stroke-action-hover-inverse),
-        var(--drawer-list-option-border-width)
-      );
-    }
-
     // remove last bottom border
     &.last-of-type:not(#{&}--focus) &__inner::before {
       content: none;


### PR DESCRIPTION
Preview: https://fix-drawer-list-remove-divid.eufemia-e25.pages.dev/uilib/components/dropdown/demos

<img width="301" height="464" alt="Screenshot 2026-06-03 at 14 01 47" src="https://github.com/user-attachments/assets/fd9ae7d5-fff9-4734-9507-93b866da3af0" />
