### PR TITLE
chore: remove outdated IE reference in before-started docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -185,7 +185,7 @@ $ yarn workspace @dnb/eufemia build
 - Assets are getting generated
 - All index and lib files are getting generated
 - All the lib code gets compiled (ECMAScript 6 and ECMAScript 5.1)
-- All SASS styles are validated and compiled (to support IE)
+- All SASS styles are validated and compiled
 - Compiled CSS under `build/**/*.css` is parsed with [Lightning CSS](https://github.com/parcel-bundler/lightningcss) so invalid selectors (for example pseudo-elements not last in a compound selector) fail the build
 - All bundles get minified
 - Icons are getting converted


### PR DESCRIPTION
The "(to support IE)" note is no longer accurate — Eufemia does not target IE.

