### PR TITLE
chore(DrawerList): respect dropdown z-index variable

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -438,7 +438,7 @@ html[data-whatinput=keyboard] .dnb-drawer-list__option--focus {
   right: -0.5rem;
 }
 .dnb-drawer-list--open .dnb-drawer-list__list {
-  z-index: 100;
+  z-index: var(--z-index-dropdown);
   display: flex;
   flex-direction: column;
 }
@@ -1005,7 +1005,7 @@ html[data-whatinput=keyboard] .dnb-drawer-list__option--focus {
   right: -0.5rem;
 }
 .dnb-drawer-list--open .dnb-drawer-list__list {
-  z-index: 100;
+  z-index: var(--z-index-dropdown);
   display: flex;
   flex-direction: column;
 }

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -6,7 +6,7 @@
 @use '../../../style/core/utilities.scss' as utilities;
 
 @mixin openDrawerList($type: 'slide') {
-  z-index: 100; // make sure we are over e.g. switch
+  z-index: var(--z-index-dropdown); // make sure we are over e.g. switch
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
## Why

`--z-index-dropdown` is documented as the shared z-index token for inline dropdowns and drawer lists. Wiring DrawerList to the token keeps the public styling surface aligned with the implementation.

⚠️ Not sure about using "drop-down" for "drawer-list" purpose. 🤔