### PR TITLE
fix(forms): re-seed shared state after clearData on remount

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -43,6 +43,7 @@ import type { SharedStateId } from '../../../../shared/helpers/useSharedState'
 import {
   createReferenceKey,
   createSharedState,
+  markForReseed,
   preSeedSharedState,
   shallowEqual,
   useSharedState,
@@ -894,8 +895,17 @@ export default function Provider<Data extends JsonObject>(
   // preSeedSharedState is used instead of createSharedState so that
   // hadInitialData stays false, allowing Form.useData(..., initialData) calls
   // to still merge their own initialData via useMountEffect.
+  //
+  // The id-tracking ref ensures we only pre-seed once per mount (or when id
+  // changes). Without it, a clearData call on a *mounted* form would be
+  // immediately undone by the next re-render’s preSeedSharedState, because
+  // markForReseed sets needsReseed = true.
+  const preSeededIdRef = useRef<SharedStateId>(undefined)
   if (id && initialData !== undefined) {
-    preSeedSharedState<Data>(id, initialData)
+    if (preSeededIdRef.current !== id) {
+      preSeededIdRef.current = id
+      preSeedSharedState<Data>(id, initialData)
+    }
   }
   const sharedData = useSharedState<Data>(id)
   const sharedAttachments = useSharedState<SharedAttachments<Data>>(
@@ -1022,6 +1032,7 @@ export default function Provider<Data extends JsonObject>(
 
     if (id) {
       setSharedData(internalDataRef.current)
+      markForReseed(id)
     }
 
     forceUpdate()

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/clearData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/clearData.test.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, act } from 'react'
+import { StrictMode, act, useEffect } from 'react'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Field, Form } from '../../..'
@@ -86,5 +86,103 @@ describe('Form.clearData', () => {
 
       expect(document.querySelector('input')).toHaveValue('')
     })
+  })
+
+  it('should re-seed shared state on first render when remounting after clearData', () => {
+    const formId = 'reseed-first-render'
+    const renderSnapshots: unknown[] = []
+
+    function DataProbe() {
+      const { data } = Form.useData(formId)
+      renderSnapshots.push(data)
+      return null
+    }
+
+    function MyForm() {
+      useEffect(() => {
+        return () => {
+          Form.clearData(formId)
+        }
+      }, [])
+
+      return (
+        <Form.Handler id={formId} data={{ myString: 'hello' }}>
+          <Field.String path="/myString" />
+        </Form.Handler>
+      )
+    }
+
+    const { unmount } = render(
+      <>
+        <MyForm />
+        <DataProbe />
+      </>
+    )
+
+    // Clear snapshots from the initial mount
+    renderSnapshots.length = 0
+
+    unmount()
+
+    render(
+      <>
+        <MyForm />
+        <DataProbe />
+      </>
+    )
+
+    // The very first render after remount must already have the data —
+    // not an empty object that only gets fixed in a later commit phase.
+    expect(renderSnapshots[0]).toEqual({ myString: 'hello' })
+  })
+
+  it('should re-seed shared state for external useData(id, initialData) after clearData', () => {
+    const formId = 'reseed-usedata-initial'
+    const renderSnapshots: unknown[] = []
+
+    function ExternalSeeder() {
+      const { data } = Form.useData(formId, {
+        myString: 'fromOutside',
+      })
+      renderSnapshots.push(data)
+      return null
+    }
+
+    function MyForm() {
+      useEffect(() => {
+        return () => {
+          Form.clearData(formId)
+        }
+      }, [])
+
+      return (
+        <Form.Handler id={formId}>
+          <Field.String path="/myString" />
+        </Form.Handler>
+      )
+    }
+
+    const { unmount } = render(
+      <>
+        <MyForm />
+        <ExternalSeeder />
+      </>
+    )
+
+    expect(document.querySelector('input')).toHaveValue('fromOutside')
+
+    renderSnapshots.length = 0
+
+    unmount()
+
+    render(
+      <>
+        <MyForm />
+        <ExternalSeeder />
+      </>
+    )
+
+    // External useData with initialData must also re-seed after clearData
+    expect(renderSnapshots[0]).toEqual({ myString: 'fromOutside' })
   })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/useSharedState.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/useSharedState.ts
@@ -195,6 +195,7 @@ type SharedStateInstance<Data> = {
   subscribe: (subscriber: Subscriber) => void
   unsubscribe: (subscriber: Subscriber) => void
   hadInitialData: boolean
+  needsReseed: boolean
 } & SharedStateReturn<Data>
 
 const sharedStates: Map<
@@ -324,6 +325,7 @@ export function createSharedState<Data>(
       subscribe,
       unsubscribe,
       hadInitialData: Boolean(initialData),
+      needsReseed: false,
       subscribersRef,
     } as SharedStateInstance<Data>)
 
@@ -331,7 +333,8 @@ export function createSharedState<Data>(
       extend(initialData)
     }
   } else if (
-    sharedStates.get(id).data === undefined &&
+    (sharedStates.get(id).data === undefined ||
+      sharedStates.get(id).needsReseed) &&
     initialData !== undefined
   ) {
     // Silently seed the store so children render with data on their first pass.
@@ -339,6 +342,7 @@ export function createSharedState<Data>(
     // would cause a "setState during render" warning. The store value will be
     // picked up by useSyncExternalStore's getSnapshot on the next render.
     sharedStates.get(id).data = cloneData(initialData) as Data
+    sharedStates.get(id).needsReseed = false
   }
 
   return sharedStates.get(id)
@@ -360,8 +364,28 @@ export function preSeedSharedState<Data>(
   // Ensure the store exists with hadInitialData = false
   createSharedState<Data>(id)
   const store = sharedStates.get(id)
-  if (store && store.data === undefined && data !== undefined) {
+  if (
+    store &&
+    (store.data === undefined || store.needsReseed) &&
+    data !== undefined
+  ) {
     store.data = cloneData(data) as Data
+    store.needsReseed = false
+  }
+}
+
+/**
+ * Mark a shared state for re-seeding. The next call to preSeedSharedState
+ * or createSharedState with initialData will overwrite the current value.
+ *
+ * Used by clearData so that a remounted Provider (or useData consumer)
+ * can re-seed the store even though store.data is not undefined.
+ */
+export function markForReseed(id: SharedStateId): void {
+  const store = sharedStates.get(id)
+  if (store) {
+    store.needsReseed = true
+    store.hadInitialData = false
   }
 }
 


### PR DESCRIPTION
After Form.clearData(id) runs, the shared store holds clearedData (Object.freeze({})) instead of undefined. When a new Form.Handler with the same id and a populated data prop mounts, preSeedSharedState skips seeding because store.data !== undefined, leaving fields empty.

Fix: guard preSeedSharedState with a per-instance ref so it only runs on the first render. On that first render, if the store holds clearedData, re-seed it with initialData. On subsequent re-renders (e.g. after clearing a mounted form), the block is skipped so the clear is preserved.

