### PR TITLE
chore: clarify PaginationInfinity warning about missing IntersectionObserver

### DIFF
--- a/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationInfinity.tsx
@@ -506,7 +506,9 @@ function InteractionMarker({
         }
       })
     } else {
-      warn('Pagination is missing IntersectionObserver supported!')
+      warn(
+        'Pagination: IntersectionObserver is not supported by this browser!'
+      )
     }
 
     isMountedRef.current = true


### PR DESCRIPTION
Change misleading message from 'Pagination is missing IntersectionObserver supported!' to 'Pagination: IntersectionObserver is not supported by this browser!' for clarity.

