### PR TITLE
chore: unify SASS/SCSS terminology across docs and scripts

### DIFF
--- a/packages/dnb-design-system-portal/postcss.config.js
+++ b/packages/dnb-design-system-portal/postcss.config.js
@@ -20,7 +20,7 @@ const postcssThemeScopePlugin = require('./postcss-eufemia-theme-scope.cjs')
 module.exports = {
   plugins:
     /**
-     * We also need to process the SASS modules from the portal.
+     * We also need to process the SCSS modules from the portal.
      * The portal imports isolated style files: *--isolated.min.css
      */
     enableBuildStyleScope() || enablePortalStyleScope()

--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -185,7 +185,7 @@ $ yarn workspace @dnb/eufemia build
 - Assets are getting generated
 - All index and lib files are getting generated
 - All the lib code gets compiled (ECMAScript 6 and ECMAScript 5.1)
-- All SCSS styles are validated and compiled (to support IE)
+- All SCSS styles are validated and compiled
 - Compiled CSS under `build/**/*.css` is parsed with [Lightning CSS](https://github.com/parcel-bundler/lightningcss) so invalid selectors (for example pseudo-elements not last in a compound selector) fail the build
 - All bundles get minified
 - Icons are getting converted

--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -39,7 +39,7 @@ The library consists of React components. The newer components are written as fu
 
 Components are written in [TypeScript](https://www.typescriptlang.org/).
 
-Components are styled using [nested CSS class selectors](https://medium.com/@andrew_barnes/bem-and-sass-a-perfect-match-5e48d9bc3894) with SASS (SCSS) and [BEM](https://getbem.com/naming/) (Block Element Modifier).
+Components are styled using [nested CSS class selectors](https://medium.com/@andrew_barnes/bem-and-sass-a-perfect-match-5e48d9bc3894) with SCSS and [BEM](https://getbem.com/naming/) (Block Element Modifier).
 
 ## Eufemia is a Mono Repository
 
@@ -185,7 +185,7 @@ $ yarn workspace @dnb/eufemia build
 - Assets are getting generated
 - All index and lib files are getting generated
 - All the lib code gets compiled (ECMAScript 6 and ECMAScript 5.1)
-- All SASS styles are validated and compiled (to support IE)
+- All SCSS styles are validated and compiled (to support IE)
 - Compiled CSS under `build/**/*.css` is parsed with [Lightning CSS](https://github.com/parcel-bundler/lightningcss) so invalid selectors (for example pseudo-elements not last in a compound selector) fail the build
 - All bundles get minified
 - Icons are getting converted

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -69,7 +69,7 @@ Theming file names ending with `-ui` will during the package release get packed 
 
 ### SCSS utilities
 
-Use the same SASS setup as all the other components. You may re-use all the [helper classes](/uilib/helpers/classes):
+Use the same SCSS setup as all the other components. You may re-use all the [helper classes](/uilib/helpers/classes):
 
 - `./packages/dnb-eufemia/src/style/core/utilities.scss`
 

--- a/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/rules.mdx
@@ -23,7 +23,7 @@ Many defaults are provided by the linting and Prettier configurations. However, 
 - Use [git message decoration](/contribute/style-guides/git) to ensure correct publish versioning.
 - Use [naming conventions](/contribute/style-guides/naming) when possible.
 - Use best practices for [CSS style structures](/uilib/usage/best-practices/for-styling#styling-structure).
-- Use [nested CSS class selectors](https://medium.com/@andrew_barnes/bem-and-sass-a-perfect-match-5e48d9bc3894) with SASS (SCSS) and [BEM](https://getbem.com/naming/) (Block Element Modifier).
+- Use [nested CSS class selectors](https://medium.com/@andrew_barnes/bem-and-sass-a-perfect-match-5e48d9bc3894) with SCSS and [BEM](https://getbem.com/naming/) (Block Element Modifier).
 - Use [React Hooks](https://react.dev/reference/react/hooks) over React class components when possible.
 - Use [TypeScript](https://www.typescriptlang.org).
 

--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
@@ -21,7 +21,7 @@ You may also check out the section about [how to use a theme in your application
     - [Button as an example](#button-as-an-example)
     - [CSS custom properties and :root](#css-custom-properties-and-root)
   - [Local Theming setup](#local-theming-setup)
-    - [yarn link and SASS](#yarn-link-and-sass)
+    - [yarn link and SCSS](#yarn-link-and-scss)
   - [Chrome Extension: Eufemia Theme Manager](#chrome-extension-eufemia-theme-manager)
 
 ## Basis information
@@ -30,7 +30,7 @@ The default DNB brand theme is called: `ui` which stands for _universal identity
 
 ## The building blocks
 
-A theme consists of several files, which again includes SASS import declarations to single component styles.
+A theme consists of several files, which again includes SCSS import declarations to single component styles.
 
 To include new or update component themes, run `yarn build`.
 
@@ -145,7 +145,7 @@ In some circumstances, you may make them share-able and place them inside `:root
 There are several solutions to **create a new theme**.
 One of which is by using the [linking feature of Yarn](https://yarnpkg.com/lang/en/docs/cli/link/).
 
-### yarn link and SASS
+### yarn link and SCSS
 
 Make sure your project can handle **\*.scss** files.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/info.mdx
@@ -10,7 +10,7 @@ import { CountryFlag } from '@dnb/eufemia'
 // Import the flag icons as CSS
 import '@dnb/eufemia/components/country-flag/style/dnb-country-flag-icons.min.css'
 
-// ... or as SASS
+// ... or as SCSS
 import '@dnb/eufemia/components/country-flag/style/dnb-country-flag-icons.scss'
 ```
 
@@ -18,7 +18,7 @@ import '@dnb/eufemia/components/country-flag/style/dnb-country-flag-icons.scss'
 
 The `CountryFlag` component lets you display a country flag based on a [ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) like `NO` for Norway.
 
-In order to use the CountryFlag component, you need to import the flag styles as CSS or SASS. The flag styles are available in the `dnb-country-flag-icons.min.css` and `dnb-country-flag-icons.scss` files. See the import example above.
+In order to use the CountryFlag component, you need to import the flag styles as CSS or SCSS. The flag styles are available in the `dnb-country-flag-icons.min.css` and `dnb-country-flag-icons.scss` files. See the import example above.
 
 These style files will import the SVG flag icon via a CSS `background-image`. This way only the used flags will be loaded by the browser.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/getting-started/requirements.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/getting-started/requirements.mdx
@@ -30,4 +30,4 @@ Why React is a good choice:
 
 ## Using the styles
 
-This library works perfectly with any styling techniques, such as **Styled Components** ([Emotion](https://emotion.sh)), CSS Modules, or SASS/LESS. You simply consume **ready-to-use CSS files** and CSS Custom Properties (CSS variables).
+This library works perfectly with any styling techniques, such as **Styled Components** ([Emotion](https://emotion.sh)), CSS Modules, or SCSS/LESS. You simply consume **ready-to-use CSS files** and CSS Custom Properties (CSS variables).

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/sass.mdx
@@ -1,11 +1,11 @@
 ---
-title: 'SASS mixins'
+title: 'SCSS mixins'
 order: 2
 ---
 
 import * as Examples from 'Docs/uilib/helpers/Examples'
 
-# SASS and mixins
+# SCSS mixins
 
 All CSS helper classes are to be found in `src/style/core/helper-classes/helper-classes.scss`
 Most helper classes are SCSS _mixins_ which are then applied to the class when invoked.

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
@@ -29,13 +29,13 @@ UX designers are using a 12 column system during their design processes.
 
 Applications in DNB actually break only twice (`small` and `medium`), but have an HTML body max-width of `large`.
 
-| React hook | Range                             | SASS mixin                  | Columns |
+| React hook | Range                             | SCSS mixin                  | Columns |
 | ---------- | --------------------------------- | --------------------------- | ------- |
 | `isSmall`  | from 0 to 40em                    | `allBelow(small)`           | 4       |
 | `isMedium` | from (not including) 40em to 60em | `allBetween(small, medium)` | 6       |
 | `isLarge`  | from (not including) 60em         | `allAbove(medium)`          | 12      |
 
-Note: if you've set [custom sass breakpoints](/uilib/helpers/sass/#custom-offset) using `$breakpoints` or `$breakpoint-offset`, the sass mixins will be different.
+Note: if you've set [custom SCSS breakpoints](/uilib/helpers/sass/#custom-offset) using `$breakpoints` or `$breakpoint-offset`, the SCSS mixins will be different.
 
 So when dealing with the naming of breakpoint ranges (between breakpoints), we use the term "large" when a media query exceeds `medium`:
 
@@ -299,9 +299,9 @@ You get an object with the values and the types as the keys.
 import { defaultBreakpoints } from '@dnb/eufemia/shared/MediaQueryUtils'
 ```
 
-## SASS / SCSS mixins
+## SCSS mixins
 
-You can re-use the SASS mixins from Eufemia:
+You can re-use the SCSS mixins from Eufemia:
 
 ```scss
 // breakpoints.scss

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling.mdx
@@ -266,4 +266,4 @@ Or override a single component's z-index:
 
 ## Known styling and CSS issues
 
-- Safari, both on mobile and desktop, has a problem where we combine `border-radius` with the usage of `inset` in a `box-shadow`. The solution for now is to not use `inset`, which results in an outer border. This is not ideal as we don't follow the UX guidelines for these browsers. We have a SASS function handling this for us: `@mixin fakeBorder`.
+- Safari, both on mobile and desktop, has a problem where we combine `border-radius` with the usage of `inset` in a `box-shadow`. The solution for now is to not use `inset`, which results in an outer border. This is not ideal as we don't follow the UX guidelines for these browsers. We have an SCSS mixin handling this for us: `@mixin fakeBorder`.

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/style-isolation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/styling/style-isolation.mdx
@@ -105,13 +105,13 @@ The plugin accepts an options object. The default options are:
 }
 ```
 
-CSS Modules are supported including SASS (SCSS) files.
+CSS Modules are supported including SCSS files.
 
 ## CSS Specificity
 
 When extending or overriding styles from Eufemia, it's essential to match the CSS specificity of the original selectors to ensure your styles are applied correctly.
 
-To help with this, you can use the PostCSS plugin (style-scope) that automatically adds the required scope class to your CSS or SCSS (SASS). This ensures your styles have the necessary specificity to take effect.
+To help with this, you can use the PostCSS plugin (style-scope) that automatically adds the required scope class to your CSS or SCSS. This ensures your styles have the necessary specificity to take effect.
 
 ```scss
 .myButtonStyle:global(.dnb-button) {

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeLibStyles.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeLibStyles.test.ts
@@ -19,7 +19,7 @@ vi.mock('ora', () => {
 
 vi.setConfig({ testTimeout: 30e3 })
 
-describe('makeLibStyles transform main SASS to CSS', () => {
+describe('makeLibStyles transform main SCSS to CSS', () => {
   beforeAll(async () => {
     global.css = await runFactory(
       './src/components/button/style/dnb-button.scss',

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeMainStyle.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeMainStyle.test.ts
@@ -23,7 +23,7 @@ vi.mock('ora', () => {
 if (isCI) {
   vi.setConfig({ testTimeout: 50e3 })
 
-  describe('makeMainStyle transforms "core" SASS to CSS', () => {
+  describe('makeMainStyle transforms "core" SCSS to CSS', () => {
     beforeAll(async () => {
       global.core = await runFactory('./src/style/dnb-ui-core.scss', {
         returnResult: true,
@@ -41,7 +41,7 @@ if (isCI) {
     })
   })
 
-  describe('makeMainStyle transforms "components" SASS to CSS', () => {
+  describe('makeMainStyle transforms "components" SCSS to CSS', () => {
     beforeAll(async () => {
       global.components = await runFactory(
         './src/style/themes/ui/ui-theme-components.scss',
@@ -95,7 +95,7 @@ if (isCI) {
     })
   })
 
-  describe('makeMainStyle transforms "elements" SASS to CSS', () => {
+  describe('makeMainStyle transforms "elements" SCSS to CSS', () => {
     beforeAll(async () => {
       global.elements = await runFactory(
         './src/style/dnb-ui-elements.scss',
@@ -112,7 +112,7 @@ if (isCI) {
     })
   })
 
-  describe('makeMainStyle transforms "theme" SASS to CSS', () => {
+  describe('makeMainStyle transforms "theme" SCSS to CSS', () => {
     beforeAll(async () => {
       global.theme = await runFactory(
         './src/style/themes/ui/ui-theme-basis.scss',

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeLibStyles.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeLibStyles.ts
@@ -69,7 +69,7 @@ export const runFactory = async (
     const absolutePath = path.resolve(ROOT_DIR, filePath)
     const content = await fs.readFile(absolutePath, 'utf-8')
 
-    // Transform SASS → CSS, fix asset paths
+    // Transform SCSS to CSS, fix asset paths
     const cssContent = sassTransform(content, { path: absolutePath })
     const cssPath = absolutePath.replace(/\.scss$/, '.css')
     const pathFixedContent = innerPathsTransform(cssContent)

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeMainStyle.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeMainStyle.ts
@@ -76,7 +76,7 @@ export const runFactory = async (
     const absolutePath = path.resolve(ROOT_DIR, filePath)
     const content = await fs.readFile(absolutePath, 'utf-8')
 
-    // Transform SASS → CSS
+    // Transform SCSS to CSS
     const cssContent = sassTransform(content, { path: absolutePath })
     const cssPath = absolutePath.replace(/\.scss$/, '.css')
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
@@ -148,7 +148,7 @@ export const runFactory = async ({
     const absolutePath = path.resolve(ROOT_DIR, filePath)
     const content = fs.readFileSync(absolutePath, 'utf-8')
 
-    // Transform SASS to CSS
+    // Transform SCSS to CSS
     const cssContent = sassTransform(content, { path: absolutePath })
 
     // Generate JS properties file
@@ -732,7 +732,7 @@ const runDesignTokenFactory = async () => {
   ]
 
   log.info(
-    `> PrePublish: "makePropertiesFile" Generating Figma sass files:`
+    `> PrePublish: "makePropertiesFile" Generating Figma SCSS files:`
   )
 
   for (const file of tokenFiles) {


### PR DESCRIPTION
Standardize on "SCSS" when referring to the file format/syntax (.scss files with curly braces) and "Sass" for the preprocessor tool.

- Replace "SASS" with "SCSS" in all documentation prose
- Replace "SASS (SCSS)" and "SCSS (SASS)" with just "SCSS"
- Fix "SASS function" to "SCSS mixin" where @mixin is referenced
- Update build script comments to say "SCSS to CSS"
- Update test descriptions to say "SCSS to CSS"
- Keep "Sass" (correct casing) for preprocessor tool references
- Keep `sass` in code identifiers (npm package, API calls)

