### PR TITLE
chore: remove commented-out Zod schema code from Section stories

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/stories/Section.stories.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/stories/Section.stories.tsx
@@ -321,38 +321,8 @@ export const SectionLevelZodSchema = () => {
       .refine(...asRequired('LastName.errorRequired')),
   })
 
-  // const formSchema = z.object({
-  //   customer: z.object({
-  //     firstName: z
-  //       .union([
-  //         z.string().min(4, 'StringField.errorMinLength'),
-  //         z.undefined(),
-  //       ])
-  //       .refine((val) => val !== undefined, {
-  //         message: 'FirstName.errorRequired',
-  //       }),
-  //     lastName: z
-  //       .union([
-  //         z.string().min(4, 'StringField.errorMinLength'),
-  //         z.undefined(),
-  //       ])
-  //       .refine((val) => val !== undefined, {
-  //         message: 'LastName.errorRequired',
-  //       }),
-  //   }),
-  // })
-
   return (
-    <Form.Handler
-      onSubmit={(data) => console.log('Submitted:', data)}
-      // schema={formSchema} // Form level schema
-      // defaultData={{
-      //   customer: {
-      //     firstName: 'Aa',
-      //     lastName: 'Bb',
-      //   },
-      // }}
-    >
+    <Form.Handler onSubmit={(data) => console.log('Submitted:', data)}>
       <Flex.Stack>
         <Form.Section
           path="/customer"


### PR DESCRIPTION
Removes ~25 lines of commented-out alternative formSchema implementation that was never going to be used. The section-level schema approach is the one being demonstrated in this story.

