### PR TITLE
feat(PortalRoot): forward HTML attributes to portal elements

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
@@ -131,3 +131,20 @@ This makes the `DatePicker` render its portal content right before `my-custom-id
   </div>
 </body>
 ```
+
+### Forward HTML attributes to portal content
+
+`PortalRoot.Provider` also forwards any extra HTML attributes to the portal DOM element. Any standard HTML attribute you pass will be applied to every portal element rendered by components inside the provider (such as Dropdown, Autocomplete, DatePicker, Dialog, Drawer, Popover, and Tooltip).
+
+```tsx
+import { PortalRoot, Dropdown, Dialog } from '@dnb/eufemia'
+
+render(
+  <PortalRoot.Provider data-my-need="something">
+    <Dropdown />
+    <Dialog />
+  </PortalRoot.Provider>
+)
+```
+
+In this example, every portal element will receive `data-my-need="something"` for content rendered outside the main React tree.

--- a/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
@@ -47,22 +47,35 @@ export type PortalRootProps = {
 } & SelectorOptions &
   Omit<HTMLProps<HTMLElement>, 'ref' | 'id'>
 
-type PortalRootContextValue = SelectorOptions
+type PortalRootContextValue = SelectorOptions & {
+  portalAttributes?: Record<string, unknown>
+}
 
 const PortalRootContext = createContext<PortalRootContextValue | null>(
   null
 )
 
-export type PortalRootProviderProps = PropsWithChildren<SelectorOptions>
+export type PortalRootProviderProps = PropsWithChildren<
+  SelectorOptions & Omit<HTMLProps<HTMLElement>, 'id' | 'children' | 'ref'>
+>
 
 export function PortalRootProvider(
   props: PortalRootProviderProps
 ): JSX.Element | null {
-  const { id, insideSelector, beforeSelector, children } = props
+  const { id, insideSelector, beforeSelector, children, ...rest } = props
+
+  const hasRest = Object.keys(rest).length > 0
+  const restKey = hasRest ? JSON.stringify(rest) : ''
 
   const value = useMemo(
-    () => ({ id, insideSelector, beforeSelector }),
-    [id, insideSelector, beforeSelector]
+    () => ({
+      id,
+      insideSelector,
+      beforeSelector,
+      ...(hasRest ? { portalAttributes: rest } : undefined),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [id, insideSelector, beforeSelector, restKey]
   )
 
   return <PortalRootContext value={value}>{children}</PortalRootContext>
@@ -154,6 +167,7 @@ function PortalRootInstance(props: PortalRootProps = {}): ReactNode {
           className
         )}
         style={{ ...scopeStyle, ...style }}
+        {...selectorContext?.portalAttributes}
         {...rest}
       >
         {children}

--- a/packages/dnb-eufemia/src/components/portal-root/PortalRootDocs.ts
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRootDocs.ts
@@ -7,7 +7,7 @@ export const PortalRootProperties: PropertiesTableProps = {
     status: 'optional',
   },
   id: {
-    doc: 'The id attribute for the portal root element.',
+    doc: 'The id used for the portal root element. Defaults to `eufemia-portal-root`. If an element with this id already exists in the DOM, it will be reused.',
     type: 'string',
     status: 'optional',
   },
@@ -25,5 +25,10 @@ export const PortalRootProperties: PropertiesTableProps = {
     doc: 'The content that will be placed in a React Portal.',
     type: 'React.ReactNode',
     status: 'required',
+  },
+  '[HTML attributes]': {
+    doc: 'When used on `PortalRoot.Provider`, any extra HTML attributes (e.g. `translate`, `lang`, `dir`, `data-*`) are forwarded to the portal DOM element. Props on `PortalRoot` itself take precedence.',
+    type: 'various',
+    status: 'optional',
   },
 }

--- a/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/__tests__/PortalRoot.test.tsx
@@ -1138,4 +1138,89 @@ describe('PortalRoot theme', () => {
 
     expect(innerDiv).not.toHaveClass('eufemia-theme')
   })
+
+  describe('Provider HTML attributes', () => {
+    it('should forward translate="no" from Provider to portal element', () => {
+      render(
+        <PortalRoot.Provider translate="no">
+          <PortalRoot>
+            <div data-testid="content">Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).toHaveAttribute('translate', 'no')
+    })
+
+    it('should forward data attributes from Provider to portal element', () => {
+      render(
+        <PortalRoot.Provider data-testid="portal-wrapper">
+          <PortalRoot>
+            <div>Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).toHaveAttribute('data-testid', 'portal-wrapper')
+    })
+
+    it('should allow PortalRoot props to override Provider attributes', () => {
+      render(
+        <PortalRoot.Provider translate="no">
+          <PortalRoot translate="yes">
+            <div data-testid="content">Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).toHaveAttribute('translate', 'yes')
+    })
+
+    it('should not set extra attributes when Provider has none', () => {
+      render(
+        <PortalRoot.Provider>
+          <PortalRoot>
+            <div data-testid="content">Content</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalElement = document.getElementById('eufemia-portal-root')
+      const innerDiv = portalElement?.querySelector('.eufemia-portal-root')
+
+      expect(innerDiv).not.toHaveAttribute('translate')
+    })
+
+    it('should forward attributes to multiple portals under one Provider', () => {
+      render(
+        <PortalRoot.Provider translate="no">
+          <PortalRoot id="portal-a">
+            <div>A</div>
+          </PortalRoot>
+          <PortalRoot id="portal-b">
+            <div>B</div>
+          </PortalRoot>
+        </PortalRoot.Provider>
+      )
+
+      const portalA = document
+        .getElementById('portal-a')
+        ?.querySelector('.eufemia-portal-root')
+      const portalB = document
+        .getElementById('portal-b')
+        ?.querySelector('.eufemia-portal-root')
+
+      expect(portalA).toHaveAttribute('translate', 'no')
+      expect(portalB).toHaveAttribute('translate', 'no')
+    })
+  })
 })


### PR DESCRIPTION
Preview: https://feat-portal-root-forward-htm.eufemia-e25.pages.dev/uilib/components/portal-root#forward-html-attributes-to-portal-content
Closes #8374