### PR TITLE
chore: remove hardcoded color fallbacks from CSS token variables

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1036,9 +1036,9 @@ button.dnb-button::-moz-focus-inner {
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;
-  color: var(--text-color, black);
+  color: var(--text-color);
   border-radius: var(--rounded-corner, 0);
-  background-color: var(--background-color, white);
+  background-color: var(--background-color);
 }
 .dnb-section::before {
   content: "";

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -1257,7 +1257,7 @@ html[data-dnb-modal-active] .eufemia-portal-root {
   --dialog-radius: var(--token-radius-md);
   --dialog-padding: calc(var(--dialog-spacing) * 1.75);
   --dialog-icon-positioning: -50%;
-  --dialog-background-color: var(--token-color-background-neutral, white);
+  --dialog-background-color: var(--token-color-background-neutral);
   --dialog-stroke-color: var(--token-color-stroke-neutral-subtle);
   position: relative;
   max-height: 100vh;

--- a/packages/dnb-eufemia/src/components/dialog/style/dnb-dialog.scss
+++ b/packages/dnb-eufemia/src/components/dialog/style/dnb-dialog.scss
@@ -17,7 +17,7 @@
   --dialog-radius: var(--token-radius-md);
   --dialog-padding: calc(var(--dialog-spacing) * 1.75);
   --dialog-icon-positioning: -50%;
-  --dialog-background-color: var(--token-color-background-neutral, white);
+  --dialog-background-color: var(--token-color-background-neutral);
   --dialog-stroke-color: var(--token-color-stroke-neutral-subtle);
 
   position: relative;

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1254,10 +1254,9 @@ html[data-dnb-modal-active] .eufemia-portal-root {
   --drawer-max-width: 40rem;
   --drawer-spacing: 2rem;
   --drawer-spacing-minus: -2rem;
-  --drawer-background-color: var(--token-color-background-neutral, white);
+  --drawer-background-color: var(--token-color-background-neutral);
   --drawer-body-background-color: var(
-    --token-color-background-neutral-subtle,
-    white
+    --token-color-background-neutral-subtle
   );
 }
 @media screen and (max-width: 40em) {

--- a/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
@@ -28,10 +28,9 @@
   --drawer-max-width: 40rem;
   --drawer-spacing: 2rem; // should reflect --spacing-large
   --drawer-spacing-minus: -2rem; // should reflect --spacing-large
-  --drawer-background-color: var(--token-color-background-neutral, white);
+  --drawer-background-color: var(--token-color-background-neutral);
   --drawer-body-background-color: var(
-    --token-color-background-neutral-subtle,
-    white
+    --token-color-background-neutral-subtle
   );
 
   @include utilities.allBelow(small) {

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -1036,9 +1036,9 @@ button.dnb-button::-moz-focus-inner {
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;
-  color: var(--text-color, black);
+  color: var(--text-color);
   border-radius: var(--rounded-corner, 0);
-  background-color: var(--background-color, white);
+  background-color: var(--background-color);
 }
 .dnb-section::before {
   content: "";

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -36,9 +36,9 @@ exports[`Section scss > has to match style dependencies css 1`] = `
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;
-  color: var(--text-color, black);
+  color: var(--text-color);
   border-radius: var(--rounded-corner, 0);
-  background-color: var(--background-color, white);
+  background-color: var(--background-color);
 }
 .dnb-section::before {
   content: "";

--- a/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
+++ b/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
@@ -39,9 +39,9 @@
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;
 
-  color: var(--text-color, black);
+  color: var(--text-color);
   border-radius: var(--rounded-corner, 0);
-  background-color: var(--background-color, white);
+  background-color: var(--background-color);
 
   // The outline border
   &::before {

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -1036,9 +1036,9 @@ button.dnb-button::-moz-focus-inner {
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;
-  color: var(--text-color, black);
+  color: var(--text-color);
   border-radius: var(--rounded-corner, 0);
-  background-color: var(--background-color, white);
+  background-color: var(--background-color);
 }
 .dnb-section::before {
   content: "";

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Tabs scss > has to match style dependencies css 1`] = `
 .dnb-tabs__tabs__tablist {
   overscroll-behavior: contain;
   scroll-behavior: smooth;
-  scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
+  scrollbar-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative)) transparent;
 }
 @supports not (scrollbar-color: auto) {
   .dnb-tabs__tabs__tablist::-webkit-scrollbar:vertical {
@@ -73,13 +73,13 @@ exports[`Tabs scss > has to match style dependencies css 1`] = `
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
-    background-color: var(--scrollbar-track-color, #eee);
+    background-color: var(--scrollbar-track-color, var(--token-color-background-neutral-base));
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-thumb-color, #888);
+    background-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative));
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scrollbar-thumb-hover-color, #666);
+    background-color: var(--scrollbar-thumb-hover-color, var(--token-color-text-neutral));
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
@@ -433,7 +433,7 @@ exports[`Tabs scss > have to match default theme snapshot 1`] = `
 .dnb-tabs__tabs__tablist {
   overscroll-behavior: contain;
   scroll-behavior: smooth;
-  scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
+  scrollbar-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative)) transparent;
 }
 @supports not (scrollbar-color: auto) {
   .dnb-tabs__tabs__tablist::-webkit-scrollbar:vertical {
@@ -444,13 +444,13 @@ exports[`Tabs scss > have to match default theme snapshot 1`] = `
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
-    background-color: var(--scrollbar-track-color, #eee);
+    background-color: var(--scrollbar-track-color, var(--token-color-background-neutral-base));
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-thumb-color, #888);
+    background-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative));
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scrollbar-thumb-hover-color, #666);
+    background-color: var(--scrollbar-thumb-hover-color, var(--token-color-text-neutral));
   }
   .dnb-tabs__tabs__tablist::-webkit-scrollbar-thumb {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
@@ -298,7 +298,7 @@ button .dnb-form-status__text {
   }
 }
 .dnb-textarea__textarea {
-  scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
+  scrollbar-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative)) transparent;
 }
 @supports not (scrollbar-color: auto) {
   .dnb-textarea__textarea::-webkit-scrollbar:vertical {
@@ -309,13 +309,13 @@ button .dnb-form-status__text {
   }
   .dnb-textarea__textarea::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
-    background-color: var(--scrollbar-track-color, #eee);
+    background-color: var(--scrollbar-track-color, var(--token-color-background-neutral-base));
   }
   .dnb-textarea__textarea::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-thumb-color, #888);
+    background-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative));
   }
   .dnb-textarea__textarea::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scrollbar-thumb-hover-color, #666);
+    background-color: var(--scrollbar-thumb-hover-color, var(--token-color-text-neutral));
   }
   .dnb-textarea__textarea::-webkit-scrollbar-thumb {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);

--- a/packages/dnb-eufemia/src/elements/lists/style/lists-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/lists/style/lists-mixins.scss
@@ -7,7 +7,7 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
 @mixin listDefaults() {
-  color: var(--token-color-text-neutral, currentColor);
+  color: var(--token-color-text-neutral);
 
   &--surface-dark {
     color: var(--token-color-text-neutral-ondark);

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
@@ -4,7 +4,7 @@
     var(--easing-default);
   --opacity-animation: opacity var(--opacity-animation-duration, 0ms)
     var(--easing-default) var(--opacity-animation-delay, 0ms);
-  --dots-color: var(--token-color-text-neutral, currentColor);
+  --dots-color: var(--token-color-text-neutral);
 
   &:has(&__label) {
     --font-animation-duration: 400ms;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`DrawerList scss > has to match style dependencies css 1`] = `
   }
 }
 .dnb-drawer-list--scroll .dnb-drawer-list__options {
-  scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
+  scrollbar-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative)) transparent;
 }
 @supports not (scrollbar-color: auto) {
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar:vertical {
@@ -164,13 +164,13 @@ exports[`DrawerList scss > has to match style dependencies css 1`] = `
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
-    background-color: var(--scrollbar-track-color, #eee);
+    background-color: var(--scrollbar-track-color, var(--token-color-background-neutral-base));
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-thumb-color, #888);
+    background-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative));
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scrollbar-thumb-hover-color, #666);
+    background-color: var(--scrollbar-thumb-hover-color, var(--token-color-text-neutral));
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar-thumb {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
@@ -720,7 +720,7 @@ exports[`DrawerList scss > have to match default theme snapshot 1`] = `
   }
 }
 .dnb-drawer-list--scroll .dnb-drawer-list__options {
-  scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
+  scrollbar-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative)) transparent;
 }
 @supports not (scrollbar-color: auto) {
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar:vertical {
@@ -731,13 +731,13 @@ exports[`DrawerList scss > have to match default theme snapshot 1`] = `
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);
-    background-color: var(--scrollbar-track-color, #eee);
+    background-color: var(--scrollbar-track-color, var(--token-color-background-neutral-base));
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-thumb-color, #888);
+    background-color: var(--scrollbar-thumb-color, var(--token-color-text-neutral-alternative));
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar-thumb:hover {
-    background-color: var(--scrollbar-thumb-hover-color, #666);
+    background-color: var(--scrollbar-thumb-hover-color, var(--token-color-text-neutral));
   }
   .dnb-drawer-list--scroll .dnb-drawer-list__options::-webkit-scrollbar-thumb {
     border-radius: var(--scrollbar-thumb-width, 0.5rem);

--- a/packages/dnb-eufemia/src/style/__tests__/__snapshots__/Elements.test.ts.snap
+++ b/packages/dnb-eufemia/src/style/__tests__/__snapshots__/Elements.test.ts.snap
@@ -384,7 +384,7 @@ del .dnb-code {
 .dnb-ul {
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
-  color: var(--token-color-text-neutral, currentColor);
+  color: var(--token-color-text-neutral);
 }
 .dnb-ul--surface-dark {
   color: var(--token-color-text-neutral-ondark);
@@ -441,7 +441,7 @@ del .dnb-code {
 .dnb-ol {
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
-  color: var(--token-color-text-neutral, currentColor);
+  color: var(--token-color-text-neutral);
 }
 .dnb-ol--surface-dark {
   color: var(--token-color-text-neutral-ondark);
@@ -477,7 +477,7 @@ del .dnb-code {
   margin-bottom: 0.5rem;
 }
 .dnb-ol {
-  color: var(--token-color-text-neutral, currentColor);
+  color: var(--token-color-text-neutral);
 }
 .dnb-ol--surface-dark {
   color: var(--token-color-text-neutral-ondark);

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -72,7 +72,7 @@
 
 .dnb-page-background {
   // Ensure themed body has a token color for page backgrounds
-  background-color: var(--token-color-background-page-background, white);
+  background-color: var(--token-color-background-page-background);
 }
 
 // ::selection appearance helper

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -12,7 +12,7 @@
   font-size: var(--font-size-small); // has to be 16px
   font-style: normal;
   line-height: var(--line-height-basis);
-  color: var(--token-color-text-neutral, #333);
+  color: var(--token-color-text-neutral);
 }
 
 @mixin coreDefault() {

--- a/packages/dnb-eufemia/src/style/core/utilities.scss
+++ b/packages/dnb-eufemia/src/style/core/utilities.scss
@@ -212,7 +212,11 @@
   // Also, on macOS, it changes the scrollbar to be so small,
   // that e.g. the textarea resize grabber gets way smaller.
 
-  scrollbar-color: var(--scrollbar-thumb-color, #888) transparent;
+  scrollbar-color: var(
+      --scrollbar-thumb-color,
+      var(--token-color-text-neutral-alternative)
+    )
+    transparent;
 
   @supports not (scrollbar-color: auto) {
     // stylelint-disable
@@ -225,13 +229,22 @@
       }
 
       border-radius: var(--scrollbar-thumb-width, 0.5rem);
-      background-color: var(--scrollbar-track-color, #eee);
+      background-color: var(
+        --scrollbar-track-color,
+        var(--token-color-background-neutral-base)
+      );
     }
     &::-webkit-scrollbar-thumb {
-      background-color: var(--scrollbar-thumb-color, #888);
+      background-color: var(
+        --scrollbar-thumb-color,
+        var(--token-color-text-neutral-alternative)
+      );
 
       &:hover {
-        background-color: var(--scrollbar-thumb-hover-color, #666);
+        background-color: var(
+          --scrollbar-thumb-hover-color,
+          var(--token-color-text-neutral)
+        );
       }
 
       border-radius: var(--scrollbar-thumb-width, 0.5rem);


### PR DESCRIPTION
Tokens are always defined on :root by the theme, making fallbacks unnecessary. The hardcoded fallbacks could cause issues in dark mode if tokens ever failed to resolve.

Personally, I don't 100% understand why some token usage has fallbacks, and others dont. Therefore suggesting to remove fallbacks.

