### PR TITLE
fix(Modal): fix controlled `open` prop not opening dialog

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -674,6 +674,45 @@ describe('Dialog', () => {
     // Verify that focus is NOT on the submit button
     expect(document.activeElement).not.toBe(submitButton)
   })
+
+  it('should open controlled dialog without noAnimation', async () => {
+    const originalIsTest = window['IS_TEST']
+    window['IS_TEST'] = false
+
+    const TestComponent = () => {
+      const [showDialog, setShowDialog] = useState(false)
+
+      return (
+        <>
+          <button
+            data-testid="trigger"
+            onClick={() => setShowDialog(true)}
+          >
+            Open
+          </button>
+          <Dialog
+            omitTriggerButton
+            open={showDialog}
+            onClose={() => setShowDialog(false)}
+          >
+            Dialog content
+          </Dialog>
+        </>
+      )
+    }
+
+    render(<TestComponent />)
+
+    expect(document.querySelector('.dnb-dialog')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('trigger'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
+    })
+
+    window['IS_TEST'] = originalIsTest
+  })
 })
 
 describe('Dialog aria', () => {

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -679,39 +679,60 @@ describe('Dialog', () => {
     const originalIsTest = window['IS_TEST']
     window['IS_TEST'] = false
 
-    const TestComponent = () => {
-      const [showDialog, setShowDialog] = useState(false)
+    try {
+      const TestComponent = () => {
+        const [showDialog, setShowDialog] = useState(false)
 
-      return (
-        <>
-          <button
-            data-testid="trigger"
-            onClick={() => setShowDialog(true)}
-          >
-            Open
-          </button>
-          <Dialog
-            omitTriggerButton
-            open={showDialog}
-            onClose={() => setShowDialog(false)}
-          >
-            Dialog content
-          </Dialog>
-        </>
+        return (
+          <>
+            <button
+              data-testid="trigger"
+              onClick={() => setShowDialog(true)}
+            >
+              Open
+            </button>
+            <Dialog
+              omitTriggerButton
+              open={showDialog}
+              onClose={() => setShowDialog(false)}
+            >
+              Dialog content
+            </Dialog>
+          </>
+        )
+      }
+
+      render(<TestComponent />)
+
+      expect(document.querySelector('.dnb-dialog')).not.toBeInTheDocument()
+
+      // Open
+      await userEvent.click(screen.getByTestId('trigger'))
+
+      await waitFor(() => {
+        expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
+      })
+
+      // Close via the close button
+      await userEvent.click(
+        document.querySelector('button.dnb-modal__close-button')
       )
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-dialog')
+        ).not.toBeInTheDocument()
+      })
+
+      // Reopen
+      await userEvent.click(screen.getByTestId('trigger'))
+
+      await waitFor(() => {
+        expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
+      })
+    } finally {
+      window['IS_TEST'] = originalIsTest
     }
-
-    render(<TestComponent />)
-
-    expect(document.querySelector('.dnb-dialog')).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByTestId('trigger'))
-
-    await waitFor(() => {
-      expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
-    })
-
-    window['IS_TEST'] = originalIsTest
   })
 })
 

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -697,6 +697,12 @@ describe('Dialog', () => {
               onClose={() => setShowDialog(false)}
             >
               Dialog content
+              <button
+                data-testid="close"
+                onClick={() => setShowDialog(false)}
+              >
+                Close
+              </button>
             </Dialog>
           </>
         )
@@ -704,32 +710,29 @@ describe('Dialog', () => {
 
       render(<TestComponent />)
 
+      const triggerButton = document.querySelector(
+        '[data-testid="trigger"]'
+      )
+
       expect(document.querySelector('.dnb-dialog')).not.toBeInTheDocument()
 
       // Open
-      await userEvent.click(screen.getByTestId('trigger'))
+      await userEvent.click(triggerButton)
 
       await waitFor(() => {
         expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
       })
 
-      // Close via the close button
       await userEvent.click(
-        document.querySelector('button.dnb-modal__close-button')
+        document.querySelector('[data-testid="close"]')
       )
 
-      await waitFor(() => {
-        expect(
-          document.querySelector('.dnb-dialog')
-        ).not.toBeInTheDocument()
-      })
+      // Reopen while the close animation is still in progress.
+      await userEvent.click(triggerButton)
 
-      // Reopen
-      await userEvent.click(screen.getByTestId('trigger'))
+      await new Promise((resolve) => setTimeout(resolve, 350))
 
-      await waitFor(() => {
-        expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
-      })
+      expect(document.querySelector('.dnb-dialog')).toBeInTheDocument()
     } finally {
       window['IS_TEST'] = originalIsTest
     }

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -406,7 +406,8 @@ function ModalComponent(ownProps: ModalAllProps) {
       prevOwnPropsRef.current !== ownProps
     prevOwnPropsRef.current = ownProps
 
-    const openChanged = prevEffectOpenRef.current !== open
+    const prevOpen = prevEffectOpenRef.current
+    const openChanged = prevOpen !== open
     prevEffectOpenRef.current = open
 
     if (!openChanged && !isNewProps) {
@@ -417,10 +418,18 @@ function ModalComponent(ownProps: ModalAllProps) {
       return // stop here
     }
 
-    if (!hide && open === true) {
-      toggleOpenClose(null, true)
-    } else if (hide && open === false) {
-      toggleOpenClose(null, false)
+    if (openChanged) {
+      if (open === true) {
+        toggleOpenClose(null, true)
+      } else if (open === false && prevOpen === true) {
+        toggleOpenClose(null, false)
+      }
+    } else if (isNewProps) {
+      if (!hide && open === true) {
+        toggleOpenClose(null, true)
+      } else if (hide && open === false) {
+        toggleOpenClose(null, false)
+      }
     }
   })
 

--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -408,7 +408,6 @@ function ModalComponent(ownProps: ModalAllProps) {
 
     const prevOpen = prevEffectOpenRef.current
     const openChanged = prevOpen !== open
-    prevEffectOpenRef.current = open
 
     if (!openChanged && !isNewProps) {
       return // stop here
@@ -417,6 +416,8 @@ function ModalComponent(ownProps: ModalAllProps) {
     if (isInTransitionRef.current) {
       return // stop here
     }
+
+    prevEffectOpenRef.current = open
 
     if (openChanged) {
       if (open === true) {


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1781087024326319
Issue reprod: https://stackblitz.com/edit/44ggkpfq-9bmvcvjy?file=src%2FApp.tsx
Fix reprod: https://stackblitz.com/edit/44ggkpfq-d5xg7pxh?file=package.json

The useEffect that calls toggleOpenClose relied on the 'hide' state to gate the open check, but 'hide' was stale (still true) when 'open' changed from false to true in the same render cycle.

Split the condition: when 'open' actually changed, use the prop directly instead of the stale 'hide' state. When only parent props changed, keep the existing hide-based checks since hide is stable in that case.

