### PR TITLE
chore(GlobalStatusProvider): remove commented-out dead conditional

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusProvider.ts
@@ -146,10 +146,6 @@ export class GlobalStatusProviderItem {
     } else {
       this.stack = this.stack.map((cur, i, arr) => {
         if (statusId ? cur.statusId === statusId : i === arr.length - 1) {
-          // if (!statusId) {
-          //   // newProps = { ...newProps }
-          //   delete newProps.statusId
-          // }
           return { ...cur, ...newProps }
         }
 


### PR DESCRIPTION
Removes commented-out code block that was handling an undefined statusId case that is no longer needed.

