### PR TITLE
fix(HelpButton): prevent VoiceOver from announcing title twice

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -139,6 +139,10 @@ export type ButtonProps = {
    * Provide a string or a React Element to be shown as the tooltip content.
    */
   tooltip?: ButtonTooltip
+  /**
+   * Whether to omit the aria-describedby attribute from the tooltip.
+   */
+  omitDescribedBy?: boolean
   id?: string
   /**
    * If you want the button to behave as a link. Use with caution! A link should normally visually be a link and not a button.
@@ -270,6 +274,7 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     title,
     customContent,
     tooltip,
+    omitDescribedBy,
     status,
     statusState,
     statusProps,
@@ -474,6 +479,7 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
           id={resolvedId + '-tooltip'}
           targetElement={elementRef}
           tooltip={tooltip}
+          omitDescribedBy={omitDescribedBy}
         />
       )}
     </>

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -139,10 +139,6 @@ export type ButtonProps = {
    * Provide a string or a React Element to be shown as the tooltip content.
    */
   tooltip?: ButtonTooltip
-  /**
-   * Whether to omit the aria-describedby attribute from the tooltip.
-   */
-  omitDescribedBy?: boolean
   id?: string
   /**
    * If you want the button to behave as a link. Use with caution! A link should normally visually be a link and not a button.
@@ -274,7 +270,6 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     title,
     customContent,
     tooltip,
-    omitDescribedBy,
     status,
     statusState,
     statusProps,
@@ -479,7 +474,10 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
           id={resolvedId + '-tooltip'}
           targetElement={elementRef}
           tooltip={tooltip}
-          omitDescribedBy={omitDescribedBy}
+          omitDescribedBy={
+            Boolean(params['aria-label']) &&
+            convertJsxToString(tooltip) === params['aria-label']
+          }
         />
       )}
     </>

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -76,6 +76,7 @@ export default function HelpButtonInstance(localProps: ButtonProps) {
 
   if (
     params['aria-label'] &&
+    typeof params.tooltip !== 'function' &&
     convertJsxToString(params.tooltip) === params['aria-label']
   ) {
     params.omitDescribedBy = true

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -74,5 +74,12 @@ export default function HelpButtonInstance(localProps: ButtonProps) {
     params.title = null
   }
 
+  if (
+    params['aria-label'] &&
+    convertJsxToString(params.tooltip) === params['aria-label']
+  ) {
+    params.omitDescribedBy = true
+  }
+
   return <Button onClick={onClick} {...params} />
 }

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -74,13 +74,5 @@ export default function HelpButtonInstance(localProps: ButtonProps) {
     params.title = null
   }
 
-  if (
-    params['aria-label'] &&
-    typeof params.tooltip !== 'function' &&
-    convertJsxToString(params.tooltip) === params['aria-label']
-  ) {
-    params.omitDescribedBy = true
-  }
-
   return <Button onClick={onClick} {...params} />
 }

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButton.test.tsx
@@ -11,7 +11,7 @@ import {
   question as QuestionIcon,
   information_medium as InformationIcon,
 } from '../../../icons'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 
 const props: HelpButtonProps = { id: 'help-button' }
 
@@ -216,6 +216,36 @@ describe('HelpButton', () => {
 
     const button = document.querySelector('.dnb-help-button')
     expect(button).toHaveClass('dnb-space__left--small')
+  })
+
+  it('should not set aria-describedby when tooltip matches aria-label', async () => {
+    render(<HelpButton {...props} title="Hjelpetekst" />)
+
+    const button = document.querySelector('.dnb-button')
+    expect(button.getAttribute('aria-label')).toBe('Hjelpetekst')
+
+    fireEvent.focus(button)
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-tooltip')).toBeInTheDocument()
+    })
+
+    expect(button).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('should set aria-describedby when tooltip differs from aria-label', async () => {
+    render(
+      <HelpButton {...props} title="Custom title" aria-label="Other" />
+    )
+
+    const button = document.querySelector('.dnb-button')
+    expect(button.getAttribute('aria-label')).toBe('Other')
+
+    fireEvent.focus(button)
+
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-describedby')
+    })
   })
 })
 

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -543,23 +543,15 @@ describe('HelpButtonInline', () => {
 
     const button = document.querySelector('.dnb-help-button')
 
-    // Tooltip only sets aria-describedby when active (hover/focus)
-    // So we need to trigger focus to activate the tooltip
+    // Tooltip only renders when active (hover/focus)
     await userEvent.hover(button)
 
-    const ariaDescribedBy = await waitFor(() => {
-      const id = button.getAttribute('aria-describedby')
-      expect(id).toBeTruthy()
-      return id
-    })
+    // aria-describedby is omitted because tooltip text matches aria-label
+    expect(button).not.toHaveAttribute('aria-describedby')
 
-    const tooltipContent = await waitFor(() => {
-      const tooltip = document.querySelector(`#${ariaDescribedBy}`)
-      expect(tooltip).toBeInTheDocument()
-      return tooltip
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-tooltip')).toBeInTheDocument()
     })
-
-    expect(ariaDescribedBy).toBe(tooltipContent.id)
   })
 
   it('calls focus with preventScroll when opening', async () => {

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -48,6 +48,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     size,
     keepInDOM = false,
     targetRefreshKey,
+    omitDescribedBy,
   } = restProps
 
   const { internalId, isControlled } = useContext(TooltipContext)
@@ -177,7 +178,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   const overlayOpen = Boolean(isOpen || isOverlayHovered)
 
-  const describedById = overlayOpen ? internalId : null
+  const describedById = overlayOpen && !omitDescribedBy ? internalId : null
 
   /**
    * Get our "target"
@@ -187,16 +188,18 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       return createElement(target.type as ComponentType<any>, {
         ...target.props,
         ref: cloneRef,
-        'aria-describedby': combineDescribedBy(
-          target.props['aria-describedby'],
-          describedById
-        ),
+        ...(!omitDescribedBy && {
+          'aria-describedby': combineDescribedBy(
+            target.props['aria-describedby'],
+            describedById
+          ),
+        }),
       })
     }
 
     cloneRef.current = target as HTMLElement
     return null
-  }, [describedById, target])
+  }, [describedById, omitDescribedBy, target])
 
   useEffect(() => {
     if (!target) {

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -681,7 +681,7 @@ describe('Tooltip', () => {
         expect(ariaDescribedBy).toContain('tooltip')
       })
 
-      it('should set aria-describedby even when omitDescribedBy is true (prop is ignored)', () => {
+      it('should not set aria-describedby when omitDescribedBy is true', () => {
         render(
           <Tooltip open showDelay={0} omitDescribedBy>
             Tooltip content
@@ -691,12 +691,10 @@ describe('Tooltip', () => {
         const buttonElem = document.querySelector('button')
         const ariaDescribedBy = buttonElem.getAttribute('aria-describedby')
 
-        // omitDescribedBy is no longer handled in TooltipWithEvents
-        expect(ariaDescribedBy).toBeTruthy()
-        expect(ariaDescribedBy).toContain('tooltip')
+        expect(ariaDescribedBy).toBeNull()
       })
 
-      it('should set aria-describedby even when omitDescribedBy is true with targetSelector (prop is ignored)', () => {
+      it('should not set aria-describedby when omitDescribedBy is true with targetSelector', () => {
         render(
           <>
             <button id="test-button">Button</button>
@@ -715,11 +713,10 @@ describe('Tooltip', () => {
         const buttonElem = document.querySelector('#test-button')
         const ariaDescribedBy = buttonElem.getAttribute('aria-describedby')
 
-        // omitDescribedBy is no longer handled in TooltipWithEvents
-        expect(ariaDescribedBy).toBeTruthy()
+        expect(ariaDescribedBy).toBeNull()
       })
 
-      it('should combine existing aria-describedby with tooltip id when omitDescribedBy is true (prop is ignored)', () => {
+      it('should preserve existing aria-describedby when omitDescribedBy is true', () => {
         const buttonWithAria = (
           <button aria-describedby="existing-id">Button</button>
         )
@@ -739,9 +736,8 @@ describe('Tooltip', () => {
         const ariaDescribedBy =
           buttonElem?.getAttribute('aria-describedby')
 
-        // omitDescribedBy is no longer handled, so aria-describedby includes both
-        expect(ariaDescribedBy).toContain('existing-id')
-        expect(ariaDescribedBy).toContain('tooltip')
+        expect(ariaDescribedBy).toBe('existing-id')
+        expect(ariaDescribedBy).not.toContain('tooltip')
       })
     })
   })


### PR DESCRIPTION
The HelpButton trigger had both aria-label and a tooltip with the same text (e.g. "Hjelpetekst"). When VoiceOver focused the button, it read the aria-label as the accessible name, then the tooltip's aria-describedby content as the description — announcing the title twice.

Re-enable omitDescribedBy support in Tooltip so it can skip setting aria-describedby. Wire it through Button, and set it automatically in HelpButtonInstance when the tooltip text matches the aria-label.

Closes #5918

