### PR TITLE
chore: remove commented-out debug console.log from tests

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5894,7 +5894,6 @@ describe('DatePicker ARIA', () => {
     )
 
     await userEvent.click(getOpenButton())
-    // console.log('sv-SE labels', Array.from(document.querySelectorAll('[aria-label$="2025"]')).map((btn) => btn.getAttribute('aria-label')))
     await userEvent.click(screen.getByLabelText(/onsdag 2\.? april 2025/i))
     await userEvent.click(
       screen.getByLabelText(/lördag 19\.? april 2025/i)

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableTr.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableTr.test.tsx
@@ -355,7 +355,6 @@ describe('TableTr', () => {
 
       elements = document.querySelectorAll('tbody tr')
       expect(elements).toHaveLength(4)
-      // console.log('document.body', document.body.innerHTML)
       expect(Array.from(elements[0].classList)).toContain(
         'dnb-table__tr--odd'
       )


### PR DESCRIPTION
Removes debug console.log statements that were left commented out in TableTr and DatePicker tests.

