### PR TITLE
chore(GlobalStatus): reduce CI-only failures from scroll assertion timing

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/GlobalStatus.test.tsx
@@ -459,12 +459,21 @@ describe('GlobalStatus component', () => {
       </>
     )
 
+    Object.defineProperty(
+      document.querySelector('.dnb-global-status__wrapper') as HTMLElement,
+      'scrollIntoView',
+      {
+        configurable: true,
+        value: undefined,
+      }
+    )
+
     // Open
     fireEvent.click(document.querySelector('input#switch'))
 
-    await refresh()
-
-    expect(scrollTo).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledTimes(1)
+    })
     expect(scrollTo).toHaveBeenCalledWith({
       behavior: 'smooth',
       top: 0,
@@ -478,15 +487,15 @@ describe('GlobalStatus component', () => {
 
     // Close
     fireEvent.click(document.querySelector('input#switch'))
-    await refresh()
-
-    expect(scrollTo).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledTimes(1)
+    })
 
     // Open
     fireEvent.click(document.querySelector('input#switch'))
-    await refresh()
-
-    expect(scrollTo).toHaveBeenCalledTimes(2)
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledTimes(2)
+    })
     expect(scrollTo).toHaveBeenCalledWith({
       behavior: 'smooth',
       top: offsetTop,


### PR DESCRIPTION
## Why

A GlobalStatus test intermittently fails in CI because it asserts `window.scrollTo` immediately after a fixed delay, while the component can schedule scrolling asynchronously and may choose a different scroll path depending on environment state.

This change makes the test deterministic by waiting for the side effect and forcing a stable code path in the test setup, so CI results reflect behavior rather than timing variance.

## Risk

Low. This updates test behavior only and does not change runtime component logic.