### PR TITLE
fix(Accordion): remove redundant whatintent check from tertiary focus detection

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionTertiary.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionTertiary.tsx
@@ -52,10 +52,7 @@ function shouldFocusContentFromClick(event: MouseEvent) {
 
   const { documentElement } = document
 
-  return (
-    documentElement.getAttribute('data-whatinput') === 'keyboard' ||
-    documentElement.getAttribute('data-whatintent') === 'keyboard'
-  )
+  return documentElement.getAttribute('data-whatinput') === 'keyboard'
 }
 
 export default function AccordionTertiary(props: AccordionTertiaryProps) {

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -24,12 +24,10 @@ const props: AccordionProps = {
 
 const setInputIntent = (value: 'keyboard' | 'mouse') => {
   document.documentElement.setAttribute('data-whatinput', value)
-  document.documentElement.setAttribute('data-whatintent', value)
 }
 
 afterEach(() => {
   document.documentElement.removeAttribute('data-whatinput')
-  document.documentElement.removeAttribute('data-whatintent')
 })
 
 describe('Accordion component', () => {


### PR DESCRIPTION
Preview: https://refactor-whatinput-keyboard.eufemia-e25.pages.dev/uilib/components/accordion#variant-tertiary

Simplify `shouldFocusContentFromClick` in AccordionTertiary to only check `data-whatinput` instead of both `data-whatinput` and `data-whatintent`.

The `data-whatintent` check was redundant here — `event.detail === 0` already covers keyboard/screen-reader activation, and `data-whatinput` correctly reflects the last input method without being affected by mouse movement or scroll.