### PR TITLE
fix(Form.SubmitIndicator): ensure correct dots color

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitIndicator/style/dnb-form-submit-indicator.scss
@@ -65,6 +65,8 @@
 
   .dnb-button &__content {
     cursor: inherit;
+
+    --dots-color: currentcolor;
   }
 }
 


### PR DESCRIPTION
Issue:

<img width="134" height="71" alt="Screenshot 2026-06-06 at 09 53 02" src="https://github.com/user-attachments/assets/cc50babb-604a-4fd5-9e62-b814fad8a70c" />
<img width="131" height="68" alt="Screenshot 2026-06-06 at 09 53 06" src="https://github.com/user-attachments/assets/79932979-3bc3-4498-a835-60352ca10e5d" />

Fix:

<img width="135" height="63" alt="Screenshot 2026-06-06 at 09 53 54" src="https://github.com/user-attachments/assets/12579547-c9b8-4e20-80c2-32e814aa854f" />
<img width="137" height="60" alt="Screenshot 2026-06-06 at 09 53 59" src="https://github.com/user-attachments/assets/61532a7a-31cb-43dc-a181-5074b6eccda4" />
