### PR TITLE
chore(Filter): fix minor text and grammar issues

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/filter/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/filter/Examples.tsx
@@ -1247,7 +1247,7 @@ export const WithQueryLocator = () => {
         const Example = () => {
           // Syncs filter state to/from URL query parameters
           Filter.useQueryLocator('query-locator-demo', {
-            // excludeSearch: true,// You can exclude search from the URL if you want, by default it is included
+            // excludeSearch: true, // You can exclude search from the URL if you want, by default it is included
           })
 
           const { filters, search } = Filter.useFilter(

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
@@ -51,7 +51,7 @@ The filter component can be used in two layout patterns:
 
 - **`Filter.Root`** — Root wrapper. Provides filter context and syncs state via `useSharedState`. Requires a unique `id`. Supports spacing props.
 - **`Filter.Header`** — Groups the filter controls (toolbar, panel, active filters) above the results. When used together with `Filter.Content` containing a `List.Container`, the header receives a subtle background and top border-radius to visually connect with the list below.
-- **`Filter.Search`** — Text input with a loupe icon. Updates the shared `search` string. Browser autocomplete, autocorrect, autocapitalize and spellcheck are disabled by default.
+- **`Filter.Search`** — Text input with a loupe icon. Updates the shared `search` string. Browser autocomplete, autocorrect, autocapitalize, and spellcheck are disabled by default.
 - **`Filter.Toolbar`** — Horizontal row that wraps `Filter.Search` and `Filter.Toolbar.Actions`.
 - **`Filter.Toolbar.Actions`** — Groups action buttons (e.g. `Filter.PanelButton`) for proper responsiveness.
 - **`Filter.Panel`** — Expandable inline panel toggled by `Filter.PanelButton`. Renders filter children as tertiary accordions with a white background.

--- a/packages/dnb-eufemia/src/components/filter/hooks/useFilter.ts
+++ b/packages/dnb-eufemia/src/components/filter/hooks/useFilter.ts
@@ -84,7 +84,7 @@ export type FilterAsyncOptions<T> = {
 /**
  * Hook for async data fetching linked to a Filter.Root.
  * Handles loading state, race conditions, and syncs resultLoading/resultCount
- * to the shared filter state so Filter.Content pick them up.
+ * to the shared filter state so Filter.Content picks them up.
  */
 export function useFilterAsync<T>(
   id: string,


### PR DESCRIPTION
- Fix subject-verb agreement in useFilterAsync JSDoc ("pick" → "picks")
- Add missing space before inline comment in Examples.tsx
- Add Oxford comma in Filter.Search description in info.mdx

