### PR TITLE
chore(DatePicker): remove unnecessary export from pad function in `useInputDates`

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/hooks/useInputDates.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/hooks/useInputDates.ts
@@ -82,7 +82,7 @@ function getInputDates(type: 'start' | 'end', date: Date | undefined) {
   return {}
 }
 
-export function pad(date: string, size: number) {
+function pad(date: string, size: number) {
   const dateWithPadding = '000000000' + date
 
   return dateWithPadding.substring(dateWithPadding.length - size)


### PR DESCRIPTION
The `pad` function in `useInputDates.ts` was exported but never imported outside its own file. Removed the `export` keyword since it's only used internally.