### PR TITLE
chore: scope sync-docs-jsdoc rule to compound sub-component groups

### DIFF
--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/compound/CompoundDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/compound/CompoundDocs.ts
@@ -1,0 +1,43 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const RootProperties: PropertiesTableProps = {
+  children: {
+    doc: 'Root children content.',
+    type: 'React.ReactNode',
+    status: 'optional',
+  },
+  onChange: {
+    doc: 'Called when root state changes.',
+    type: 'function',
+    status: 'optional',
+  },
+}
+
+export const SortButtonProperties: PropertiesTableProps = {
+  data: {
+    doc: 'Sort options for the dropdown.',
+    type: 'Array',
+    status: 'required',
+  },
+  onChange: {
+    doc: 'Called when a sort option is selected.',
+    type: 'function',
+    status: 'optional',
+  },
+}
+
+export const SearchProperties: PropertiesTableProps = {
+  label: {
+    doc: 'Label for the search input.',
+    type: 'string',
+    status: 'required',
+  },
+  onChange: {
+    doc: 'Called when the search value changes.',
+    type: 'function',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
@@ -171,6 +171,34 @@ tester.run('sync-docs-jsdoc', rule, {
       `,
       filename: path.join(fixturesDir, 'basic/types.ts'),
     },
+
+    // ── Compound sub-component: matches only its own export group ──
+    {
+      code: `
+        export type CompoundSortButtonProps = {
+          /** Sort options for the dropdown. */
+          data?: Array<unknown>
+
+          /** Called when a sort option is selected. */
+          onChange?: () => void
+        }
+      `,
+      filename: path.join(fixturesDir, 'compound/CompoundSortButton.tsx'),
+    },
+
+    // ── Compound sub-component: onChange from Search group is not matched ──
+    {
+      code: `
+        export type CompoundSearchProps = {
+          /** Label for the search input. */
+          label?: string
+
+          /** Called when the search value changes. */
+          onChange?: () => void
+        }
+      `,
+      filename: path.join(fixturesDir, 'compound/CompoundSearch.tsx'),
+    },
   ],
 
   invalid: [
@@ -612,6 +640,34 @@ tester.run('sync-docs-jsdoc', rule, {
       filename: path.join(fixturesDir, 'basic/types.ts'),
       options: [{ requireJsdoc: true }],
       errors: [{ messageId: 'missingJsdoc' }],
+    },
+
+    // ── Compound sub-component: wrong onChange doc uses SortButton group ──
+    {
+      code: `
+        export type CompoundSortButtonProps = {
+          /** Wrong description for onChange. */
+          onChange?: () => void
+        }
+      `,
+      output: `
+        export type CompoundSortButtonProps = {
+          /**
+           * Called when a sort option is selected.
+           */
+          onChange?: () => void
+        }
+      `,
+      filename: path.join(fixturesDir, 'compound/CompoundSortButton.tsx'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'CompoundDocs.ts',
+            expected: 'Called when a sort option is selected.',
+          },
+        },
+      ],
     },
   ],
 })

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
@@ -43,6 +43,49 @@ function extractDocsFromFile(filePath) {
   return docs
 }
 
+/**
+ * Like extractDocsFromFile, but returns docs grouped by their export
+ * variable name.  e.g. { SortButtonProperties: Map { data → …, … } }
+ */
+function extractGroupedDocsFromFile(filePath) {
+  if (!ts) {
+    return new Map()
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true
+  )
+
+  const groups = new Map()
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer) &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    ) {
+      const varName = node.name.text
+      const props = new Map()
+      extractFromObjectLiteral(node.initializer, props)
+
+      if (props.size > 0) {
+        groups.set(varName, props)
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return groups
+}
+
 function extractFromObjectLiteral(objLiteral, docs) {
   for (const prop of objLiteral.properties) {
     if (!ts.isPropertyAssignment(prop)) {
@@ -172,7 +215,7 @@ function extractJsdocTags(commentValue) {
   return tags
 }
 
-function getDocsMap(dir) {
+function getDocsMap(dir, sourceBasename) {
   let files
 
   try {
@@ -192,11 +235,34 @@ function getDocsMap(dir) {
     const filePath = path.join(dir, file)
 
     try {
-      const extracted = extractDocsFromFile(filePath)
+      const groups = extractGroupedDocsFromFile(filePath)
 
-      for (const [key, value] of extracted) {
-        docs.set(key, value)
-        fileMap.set(key, file)
+      // Derive the component prefix from the docs filename,
+      // e.g. "FilterDocs.ts" → "Filter"
+      const docsPrefix = file.replace(/Docs\.[jt]sx?$/, '')
+
+      // Derive the sub-component name from the source filename,
+      // e.g. sourceBasename "FilterSortButton" with prefix "Filter"
+      //      → subComponent "SortButton"
+      let subComponent = null
+
+      if (sourceBasename && sourceBasename.startsWith(docsPrefix)) {
+        subComponent = sourceBasename.slice(docsPrefix.length)
+      }
+
+      for (const [varName, props] of groups) {
+        // When a sub-component name is known and multiple groups exist,
+        // only include exports that belong to this sub-component.
+        if (subComponent && groups.size > 1) {
+          if (!varName.startsWith(subComponent)) {
+            continue
+          }
+        }
+
+        for (const [key, value] of props) {
+          docs.set(key, value)
+          fileMap.set(key, file)
+        }
       }
     } catch {
       // Skip files that fail to parse
@@ -257,7 +323,10 @@ module.exports = {
 
     const resolvedPath = path.resolve(filename)
     const dir = path.dirname(resolvedPath)
-    const docsData = getDocsMap(dir)
+    const sourceBasename = path
+      .basename(filename)
+      .replace(/\.[jt]sx?$/, '')
+    const docsData = getDocsMap(dir, sourceBasename)
 
     if (!docsData) {
       return {} // stop here


### PR DESCRIPTION
The `sync-docs-jsdoc` ESLint rule previously merged all property groups from a `*Docs.ts` file into a single flat map. For compound components (e.g. `Filter` with `SortButton`, `Search` sub-components), this caused wrong JSDoc matches — a `SortButton`'s `onChange` would be matched against `Search`'s `onChange` docs if `Search` was processed last.

This change groups docs by their export variable name and scopes matching to the sub-component derived from the source filename. For example, `FilterSortButton.tsx` only sees properties from `SortButtonProperties`, not from `SearchProperties` or `RootProperties`.

Includes test fixtures and cases for both valid and invalid compound scenarios.