### PR TITLE
chore: remove unused convertWebStyles.js script

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/convertWebStyles.js
+++ b/packages/dnb-eufemia/scripts/tools/convertWebStyles.js
@@ -1,8 +1,0 @@
-/**
- * Prepublish
- *
- *
- */
-
-import makeEveryComponentStyle from '../prebuild/tasks/makeEveryComponentStyle'
-makeEveryComponentStyle({ preventDelete: true })


### PR DESCRIPTION
This script is not referenced in any npm script or imported anywhere. It simply wraps makeEveryComponentStyle which can be called directly if needed.

