### PR TITLE
chore: remove commented-out small element typography styles

### DIFF
--- a/packages/dnb-eufemia/src/elements/typography/style/dnb-typography.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/dnb-typography.scss
@@ -76,12 +76,6 @@
   font-size: var(--font-size-small);
 }
 
-// // Small: do not set this for h1, like ".dnb-h--xx-large > .dnb-small"
-// .dnb-p > small,
-// .dnb-p > .dnb-small {
-//   line-height: var(--line-height-xx-small--em); // for vertical alignment, we have to have no line-height
-// }
-
 // superscript and subscript typography
 sup,
 sub {


### PR DESCRIPTION
Removes disabled styling rules for .dnb-p > small that were commented out and not being used.

