### PR TITLE
chore: remove unused CSS custom properties

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1032,7 +1032,6 @@ button.dnb-button::-moz-focus-inner {
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  --color-transparent: transparent;
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -1032,7 +1032,6 @@ button.dnb-button::-moz-focus-inner {
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  --color-transparent: transparent;
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;

--- a/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/section/__tests__/__snapshots__/Section.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`Section scss > has to match style dependencies css 1`] = `
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  --color-transparent: transparent;
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;

--- a/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
+++ b/packages/dnb-eufemia/src/components/section/style/dnb-section.scss
@@ -33,7 +33,6 @@
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  --color-transparent: transparent;
   // reset to prevent inheriting from parent
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -1032,7 +1032,6 @@ button.dnb-button::-moz-focus-inner {
   --left: -100vw;
   --width: 100vw;
   --height: 100%;
-  --color-transparent: transparent;
   --rounded-corner--small: 0;
   --rounded-corner--medium: 0;
   --rounded-corner--large: 0;

--- a/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -212,7 +212,6 @@ button .dnb-form-status__text {
   --switch-button-size-on--large: 1.625rem;
   --switch-width--large: 3.25rem;
   --switch-height--large: 2rem;
-  --switch-border-width--medium: 0.0625rem;
   --switch-border-width--large: 0.125rem;
   display: inline-flex;
   flex-direction: column;

--- a/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
@@ -14,7 +14,6 @@
   --switch-button-size-on--large: 1.625rem;
   --switch-width--large: 3.25rem;
   --switch-height--large: 2rem;
-  --switch-border-width--medium: 0.0625rem;
   --switch-border-width--large: 0.125rem;
 
   display: inline-flex;

--- a/packages/dnb-eufemia/src/elements/typography/style/dnb-typography.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/dnb-typography.scss
@@ -8,8 +8,6 @@
 @use './typography-mixins.scss';
 
 @include typography-mixins.typographySelectors() {
-  --typography-h-default-font-weight: var(--font-weight-medium);
-
   // Heading xx-large
   --typography-h-xx-large-font-size: var(--font-size-xx-large);
   --typography-h-xx-large-line-height: var(--line-height-xx-large);

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/dnb-number.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/style/dnb-number.scss
@@ -1,7 +1,6 @@
 @use '../../../../../style/core/utilities.scss' as utilities;
 
 .dnb-forms-field-number {
-  --number-control-button-border-width--focus: 0.125rem;
   --number-control-button-width--small: 2rem;
   --number-control-button-width--medium: 2.5rem;
   --number-control-button-width--large: 3rem;

--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -113,7 +113,6 @@ exports[`PaymentCard scss > has to match style dependencies css 1`] = `
    * Define custom CSS variables used throughout the PaymentCard component.
    * These variables allow for reusable colors, border-radius, and overlay background transitions.
    */
-  --color-dark-cyan: #003b47;
   --dnb-payment-bg-default: var(--color-sea-green);
   --dnb-payment-bg-pluss: var(--color-ocean-green);
   --dnb-payment-bg-white: var(--color-white);

--- a/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
+++ b/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
@@ -11,7 +11,6 @@
    * Define custom CSS variables used throughout the PaymentCard component.
    * These variables allow for reusable colors, border-radius, and overlay background transitions.
    */
-  --color-dark-cyan: #003b47;
   --dnb-payment-bg-default: var(--color-sea-green);
   --dnb-payment-bg-pluss: var(--color-ocean-green);
   --dnb-payment-bg-white: var(--color-white);

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`DrawerList scss > has to match style dependencies css 1`] = `
   --drawer-list-option-border-width: 0.25rem;
   --drawer-list-option-gap: 0.5rem;
   --drawer-list-option-divider: 0.0625rem;
-  --drawer-list-padding-horizontal--default: 1rem;
   --drawer-list-padding-horizontal--large: 1.25rem;
   --drawer-list-height--small: 1.5rem;
   --drawer-list-height--default: 2rem;
@@ -31,12 +30,6 @@ exports[`DrawerList scss > has to match style dependencies css 1`] = `
   );
   --drawer-list-list-background: var(--token-color-background-neutral);
   --drawer-list-list-line-height: var(--line-height-basis);
-  --drawer-list-option-disabled-background: var(
-    --token-color-background-neutral
-  );
-  --drawer-list-option-disabled-color: var(
-    --token-color-text-action-disabled
-  );
   --drawer-list-group-title-color: var(--token-color-text-neutral);
   --drawer-list-group-title-bg: var(
     --token-color-background-neutral-alternative
@@ -587,7 +580,6 @@ exports[`DrawerList scss > have to match default theme snapshot 1`] = `
   --drawer-list-option-border-width: 0.25rem;
   --drawer-list-option-gap: 0.5rem;
   --drawer-list-option-divider: 0.0625rem;
-  --drawer-list-padding-horizontal--default: 1rem;
   --drawer-list-padding-horizontal--large: 1.25rem;
   --drawer-list-height--small: 1.5rem;
   --drawer-list-height--default: 2rem;
@@ -598,12 +590,6 @@ exports[`DrawerList scss > have to match default theme snapshot 1`] = `
   );
   --drawer-list-list-background: var(--token-color-background-neutral);
   --drawer-list-list-line-height: var(--line-height-basis);
-  --drawer-list-option-disabled-background: var(
-    --token-color-background-neutral
-  );
-  --drawer-list-option-disabled-color: var(
-    --token-color-text-action-disabled
-  );
   --drawer-list-group-title-color: var(--token-color-text-neutral);
   --drawer-list-group-title-bg: var(
     --token-color-background-neutral-alternative

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -51,7 +51,6 @@
   --drawer-list-option-divider: 0.0625rem;
 
   // Template
-  --drawer-list-padding-horizontal--default: 1rem;
   --drawer-list-padding-horizontal--large: 1.25rem;
   --drawer-list-height--small: 1.5rem;
   --drawer-list-height--default: 2rem;
@@ -64,13 +63,6 @@
   );
   --drawer-list-list-background: var(--token-color-background-neutral);
   --drawer-list-list-line-height: var(--line-height-basis);
-  // Disabled option
-  --drawer-list-option-disabled-background: var(
-    --token-color-background-neutral
-  );
-  --drawer-list-option-disabled-color: var(
-    --token-color-text-action-disabled
-  );
   // Group
   --drawer-list-group-title-color: var(--token-color-text-neutral);
   --drawer-list-group-title-bg: var(

--- a/packages/dnb-eufemia/src/style/__tests__/__snapshots__/Elements.test.ts.snap
+++ b/packages/dnb-eufemia/src/style/__tests__/__snapshots__/Elements.test.ts.snap
@@ -697,7 +697,6 @@ del .dnb-code {
  *
  */
 .dnb-lead, .dnb-h--xx-large, .dnb-h--x-large, .dnb-h--large, .dnb-h--medium, .dnb-h--basis, .dnb-h--small, .dnb-h--x-small, .dnb-core-style .dnb-lead, .dnb-core-style .dnb-h--xx-large, .dnb-core-style .dnb-h--x-large, .dnb-core-style .dnb-h--large, .dnb-core-style .dnb-h--medium, .dnb-core-style .dnb-h--basis, .dnb-core-style .dnb-h--small, .dnb-core-style .dnb-h--x-small, h1, h2, h3, h4, h5, h6, p, b, small, strong, .dnb-p, .dnb-small, .dnb-table, sub, sup {
-  --typography-h-default-font-weight: var(--font-weight-medium);
   --typography-h-xx-large-font-size: var(--font-size-xx-large);
   --typography-h-xx-large-line-height: var(--line-height-xx-large);
   --typography-h-xx-large-small-font-size: var(--font-size-x-large);

--- a/packages/dnb-eufemia/src/style/core/z-index.scss
+++ b/packages/dnb-eufemia/src/style/core/z-index.scss
@@ -14,7 +14,6 @@
 
 :root {
   --z-index-section: 1;
-  --z-index-dropdown: 100;
   --z-index-popover: 1000;
   --z-index-tooltip: 1100;
   --z-index-modal: 3000;

--- a/packages/dnb-eufemia/src/style/core/z-index.scss
+++ b/packages/dnb-eufemia/src/style/core/z-index.scss
@@ -14,6 +14,7 @@
 
 :root {
   --z-index-section: 1;
+  --z-index-dropdown: 100;
   --z-index-popover: 1000;
   --z-index-tooltip: 1100;
   --z-index-modal: 3000;


### PR DESCRIPTION
Remove CSS custom properties that are defined but never consumed via var() anywhere in the codebase:

- --z-index-dropdown (z-index.scss)
- --switch-border-width--medium (dnb-switch.scss)
- --typography-h-default-font-weight (dnb-typography.scss)
- --drawer-list-padding-horizontal--default (dnb-drawer-list.scss)
- --drawer-list-option-disabled-background (dnb-drawer-list.scss)
- --drawer-list-option-disabled-color (dnb-drawer-list.scss)
- --number-control-button-border-width--focus (dnb-number.scss)
- --color-dark-cyan (dnb-payment-card.scss)
- --color-transparent (dnb-section.scss)

