### PR TITLE
chore(Portal): refactor deprecated ESLint config

### DIFF
--- a/packages/dnb-design-system-portal/eslint.config.mjs
+++ b/packages/dnb-design-system-portal/eslint.config.mjs
@@ -2,8 +2,7 @@ import eufemiaConfig from '@dnb/eufemia/eslint.config.mjs'
 import * as mdxPlugin from 'eslint-plugin-mdx'
 import workspacesPlugin from 'eslint-plugin-workspaces'
 
-const workspacesRecommended =
-  workspacesPlugin.configs?.['flat/recommended'] || {}
+const workspacesRecommended = workspacesPlugin.configs?.recommended || {}
 
 export default [
   {


### PR DESCRIPTION
The portal ESLint setup was still loading the deprecated `flat/recommended` config from `eslint-plugin-workspaces`, which now emits a warning during lint runs and is scheduled for removal in the plugin's next major version.

This keeps lint output clean and avoids depending on the deprecated config alias.