### PR TITLE
fix(Forms): skip onBlurValidator on submit when already validated

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -6982,6 +6982,206 @@ describe('useFieldProps', () => {
         document.querySelector('.dnb-form-status')
       ).not.toBeInTheDocument()
     })
+
+    it('should not re-call onBlurValidator on submit when it already ran on blur with the same value', async () => {
+      const onBlurValidator = vi.fn(() => undefined)
+
+      render(
+        <Form.Handler>
+          <Field.String
+            path="/myField"
+            onBlurValidator={onBlurValidator}
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+
+      // Type a value and blur
+      await userEvent.type(input, '123')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+
+      // Submit the form
+      fireEvent.submit(document.querySelector('form'))
+
+      await wait(100)
+
+      // Should still be 1 — not re-called on submit since the value hasn't changed
+      expect(onBlurValidator).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not re-call async onBlurValidator on submit when it already ran on blur', async () => {
+      const onBlurValidator = vi.fn(async () => undefined)
+
+      render(
+        <Form.Handler>
+          <Field.String
+            path="/myField"
+            onBlurValidator={onBlurValidator}
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+
+      // Type a value and blur
+      await userEvent.type(input, '123')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+
+      // Submit the form
+      fireEvent.submit(document.querySelector('form'))
+
+      await wait(100)
+
+      // Should still be 1 — not re-called on submit since the value hasn't changed
+      expect(onBlurValidator).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not re-call async onBlurValidator on submit via Form.useSubmit', async () => {
+      const onBlurValidator = vi.fn(async () => undefined)
+
+      const SubmitButton = ({ id }: { id: string }) => {
+        const { submit } = Form.useSubmit(id)
+        return <button data-testid="submit" onClick={() => submit()} />
+      }
+
+      render(
+        <>
+          <Form.Handler id="submit-test">
+            <Field.String
+              path="/myField"
+              onBlurValidator={onBlurValidator}
+            />
+          </Form.Handler>
+          <SubmitButton id="submit-test" />
+        </>
+      )
+
+      const input = document.querySelector('input')
+
+      // Type a value and blur
+      await userEvent.type(input, '123')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+
+      // Submit via external Form.useSubmit — clicking the button
+      // triggers a blur on the input, but the validator should not re-run
+      await userEvent.click(screen.getByTestId('submit'))
+
+      await wait(100)
+
+      // Should still be 1 — not re-called on blur or submit since the value hasn't changed
+      expect(onBlurValidator).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onBlurValidator on submit when field was never blurred', async () => {
+      const onBlurValidator = vi.fn(() => undefined)
+
+      render(
+        <Form.Handler>
+          <Field.String
+            path="/myField"
+            defaultValue="hello"
+            onBlurValidator={onBlurValidator}
+          />
+        </Form.Handler>
+      )
+
+      // Submit without blur
+      fireEvent.submit(document.querySelector('form'))
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should re-call onBlurValidator on submit when value changed after blur', async () => {
+      const onBlurValidator = vi.fn(() => undefined)
+
+      render(
+        <Form.Handler>
+          <Field.String
+            path="/myField"
+            onBlurValidator={onBlurValidator}
+          />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+
+      // Type a value and blur
+      await userEvent.type(input, '1')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+
+      // Focus, type more (value changes)
+      await userEvent.type(input, '23')
+
+      // Submit without blurring again
+      fireEvent.submit(document.querySelector('form'))
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it('should re-call onBlurValidator on submit when value was changed externally after blur', async () => {
+      const onBlurValidator = vi.fn(() => undefined)
+
+      const MockComponent = () => {
+        const { update } = Form.useData('external-change-form')
+        return (
+          <>
+            <Form.Handler id="external-change-form">
+              <Field.String
+                path="/myField"
+                onBlurValidator={onBlurValidator}
+              />
+            </Form.Handler>
+            <button
+              data-testid="external-set"
+              onClick={() => update('/myField', () => 'externally-set')}
+            />
+          </>
+        )
+      }
+
+      render(<MockComponent />)
+
+      const input = document.querySelector('input')
+
+      // Type a value and blur
+      await userEvent.type(input, 'hello')
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(1)
+      })
+
+      // Change value externally
+      await userEvent.click(screen.getByTestId('external-set'))
+
+      // Submit
+      fireEvent.submit(document.querySelector('form'))
+
+      await waitFor(() => {
+        expect(onBlurValidator).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 
   describe('revealError', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -282,6 +282,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const valueRef = useRef<Value>(undefined as Value)
   const changedRef = useRef<boolean>(undefined)
   const hasFocusRef = useRef<boolean>(undefined)
+  const blurValidatorCalledRef = useRef(false)
 
   // ─── useFieldTransform ───────────────────────────────────────────────
 
@@ -637,6 +638,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     if (valueRef.current !== externalValue) {
       valueRef.current = externalValue
       externalValueDidChangeRef.current = true
+      blurValidatorCalledRef.current = false
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -697,9 +699,17 @@ export default function useFieldProps<Value, EmptyValue, Props>(
           return undefined
         }
 
+        if (blurValidatorCalledRef.current) {
+          // Avoid re-running the blur validator when the value hasn't changed since the last blur
+          return undefined
+        }
+
         addToPool(
           'onBlurValidator',
-          async () => await startOnBlurValidatorProcess({ overrideValue }),
+          async () => {
+            await startOnBlurValidatorProcess({ overrideValue })
+            blurValidatorCalledRef.current = true
+          },
           isAsync(onBlurValidatorRef.current)
         )
 
@@ -751,6 +761,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       )
 
       valueRef.current = transformedValue
+      blurValidatorCalledRef.current = false
 
       if (hasPath || itemPath) {
         handlePathChangeUnvalidatedDataContext(
@@ -1523,11 +1534,13 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       isAsync(onChangeValidatorRef.current)
     )
 
-    addToPool(
-      'onBlurValidator',
-      startOnBlurValidatorProcess,
-      isAsync(onBlurValidatorRef.current)
-    )
+    if (!blurValidatorCalledRef.current) {
+      addToPool(
+        'onBlurValidator',
+        startOnBlurValidatorProcess,
+        isAsync(onBlurValidatorRef.current)
+      )
+    }
 
     await runPool()
   }, [


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1781073525433709
Issue reprod: https://codesandbox.io/p/sandbox/elastic-heyrovsky-forked-9kyw2x
Fix reprod: https://stackblitz.com/edit/44ggkpfq-ajezdn4e?file=src%2FApp.tsx

When a field's onBlurValidator has already run on blur with the current value, skip re-running it during form submit. The validator still runs on submit if the field was never blurred or if the value changed after the last blur.

