### PR TITLE
chore: remove unused SCSS mixins

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/style/anchor-mixins.scss
+++ b/packages/dnb-eufemia/src/components/anchor/style/anchor-mixins.scss
@@ -240,17 +240,6 @@
   }
 }
 
-@mixin notInline() {
-  &:where(:not(.dnb-anchor--inline)) {
-    @content;
-  }
-  &:not(.dnb-anchor--inline) {
-    @include whereFallback() {
-      @content;
-    }
-  }
-}
-
 @mixin whereFallback() {
   /* stylelint-disable-next-line scss/operator-no-unspaced */
   @supports not (selector(*:where(*))) {

--- a/packages/dnb-eufemia/src/components/modal/style/modal-mixins.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/modal-mixins.scss
@@ -114,13 +114,6 @@
   }
 }
 
-@mixin modalReducedMotion() {
-  @include utilities.reducedMotion() {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-  }
-}
-
 // Mixin for sticky navigation bar with drop shadow
 // Used by Dialog and Drawer components
 @mixin modalStickyNav() {

--- a/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
+++ b/packages/dnb-eufemia/src/components/table/style/themes/dnb-table-theme-sbanken.scss
@@ -5,15 +5,6 @@
 
 @use '../table-mixins.scss' as table-mixins;
 
-@mixin tableFocusRing() {
-  &::before {
-    top: -0.375rem;
-    bottom: -0.25rem;
-    left: -0.6875rem;
-    right: -0.4375rem;
-  }
-}
-
 .dnb-table {
   text-align: left;
 


### PR DESCRIPTION
Remove three SCSS mixins that are defined but never @include'd anywhere:

- modalReducedMotion in modal-mixins.scss
- notInline in anchor-mixins.scss
- tableFocusRing in dnb-table-theme-sbanken.scss

