### PR TITLE
chore(Portal): format code in search results

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -21,6 +21,7 @@ import {
   applyPageFocus,
   isModifiedClickEvent,
 } from '@dnb/eufemia/src/shared/helpers'
+import { formatSearchResultMarkdown } from './SearchBarMarkdown'
 
 export const SearchBarInput = () => {
   const searchIndex = useRef(null)
@@ -156,10 +157,10 @@ const makeHitsHumanFriendly = ({ hits, setHidden }) => {
         onMouseDown={(event) => event.stopPropagation()}
         onClick={handleTitleClick}
       >
-        {title}
+        {formatSearchResultMarkdown(title)}
       </Anchor>,
-      description,
-      search,
+      formatSearchResultMarkdown(description),
+      formatSearchResultMarkdown(search),
     ].filter(Boolean)
 
     hit.headings?.forEach(({ value, slug: hash }, i) => {
@@ -189,7 +190,7 @@ const makeHitsHumanFriendly = ({ hits, setHidden }) => {
             onMouseDown={(event) => event.stopPropagation()}
             onClick={handleHeadingClick}
           >
-            {value}
+            {formatSearchResultMarkdown(value)}
           </Anchor>
         )
       }

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBarMarkdown.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBarMarkdown.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react'
+import { Code } from '@dnb/eufemia/src'
+
+export function formatSearchResultMarkdown(
+  value: string | null | undefined
+): ReactNode {
+  if (!value?.includes('`')) {
+    return value
+  }
+
+  const parts: ReactNode[] = []
+  let index = 0
+
+  while (index < value.length) {
+    const openingIndex = value.indexOf('`', index)
+
+    if (openingIndex === -1) {
+      parts.push(value.slice(index))
+      break
+    }
+
+    const tickCount = countBackticks(value, openingIndex)
+    const contentStart = openingIndex + tickCount
+    const closingIndex = findClosingBackticks(
+      value,
+      contentStart,
+      tickCount
+    )
+
+    if (closingIndex === -1) {
+      parts.push(value.slice(index))
+      break
+    }
+
+    if (openingIndex > index) {
+      parts.push(value.slice(index, openingIndex))
+    }
+
+    parts.push(
+      <Code key={`code-${openingIndex}`}>
+        {normalizeCodeSpan(value.slice(contentStart, closingIndex))}
+      </Code>
+    )
+
+    index = closingIndex + tickCount
+  }
+
+  return parts.some((part) => typeof part !== 'string') ? parts : value
+}
+
+function countBackticks(value: string, startIndex: number) {
+  let count = 0
+
+  while (value[startIndex + count] === '`') {
+    count++
+  }
+
+  return count
+}
+
+function findClosingBackticks(
+  value: string,
+  startIndex: number,
+  tickCount: number
+) {
+  let index = startIndex
+
+  while (index < value.length) {
+    const nextIndex = value.indexOf('`', index)
+
+    if (nextIndex === -1) {
+      return -1
+    }
+
+    if (countBackticks(value, nextIndex) === tickCount) {
+      return nextIndex
+    }
+
+    index = nextIndex + 1
+  }
+
+  return -1
+}
+
+function normalizeCodeSpan(value: string) {
+  if (
+    value.length > 2 &&
+    value.startsWith(' ') &&
+    value.endsWith(' ') &&
+    value.trim().length > 0
+  ) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -90,4 +90,32 @@ describe('SearchBar', () => {
     expect(highlight).not.toBeNull()
     expect(highlight?.textContent).toBe('--z-index')
   })
+
+  it('keeps inline code highlighting inside linked search results', () => {
+    const { container } = render(
+      <Autocomplete
+        data={[
+          <a key="result" href="/components/card">
+            {formatSearchResultMarkdown('Use `Card`')}
+          </a>,
+        ]}
+        open
+        inputValue="Ca"
+        id="portal-search-link-test"
+        disableFilter
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const link = container.querySelector('a')
+    const code = link?.querySelector('code')
+    const highlight = code?.querySelector(
+      '.dnb-drawer-list__option__item--highlight'
+    )
+
+    expect(link).not.toBeNull()
+    expect(code?.textContent).toBe('Card')
+    expect(highlight?.textContent).toBe('Ca')
+  })
 })

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeAll, describe, it, expect, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { Autocomplete } from '@dnb/eufemia/src/components'
+import { formatSearchResultMarkdown } from '../SearchBarMarkdown'
+
+type CustomResizeTo = (opts: { width?: number; height?: number }) => void
+
+beforeAll(() => {
+  ;(window as unknown as { resizeTo: CustomResizeTo }).resizeTo =
+    function resizeTo({
+      width = window.innerWidth,
+      height = window.innerHeight,
+    }) {
+      Object.assign(window, {
+        innerWidth: width,
+        innerHeight: height,
+      })
+
+      vi.spyOn(
+        document.documentElement,
+        'clientWidth',
+        'get'
+      ).mockImplementation(() => width)
+      vi.spyOn(
+        document.documentElement,
+        'clientHeight',
+        'get'
+      ).mockImplementation(() => height)
+    }
+  ;(window.resizeTo as unknown as CustomResizeTo)({
+    height: window.innerHeight,
+  })
+})
+
+afterEach(cleanup)
+
+describe('SearchBar', () => {
+  it('formats inline markdown code in search results', () => {
+    const { container } = render(
+      <>{formatSearchResultMarkdown('Use `--z-index-dropdown`')}</>
+    )
+
+    const code = container.querySelector('code')
+
+    expect(container.textContent).toBe('Use --z-index-dropdown')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toBe('--z-index-dropdown')
+  })
+
+  it('formats inline markdown code wrapped in double backticks', () => {
+    const { container } = render(
+      <>{formatSearchResultMarkdown('Use ``--z-index-dropdown``')}</>
+    )
+
+    const code = container.querySelector('code')
+
+    expect(container.textContent).toBe('Use --z-index-dropdown')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toBe('--z-index-dropdown')
+  })
+
+  it('keeps unmatched backticks as plain text', () => {
+    const { container } = render(
+      <>{formatSearchResultMarkdown('Use `--z-index-dropdown')}</>
+    )
+
+    expect(container.textContent).toBe('Use `--z-index-dropdown')
+    expect(container.querySelector('code')).toBeNull()
+  })
+
+  it('keeps Autocomplete highlighting inside inline code', () => {
+    const { container } = render(
+      <Autocomplete
+        data={[formatSearchResultMarkdown('Use `--z-index-dropdown`')]}
+        open
+        inputValue="--z-index"
+        id="portal-search-test"
+        disableFilter
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const code = container.querySelector('code')
+    const highlight = code?.querySelector(
+      '.dnb-drawer-list__option__item--highlight'
+    )
+
+    expect(code).not.toBeNull()
+    expect(highlight).not.toBeNull()
+    expect(highlight?.textContent).toBe('--z-index')
+  })
+})

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -20,7 +20,6 @@ import type {
   KeyboardEvent,
   MouseEvent,
   MouseEventHandler,
-  ReactElement,
   ReactNode,
   RefObject,
   SyntheticEvent,
@@ -49,7 +48,6 @@ import {
   dispatchCustomElementEvent,
   getStatusState,
   combineDescribedBy,
-  convertJsxToString,
   escapeRegexChars,
   getClosestParent,
 } from '../../shared/component-helper'
@@ -1250,164 +1248,153 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
             return cacheMemoryRef.current[cacheHash] as ReactNode
           }
 
-          const isComponent =
-            typeof children !== 'string' && isValidElement(children)
+          const highlightText = (
+            text: string,
+            keyPart: string
+          ): ReactNode[] | string => {
+            let segment = text
 
-          let childArray: Array<ReactNode>
-          if (
-            isComponent &&
-            Array.isArray(
-              (
-                children as ReactElement<{
-                  children?: ReactNode[]
-                }>
-              ).props?.children
-            )
-          ) {
-            childArray = (
-              children as ReactElement<{
-                children: ReactNode[]
-              }>
-            ).props.children
-          } else if (!Array.isArray(children)) {
-            childArray = [children]
-          } else {
-            childArray = children
-          }
+            searchWords.forEach((word, wordIndex) => {
+              if (segment) {
+                word = escapeRegexChars(word)
 
-          const segments = childArray.map((originalChild) => ({
-            originalChild,
-            segment: convertJsxToString(originalChild, ' '),
-          }))
-
-          const processed = segments.map(
-            ({ originalChild, segment }, idx) => {
-              searchWords.forEach((word, wordIndex) => {
-                if (segment) {
-                  word = escapeRegexChars(word)
-
-                  if (snParam) {
-                    const cleanedWord = word.replace(
-                      // @ts-expect-error Unicode property escapes are supported at runtime here
-                      /[^\p{L}\p{N}]+/gu,
-                      ''
-                    )
-                    if (cleanedWord) {
-                      const escapedWord = escapeRegexChars(cleanedWord)
-                      segment = segment.replace(
-                        new RegExp(`(${escapedWord})`, 'gi'),
-                        (match) => {
-                          if (match.includes(strS)) {
-                            return match
-                          }
-                          return `${strS}${match}${strE}`
+                if (snParam) {
+                  const cleanedWord = word.replace(
+                    // @ts-expect-error Unicode property escapes are supported at runtime here
+                    /[^\p{L}\p{N}]+/gu,
+                    ''
+                  )
+                  if (cleanedWord) {
+                    const escapedWord = escapeRegexChars(cleanedWord)
+                    segment = segment.replace(
+                      new RegExp(`(${escapedWord})`, 'gi'),
+                      (match) => {
+                        if (match.includes(strS)) {
+                          return match
                         }
-                      )
-                    }
+                        return `${strS}${match}${strE}`
+                      }
+                    )
+                  }
+                } else {
+                  if (wordIndex >= inWordIndex) {
+                    segment = segment.replace(
+                      new RegExp(`(${word})`, 'gi'),
+                      `${strS}$1${strE}`
+                    )
                   } else {
-                    if (wordIndex >= inWordIndex) {
-                      segment = segment.replace(
-                        new RegExp(`(${word})`, 'gi'),
-                        `${strS}$1${strE}`
-                      )
-                    } else {
-                      segment = segment.replace(
-                        new RegExp(
-                          `(${getWordBoundary(wordIndex)})(${word})`,
-                          'gi'
-                        ),
-                        `$1${strS}$2${strE}`
-                      )
-                    }
+                    segment = segment.replace(
+                      new RegExp(
+                        `(${getWordBoundary(wordIndex)})(${word})`,
+                        'gi'
+                      ),
+                      `$1${strS}$2${strE}`
+                    )
                   }
                 }
+              }
+            })
+
+            if (segment.includes(strS)) {
+              const startRepeatRegex = new RegExp(`(${strS})+`, 'g')
+              const endRepeatRegex = new RegExp(`(${strE})+`, 'g')
+              const adjacentRegex = new RegExp(`(${strE}${strS})`, 'g')
+              const splitRegex = new RegExp(`(${strS}|${strE})`, 'g')
+
+              const normalized = segment
+                .replace(startRepeatRegex, strS)
+                .replace(endRepeatRegex, strE)
+                .replace(adjacentRegex, '')
+
+              const tokens = normalized.split(splitRegex).filter(Boolean)
+
+              let isHighlighted = false
+              let highlightIndex = 0
+              const parts = tokens.map((token) => {
+                if (token === strS) {
+                  isHighlighted = true
+                  return null
+                }
+                if (token === strE) {
+                  isHighlighted = false
+                  return null
+                }
+
+                if (isHighlighted) {
+                  const key = `highlight-${cacheHash}-${keyPart}-${highlightIndex++}`
+                  return (
+                    <span
+                      key={key}
+                      className="dnb-drawer-list__option__item--highlight"
+                    >
+                      {token}
+                    </span>
+                  )
+                }
+
+                return token
               })
 
-              let result: ReactNode = segment
-
-              if (segment.includes(strS)) {
-                const startRepeatRegex = new RegExp(`(${strS})+`, 'g')
-                const endRepeatRegex = new RegExp(`(${strE})+`, 'g')
-                const adjacentRegex = new RegExp(`(${strE}${strS})`, 'g')
-                const splitRegex = new RegExp(`(${strS}|${strE})`, 'g')
-
-                const normalized = segment
-                  .replace(startRepeatRegex, strS)
-                  .replace(endRepeatRegex, strE)
-                  .replace(adjacentRegex, '')
-
-                const tokens = normalized.split(splitRegex).filter(Boolean)
-
-                let isHighlighted = false
-                let highlightIndex = 0
-                const parts = tokens.map((token) => {
-                  if (token === strS) {
-                    isHighlighted = true
-                    return null
-                  }
-                  if (token === strE) {
-                    isHighlighted = false
-                    return null
-                  }
-
-                  if (isHighlighted) {
-                    const key = `highlight-${cacheHash}-${idx}-${highlightIndex++}`
-                    return (
-                      <span
-                        key={key}
-                        className="dnb-drawer-list__option__item--highlight"
-                      >
-                        {token}
-                      </span>
-                    )
-                  }
-
-                  return token
-                })
-
-                result = <span key={cacheHash + idx}>{parts}</span>
-              } else {
-                result = <span key={cacheHash + idx}>{segment}</span>
-              }
-
-              if (isComponent) {
-                const element = originalChild as ReactElement<{
-                  children?: ReactNode | ReactNode[]
-                }>
-                if (Array.isArray(element?.props?.children)) {
-                  result = element.props.children.map(
-                    (Comp: ReactNode) => {
-                      const compEl = Comp as ReactElement<{
-                        children?: ReactNode
-                      }>
-                      return Comp === originalChild ||
-                        (compEl.props &&
-                          compEl.props.children === originalChild)
-                        ? result
-                        : Comp
-                    }
-                  )
-                } else if (typeof originalChild === 'string') {
-                  result = originalChild
-                }
-
-                if (
-                  isValidElement<Record<string, unknown>>(originalChild)
-                ) {
-                  result = createElement(
-                    originalChild.type as ComponentType<any>,
-                    {
-                      ...originalChild.props,
-                      key: 'clone' + cacheHash + idx,
-                    },
-                    result
-                  )
-                }
-              }
-
-              return result
+              return parts
             }
-          )
+
+            return segment
+          }
+
+          const renderText = (
+            text: string,
+            keyPart: string,
+            wrapInSpan: boolean
+          ) => {
+            const result = highlightText(text, keyPart)
+
+            if (wrapInSpan) {
+              return <span key={cacheHash + keyPart}>{result}</span>
+            }
+
+            return result
+          }
+
+          const renderNode = (
+            node: ReactNode,
+            keyPart: string,
+            wrapText = false
+          ): ReactNode => {
+            if (Array.isArray(node)) {
+              return node.map((child, idx) =>
+                renderNode(child, `${keyPart}-${idx}`)
+              )
+            }
+
+            if (typeof node === 'string' || typeof node === 'number') {
+              return renderText(String(node), keyPart, wrapText)
+            }
+
+            if (isValidElement<{ children?: ReactNode }>(node)) {
+              const child = node.props.children
+
+              if (typeof child === 'undefined') {
+                return node
+              }
+
+              return createElement(
+                node.type as ComponentType<any>,
+                {
+                  ...node.props,
+                  key: node.key ?? 'clone' + cacheHash + keyPart,
+                },
+                renderNode(child, keyPart)
+              )
+            }
+
+            return node
+          }
+
+          const processed = Array.isArray(children)
+            ? children.map((child, idx) =>
+                renderNode(child, String(idx), true)
+              )
+            : renderNode(children, '0', true)
 
           return (cacheMemoryRef.current[cacheHash] = processed)
         }

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -107,6 +107,33 @@ describe('Autocomplete component', () => {
     expect(option.innerHTML).toContain('&lt;/em&gt;')
   })
 
+  it('keeps highlighting inside nested components', () => {
+    render(
+      <Autocomplete
+        data={[
+          <a key="item" href="/styling">
+            Use <code>Card</code>
+          </a>,
+        ]}
+        open
+        inputValue="Ca"
+        disableFilter
+        {...mockProps}
+      />
+    )
+
+    const option = document.querySelector('li.dnb-drawer-list__option')
+    const link = option?.querySelector('a')
+    const code = link?.querySelector('code')
+    const highlight = code?.querySelector(
+      '.dnb-drawer-list__option__item--highlight'
+    )
+
+    expect(link).toBeInTheDocument()
+    expect(code).toHaveTextContent('Card')
+    expect(highlight).toHaveTextContent('Ca')
+  })
+
   it('has correct attributes on input', () => {
     render(<Autocomplete data={mockData} open {...mockProps} />)
 


### PR DESCRIPTION
Relies on #8500

Search results can include markdown-style inline code from docs content. Formatting those spans in the result list makes token-heavy results easier to scan while keeping the existing Autocomplete highlighting behavior intact.

Before:
<img width="420" height="293" alt="Screenshot 2026-06-08 at 20 25 45" src="https://github.com/user-attachments/assets/3065332b-b715-42e8-ae14-bf935c0ebe4c" />


After:
<img width="403" height="173" alt="Screenshot 2026-06-08 at 21 58 42" src="https://github.com/user-attachments/assets/5485fa89-5e1c-4e71-85a5-4cf34c34b1cd" />

