### PR TITLE
feat(PortalRoot): Forward HTML attributes from Provider to portal elements

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
@@ -131,3 +131,19 @@ This makes the `DatePicker` render its portal content right before `my-custom-id
   </div>
 </body>
 ```
+
+### Forward HTML attributes to portal content
+
+`PortalRoot.Provider` also forwards any extra HTML attributes to the portal DOM element. This is useful when you need to prevent browser features like Google Translate from modifying portal content, which can cause React crashes.
+
+```tsx
+import { PortalRoot, Dropdown } from '@dnb/eufemia'
+
+render(
+  <PortalRoot.Provider translate="no">
+    <Dropdown />
+  </PortalRoot.Provider>
+)
+```
+
+Every portal rendered by components inside the provider (such as Dropdown, Autocomplete, DatePicker, Dialog, Drawer, Popover, and Tooltip) will have `translate="no"` on its portal element, preventing Google Translate from wrapping text nodes in those portals.

--- a/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
@@ -47,22 +47,34 @@ export type PortalRootProps = {
 } & SelectorOptions &
   Omit<HTMLProps<HTMLElement>, 'ref' | 'id'>
 
-type PortalRootContextValue = SelectorOptions
+type PortalRootContextValue = SelectorOptions & {
+  portalAttributes?: Record<string, unknown>
+}
 
 const PortalRootContext = createContext<PortalRootContextValue | null>(
   null
 )
 
-export type PortalRootProviderProps = PropsWithChildren<SelectorOptions>
+export type PortalRootProviderProps = PropsWithChildren<
+  SelectorOptions & Omit<HTMLProps<HTMLElement>, 'id' | 'children'>
+>
 
 export function PortalRootProvider(
   props: PortalRootProviderProps
 ): JSX.Element | null {
-  const { id, insideSelector, beforeSelector, children } = props
+  const { id, insideSelector, beforeSelector, children, ...rest } = props
+
+  const hasRest = Object.keys(rest).length > 0
 
   const value = useMemo(
-    () => ({ id, insideSelector, beforeSelector }),
-    [id, insideSelector, beforeSelector]
+    () => ({
+      id,
+      insideSelector,
+      beforeSelector,
+      ...(hasRest ? { portalAttributes: rest } : undefined),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [id, insideSelector, beforeSelector, ...Object.values(rest)]
   )
 
   return <PortalRootContext value={value}>{children}</PortalRootContext>
@@ -154,6 +166,7 @@ function PortalRootInstance(props: PortalRootProps = {}): ReactNode {
           className
         )}
         style={{ ...scopeStyle, ...style }}
+        {...selectorContext?.portalAttributes}
         {...rest}
       >
         {children}

--- a/packages/dnb-eufemia/src/components/portal-root/PortalRootDocs.ts
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRootDocs.ts
@@ -26,4 +26,9 @@ export const PortalRootProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'required',
   },
+  '[HTML attributes]': {
+    doc: 'When used on `PortalRoot.Provider`, any extra HTML attributes (e.g. `translate`, `lang`, `dir`, `data-*`) are forwarded to the portal DOM element. Props on `PortalRoot` itself take precedence.',
+    type: 'various',
+    status: 'optional',
+  },
 }

--- a/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
@@ -1138,4 +1138,66 @@ describe('PortalRoot theme', () => {
 
     expect(innerDiv).not.toHaveClass('eufemia-theme')
   })
+
+  describe('Provider HTML attributes', () => {
+    it('should forward translate="no" from Provider to portal element', () => {
+      render(
+        <PortalRoot.Provider translate="no">
+          <PortalRoot>
+            <div data-testid="content">Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).toHaveAttribute('translate', 'no')
+    })
+
+    it('should forward data attributes from Provider to portal element', () => {
+      render(
+        <PortalRoot.Provider data-testid="portal-wrapper">
+          <PortalRoot>
+            <div>Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).toHaveAttribute('data-testid', 'portal-wrapper')
+    })
+
+    it('should allow PortalRoot props to override Provider attributes', () => {
+      render(
+        <PortalRoot.Provider translate="no">
+          <PortalRoot translate="yes">
+            <div data-testid="content">Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).toHaveAttribute('translate', 'yes')
+    })
+
+    it('should not set extra attributes when Provider has none', () => {
+      render(
+        <PortalRoot.Provider>
+          <PortalRoot>
+            <div data-testid="content">Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).not.toHaveAttribute('translate')
+    })
+  })
 })


### PR DESCRIPTION
## Why

Google Translate wraps text nodes inside `<font>` elements, which breaks React's DOM reconciliation and causes crashes ([facebook/react#11538](https://github.com/facebook/react/issues/11538)). Components that render portal content (Dropdown, Autocomplete, DatePicker, Dialog, Drawer, Popover, Tooltip, Modal) are especially vulnerable because their portal DOM trees live outside the component hierarchy — meaning `translate="no"` set on a parent element doesn't reach the portal content.

## Solution

`PortalRoot.Provider` now forwards any extra HTML attributes to the portal DOM element. This lets consumers prevent Google Translate from modifying portal content with a single wrapper:

```tsx
<PortalRoot.Provider translate="no">
  <Dropdown />
</PortalRoot.Provider>
```

Every portal rendered by components inside the provider will have `translate="no"` on its portal element, preventing Google Translate from wrapping text nodes in those portals.

- Provider attributes are applied first, then `PortalRoot` instance props override them
- When the provider has no extra attributes, no additional DOM attributes are set
- Works with any HTML attribute (`translate`, `lang`, `dir`, `data-*`, etc.)
