### PR TITLE
chore(FormElementProps): add missing skeleton type

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
@@ -61,6 +61,7 @@ describe('filterValidProps', () => {
     const props: Props = {
       labelDirection: 'horizontal',
       vertical: true,
+      skeleton: true,
       foo: 'test',
       bar: false,
       fizz: 123,
@@ -71,6 +72,7 @@ describe('filterValidProps', () => {
     expect(elementProps).toEqual({
       labelDirection: 'horizontal',
       vertical: true,
+      skeleton: true,
     })
   })
 

--- a/packages/dnb-eufemia/src/shared/helpers/filterValidProps.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/filterValidProps.ts
@@ -52,6 +52,7 @@ export function prepareFormElementContext<Props>(
   return props
 }
 export type FormElementProps = {
+  skeleton?: boolean
   disabled?: boolean
   vertical?: boolean
   labelDirection?: 'vertical' | 'horizontal'


### PR DESCRIPTION
I think the type was only missing, as skeleton was already listed under `validFormElementProps`.

https://eufemia.dnb.no/uilib/components/skeleton/demos#skeleton-using-eufemia-provider