### PR TITLE
chore(Portal): reset aside-width on 404 page

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -239,7 +239,7 @@
   }
 }
 
-.fullscreenStyle {
-  /* ensure the sidebar has not left over margin during fullscreen (SSR issue) */
+.fullscreenStyle,
+.hideSidebarStyle {
   --aside-width: 0;
 }

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -24,6 +24,7 @@ import {
   contentStyle,
   wrapperStyle,
   fullscreenStyle,
+  hideSidebarStyle,
 } from './Layout.module.scss'
 import SidebarMenu from '../menu/SidebarMenu'
 import { scrollToAnimation } from './layout-utils'
@@ -153,6 +154,7 @@ function Layout(props: LayoutProps) {
       className={clsx(
         portalStyle,
         fs && fullscreenStyle,
+        hideSidebar && hideSidebarStyle,
         codeFocusMode && 'focusmode'
       )}
     >


### PR DESCRIPTION
The 404 page passes `hideSidebar` to `Layout`, which prevents the sidebar from rendering. However, `--aside-width` was still defined on `:root`, causing the content area to retain `margin-left: var(--aside-width)` and leaving a gap where the sidebar would be.

This adds a `hideSidebarStyle` class that resets `--aside-width: 0` and applies it when `hideSidebar` is true.