### PR TITLE
fix(Field.MultiSelection): round nested list corners

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
@@ -163,29 +163,6 @@
     }
   }
 
-  // When the popover has no inner space, items are flush against the
-  // popover edges. Apply matching border-radius so backgrounds and
-  // borders follow the popover's rounded corners in every state.
-  .dnb-popover--no-inner-space &__list {
-    > li:first-child {
-      border-top-left-radius: var(--popover-border-radius);
-      border-top-right-radius: var(--popover-border-radius);
-
-      &::after {
-        border-radius: inherit;
-      }
-    }
-
-    > li:last-of-type {
-      border-bottom-left-radius: var(--popover-border-radius);
-      border-bottom-right-radius: var(--popover-border-radius);
-
-      &::after {
-        border-radius: inherit;
-      }
-    }
-  }
-
   &__popover-content {
     display: flex;
     flex-direction: column;
@@ -241,6 +218,37 @@
   }
   &__no-options-text {
     color: var(--token-color-text-neutral-alternative);
+  }
+
+  // When the popover has no inner space, items are flush against the
+  // popover edges. Apply matching border-radius so backgrounds and
+  // borders follow the popover's rounded corners in every state.
+  .dnb-popover--no-inner-space &__items {
+    border-radius: var(--popover-border-radius);
+  }
+
+  .dnb-popover--no-inner-space &__list {
+    > li:first-child {
+      border-top-left-radius: var(--popover-border-radius);
+      border-top-right-radius: var(--popover-border-radius);
+
+      &::after {
+        border-radius: inherit;
+      }
+    }
+
+    > :last-child,
+    > :last-child
+      .dnb-forms-field-multi-selection__nested-items:last-child,
+    > :last-child .dnb-forms-field-multi-selection__item:last-child {
+      border-bottom-left-radius: var(--popover-border-radius);
+      border-bottom-right-radius: var(--popover-border-radius);
+      overflow: clip;
+
+      &::after {
+        border-radius: inherit;
+      }
+    }
   }
 
   &__selected-items__inner {


### PR DESCRIPTION
Field.MultiSelection list items should keep the popover corner radius when the list is rendered flush with the popover edge.

Why:
- Nested item groups are rendered as sibling lists, so `:last-of-type` can match a row that is not visually last.
- When the list scrolls, the ScrollView wrapper becomes the visible clipped edge and also needs the popover radius.

<img width="425" height="640" alt="Screenshot 2026-06-09 at 19 06 59" src="https://github.com/user-attachments/assets/d1df9671-6c92-4346-b271-fe80735a634b" />
