### PR TITLE
chore(DrawerList): remove orphaned theme file

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/ui.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/themes/ui.ts
@@ -1,6 +1,0 @@
-/**
- * Imports the default theme
- *
- */
-
-import './dnb-drawer-list-theme-ui.scss'


### PR DESCRIPTION
The ui.ts file imported a non-existent dnb-drawer-list-theme-ui.scss file. The themes directory is kept as it contains the sbanken theme file.

