### PR TITLE
chore(Accordion): remove commented-out media queries

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
+++ b/packages/dnb-eufemia/src/components/accordion/style/dnb-accordion.scss
@@ -299,13 +299,6 @@
         }
       }
     }
-
-    // NB: This has a negative side effect once it is integrated in a 60rem max-width container
-    // @media screen and (min-width: 80em) {
-    //   &__header {
-    //     width: 44rem;
-    //   }
-    // }
   }
 
   &-group {
@@ -328,13 +321,6 @@
             width: 60%; // 40% / 60%
           }
         }
-
-        // NB: This has a negative side effect once it is integrated in a 60rem max-width container
-        // @media screen and (min-width: 80em) {
-        //   .dnb-accordion__content {
-        //     left: 44rem;
-        //   }
-        // }
       }
     }
   }


### PR DESCRIPTION
Removes two commented-out 80em media query blocks that were disabled due to negative side effects in 60rem max-width containers. These queries were never going to be enabled without redesigning the approach.

