### PR TITLE
fix(whatInput): allow all non-modifier keys to trigger keyboard detection

### DIFF
--- a/packages/dnb-eufemia/src/__tests__/e2e/whatInput.e2e.spec.ts
+++ b/packages/dnb-eufemia/src/__tests__/e2e/whatInput.e2e.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('whatInput keyboard detection', () => {
+  test('should set data-whatinput to keyboard when pressing arrow keys after mouse click', async ({
+    page,
+  }) => {
+    await page.goto('/uilib/components/autocomplete/demos')
+
+    const input = page.locator('.dnb-autocomplete__input').first()
+
+    await input.click()
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-whatinput',
+      'mouse'
+    )
+
+    await page.keyboard.press('ArrowDown')
+
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-whatinput',
+      'keyboard'
+    )
+  })
+})

--- a/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuRoot.tsx
@@ -23,10 +23,8 @@ import {
 import type { MenuRootProps, MenuContextValue } from './types'
 import type { PopoverTriggerRenderProps } from '../popover/types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
-import whatInput from '../../shared/helpers/whatInput'
 import MenuButton from './MenuButton'
 import MenuAction from './MenuAction'
-import useIsomorphicLayoutEffect from '../../shared/helpers/useIsomorphicLayoutEffect'
 
 export default function MenuRoot(props: MenuRootProps) {
   const {
@@ -153,31 +151,6 @@ export default function MenuRoot(props: MenuRootProps) {
       setActiveIndex(-1)
     }
   }, [isOpen, setActiveIndex])
-
-  // Register arrow/nav keys with whatInput so they count as "keyboard" input.
-  // This lets the focus ring show during arrow navigation, even when the menu
-  // was opened by mouse click. Uses useLayoutEffect to ensure specificKeys is
-  // set before the browser paints, preventing a race on re-open.
-  useIsomorphicLayoutEffect(() => {
-    if (isOpen) {
-      // Tab, Left/Up/Right/Down, PageUp/PageDown, End/Home.
-      whatInput.specificKeys([
-        'Tab',
-        'ArrowLeft',
-        'ArrowUp',
-        'ArrowRight',
-        'ArrowDown',
-        'PageUp',
-        'PageDown',
-        'End',
-        'Home',
-      ])
-    }
-
-    return () => {
-      whatInput.specificKeys(['Tab'])
-    }
-  }, [isOpen])
 
   // Focus the <ul> when the menu opens — it's always in the DOM before items
   const focusOnOpenElement = useCallback(() => {

--- a/packages/dnb-eufemia/src/components/menu/style/dnb-menu.scss
+++ b/packages/dnb-eufemia/src/components/menu/style/dnb-menu.scss
@@ -86,8 +86,8 @@
     // Use :focus + whatInput('keyboard') instead of focusVisible().
     // focusVisible() relies on the browser's :focus-visible heuristic,
     // which doesn't reliably fire when .focus() is called programmatically.
-    // We control data-whatinput via specificKeys() in MenuRoot, so
-    // arrow/nav keys register as keyboard input — making this reliable.
+    // whatInput detects all non-modifier keys as keyboard input globally,
+    // so it works even when focus is triggered programmatically.
     @include utilities.whatInput('keyboard') {
       &:focus:not([disabled]) {
         --menu-action-background-color: var(

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -51,7 +51,6 @@ import Button from '../button/Button'
 import useId from '../../shared/helpers/useId'
 import useIsomorphicLayoutEffect from '../../shared/helpers/useIsomorphicLayoutEffect'
 import useUpdateEffect from '../../shared/helpers/useUpdateEffect'
-import whatInput from '../../shared/helpers/whatInput'
 import CustomContent from './TabsCustomContent'
 import ContentWrapper from './TabsContentWrapper'
 import {
@@ -752,16 +751,6 @@ function TabsComponent(ownProps: TabsProps) {
       'onFocus',
       getEventArgs({ event, focusKey: newFocusKey })
     )
-
-    whatInput.specificKeys([
-      'Tab',
-      'ArrowLeft',
-      'ArrowRight',
-      'PageUp',
-      'PageDown',
-      'End',
-      'Home',
-    ])
   }
 
   // Focus tab button when focusKey changes
@@ -777,7 +766,6 @@ function TabsComponent(ownProps: TabsProps) {
     // saving the position will avoid flickering if the new tab will be done by a new page load
     saveLastPosition()
     saveLastUsedTab()
-    whatInput.specificKeys(['Tab'])
 
     // for handling openPrevTab and openNextTab
     if (mode === 'step' && parseFloat(String(newSelectedKey))) {
@@ -913,7 +901,6 @@ function TabsComponent(ownProps: TabsProps) {
 
     return () => {
       isMounted = false
-      whatInput.specificKeys(['Tab'])
       sharedStateRef.current = null
       resizeObserver?.disconnect()
       if (typeof window !== 'undefined') {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -19,8 +19,6 @@ import DataContext from '../../DataContext/Context'
 import useDataValue from '../../hooks/useDataValue'
 import useTranslation from '../../hooks/useTranslation'
 import { convertJsxToString } from '../../../../shared/component-helper'
-import whatInput from '../../../../shared/helpers/whatInput'
-import useIsomorphicLayoutEffect from '../../../../shared/helpers/useIsomorphicLayoutEffect'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 import { createSharedState } from '../../../../shared/helpers/useSharedState'
 import { MultiSelectionTrigger } from './MultiSelectionTrigger'
@@ -247,28 +245,6 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   const toSearchText = useCallback((content?: ReactNode) => {
     return convertJsxToString(content || '').toLowerCase()
   }, [])
-
-  // Match the existing menu pattern so arrow-key navigation is treated as
-  // keyboard input even when focus is moved programmatically after mouse-open.
-  useIsomorphicLayoutEffect(() => {
-    if (isOpen) {
-      whatInput.specificKeys([
-        'Tab',
-        'ArrowLeft',
-        'ArrowUp',
-        'ArrowRight',
-        'ArrowDown',
-        'PageUp',
-        'PageDown',
-        'End',
-        'Home',
-      ])
-    }
-
-    return () => {
-      whatInput.specificKeys(['Tab'])
-    }
-  }, [isOpen])
 
   // Flatten nested items to a single array for searching and counting
   const flattenItems = useCallback(

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -26,7 +26,7 @@ export { getClosestParent, warn }
 init()
 
 // run component helper functions
-whatInput.specificKeys(['Tab'])
+whatInput.specificKeys([])
 defineNavigator()
 
 /** @private */

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/whatInput.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/whatInput.test.ts
@@ -71,6 +71,28 @@ describe('whatInput', () => {
     // Reset
     whatInput.specificKeys([])
   })
+
+  it('should treat all non-modifier keys as keyboard input by default', () => {
+    whatInput.specificKeys([])
+
+    dispatchMouse()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+    )
+    expect(document.documentElement.getAttribute('data-whatinput')).toBe(
+      'keyboard'
+    )
+
+    dispatchMouse()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    )
+    expect(document.documentElement.getAttribute('data-whatinput')).toBe(
+      'keyboard'
+    )
+  })
 })
 
 describe('whatInput deferred setup', () => {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/C04NL73S2Q5/p1780568659639189?thread_ts=1780482479.487819&cid=C04NL73S2Q5
Preview: https://fix-whatinput-keyboard-all-k.eufemia-e25.pages.dev/uilib/components/autocomplete/demos

## Summary

Remove the global `specificKeys(['Tab'])` restriction so that all non-modifier keys (including arrow keys) flip `data-whatinput` to `"keyboard"`.

## Problem

The global `whatInput.specificKeys(['Tab'])` call in `component-helper.ts` restricted keyboard detection to only the Tab key. This meant arrow keys never set `data-whatinput` to `"keyboard"`, causing the DrawerList focus ring (gated behind `html[data-whatinput='keyboard']`) to not appear when navigating items with arrow keys after a mouse click — affecting Autocomplete, Dropdown, and other DrawerList-based components.

## Changes

- **component-helper.ts**: Change `specificKeys(['Tab'])` → `specificKeys([])` to allow all non-modifier keys
- **Tabs.tsx**: Remove all three `specificKeys` calls and unused `whatInput` import (they were redundantly re-setting the global restriction)
- **MenuRoot.tsx**: Remove `specificKeys` effect and unused imports (no longer needed with the permissive global default)
- **MultiSelection.tsx**: Same as MenuRoot
- **whatInput.test.ts**: Add test verifying all non-modifier keys trigger keyboard detection by default
- **whatInput.e2e.spec.ts**: Add e2e test verifying arrow keys flip `data-whatinput` after mouse click