### PR TITLE
chore: fix text and grammar issues in recent changes

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -156,7 +156,7 @@ export type DatePickerProps = {
    */
   onlyMonth?: boolean
   /**
-   * Use `true` to only show the last week in the current month if it needs to be shown. The result is that there will mainly be shows five (5) weeks (rows) instead of six (6). Defaults to `false`.
+   * Use `true` to only show the last week in the current month if it needs to be shown. The result is that there will mainly be shown five (5) weeks (rows) instead of six (6). Defaults to `false`.
    */
   hideLastWeek?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -122,7 +122,7 @@ export type FormStatusProps = {
    */
   variant?: FormStatusVariant
   /**
-   * Defines the appearance size. There are these sizes `default`, `large`. The default status is `default`.
+   * Defines the appearance size. There are these sizes `default`, `large`. The default size is `default`.
    */
   size?: FormStatusSize
   attributes?: FormStatusAttributes

--- a/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
@@ -33,7 +33,7 @@ export const FormStatusProperties: PropertiesTableProps = {
     status: 'optional',
   },
   size: {
-    doc: 'Defines the appearance size. There are these sizes `default`, `large`. The default status is `default`.',
+    doc: 'Defines the appearance size. There are these sizes `default`, `large`. The default size is `default`.',
     type: ['"default"', '"large"'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlockDocs.ts
@@ -7,7 +7,7 @@ export const FieldBlockSharedProperties: PropertiesTableProps = {
     status: 'optional',
   },
   labelDescription: {
-    doc: 'A more discreet text displayed beside the label (e.g. "(optional)")',
+    doc: 'A more discreet text displayed beside the label (e.g. "(optional)").',
     type: 'string',
     status: 'optional',
   },


### PR DESCRIPTION
- DatePicker: "shows" → "shown" in hideLastWeek JSDoc
- FormStatus: "default status" → "default size" in size JSDoc
- FormStatusDocs: same size doc fix
- FieldBlockDocs: add missing trailing period in labelDescription doc

