### PR TITLE
chore(GlobalStatus): fix flaky CI test

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -851,17 +851,19 @@ describe('GlobalStatus component', () => {
 
     fireEvent.click(document.querySelector('input#switch'))
 
-    await refresh()
-
-    expect(
-      document.querySelectorAll('.dnb-global-status__message p')[0]
-        .textContent
-    ).toBe("'error-message'")
-    expect(
-      document
-        .querySelectorAll('.dnb-global-status__message__content ul li')[0]
-        .querySelector('a.dnb-anchor').textContent
-    ).toBe("custom anchor text 'my-label'")
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('.dnb-global-status__message p')[0]
+          .textContent
+      ).toBe("'error-message'")
+      expect(
+        document
+          .querySelectorAll(
+            '.dnb-global-status__message__content ul li'
+          )[0]
+          .querySelector('a.dnb-anchor').textContent
+      ).toBe("custom anchor text 'my-label'")
+    })
   })
 
   it('should have a working auto close', async () => {


### PR DESCRIPTION
The "should support component given as labels" test in GlobalStatus uses a fixed 10ms delay (`await refresh()`) before asserting on DOM content. On slower CI runners, the component hasn't rendered yet, causing a `Cannot read properties of undefined` error.

Replaced with `waitFor()` which polls until the assertions pass, eliminating the race condition.