### PR TITLE
fix(DatePicker): preserve range focus contrast

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2875,7 +2875,7 @@ html[data-whatinput=keyboard] .dnb-date-picker__container table.dnb-no-focus:foc
   border-radius: 50%;
   background-color: currentcolor;
 }
-.dnb-date-picker__day--preview .dnb-button, .dnb-date-picker__day--inactive .dnb-button, .dnb-date-picker__day--within-selection:not(.dnb-date-picker__day--start-date):not(.dnb-date-picker__day--end-date) .dnb-button:not(:hover) {
+.dnb-date-picker__day--preview .dnb-button, .dnb-date-picker__day--inactive .dnb-button, .dnb-date-picker__day--within-selection:not(.dnb-date-picker__day--start-date):not(.dnb-date-picker__day--end-date) .dnb-button:not(:hover):not(:focus-visible) {
   background-color: transparent;
 }
 .dnb-date-picker__day--preview:not(.dnb-date-picker__day--inactive):not(.dnb-date-picker__day--start-date):not(.dnb-date-picker__day--end-date), .dnb-date-picker__day--within-selection:not(.dnb-date-picker__day--inactive):not(.dnb-date-picker__day--start-date):not(.dnb-date-picker__day--end-date) {

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -395,7 +395,7 @@
     &--preview .dnb-button,
     &--inactive .dnb-button,
     &--within-selection:not(#{&}--start-date):not(#{&}--end-date)
-      .dnb-button:not(:hover) {
+      .dnb-button:not(:hover):not(:focus-visible) {
       background-color: transparent;
     }
 


### PR DESCRIPTION
Preview: https://chore-date-picker-range-focu.eufemia-e25.pages.dev/uilib/components/date-picker/demos

Focused day buttons inside a DatePicker range were still matched by the transparent in-range button rule, so the blue focus styling could lose its background surface. This keeps the transparent rule away from `:focus-visible`, allowing the existing focus background to provide the needed contrast.

<img width="311" height="138" alt="Screenshot 2026-06-10 at 14 24 12" src="https://github.com/user-attachments/assets/cdd68e19-8e5d-4b6a-b464-67e98f6f2ceb" />

