### PR TITLE
fix(Dialog): close nested confirmation dialog when declining

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/Examples.tsx
@@ -156,6 +156,30 @@ export const FullDialogExample = () => (
   </ComponentBox>
 )
 
+export const DialogExampleNested = () => (
+  <ComponentBox>
+    <Dialog
+      title="Account settings"
+      triggerProps={{ text: 'Open settings' }}
+    >
+      <P bottom>
+        Review your account settings below. To permanently remove your
+        account, use the button below.
+      </P>
+      <Dialog
+        variant="confirmation"
+        confirmType="warning"
+        title="Are you sure?"
+        description="Deleting your account is permanent and cannot be undone. All your data will be lost."
+        triggerProps={{
+          text: 'Delete account',
+          variant: 'secondary',
+        }}
+      />
+    </Dialog>
+  </ComponentBox>
+)
+
 export const DialogExampleProgressIndicator = () => (
   <ComponentBox data-visual-test="dialog-progress-indicator">
     <Dialog

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/demos.mdx
@@ -8,6 +8,7 @@ import {
   DialogExampleFullscreen,
   DialogExampleVerticalAlignment,
   DialogExampleDelayClose,
+  DialogExampleNested,
   DialogExampleCustomTrigger,
   DialogExampleProgressIndicator,
   FullDialogExample,
@@ -53,6 +54,12 @@ import {
 ### Dialog as progress indicator
 
 <DialogExampleProgressIndicator />
+
+### Nested Dialog
+
+Open a confirmation dialog from within another dialog — for example to confirm a destructive action.
+
+<DialogExampleNested />
 
 ### Dialog with close delay
 

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -526,6 +526,57 @@ describe('Dialog', () => {
     })
   })
 
+  it('closes only the nested confirmation dialog when declining', async () => {
+    const onCloseOuter = vi.fn()
+    const onCloseInner = vi.fn()
+
+    render(
+      <Dialog
+        noAnimation
+        id="outer-dialog"
+        title="Outer"
+        onClose={onCloseOuter}
+      >
+        <Dialog
+          noAnimation
+          id="inner-dialog"
+          variant="confirmation"
+          title="Confirm?"
+          triggerProps={{ text: 'Delete' }}
+          onClose={onCloseInner}
+        />
+      </Dialog>
+    )
+
+    // Open outer dialog
+    fireEvent.click(document.querySelector('button#outer-dialog'))
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('outer-dialog')
+
+    // Open inner confirmation dialog
+    fireEvent.click(document.querySelector('button#inner-dialog'))
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('inner-dialog')
+
+    // Click decline (Avbryt) – should close only the inner dialog
+    const declineButton = Array.from(
+      document.querySelectorAll('.dnb-dialog__actions button')
+    ).find((btn) => btn.classList.contains('dnb-button--secondary'))
+
+    fireEvent.click(declineButton)
+
+    await waitFor(() => {
+      expect(onCloseInner).toHaveBeenCalledTimes(1)
+      expect(onCloseOuter).toHaveBeenCalledTimes(0)
+    })
+
+    expect(
+      document.documentElement.getAttribute('data-dnb-modal-active')
+    ).toBe('outer-dialog')
+  })
+
   it('will close dialog by using callback method', () => {
     const onClose = vi.fn()
     const onOpen = vi.fn()

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -358,7 +358,7 @@ function ModalComponent(ownProps: ModalAllProps) {
           const list = getListOfModalRoots()
           if (list.length > 1) {
             const last = getModalRoot(-1)
-            if (last !== modalStackIdentityRef.current) {
+            if (last?._id !== modalStackIdentityRef.current._id) {
               return // stop here
             }
           }


### PR DESCRIPTION
## Problem

Clicking the decline button ("Avbryt") on a nested confirmation `Dialog` silently did nothing — the inner dialog stayed open.

## Root cause

The `closeHandler` in `Modal.tsx` has an `ifIsLatest` guard that prevents closing a modal unless it's the topmost in the stack. This guard compared `getModalRoot(-1)` (a `selfRef` object from `ModalContent.tsx`) against `modalStackIdentityRef.current` (a separate object from `Modal.tsx`) using strict equality (`!==`). Since these are always different object references, the check always failed and `close()` returned early.

Other close paths (Escape key, close button, overlay click) bypassed this guard because they pass `{ triggeredBy }` as the second argument, making `ifIsLatest` undefined. Only the decline/confirm button's default `close()` call (with no arguments, defaulting `ifIsLatest` to `true`) hit this bug.

## Fix

Compare by `_id` instead of object identity.

Also adds a test for the scenario and a nested Dialog example to the portal docs.

## Preview

https://fix-nested-dialog-close-pr.eufemia-e25.pages.dev/uilib/components/dialog#nested-dialog