### PR TITLE
chore(Portal): restore hash scrolling after route changes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started.mdx
@@ -16,7 +16,7 @@ import UpdateChangeLogs from './getting-started/update-change-logs'
 # Getting started
 
 You are now ready to get started. Here you will find a step-by-step guide to making changes in the Eufemia repo.
-If you are new to the repository, first check out [what you should know before getting started](/contribute/first-contribution#what-should-i-know-before-getting-started).
+If you are new to the repository, first check out [how to report an issue or suggest a new feature](/contribute/first-contribution#how-to-report-an-issue-or-suggest-a-new-feature).
 
 <Toc />
 

--- a/packages/dnb-design-system-portal/src/e2e/pageScroll.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageScroll.spec.ts
@@ -61,4 +61,29 @@ test.describe('Page Scroll', () => {
     })
     expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
   })
+
+  test('should scroll to hash element after route change', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/contribute/first-contribution#how-to-report-an-issue-or-suggest-a-new-feature'
+    )
+
+    await expect(page).toHaveURL(
+      /\/contribute\/first-contribution\/?#how-to-report-an-issue-or-suggest-a-new-feature$/
+    )
+
+    const target = page.locator(
+      '#how-to-report-an-issue-or-suggest-a-new-feature'
+    )
+    await expect(target).toBeAttached()
+
+    await expect
+      .poll(async () => {
+        return target.evaluate((element) => {
+          return element.getBoundingClientRect().top
+        })
+      })
+      .toBeLessThan(300)
+  })
 })

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -129,7 +129,11 @@ function Layout(props: LayoutProps) {
     setPageFocusElement('.dnb-app-content h1:nth-of-type(1)', 'content')
 
     scrollToAnimation()
-  }, [])
+
+    // Keep pathname and hash as dependencies because Layout is not
+    // remounted on SPA route changes, and hash targets may only exist
+    // after the new page content has mounted.
+  }, [location.hash, location.pathname])
 
   const skipToContentHandler = (event) => {
     // because we want to avoid that the hash get's set (#dnb-app-content)


### PR DESCRIPTION
## Summary

Portal hash links can miss their target after client-side route changes because the layout stays mounted while the new page content is rendered. This reruns the hash scroll behavior when the pathname or hash changes so route-change anchors scroll after the target content exists.
