### PR TITLE
chore: add descriptive comment to empty catch block in ArrayItemArea

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayItemArea.tsx
@@ -173,7 +173,7 @@ function ArrayItemArea(
         localContextRef.current.elementRef.current.parentElement.childNodes
       ).at(index - 1) as HTMLElement
     } catch (e) {
-      //
+      // Gracefully handle missing DOM elements during removal animation
     }
     isRemoving.current = true
     setOpenState(false)


### PR DESCRIPTION
Replace empty catch comment with a meaningful explanation of why the error is intentionally ignored during DOM element lookup for focus management in removal animations.

