### PR TITLE
chore: remove commented-out alternative regex check in component-helper

### DIFF
--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -120,7 +120,6 @@ export const validateDOMAttributes = (
         // we don't want if there are any characters except "a-z", "A-Z" or "-"
         // Removes non-standard DOM attribute names (e.g. containing underscores)
         notOnlyAZOrHyphenRegex.test(i)
-        // (typeof params[i] !== 'string' && /[^a-z-]/i.test(i))
       ) {
         delete params[i]
       }


### PR DESCRIPTION
Removes commented inline regex that was replaced by the notOnlyAZOrHyphenRegex constant.

