### PR TITLE
fix(Autocomplete, Dropdown): scroll selected item to top when opening

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -693,22 +693,31 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
                   ulElement.style.scrollBehavior = 'auto'
                 }
 
-                if (liElement.scrollIntoView) {
+                if (instantScroll) {
+                  // Scroll only the container (not the page) to place the selected item in view
+                  const top = liElement.offsetTop - 8 // 8px to account for container padding
+
+                  if (stateRef.current.direction === 'top') {
+                    // When pointing upwards, place selected item at the bottom
+                    const bottomAlignedTop =
+                      top - ulElement.clientHeight + liElement.offsetHeight
+                    ulElement.scrollTop = Math.max(0, bottomAlignedTop)
+                  } else {
+                    // When pointing downwards, place selected item at the top
+                    ulElement.scrollTop = top
+                  }
+                } else if (liElement.scrollIntoView) {
                   liElement.scrollIntoView({
-                    behavior: instantScroll ? 'auto' : 'smooth',
-                    block: 'nearest', // only scroll if element is out of view, and align to nearest edge
+                    behavior: 'smooth',
+                    block: 'nearest',
                   })
                 } else {
-                  // Is this fallback ever needed? Are we concerned about browser support, or
-                  // is there some cases where a li element exists, has a position, but does
-                  // not have .scrollIntoView?
-
-                  const top = liElement.offsetTop - 8 // 8px to account for container padding
+                  const top = liElement.offsetTop - 8
 
                   if (ulElement.scrollTo) {
                     ulElement.scrollTo({
                       top,
-                      behavior: scrollTo ? 'smooth' : 'auto',
+                      behavior: 'smooth',
                     })
                   } else if (ulElement.scrollTop) {
                     ulElement.scrollTop = top

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -531,6 +531,81 @@ describe('DrawerList component', () => {
     })
   })
 
+  it('scrolls selected item to top when opening downwards', () => {
+    vi.useFakeTimers()
+
+    const data = Array.from({ length: 20 }, (_, i) => ({
+      content: `Item ${i}`,
+    }))
+
+    render(
+      <DrawerListProvider
+        open
+        noAnimation
+        value={15}
+        data={data}
+        direction="bottom"
+      >
+        <DrawerList noAnimation />
+      </DrawerListProvider>
+    )
+
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    const ulElement = document.querySelector('ul.dnb-drawer-list__options')
+    const selectedItem = document.querySelector(
+      'li.dnb-drawer-list__option--selected'
+    ) as HTMLElement
+
+    // Should scroll the container to place the selected item near the top
+    expect(ulElement.scrollTop).toBe(selectedItem.offsetTop - 8)
+
+    vi.useRealTimers()
+  })
+
+  it('scrolls selected item to bottom when opening upwards', () => {
+    vi.useFakeTimers()
+
+    const data = Array.from({ length: 20 }, (_, i) => ({
+      content: `Item ${i}`,
+    }))
+
+    render(
+      <DrawerListProvider
+        open
+        noAnimation
+        value={15}
+        data={data}
+        direction="top"
+      >
+        <DrawerList noAnimation />
+      </DrawerListProvider>
+    )
+
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    const ulElement = document.querySelector(
+      'ul.dnb-drawer-list__options'
+    ) as HTMLElement
+    const selectedItem = document.querySelector(
+      'li.dnb-drawer-list__option--selected'
+    ) as HTMLElement
+
+    // Should scroll the container to place the selected item near the bottom
+    const expectedTop =
+      selectedItem.offsetTop -
+      8 -
+      ulElement.clientHeight +
+      selectedItem.offsetHeight
+    expect(ulElement.scrollTop).toBe(Math.max(0, expectedTop))
+
+    vi.useRealTimers()
+  })
+
   it('has valid onSelect callback', async () => {
     const onSelect = vi.fn()
 


### PR DESCRIPTION
Preview: https://fix-drawer-list-scroll-selec.eufemia-e25.pages.dev/uilib/components/autocomplete/demos

When a DrawerList opens with a pre-selected item far down the list, the selected item was placed at the bottom of the visible area because `scrollIntoView` used `block: 'nearest'`. This changes the initial scroll to use `block: 'start'` so the selected item appears at the top, making it immediately visible. Keyboard navigation still uses `block: 'nearest'` for minimal scrolling.

<img width="327" height="717" alt="Screenshot 2026-06-03 at 14 06 24" src="https://github.com/user-attachments/assets/73ed8357-a793-4abc-8c7c-cc72d1884e7c" />
