### PR TITLE
fix: prevent Wizard navigation when required Field.Upload has validateInitially={false}

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/__tests__/Upload.test.tsx
@@ -2193,6 +2193,141 @@ describe('Field.Upload', () => {
         expect(screen.queryByText('fileName.png')).toBeInTheDocument()
       })
     })
+
+    it('should prevent navigation to next step when required Field.Upload has validateInitially={false} and no files', async () => {
+      render(
+        <Form.Handler>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Field.Upload
+                required
+                validateInitially={false}
+                path="/files"
+              />
+              <Wizard.Buttons />
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+              <Wizard.Buttons />
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+
+      // No error should be shown initially because validateInitially={false}
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      // Click next without uploading any files
+      await userEvent.click(nextButton())
+
+      // Should still be on Step 1 — navigation prevented
+      expect(output()).toHaveTextContent('Step 1')
+
+      // Required error should now be visible
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-block__status .dnb-form-status'
+          )
+        ).toHaveTextContent(nbForms.Upload.errorRequired)
+      })
+    })
+
+    it('should allow navigation to next step when required Field.Upload has validateInitially={false} and files are uploaded', async () => {
+      render(
+        <Form.Handler>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Field.Upload
+                required
+                validateInitially={false}
+                path="/files"
+              />
+              <Wizard.Buttons />
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+              <Wizard.Buttons />
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      const element = getRootElement()
+      const file = createMockFile('fileName-1.png', 100, 'image/png')
+
+      fireEvent.drop(element, {
+        dataTransfer: {
+          files: [file],
+        },
+      })
+
+      expect(output()).toHaveTextContent('Step 1')
+
+      await userEvent.click(nextButton())
+
+      // Should navigate to Step 2 since a file was uploaded
+      expect(output()).toHaveTextContent('Step 2')
+    })
+
+    it('should prevent navigation when required comes from schema and validateInitially={false}', async () => {
+      const schema = {
+        type: 'object',
+        required: ['files'],
+        properties: {
+          files: {
+            type: 'array',
+          },
+        },
+      } as const
+
+      render(
+        <Form.Handler schema={schema}>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Field.Upload validateInitially={false} path="/files" />
+              <Wizard.Buttons />
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+              <Wizard.Buttons />
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+
+      // No error initially
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      // Click next without uploading
+      await userEvent.click(nextButton())
+
+      // Should still be on Step 1
+      expect(output()).toHaveTextContent('Step 1')
+
+      // Required error should be shown
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-block__status .dnb-form-status'
+          )
+        ).toHaveTextContent(nbForms.Upload.errorRequired)
+      })
+    })
   })
 
   it('should handle a mix of successful and failed files in fileHandler with async function', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -407,7 +407,8 @@ function WizardContainer(props: WizardContainerProps) {
             // because the form contains errors. Thats why onSubmit will not be called via handleSubmitCall.
             if (
               !hasInvalidStepsState(activeIndexRef.current) &&
-              !hasFieldState?.('pending')
+              !hasFieldState?.('pending') &&
+              !hasFieldState?.('error')
             ) {
               await onSubmit()
             }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
@@ -546,17 +546,25 @@ export default function useFieldError<Value>({
   )
 
   // Will reveal the error as a visible error (hasVisibleError)
-  const revealError = useCallback(() => {
-    // To support "validateInitially={false}" prop
-    if (validateInitially === false && revealErrorRef.current === false) {
-      revealErrorRef.current = undefined
-      return undefined // stop here
-    }
+  const revealError = useCallback(
+    (options?: { force?: boolean }) => {
+      // To support "validateInitially={false}" prop
+      if (
+        validateInitially === false &&
+        revealErrorRef.current === false
+      ) {
+        if (!options?.force) {
+          revealErrorRef.current = undefined
+          return undefined // stop here
+        }
+      }
 
-    const hasError = Boolean(localErrorRef.current)
-    revealErrorRef.current = true
-    setErrorState(hasError)
-  }, [validateInitially, setErrorState])
+      const hasError = Boolean(localErrorRef.current)
+      revealErrorRef.current = true
+      setErrorState(hasError)
+    },
+    [validateInitially, setErrorState]
+  )
 
   const hideError = useCallback(() => {
     if (revealErrorRef.current) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1478,13 +1478,23 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
   // ─── Show / hide errors based on context ─────────────────────────────
 
+  const prevShowAllErrorsRef = useRef(showAllErrors)
+
   useEffect(() => {
+    const showAllErrorsTransitioned =
+      showAllErrors && !prevShowAllErrorsRef.current
+    prevShowAllErrorsRef.current = showAllErrors
+
     if (showAllErrors || showBoundaryErrors) {
       // In case of async validation, we don't want to show existing errors before the validation has been completed
       if (fieldStateRef.current !== 'validating') {
-        // If showError on a surrounding data context was changed and set to true, it is because the user clicked next, submit or
-        // something else that should lead to showing the user all errors.
-        revealError()
+        // When showAllErrors transitions from false to true (e.g., Wizard next button),
+        // force reveal to bypass the validateInitially={false} skip.
+        // We don't force when showAllErrors is already true on mount (e.g., EditContainer),
+        // because validateInitially={false} should still be respected until user interaction.
+        revealError(
+          showAllErrorsTransitioned ? { force: true } : undefined
+        )
       }
     } else if (showBoundaryErrors === false) {
       hideError()


### PR DESCRIPTION
When a required Field.Upload uses validateInitially={false} inside a Wizard, clicking next would incorrectly allow navigation to the next step despite no files being uploaded.

Two changes fix this:

1. WizardContainer: Also check Provider's hasFieldState('error') in the fallback path, so the Wizard respects errors the Provider knows about even when the Wizard's own step tracking hasn't been informed yet.

2. useFieldError/useFieldProps: Add a force option to revealError() so that when showAllErrors transitions from false to true (Wizard submit), the validateInitially={false} one-time skip is bypassed, making the error message visible to the user.

Fixes #4989

