### PR TITLE
fix(DatePicker): range mode showing same month in both calendar views

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1332,10 +1332,9 @@ describe('DatePicker component', () => {
     expect(
       leftPicker.querySelector('.dnb-date-picker__header__title')
     ).toHaveTextContent('oktober 2024')
-    // Known pre-existing bug: right picker shows oktober instead of november
     expect(
       rightPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('oktober 2024')
+    ).toHaveTextContent('november 2024')
 
     await userEvent.click(leftPrev)
     await userEvent.click(leftPrev)
@@ -1346,7 +1345,7 @@ describe('DatePicker component', () => {
     ).toHaveTextContent('juli 2024')
     expect(
       rightPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('oktober 2024')
+    ).toHaveTextContent('november 2024')
 
     await userEvent.hover(screen.getByLabelText('torsdag 11. juli 2024'))
 
@@ -1355,7 +1354,7 @@ describe('DatePicker component', () => {
     ).toHaveTextContent('juli 2024')
     expect(
       rightPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('oktober 2024')
+    ).toHaveTextContent('november 2024')
 
     await userEvent.click(rightPrev)
     await userEvent.click(rightPrev)
@@ -1365,25 +1364,29 @@ describe('DatePicker component', () => {
     ).toHaveTextContent('juli 2024')
     expect(
       rightPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('august 2024')
+    ).toHaveTextContent('september 2024')
 
-    await userEvent.hover(screen.getByLabelText('tirsdag 20. august 2024'))
-
-    expect(
-      leftPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('juli 2024')
-    expect(
-      rightPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('august 2024')
-
-    await userEvent.click(screen.getByLabelText('tirsdag 20. august 2024'))
+    await userEvent.hover(
+      screen.getByLabelText('fredag 20. september 2024')
+    )
 
     expect(
       leftPicker.querySelector('.dnb-date-picker__header__title')
     ).toHaveTextContent('juli 2024')
     expect(
       rightPicker.querySelector('.dnb-date-picker__header__title')
-    ).toHaveTextContent('august 2024')
+    ).toHaveTextContent('september 2024')
+
+    await userEvent.click(
+      screen.getByLabelText('fredag 20. september 2024')
+    )
+
+    expect(
+      leftPicker.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('juli 2024')
+    expect(
+      rightPicker.querySelector('.dnb-date-picker__header__title')
+    ).toHaveTextContent('september 2024')
   })
 
   it('should not set the month pickers to same month when `startDate` and `endDate` are set to same day in range mode', async () => {

--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useDates.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { convertStringToDate } from '../DatePickerCalc'
-import { addMonths, isSameDay } from 'date-fns'
+import { addMonths, isSameDay, isSameMonth } from 'date-fns'
 import type { DatePickerDateType } from '../DatePickerContext'
 
 export type DatePickerDateProps = {
@@ -155,10 +155,11 @@ function mapDates(
       dateFormat: dateFormat,
     }) ??
     (isRange
-      ? // If startMonth is explicitly provided, use it + 1 month; otherwise fallback to endDate
-        hasExplicitStartMonth
+      ? hasExplicitStartMonth
         ? addMonths(startMonth, 1)
-        : (endDate ?? addMonths(startMonth, 1))
+        : endDate && !isSameMonth(endDate, startMonth)
+          ? endDate
+          : addMonths(startMonth, 1)
       : startMonth)
 
   const minDate = convertStringToDate(dateProps.minDate, {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -3312,7 +3312,7 @@ describe('Field.Date', () => {
       ).toHaveTextContent('oktober 2024')
       expect(
         leftCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('oktober 2024')
+      ).toHaveTextContent('november 2024')
 
       await userEvent.click(rightPrev)
 
@@ -3321,7 +3321,7 @@ describe('Field.Date', () => {
       ).toHaveTextContent('oktober 2024')
       expect(
         leftCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('oktober 2024')
+      ).toHaveTextContent('november 2024')
 
       await userEvent.click(rightNext)
 
@@ -3330,7 +3330,7 @@ describe('Field.Date', () => {
       ).toHaveTextContent('oktober 2024')
       expect(
         leftCalendar.querySelector('.dnb-date-picker__header__title')
-      ).toHaveTextContent('oktober 2024')
+      ).toHaveTextContent('november 2024')
 
       await userEvent.click(leftPrev)
 


### PR DESCRIPTION
When startDate and endDate are in the same month, the right calendar
view incorrectly displayed the same month as the left. It now correctly
shows the next month.

For the following example:
`<DatePicker range startDate="2024-10-01" endDate="2024-10-24" />`

From:
<img width="689" height="582" alt="Screenshot 2026-06-05 at 10 04 04" src="https://github.com/user-attachments/assets/454494c0-3421-4231-81b7-43e8469f9bee" />



To:
<img width="751" height="621" alt="Screenshot 2026-06-05 at 10 04 20" src="https://github.com/user-attachments/assets/f0dc0d8d-a872-4f7b-baab-2c05a6d66669" />
