### PR TITLE
chore(Autocomplete): remove orphaned theme file

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/style/themes/ui.ts
@@ -1,6 +1,0 @@
-/**
- * Imports the default theme
- *
- */
-
-import './dnb-autocomplete-theme-ui.scss'


### PR DESCRIPTION
The ui.ts file imported a non-existent dnb-autocomplete-theme-ui.scss file. Since no UI theme SCSS exists, the entire themes directory is removed.

