### PR TITLE
fix(MultiSelection): add accessible label to search input

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterMultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterMultiSelection.test.tsx
@@ -1,5 +1,4 @@
 import { render, fireEvent } from '@testing-library/react'
-import { axeComponent } from '../../../core/test-utils/testSetup'
 import FilterRoot from '../FilterRoot'
 import FilterMultiSelection from '../FilterMultiSelection'
 import { useFilterContext } from '../hooks/useFilter'
@@ -118,27 +117,5 @@ describe('Filter.MultiSelection state', () => {
     expect(
       document.querySelector('[data-testid="count"]').textContent
     ).toBe('0')
-  })
-})
-
-describe('Filter.MultiSelection accessibility', () => {
-  const data = [
-    { value: 'acme', title: 'Acme Corp' },
-    { value: 'globex', title: 'Globex Inc' },
-  ]
-
-  it('has no axe violations', async () => {
-    const { container } = render(
-      <FilterRoot id="multi-sel-a11y-test">
-        <FilterMultiSelection
-          label="Client"
-          filterKey="/client"
-          data={data}
-          defaultOpen
-        />
-      </FilterRoot>
-    )
-
-    expect(await axeComponent(container)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterMultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterMultiSelection.test.tsx
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@testing-library/react'
+import { axeComponent } from '../../../core/test-utils/testSetup'
 import FilterRoot from '../FilterRoot'
 import FilterMultiSelection from '../FilterMultiSelection'
 import { useFilterContext } from '../hooks/useFilter'
@@ -117,5 +118,27 @@ describe('Filter.MultiSelection state', () => {
     expect(
       document.querySelector('[data-testid="count"]').textContent
     ).toBe('0')
+  })
+})
+
+describe('Filter.MultiSelection accessibility', () => {
+  const data = [
+    { value: 'acme', title: 'Acme Corp' },
+    { value: 'globex', title: 'Globex Inc' },
+  ]
+
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <FilterRoot id="multi-sel-a11y-test">
+        <FilterMultiSelection
+          label="Client"
+          filterKey="/client"
+          data={data}
+          defaultOpen
+        />
+      </FilterRoot>
+    )
+
+    expect(await axeComponent(container)).toHaveNoViolations()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSearch.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSearch.tsx
@@ -23,7 +23,8 @@ export function MultiSelectionSearch({
   return (
     <>
       <Input
-        label={false}
+        label={placeholder}
+        labelSrOnly
         icon="loupe"
         iconPosition="left"
         placeholder={placeholder}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -2212,9 +2212,9 @@ describe('MultiSelection', () => {
         '.dnb-forms-field-multi-selection__item'
       )
       expect(items).toHaveLength(1)
-      expect(
-        items[0].querySelector('.dnb-form-label')
-      ).toHaveTextContent('Banana')
+      expect(items[0].querySelector('.dnb-form-label')).toHaveTextContent(
+        'Banana'
+      )
     })
 
     it('does not render a popover', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -821,6 +821,28 @@ describe('MultiSelection', () => {
   })
 
   describe('showSearchField', () => {
+    it('renders search input with accessible label', () => {
+      const data = [
+        { value: 'option1', title: 'Option 1' },
+        { value: 'option2', title: 'Option 2' },
+      ]
+
+      render(<Field.MultiSelection data={data} showSearchField />)
+
+      fireEvent.click(document.querySelector('button'))
+
+      const searchWrapper = document.querySelector(
+        '.dnb-forms-field-multi-selection__search'
+      )
+      const searchInput = searchWrapper.querySelector('input')
+      const searchLabel = searchWrapper.querySelector('label')
+
+      expect(searchInput).toBeInTheDocument()
+      expect(searchLabel).toBeInTheDocument()
+      expect(searchLabel).toHaveClass('dnb-sr-only')
+      expect(searchLabel.getAttribute('for')).toBe(searchInput.id)
+    })
+
     it('filters on description text', async () => {
       const data = [
         {
@@ -2190,9 +2212,9 @@ describe('MultiSelection', () => {
         '.dnb-forms-field-multi-selection__item'
       )
       expect(items).toHaveLength(1)
-      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
-        'Banana'
-      )
+      expect(
+        items[0].querySelector('.dnb-form-label')
+      ).toHaveTextContent('Banana')
     })
 
     it('does not render a popover', () => {


### PR DESCRIPTION
Deploy preview https://fix-multi-selection-search-a.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection/demos#with-search
Latest release: https://eufemia.dnb.no/uilib/extensions/forms/base-fields/MultiSelection/demos/#with-search

- Add proper accessible label to MultiSelectionSearch input using labelSrOnly
- Add axe accessibility test for Filter.MultiSelection

The search input was missing an accessible label which violated WCAG 4.1.2. Now uses the placeholder text as a screen-reader-only label.

