### PR TITLE
chore(SkipContent, Popover): add type="button" to native button elements

### DIFF
--- a/packages/dnb-eufemia/src/components/popover/Popover.tsx
+++ b/packages/dnb-eufemia/src/components/popover/Popover.tsx
@@ -661,7 +661,7 @@ export default function Popover(props: PopoverProps) {
   const overlayContent = (
     <>
       {!disableFocusTrap && (
-        <button className="dnb-sr-only" onFocus={close}>
+        <button className="dnb-sr-only" type="button" onFocus={close}>
           {tr.focusTrapTitle}
         </button>
       )}
@@ -687,7 +687,7 @@ export default function Popover(props: PopoverProps) {
       {closeButton}
 
       {!disableFocusTrap && (
-        <button className="dnb-sr-only" onFocus={close}>
+        <button className="dnb-sr-only" type="button" onFocus={close}>
           {tr.focusTrapTitle}
         </button>
       )}

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -854,6 +854,26 @@ describe('Popover', () => {
     })
   })
 
+  it('renders focus trap buttons with type="button"', async () => {
+    renderWithTrigger()
+
+    const trigger = document.querySelector('button[aria-controls]')
+    await userEvent.click(trigger)
+
+    await waitFor(() =>
+      expect(document.querySelector('.dnb-popover')).toBeInTheDocument()
+    )
+
+    const focusTrapButtons = document.querySelectorAll(
+      '.dnb-popover button.dnb-sr-only'
+    )
+
+    expect(focusTrapButtons.length).toBeGreaterThanOrEqual(2)
+    focusTrapButtons.forEach((button) => {
+      expect(button).toHaveAttribute('type', 'button')
+    })
+  })
+
   it('provides default trigger aria attributes', () => {
     const baseTranslation = defaultLocales['nb-NO']
     const customTranslation = {

--- a/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
@@ -131,7 +131,11 @@ const SkipContent = (localProps: SkipContentAllProps) => {
     >
       <>
         {!visible && (
-          <button className="dnb-sr-only" onKeyUp={handleKeyUp}>
+          <button
+            className="dnb-sr-only"
+            type="button"
+            onKeyUp={handleKeyUp}
+          >
             {text || children}
           </button>
         )}

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
@@ -62,6 +62,7 @@ describe('SkipContent', () => {
       .toMatchInlineSnapshot(`
       NamedNodeMap {
         "class": "dnb-sr-only",
+        "type": "button",
       }
     `)
   })


### PR DESCRIPTION
Native <button> elements without type default to "submit", which can cause accidental form submissions when these components are used inside a form. The Eufemia Button component already defaults to type="button", but these raw <button> elements were missing the attribute.

