### PR TITLE
chore: remove unused default export from structuredClone helper

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/structuredClone.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/structuredClone.ts
@@ -23,4 +23,3 @@ const cloneFunction =
       structuredClonePolyfill
 
 export { cloneFunction as structuredClone }
-export default cloneFunction


### PR DESCRIPTION
All consumers import the named export { structuredClone }. The default export cloneFunction was never imported anywhere.

