### PR TITLE
chore(Form.Appearance): clarify size example typing

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Appearance/Examples.tsx
@@ -1,14 +1,20 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Form, Field } from '@dnb/eufemia/src/extensions/forms'
 import { Flex } from '@dnb/eufemia/src'
+import type { FormAppearanceProps } from '@dnb/eufemia/src/extensions/forms/Form/Appearance'
 
 export const Size = () => {
   return (
     <ComponentBox data-visual-test="form-appearance-size">
       {() => {
+        type AppearanceData = {
+          size: 'default' | NonNullable<FormAppearanceProps['size']>
+        }
         const Appearance = () => {
-          const { data } = Form.useData('appearance', { size: 'medium' })
-          const size: any = data.size
+          const { data } = Form.useData<AppearanceData>('appearance', {
+            size: 'medium',
+          })
+          const size = data.size === 'default' ? undefined : data.size
           return (
             <Form.Appearance size={size}>
               <Form.Handler id="appearance">


### PR DESCRIPTION
Tightens the Form.Appearance size example so the documented default option maps cleanly to the component API. This keeps the example type-safe while preserving the intended runtime behavior.