### PR TITLE
chore: remove unused blockquote-gfx.svg

### DIFF
--- a/packages/dnb-eufemia/assets/elements/blockquote/blockquote-gfx.svg
+++ b/packages/dnb-eufemia/assets/elements/blockquote/blockquote-gfx.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="none">
-  <path fill="#A5E1D2" stroke="#A5E1D2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M37.5 27.5a9 9 0 1 0 0-18 9 9 0 0 0 0 18z"/>
-  <path stroke="#A5E1D2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M46.5 18.5a21 21 0 0 1-21 21"/>
-  <path fill="#A5E1D2" stroke="#A5E1D2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.5 27.5a9 9 0 1 0 0-18 9 9 0 0 0 0 18z"/>
-  <path stroke="#A5E1D2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M22.5 18.5a21 21 0 0 1-21 21"/>
-</svg>


### PR DESCRIPTION
This SVG asset is never referenced in any source file, SCSS file, or build script.

