### PR TITLE
fix(Field.Toggle): derive checked from value instead of stale component ref

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { MouseEvent } from 'react'
 import { clsx } from 'clsx'
 import {
@@ -90,28 +90,22 @@ function Toggle(props: FieldToggleProps) {
     ) : undefined
   const hideHelpButton = Boolean(helpButton)
 
-  const preventChangeRef = useRef(false)
-
   const onClick = preparedProps?.onClick
   const handleClick = useCallback(
     (args: CheckboxOnClickParams) => {
       const preventDefault = () => {
-        preventChangeRef.current = true
         args.preventDefault?.()
       }
 
-      if (preventChangeRef.current) {
-        args.checked = !args.checked
-        preventChangeRef.current = false
-      }
-
+      const checked = value === valueOn
       const event = {
         ...args,
+        checked,
         preventDefault,
       }
-      onClick?.(args.checked ? valueOn : valueOff, event)
+      onClick?.(checked ? valueOn : valueOff, event)
     },
-    [onClick, valueOff, valueOn]
+    [onClick, value, valueOff, valueOn]
   )
   const handleCheckboxChange = useCallback(
     (args: CheckboxOnChangeParams | ToggleButtonChangeEvent) => {


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/pull/8413

The old handleClick used preventChangeRef + args.checked flip to compensate for the underlying Checkbox/Switch passing a stale checked value after preventDefault. This caused the flag to persist across clicks and incorrectly flip the checked value on subsequent clicks.

Fix: derive checked from Toggle's own value state (value === valueOn) instead of relying on args.checked from the underlying component. This ensures the consumer's onClick always receives the correct current value, regardless of the underlying component's internal state. Remove the now-unused preventChangeRef.

