### PR TITLE
docs(Form.useSubmit): add Properties tab

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
@@ -7,6 +7,8 @@ tabs:
     key: '/info'
   - title: Demos
     key: '/demos'
+  - title: Properties
+    key: '/properties'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
@@ -18,6 +20,8 @@ breadcrumb:
 
 import Info from 'Docs/uilib/extensions/forms/Form/useSubmit/info'
 import Demos from 'Docs/uilib/extensions/forms/Form/useSubmit/demos'
+import Properties from 'Docs/uilib/extensions/forms/Form/useSubmit/properties'
 
 <Info />
 <Demos />
+<Properties />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
@@ -23,4 +23,3 @@ import Demos from 'Docs/uilib/extensions/forms/Form/useSubmit/demos'
 
 <Info />
 <Demos />
-<Properties />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
@@ -20,7 +20,6 @@ breadcrumb:
 
 import Info from 'Docs/uilib/extensions/forms/Form/useSubmit/info'
 import Demos from 'Docs/uilib/extensions/forms/Form/useSubmit/demos'
-import Properties from 'Docs/uilib/extensions/forms/Form/useSubmit/properties'
 
 <Info />
 <Demos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit/properties.mdx
@@ -1,0 +1,21 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import {
+  UseSubmitParameters,
+  UseSubmitReturnProperties,
+} from '@dnb/eufemia/src/extensions/forms/Form/DataContext/useSubmitDocs'
+
+## Parameters
+
+Properties passed to the `Form.useSubmit` hook.
+
+<PropertiesTable props={UseSubmitParameters} />
+
+## Return Values
+
+Properties and methods returned from the `Form.useSubmit` hook.
+
+<PropertiesTable props={UseSubmitReturnProperties} />


### PR DESCRIPTION
Creates properties.mdx that uses the existing useSubmitDocs.ts to document the hook's parameters and return values.

