### PR TITLE
fix(Field.Expiry): prevent disabled field focus

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/SegmentedField.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/SegmentedField.test.tsx
@@ -175,11 +175,51 @@ describe('SegmentedField', () => {
     it('should support disabled state', () => {
       renderSegmentedField({ disabled: true })
 
+      const hiddenInput: HTMLInputElement = document.querySelector(
+        '.dnb-segmented-field__hidden-input'
+      )
+
+      expect(hiddenInput.tagName).toBe('SPAN')
+
       const sections = getSections()
       sections.forEach((section) => {
         expect(section).toHaveAttribute('aria-disabled', 'true')
         expect(section).toHaveAttribute('contenteditable', 'false')
+        expect(section).not.toHaveAttribute('tabindex')
       })
+    })
+
+    it('should not focus sections when disabled sections are focused', () => {
+      renderSegmentedField({ disabled: true })
+
+      const first = getFirst()
+
+      first.focus()
+
+      expect(document.activeElement).not.toBe(first)
+    })
+
+    it('should not redirect hidden input focus when disabled', () => {
+      renderSegmentedField({ disabled: true })
+
+      const hiddenInput: HTMLInputElement = document.querySelector(
+        '.dnb-segmented-field__hidden-input'
+      )
+
+      hiddenInput.focus()
+
+      expect(document.activeElement).not.toBe(hiddenInput)
+      expect(document.activeElement).not.toBe(getFirst())
+    })
+
+    it('should not focus sections when disabled sections are clicked', () => {
+      renderSegmentedField({ disabled: true })
+
+      const first = getFirst()
+
+      fireEvent.mouseDown(first)
+
+      expect(document.activeElement).not.toBe(first)
     })
 
     it('should render status', () => {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1571,6 +1571,12 @@ html[data-visual-test] .dnb-input__input {
   padding-left: 0.0625rem;
 }
 
+.dnb-segmented-field:not(.dnb-input--disabled) .dnb-input__shell {
+  cursor: text;
+}
+.dnb-segmented-field.dnb-input--disabled .dnb-input__shell {
+  cursor: not-allowed;
+}
 .dnb-segmented-field__delimiter {
   display: flex;
   user-select: none;
@@ -1600,10 +1606,15 @@ html[data-visual-test] .dnb-input__input {
 .dnb-segmented-field .dnb-segmented-field__section {
   overflow: hidden;
   outline: none;
-  cursor: text;
   white-space: nowrap;
   font-family: var(--font-family-monospace);
   border: none;
   background: transparent;
+}
+.dnb-segmented-field .dnb-segmented-field__section:not([aria-disabled=true]) {
+  cursor: text;
+}
+.dnb-segmented-field .dnb-segmented-field__section[aria-disabled=true] {
+  cursor: not-allowed;
 }"
 `;

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedField.tsx
@@ -339,15 +339,23 @@ function SegmentedField<T extends string>(props: SegmentedFieldProps<T>) {
         first contentEditable section, while still exposing the joined value
         as the canonical field string.
       */}
-      <input
-        id={id}
-        className="dnb-segmented-field__hidden-input dnb-sr-only"
-        value={hiddenInputValue}
-        onFocus={focusFirstSection}
-        readOnly
-        tabIndex={-1}
-        aria-hidden
-      />
+      {disabled ? (
+        <span
+          id={id}
+          className="dnb-segmented-field__hidden-input dnb-sr-only"
+          aria-hidden
+        />
+      ) : (
+        <input
+          id={id}
+          className="dnb-segmented-field__hidden-input dnb-sr-only"
+          value={hiddenInputValue}
+          onFocus={focusFirstSection}
+          readOnly
+          tabIndex={-1}
+          aria-hidden
+        />
+      )}
     </>
   )
   const labelElement = label && (

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldSection.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/SegmentedFieldSection.tsx
@@ -510,7 +510,7 @@ export default function SegmentedFieldSection({
          */
         suppressContentEditableWarning
         role={spinButton ? 'spinbutton' : 'textbox'}
-        tabIndex={disabled ? -1 : 0}
+        tabIndex={disabled ? undefined : 0}
         spellCheck={false}
         aria-label={String(label)}
         aria-readonly={disabled}
@@ -525,13 +525,22 @@ export default function SegmentedFieldSection({
         aria-valuetext={
           spinButton ? (hasTypedValue ? value : 'Empty') : undefined
         }
-        onFocus={() => {
+        onFocus={(event) => {
+          if (disabled) {
+            event.currentTarget.blur()
+            return
+          }
+
           clearGroupSelection()
           onGroupFocus()
           selectSection(inputId)
         }}
         onBlur={onGroupBlur}
         onMouseDown={(event) => {
+          if (disabled) {
+            return
+          }
+
           clearGroupSelection()
 
           event.preventDefault()

--- a/packages/dnb-eufemia/src/components/input-masked/style/dnb-input-masked.scss
+++ b/packages/dnb-eufemia/src/components/input-masked/style/dnb-input-masked.scss
@@ -53,6 +53,14 @@
 }
 
 .dnb-segmented-field {
+  &:not(.dnb-input--disabled) .dnb-input__shell {
+    cursor: text;
+  }
+
+  &.dnb-input--disabled .dnb-input__shell {
+    cursor: not-allowed;
+  }
+
   &__delimiter {
     display: flex;
     user-select: none;
@@ -85,11 +93,17 @@
     overflow: hidden;
     outline: none;
 
-    cursor: text;
-
     white-space: nowrap;
     font-family: var(--font-family-monospace);
     border: none;
     background: transparent;
+
+    &:not([aria-disabled='true']) {
+      cursor: text;
+    }
+
+    &[aria-disabled='true'] {
+      cursor: not-allowed;
+    }
   }
 }

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/Pagination.test.tsx
@@ -888,9 +888,13 @@ describe('Infinity scroller', () => {
 
     await waitForComponent()
 
-    const loadButton = document.querySelector(
-      '.dnb-button--secondary'
-    ) as HTMLButtonElement
+    const loadButton = await waitFor(() => {
+      const element = document.querySelector('.dnb-button--secondary')
+
+      expect(element).toBeInTheDocument()
+
+      return element as HTMLButtonElement
+    })
 
     expect(loadButton).toHaveTextContent('Load please')
     expect(loadButton).toHaveClass('dnb-button--icon-position-right')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx
@@ -134,6 +134,38 @@ describe('Field.Expiry', () => {
     expect(year).toHaveAttribute('autocomplete', 'cc-exp-year')
   })
 
+  it('should not focus segmented inputs when disabled inputs are focused or clicked', async () => {
+    render(<Field.Expiry disabled />)
+
+    const month = getMonthInput()
+    const hiddenInput: HTMLInputElement = document.querySelector(
+      '.dnb-segmented-field__hidden-input'
+    )
+    const label = document.querySelector('label[for]')
+
+    expect(month).toHaveAttribute('aria-disabled', 'true')
+    expect(month).not.toHaveAttribute('tabindex')
+    expect(hiddenInput.tagName).toBe('SPAN')
+
+    month.focus()
+
+    expect(document.activeElement).not.toBe(month)
+
+    hiddenInput.focus()
+
+    expect(document.activeElement).not.toBe(hiddenInput)
+    expect(document.activeElement).not.toBe(month)
+
+    await userEvent.click(label)
+
+    expect(document.activeElement).not.toBe(hiddenInput)
+    expect(document.activeElement).not.toBe(month)
+
+    fireEvent.mouseDown(month)
+
+    expect(document.activeElement).not.toBe(month)
+  })
+
   it('should focus and select month input on label click', async () => {
     render(<Field.Expiry label="Expiry" value="1225" />)
 


### PR DESCRIPTION
Disabled expiry fields should not expose a focusable segmented-input target through the hidden label target or direct section focus. This keeps the disabled state consistent with native fields and prevents label clicks from moving focus into the control.

Verified with:
- `yarn workspace @dnb/eufemia test src/components/input-masked/__tests__/SegmentedField.test.tsx src/extensions/forms/Field/Expiry/__tests__/Expiry.test.tsx`

<img width="117" height="81" alt="Screenshot 2026-06-08 at 14 42 08" src="https://github.com/user-attachments/assets/75a434e3-f167-4d0d-924f-c6582fb9c307" />

vs

<img width="177" height="99" alt="Screenshot 2026-06-08 at 14 42 14" src="https://github.com/user-attachments/assets/1f8758b6-7480-4ef7-8d4d-fd755e380d72" />

