### PR TITLE
chore: remove orphaned dead-code convertWebStyles script

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/convertWebStyles.js
+++ b/packages/dnb-eufemia/scripts/tools/convertWebStyles.js
@@ -1,8 +1,0 @@
-/**
- * Prepublish
- *
- *
- */
-
-import makeEveryComponentStyle from '../prebuild/tasks/makeEveryComponentStyle'
-makeEveryComponentStyle({ preventDelete: true })


### PR DESCRIPTION
The file imports a non-existent module (makeEveryComponentStyle) and is not referenced by any npm script or imported by any other file.

