### PR TITLE
fix(DatePicker): clear hide timeout on unmount

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -424,6 +424,13 @@ function DatePicker(externalProps: DatePickerAllProps) {
   const getReturnObject =
     useRef<DatePickerContextValue['getReturnObject']>(undefined)
   const hideTimeout = useRef<NodeJS.Timeout>(undefined)
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(hideTimeout.current)
+    }
+  }, [])
+
   const calendarContainerRef = useRef<HTMLSpanElement>(null)
 
   const translation = useTranslation().DatePicker


### PR DESCRIPTION
To prevent CI flake, clear the timeout on unmount.
