### PR TITLE
fix(DatePicker): prevent shortcuts from widening picker

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2777,6 +2777,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
 }
 .dnb-date-picker__addon {
   display: flex;
+  contain: inline-size;
   flex-flow: row wrap;
   justify-content: flex-start;
   gap: 1rem;

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -265,6 +265,7 @@
 
   &__addon {
     display: flex;
+    contain: inline-size;
     flex-flow: row wrap;
     justify-content: flex-start;
     gap: 1rem;


### PR DESCRIPTION
Preview: https://chore-date-picker-addon-wrap.eufemia-e25.pages.dev/uilib/components/date-picker/demos

The DatePicker addon could make the picker wider than the calendar when shortcut buttons had enough content to fit on one long row. This keeps shortcut content wrapping within the picker width so the calendar remains the sizing anchor.

Verified with the focused DatePicker SCSS Vitest block.

<img width="840" height="589" alt="Screenshot 2026-06-10 at 13 52 08" src="https://github.com/user-attachments/assets/91da73a2-e403-4d13-93d6-4551538bdf71" />
