### PR TITLE
chore(Portal): make sidebar resizable

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/sidebarResize.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/sidebarResize.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+import waitForApp from './shared/waitForApp'
+
+test.describe('Sidebar resize', () => {
+  async function gotoAndWait(page: Page) {
+    await page.goto('/uilib/components/button/demos/')
+    await waitForApp(page)
+  }
+
+  async function dragSidebarToWidth(
+    page: Page,
+    resizeHandle: Locator,
+    width: number
+  ) {
+    const start = await resizeHandle.evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      const lineX =
+        rect.left + parseFloat(getComputedStyle(element, '::before').left)
+
+      return {
+        x: lineX,
+        y: rect.top + rect.height / 2,
+      }
+    })
+
+    await page.mouse.move(start.x, start.y)
+    await page.mouse.down()
+    await page.mouse.move(width, start.y)
+    await page.mouse.up()
+  }
+
+  test('should resize the sidebar and reset the width on reload', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await gotoAndWait(page)
+
+    const sidebar = page.locator('#portal-sidebar-menu')
+    const resizeHandle = page.getByRole('button', {
+      name: 'Resize sidebar',
+    })
+    const initialWidth = await sidebar.evaluate(
+      (element) => element.getBoundingClientRect().width
+    )
+
+    const sidebarLayout = await page.evaluate(() => {
+      const sidebar = document.querySelector('#portal-sidebar-menu')
+      const resizeHandle = document.querySelector(
+        '[aria-label="Resize sidebar"]'
+      )
+
+      return {
+        viewportHeight: window.innerHeight,
+        sidebarTop: Math.round(sidebar.getBoundingClientRect().top),
+        sidebarBottom: Math.round(sidebar.getBoundingClientRect().bottom),
+        handleTop: Math.round(resizeHandle.getBoundingClientRect().top),
+        handleBottom: Math.round(
+          resizeHandle.getBoundingClientRect().bottom
+        ),
+      }
+    })
+
+    expect(sidebarLayout.handleTop).toBe(sidebarLayout.sidebarTop)
+    expect(sidebarLayout.sidebarBottom).toBe(sidebarLayout.viewportHeight)
+    expect(sidebarLayout.handleBottom).toBe(sidebarLayout.viewportHeight)
+
+    await expect(
+      sidebar.evaluate(
+        (element) => element.scrollWidth <= element.clientWidth
+      )
+    ).resolves.toBe(true)
+
+    await expect(resizeHandle).toHaveCSS('cursor', 'ew-resize')
+
+    const hitArea = await resizeHandle.evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      const lineX =
+        rect.left + parseFloat(getComputedStyle(element, '::before').left)
+
+      return {
+        width: rect.width,
+        leftOfLine: lineX - rect.left,
+        rightOfLine: rect.right - lineX,
+      }
+    })
+
+    expect(hitArea.width).toBeGreaterThan(12)
+    expect(hitArea.rightOfLine).toBeGreaterThan(hitArea.leftOfLine)
+
+    const resizedWidth = 760
+
+    await dragSidebarToWidth(page, resizeHandle, resizedWidth)
+
+    await expect(sidebar).toHaveCSS('width', `${resizedWidth}px`)
+
+    await page.reload()
+    await waitForApp(page)
+
+    await expect(sidebar).toHaveCSS('width', `${initialWidth}px`)
+  })
+
+  test('should support focus and keyboard resize', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await gotoAndWait(page)
+
+    const sidebar = page.locator('#portal-sidebar-menu')
+    const resizeHandle = page.getByRole('button', {
+      name: 'Resize sidebar',
+    })
+
+    const initialWidth = await sidebar.evaluate(
+      (element) => element.getBoundingClientRect().width
+    )
+
+    await expect(resizeHandle).toHaveAttribute(
+      'aria-controls',
+      'portal-sidebar-menu'
+    )
+
+    await resizeHandle.focus()
+    await expect(resizeHandle).toBeFocused()
+
+    await page.keyboard.press('ArrowRight')
+
+    await expect(sidebar).toHaveCSS('width', `${initialWidth + 16}px`)
+
+    await page.keyboard.press('ArrowLeft')
+
+    await expect(sidebar).toHaveCSS('width', `${initialWidth}px`)
+  })
+
+  test('should show horizontal overflow when the sidebar is narrow', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await gotoAndWait(page)
+
+    const sidebar = page.locator('#portal-sidebar-menu')
+    const resizeHandle = page.getByRole('button', {
+      name: 'Resize sidebar',
+    })
+
+    await dragSidebarToWidth(page, resizeHandle, 120)
+
+    const overflow = await sidebar.evaluate((element) => {
+      return {
+        overflowX: getComputedStyle(element).overflowX,
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }
+    })
+
+    expect(overflow.overflowX).toBe('auto')
+    expect(overflow.scrollWidth).toBeGreaterThan(overflow.clientWidth)
+  })
+})

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
@@ -2,7 +2,11 @@
 
 :global {
   :root {
-    --aside-width: calc(25vw + 5rem);
+    --portal-sidebar-scrollbar-gutter: 1.5rem;
+    --aside-width: calc(
+      25vw + 5rem + var(--portal-sidebar-scrollbar-gutter)
+    );
+    --portal-sidebar-top: 3.5rem;
   }
 
   .dnb-sidebar-menu {
@@ -264,6 +268,12 @@
       }
     }
   }
+
+  html.portal-sidebar-is-resizing,
+  html.portal-sidebar-is-resizing * {
+    cursor: ew-resize !important;
+    user-select: none;
+  }
 }
 
 .navStyle {
@@ -276,6 +286,7 @@
   z-index: 1;
 
   @include utilities.scrollY(auto);
+  overflow-x: auto;
 
   @include utilities.allBelow(medium) {
     position: relative;
@@ -286,15 +297,71 @@
 
   @include utilities.allAbove(medium) {
     width: var(--aside-width); // has to be the same value as margin-left
-    height: calc(100vh - 4rem); // height of StickyMenuBar
+    height: calc(100vh - var(--portal-sidebar-top));
   }
 
-  margin: 3.5rem 0 0;
+  margin: var(--portal-sidebar-top) 0 0;
 
   ul {
+    width: max-content;
+    min-width: 100%;
     margin: 0;
     padding: 0;
   }
 
   background-color: var(--token-color-background-neutral);
+}
+
+.resizeHandleStyle {
+  position: fixed;
+  z-index: 3;
+  top: var(--portal-sidebar-top);
+  bottom: 0;
+  left: calc(var(--aside-width) - 0.375rem);
+
+  width: 1.5rem;
+  margin: 0;
+  padding: 0;
+
+  color: var(--token-color-stroke-neutral-subtle);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  cursor: ew-resize !important;
+  touch-action: none;
+
+  @include utilities.allBelow(medium) {
+    display: none;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0.375rem;
+
+    width: 1px;
+
+    background-color: currentcolor;
+    opacity: 0;
+
+    transform: translateX(-50%);
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: var(--token-color-stroke-action);
+
+    &::before {
+      width: 2px;
+      opacity: 1;
+    }
+  }
+
+  &:focus-visible {
+    outline: var(--focus-ring-width) solid
+      var(--token-color-stroke-action-focus);
+    outline-offset: -0.25rem;
+  }
 }

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -4,7 +4,12 @@
  */
 
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
-import type { RefObject } from 'react'
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+} from 'react'
 import { clsx } from 'clsx'
 import Anchor from '../tags/Anchor'
 import { useStaticQuery, graphql } from 'portal-query'
@@ -24,10 +29,11 @@ import {
   applyPageFocus,
 } from '@dnb/eufemia/src/shared/helpers'
 import PortalToolsMenu from './PortalToolsMenu'
-import { navStyle } from './SidebarMenu.module.scss'
+import { navStyle, resizeHandleStyle } from './SidebarMenu.module.scss'
 import { defaultTabsValue } from '../tags/defaultValues'
 
 const showAlwaysMenuItems = [] // like "uilib" something like that
+const sidebarWidthScopeSelector = '.eufemia-scope--portal'
 
 type SidebarLayoutProps = {
   location: Location
@@ -40,6 +46,7 @@ export default function SidebarLayout({
 }: SidebarLayoutProps) {
   const { isClosing, closeMenu, isOpen } = useContext(SidebarMenuContext)
   const scrollRef = useRef<HTMLElement>(null)
+  const sidebarResizeHandlers = useSidebarResize(scrollRef)
 
   const {
     allMdx,
@@ -82,12 +89,18 @@ export default function SidebarLayout({
   useEffect(() => {
     setPageFocusElement('nav ul li.is-active a:nth-of-type(1)', 'sidebar')
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMenu()
+      }
+    }
+
     if (typeof document !== 'undefined') {
       document.addEventListener('keydown', handleKeyDown)
     }
 
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  }, [closeMenu])
 
   useEffect(() => {
     if (isOpen && !isClosing) {
@@ -150,31 +163,35 @@ export default function SidebarLayout({
     )
 
   return (
-    <nav
-      id="portal-sidebar-menu"
-      aria-labelledby="toggle-sidebar-menu"
-      className={clsx(
-        navStyle,
-        'dnb-scrollbar-appearance',
-        isOpen && 'show-mobile-menu',
-        isClosing && 'hide-mobile-menu'
-      )}
-      ref={scrollRef}
-    >
-      <PortalToolsMenu
-        triggerProps={{
-          left: 'large',
-          top: 'large',
-          bottom: 'large',
-          text: 'Portal Tools',
-          icon: 'chevron_right',
-          iconPosition: 'right',
-        }}
-        tooltipPosition="bottom"
-        hideWhenMediaLarge
-      />
-      <ul className="dev-grid">{navItems}</ul>
-    </nav>
+    <>
+      <nav
+        id="portal-sidebar-menu"
+        aria-labelledby="toggle-sidebar-menu"
+        className={clsx(
+          navStyle,
+          'dnb-scrollbar-appearance',
+          isOpen && 'show-mobile-menu',
+          isClosing && 'hide-mobile-menu'
+        )}
+        ref={scrollRef}
+      >
+        <PortalToolsMenu
+          triggerProps={{
+            left: 'large',
+            top: 'large',
+            bottom: 'large',
+            text: 'Portal Tools',
+            icon: 'chevron_right',
+            iconPosition: 'right',
+          }}
+          tooltipPosition="bottom"
+          hideWhenMediaLarge
+        />
+        <ul className="dev-grid">{navItems}</ul>
+      </nav>
+
+      <SidebarResizeHandle {...sidebarResizeHandlers} />
+    </>
   )
 
   function scrollToActiveItem() {
@@ -200,14 +217,169 @@ export default function SidebarLayout({
         behavior: 'smooth',
       })
     } catch (e) {
-      console.error('Could not set scrollToActiveItem', e)
+      // Ignore scroll errors.
+    }
+  }
+}
+
+type SidebarResizeHandleProps = ReturnType<typeof useSidebarResize>
+
+function SidebarResizeHandle({
+  handleResizePointerDown,
+  handleResizeMouseDown,
+  handleResizeKeyDown,
+  resetSidebarWidth,
+}: SidebarResizeHandleProps) {
+  return (
+    <button
+      type="button"
+      className={resizeHandleStyle}
+      aria-label="Resize sidebar"
+      aria-controls="portal-sidebar-menu"
+      onPointerDown={handleResizePointerDown}
+      onMouseDown={handleResizeMouseDown}
+      onKeyDown={handleResizeKeyDown}
+      onDoubleClick={resetSidebarWidth}
+    />
+  )
+}
+
+function useSidebarResize(scrollRef: RefObject<HTMLElement>) {
+  const cleanupResizeRef = useRef<() => void>(undefined)
+
+  useEffect(() => {
+    return () => {
+      cleanupResizeRef.current?.()
+    }
+  }, [])
+
+  function getSidebarWidth() {
+    return scrollRef.current?.getBoundingClientRect().width || 0
+  }
+
+  function getSidebarWidthStyleElement() {
+    return (
+      scrollRef.current?.closest<HTMLElement>(sidebarWidthScopeSelector) ||
+      document.querySelector<HTMLElement>(sidebarWidthScopeSelector) ||
+      document.documentElement
+    )
+  }
+
+  function setSidebarWidth(width: number) {
+    if (typeof document === 'undefined') {
+      return
+    }
+
+    const widthWithMin = Math.round(Math.max(width, 1))
+    getSidebarWidthStyleElement().style.setProperty(
+      '--aside-width',
+      `${widthWithMin}px`
+    )
+  }
+
+  function resetSidebarWidth() {
+    if (typeof document === 'undefined') {
+      return
+    }
+
+    getSidebarWidthStyleElement().style.removeProperty('--aside-width')
+    document.documentElement.style.removeProperty('--aside-width')
+  }
+
+  function handleResizePointerDown(
+    event: ReactPointerEvent<HTMLButtonElement>
+  ) {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+    startSidebarResize(event.clientX, (handleMove, handleEnd) => {
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleEnd, { once: true })
+
+      return () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleEnd)
+      }
+    })
+  }
+
+  function handleResizeMouseDown(
+    event: ReactMouseEvent<HTMLButtonElement>
+  ) {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+    startSidebarResize(event.clientX, (handleMove, handleEnd) => {
+      window.addEventListener('mousemove', handleMove)
+      window.addEventListener('mouseup', handleEnd, { once: true })
+
+      return () => {
+        window.removeEventListener('mousemove', handleMove)
+        window.removeEventListener('mouseup', handleEnd)
+      }
+    })
+  }
+
+  function startSidebarResize(
+    clientX: number,
+    addListeners: (
+      handleMove: (event: MouseEvent | PointerEvent) => void,
+      handleEnd: () => void
+    ) => () => void
+  ) {
+    cleanupResizeRef.current?.()
+    document.documentElement.classList.add('portal-sidebar-is-resizing')
+
+    const pointerOffset = clientX - getSidebarWidth()
+
+    const handleMove = (event: MouseEvent | PointerEvent) => {
+      setSidebarWidth(event.clientX - pointerOffset)
+    }
+
+    let removeListeners = () => null
+
+    const cleanupResize = () => {
+      removeListeners()
+      document.documentElement.classList.remove(
+        'portal-sidebar-is-resizing'
+      )
+      cleanupResizeRef.current = undefined
+    }
+
+    const handleEnd = () => {
+      cleanupResize()
+    }
+
+    removeListeners = addListeners(handleMove, handleEnd)
+    cleanupResizeRef.current = cleanupResize
+  }
+
+  function handleResizeKeyDown(
+    event: ReactKeyboardEvent<HTMLButtonElement>
+  ) {
+    const width = getSidebarWidth()
+    const step = event.shiftKey ? 48 : 16
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      setSidebarWidth(width - step)
+    }
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      setSidebarWidth(width + step)
     }
   }
 
-  function handleKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      closeMenu()
-    }
+  return {
+    handleResizePointerDown,
+    handleResizeMouseDown,
+    handleResizeKeyDown,
+    resetSidebarWidth,
   }
 }
 


### PR DESCRIPTION
I had the need sometimes to just quickly adjust the left side. But;

- Maybe a toggle button would do the trick instead (would replace full screen button in the Tab bar).
- Maybe this feature is nice, but the width should be remembered in session storage so it makes more sense? I don't know.
- Double-click resets the position.

Preview: https://chore-make-portal-sidebar-re.eufemia-e25.pages.dev/uilib/