### PR TITLE
fix(Switch): prevent visual toggle when preventDefault is called in onClick

### DIFF
--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -184,6 +184,7 @@ function Switch(props: SwitchProps) {
   const onChangeHandler = useCallback(
     (event) => {
       if (preventChangeRef.current) {
+        preventChangeRef.current = false
         return // stop here
       }
 
@@ -210,18 +211,16 @@ function Switch(props: SwitchProps) {
 
   const onClickHandler: MouseEventHandler<HTMLInputElement> = useCallback(
     (event) => {
-      const preventDefault = () => {
-        event.preventDefault()
+      preventChangeRef.current = false
 
-        if (event.target['checked'] !== isCheckedRef.current) {
-          preventChangeRef.current = true
-          isCheckedRef.current = !isCheckedRef.current
-          forceUpdate()
-        }
+      const preventDefault = () => {
+        preventChangeRef.current = true
       }
 
       if (readOnly) {
-        return preventDefault()
+        event.preventDefault()
+        preventChangeRef.current = true
+        return // stop here
       }
 
       onClick?.({
@@ -230,6 +229,11 @@ function Switch(props: SwitchProps) {
         event,
         ...event,
       })
+
+      if (preventChangeRef.current) {
+        event.preventDefault()
+        forceUpdate()
+      }
     },
     [onClick, readOnly]
   )

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -185,6 +185,13 @@ function Switch(props: SwitchProps) {
     (event) => {
       if (preventChangeRef.current) {
         preventChangeRef.current = false
+
+        // Revert the checked state that was toggled by the browser's
+        // activation behavior, since the change is being prevented
+        if (inputRef.current) {
+          inputRef.current.checked = isCheckedRef.current
+        }
+
         return // stop here
       }
 
@@ -218,22 +225,16 @@ function Switch(props: SwitchProps) {
       }
 
       if (readOnly) {
-        event.preventDefault()
         preventChangeRef.current = true
         return // stop here
       }
 
       onClick?.({
         checked: isCheckedRef.current,
-        preventDefault,
         event,
         ...event,
+        preventDefault,
       })
-
-      if (preventChangeRef.current) {
-        event.preventDefault()
-        forceUpdate()
-      }
     },
     [onClick, readOnly]
   )

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -195,6 +195,70 @@ describe('Switch component', () => {
     expect(ref.current.getAttribute('id')).toBe('unique')
     expect(ref.current.classList).toContain('dnb-switch__input')
   })
+
+  it('should not visually flip when preventDefault is called in onClick', () => {
+    const onChange = vi.fn()
+
+    const Controlled = () => {
+      const [checked, setChecked] = useState(false)
+
+      return (
+        <Switch
+          checked={checked}
+          onChange={({ checked }) => {
+            onChange(checked)
+            setChecked(checked)
+          }}
+          onClick={({ preventDefault }) => {
+            preventDefault()
+          }}
+        />
+      )
+    }
+
+    render(<Controlled />)
+
+    const input = document.querySelector('input')
+
+    // Click should be prevented — state stays false
+    fireEvent.click(input)
+    expect(input.getAttribute('aria-checked')).toBe('false')
+    expect(onChange).not.toHaveBeenCalled()
+
+    // Click again — still prevented, still false
+    fireEvent.click(input)
+    expect(input.getAttribute('aria-checked')).toBe('false')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('should allow normal toggling when preventDefault is not called in onClick', () => {
+    const onChange = vi.fn()
+
+    const Controlled = () => {
+      const [checked, setChecked] = useState(false)
+
+      return (
+        <Switch
+          checked={checked}
+          onChange={({ checked }) => {
+            onChange(checked)
+            setChecked(checked)
+          }}
+          onClick={() => {
+            // onClick present but not calling preventDefault
+          }}
+        />
+      )
+    }
+
+    render(<Controlled />)
+
+    const input = document.querySelector('input')
+
+    fireEvent.click(input)
+    expect(input.getAttribute('aria-checked')).toBe('true')
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
 })
 
 describe('Switch scss', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { MouseEvent } from 'react'
 import { clsx } from 'clsx'
 import {
@@ -90,28 +90,22 @@ function Toggle(props: FieldToggleProps) {
     ) : undefined
   const hideHelpButton = Boolean(helpButton)
 
-  const preventChangeRef = useRef(false)
-
   const onClick = preparedProps?.onClick
   const handleClick = useCallback(
     (args: CheckboxOnClickParams) => {
       const preventDefault = () => {
-        preventChangeRef.current = true
         args.preventDefault?.()
       }
 
-      if (preventChangeRef.current) {
-        args.checked = !args.checked
-        preventChangeRef.current = false
-      }
-
+      const checked = value === valueOn
       const event = {
         ...args,
+        checked,
         preventDefault,
       }
-      onClick?.(args.checked ? valueOn : valueOff, event)
+      onClick?.(checked ? valueOn : valueOff, event)
     },
-    [onClick, valueOff, valueOn]
+    [onClick, value, valueOff, valueOn]
   )
   const handleCheckboxChange = useCallback(
     (args: CheckboxOnChangeParams | ToggleButtonChangeEvent) => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1780566122012469
Issue reprod: https://stackblitz.com/edit/u6dlg7ok-bke62smr?file=src%2FApp.tsx
Fix reprod: https://stackblitz.com/edit/u6dlg7ok-98jq1e2i?file=src%2FApp.tsx

The preventDefault callback in onClick was mutating internal checked state (isCheckedRef) and calling forceUpdate, causing the switch to visually flip even though the controlled checked prop hadn't changed. The flag was also never reset, permanently blocking subsequent onChange events.

Now preventDefault only sets a flag, and event.preventDefault() is called after the user's onClick returns. The flag is reset at the start of each click and in onChangeHandler as a safety net.

