### PR TITLE
chore(Portal): show released version instead of 'Not released' in footer

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -8,6 +8,7 @@
 // run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/postbuild/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
 
 const { execFile } = require('child_process')
+const path = require('path')
 const simpleGit = require('simple-git')
 
 try {
@@ -17,6 +18,7 @@ try {
 }
 
 const srBin = require.resolve('semantic-release/bin/semantic-release.js')
+const eufemiaRoot = path.resolve(__dirname, '..', '..')
 const releaseBranches = ['release', 'beta', 'alpha']
 
 // run this script if it is called from bash / command line
@@ -33,7 +35,7 @@ async function getNextReleaseVersion() {
         execFile(
           process.execPath,
           [srBin, '--dry-run'],
-          { timeout: 120000 },
+          { timeout: 120000, cwd: eufemiaRoot },
           (_error, stdout, stderr) => {
             // Resolve with combined output regardless of exit code —
             // semantic-release may exit non-zero in dry-run mode


### PR DESCRIPTION
Reverted the previous attempt in https://github.com/dnbexperience/eufemia/pull/8409

Verification steps ran locally:

1. Checked path resolution from the portal directory — confirmed eufemiaRoot resolves to dnb-eufemia which contains the release config in package.json. 
2. Demonstrated the root cause — ran from the portal directory and showed: Without cwd: the portal's package.json has no release config → semantic-release silently exits with no output With cwd: eufemiaRoot: the eufemia package.json has the release config → semantic-release loads correctly 
3. Tested on the release branch with no new commits — checked out release, cherry-picked the fix (without committing), and ran `semantic-release --dry-run`. Result: "Found 0 commits since last release" → null → "Not released" (correct behavior). 
4. Tested on the release branch with a releasable commit — added a dummy fix: commit on top of release, then ran `semantic-release --dry-run` from the portal directory. Result: "The next release version is 11.5.2" — correctly detected v11.5.1 as the last tag and bumped the patch version. 

I've not tested `build:version`, as I would need tokens for that.