### PR TITLE
fix(Theme): prevent nested Theme from overriding body color scheme

### DIFF
--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -90,9 +90,17 @@ export default function Theme(themeProps: ThemeAllProps) {
     theme.surface = undefined
   }
 
+  // Detect if this Theme is nested inside another Theme with colorScheme
+  const isNestedColorScheme = Boolean(context?.theme?.colorScheme)
+
   return (
     <Provider theme={theme}>
-      <ThemeWrapper element={element} theme={theme} {...restProps}>
+      <ThemeWrapper
+        element={element}
+        theme={theme}
+        isNestedColorScheme={isNestedColorScheme}
+        {...restProps}
+      >
         {children}
       </ThemeWrapper>
     </Provider>
@@ -111,12 +119,13 @@ export function ThemeWrapper({
   theme,
   element = null,
   className = null,
+  isNestedColorScheme = false,
   ...rest
 }) {
   const Wrapper = element === false ? Fragment : element || 'div'
   const ref = useRef<HTMLElement>(null)
 
-  useSyncBodyColorScheme(theme)
+  useSyncBodyColorScheme(theme, isNestedColorScheme)
   useSyncElementColorScheme(ref, theme)
 
   const classNames = getThemeClasses(theme, className)
@@ -184,11 +193,20 @@ function useSyncElementColorScheme(
   }, [colorScheme])
 }
 
-function useSyncBodyColorScheme(theme: ThemeProps) {
+function useSyncBodyColorScheme(
+  theme: ThemeProps,
+  isNestedColorScheme: boolean
+) {
   const colorScheme = theme?.colorScheme
 
   useIsomorphicLayoutEffect(() => {
-    if (typeof document === 'undefined' || !colorScheme) {
+    // Skip body sync for nested Theme components to avoid overriding
+    // the root Theme's color scheme
+    if (
+      typeof document === 'undefined' ||
+      !colorScheme ||
+      isNestedColorScheme
+    ) {
       return // stop here
     }
 
@@ -199,7 +217,7 @@ function useSyncBodyColorScheme(theme: ThemeProps) {
     document.body.classList.add(
       `eufemia-theme__color-scheme--${colorScheme}`
     )
-  }, [colorScheme])
+  }, [colorScheme, isNestedColorScheme])
 }
 
 const STORAGE_KEY = 'eufemia-theme'

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -510,6 +510,34 @@ describe('Portals', () => {
         element.classList.contains('eufemia-theme__color-scheme--dark')
       ).toBe(true)
     })
+
+    it('does not sync body class for nested Theme', () => {
+      render(
+        <Theme colorScheme="light">
+          <Theme colorScheme="dark">nested content</Theme>
+        </Theme>
+      )
+
+      // Body should have the outer Theme's color scheme, not the nested one
+      expect(
+        document.body.classList.contains(
+          'eufemia-theme__color-scheme--light'
+        )
+      ).toBe(true)
+      expect(
+        document.body.classList.contains(
+          'eufemia-theme__color-scheme--dark'
+        )
+      ).toBe(false)
+
+      // But the nested element should still have the dark class
+      const nestedElement = document.querySelectorAll('.eufemia-theme')[1]
+      expect(
+        nestedElement.classList.contains(
+          'eufemia-theme__color-scheme--dark'
+        )
+      ).toBe(true)
+    })
   })
 
   describe('globalThis.__eufemiaColorScheme', () => {


### PR DESCRIPTION
Not entirely sure about this.

Motivation is that when visiting the following page in light mode https://eufemia.dnb.no/uilib/usage/customisation/theming/design-tokens/dark-mode/ then several "scroll surfaces" becomes dark/black. And it does not stop when I visit other pages, it still is changed to be black forever.


https://github.com/user-attachments/assets/ec152669-7ebf-449c-9811-b880a4f9c8b7




When a Theme with colorScheme is nested inside another Theme with colorScheme, the nested one no longer syncs its color scheme class to document.body. This prevents issues like the dark mode documentation page permanently switching the page background to dark when visited.

