### PR TITLE
docs: add dark surface context link in examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/demos.mdx
@@ -41,7 +41,7 @@ Icons can be added with the `icon` and `iconPosition` properties. Normally by se
 
 ### On dark surface
 
-Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
 
 <AnchorDarkSurfaceExample />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/demos.mdx
@@ -41,6 +41,8 @@ Icons can be added with the `icon` and `iconPosition` properties. Normally by se
 
 ### On dark surface
 
+Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
 <AnchorDarkSurfaceExample />
 
 ### Additional Anchor helper classes

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.mdx
@@ -75,7 +75,7 @@ This is, as all of the demos, only an example of how to achieve various needs, a
 
 ### Button on dark surface
 
-Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
 
 <ButtonOnDarkSurface />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/demos.mdx
@@ -75,6 +75,8 @@ This is, as all of the demos, only an example of how to achieve various needs, a
 
 ### Button on dark surface
 
+Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
 <ButtonOnDarkSurface />
 
 ### Button with custom SVG

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
@@ -32,7 +32,7 @@ Where `breakout`, `outline`, `roundedCorner`, `backgroundColor` and `dropShadow`
 
 ### Dark surface
 
-Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
 
 <Examples.DarkSurface />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/demos.mdx
@@ -32,6 +32,8 @@ Where `breakout`, `outline`, `roundedCorner`, `backgroundColor` and `dropShadow`
 
 ### Dark surface
 
+Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
 <Examples.DarkSurface />
 
 ### Variant: divider

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
@@ -19,9 +19,9 @@ import { Code } from '@dnb/eufemia/elements'
 
 ## `code` and `pre` tag usage
 
-Both `code` and `pre` tags are styled:
+Both `code` and `pre` tags are styled.
 
-Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
 
 <Examples.CodeExample />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
@@ -21,6 +21,8 @@ import { Code } from '@dnb/eufemia/elements'
 
 Both `code` and `pre` tags are styled:
 
+Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
 <Examples.CodeExample />
 
 ### Code and Typography

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/heading/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/heading/demos.mdx
@@ -54,6 +54,8 @@ Only the largest margin takes effect.
 
 ### Dark surface
 
+Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
 Headings automatically adapt their color when rendered on a dark surface:
 
 <HeadingDarkSurfaceExample />

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/heading/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/heading/demos.mdx
@@ -54,7 +54,7 @@ Only the largest margin takes effect.
 
 ### Dark surface
 
-Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
 
 Headings automatically adapt their color when rendered on a dark surface:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/paragraph/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/paragraph/demos.mdx
@@ -92,7 +92,7 @@ Paragraph also adds some default styling to child typography HTML elements. Like
 
 ### Dark surface
 
-Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
 
 Paragraphs automatically adapt their color when rendered on a dark surface:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/paragraph/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/paragraph/demos.mdx
@@ -92,6 +92,8 @@ Paragraph also adds some default styling to child typography HTML elements. Like
 
 ### Dark surface
 
+Use [`Section`](/uilib/components/section/demos/#dark-surface) or [`Theme.Context`](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
 Paragraphs automatically adapt their color when rendered on a dark surface:
 
 <ParagraphDarkSurface />


### PR DESCRIPTION
Adds direct guidance from dark-surface examples to the Theme surface documentation so developers can find how to propagate dark surface context with Section or Theme.Context.