### PR TITLE
fix(Checkbox): fix preventChangeRef never being reset after preventDefault

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -197,9 +197,9 @@ function Checkbox(localProps: CheckboxProps) {
   const handleChange = useCallback(
     (event: CheckboxOnChangeParams['event']) => {
       if (preventChangeRef.current) {
+        preventChangeRef.current = false
         return // stop here
       }
-      preventChangeRef.current = false
       const updatedCheck = !isCheckedRef.current
 
       isCheckedRef.current = updatedCheck
@@ -225,6 +225,8 @@ function Checkbox(localProps: CheckboxProps) {
 
   const onClickHandler: MouseEventHandler<HTMLInputElement> = useCallback(
     (event) => {
+      preventChangeRef.current = false
+
       const preventDefault = () => {
         event.preventDefault()
 

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -211,6 +211,68 @@ describe('Checkbox component', () => {
     expect(checkbox.checked).toBe(true)
   })
 
+  it('should not visually flip when custom preventDefault is called in onClick', async () => {
+    const onChange = vi.fn()
+
+    const Controlled = () => {
+      const [checked, setChecked] = useState(false)
+
+      return (
+        <Checkbox
+          checked={checked}
+          onChange={({ checked }) => {
+            onChange(checked)
+            setChecked(checked)
+          }}
+          onClick={({ preventDefault }) => {
+            preventDefault()
+          }}
+        />
+      )
+    }
+
+    render(<Controlled />)
+
+    const input = document.querySelector('input')
+
+    await userEvent.click(input)
+    expect(input.checked).toBe(false)
+    expect(onChange).not.toHaveBeenCalled()
+
+    await userEvent.click(input)
+    expect(input.checked).toBe(false)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('should allow normal toggling when custom preventDefault is not called in onClick', async () => {
+    const onChange = vi.fn()
+
+    const Controlled = () => {
+      const [checked, setChecked] = useState(false)
+
+      return (
+        <Checkbox
+          checked={checked}
+          onChange={({ checked }) => {
+            onChange(checked)
+            setChecked(checked)
+          }}
+          onClick={() => {
+            // onClick present but not calling preventDefault
+          }}
+        />
+      )
+    }
+
+    render(<Controlled />)
+
+    const input = document.querySelector('input')
+
+    await userEvent.click(input)
+    expect(input.checked).toBe(true)
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
   it('has "onChange" event which will trigger on a input change', () => {
     const myEvent = vi.fn()
     render(<Checkbox onChange={myEvent} checked={false} />)


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/pull/8413

Issue reprod: https://xmk5dy53.stackblitz.io
Fix reprod: https://stackblitz.com/edit/xmk5dy53-zbbufehf?file=src%2FApp.tsx

The preventChangeRef flag was set to true when preventDefault was called but never reset: the reset line was placed after the early return in handleChange, making it unreachable. Additionally, the flag persisted across clicks, permanently blocking onChange after a single prevented click.

Now the flag is reset in handleChange before the early return, and at the start of each onClickHandler invocation.

