### PR TITLE
chore(Dialog): remove orphaned theme file

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/dialog/style/themes/ui.ts
@@ -1,6 +1,0 @@
-/**
- * Imports the default theme
- *
- */
-
-import './dnb-dialog-theme-ui.scss'


### PR DESCRIPTION
The ui.ts file imported a non-existent dnb-dialog-theme-ui.scss file. The themes directory is kept as it contains sbanken and carnegie theme files.

