### PR TITLE
chore(Dropdown): remove orphaned theme file

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/components/dropdown/style/themes/ui.ts
@@ -1,6 +1,0 @@
-/**
- * Imports the default theme
- *
- */
-
-import './dnb-dropdown-theme-ui.scss'


### PR DESCRIPTION
The ui.ts file imported a non-existent dnb-dropdown-theme-ui.scss file. The themes directory is kept as it contains the sbanken theme file.

