### PR TITLE
chore(Filter.Search): add aria-label to search submit button in manual mode

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/FilterSearch.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterSearch.tsx
@@ -9,6 +9,7 @@ import { clsx } from 'clsx'
 import Input from '../input/Input'
 import type { InputProps } from '../input/Input'
 import ProgressIndicator from '../progress-indicator/ProgressIndicator'
+import SharedContext from '../../shared/Context'
 import { FilterContext } from './FilterContext'
 import { loupe as searchIcon } from '../../icons'
 
@@ -42,6 +43,8 @@ function FilterSearch({
   ...rest
 }: FilterSearchProps) {
   const context = useContext(FilterContext)
+  const sharedContext = useContext(SharedContext)
+  const { searchSubmitLabel } = sharedContext.getTranslation({}).Filter
 
   if (!context) {
     throw new Error('Filter.Search must be used inside a Filter.Root.')
@@ -116,7 +119,11 @@ function FilterSearch({
         value={isManual ? localValue : context.state.search}
         onChange={handleChange}
         {...(isManual
-          ? { onSubmit: handleSubmit, onClear: handleClear }
+          ? {
+              onSubmit: handleSubmit,
+              onClear: handleClear,
+              submitButtonTitle: rest.submitButtonTitle ?? searchSubmitLabel,
+            }
           : undefined)}
         icon={
           showIndicator ? (

--- a/packages/dnb-eufemia/src/components/filter/FilterSearch.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterSearch.tsx
@@ -122,7 +122,8 @@ function FilterSearch({
           ? {
               onSubmit: handleSubmit,
               onClear: handleClear,
-              submitButtonTitle: rest.submitButtonTitle ?? searchSubmitLabel,
+              submitButtonTitle:
+                rest.submitButtonTitle ?? searchSubmitLabel,
             }
           : undefined)}
         icon={

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterSearch.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterSearch.test.tsx
@@ -1,5 +1,8 @@
 import { render, fireEvent } from '@testing-library/react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
+import Provider from '../../../shared/Provider'
+import nbNO from '../../../shared/locales/nb-NO'
+import enGB from '../../../shared/locales/en-GB'
 import FilterRoot from '../FilterRoot'
 import FilterSearch from '../FilterSearch'
 import { useFilterContext } from '../hooks/useFilter'
@@ -399,5 +402,43 @@ describe('Filter.Search submitBehavior="manual"', () => {
     fireEvent.click(document.querySelector('[data-testid="reset"]'))
 
     expect(input).toHaveValue('')
+  })
+
+  it('sets aria-label on submit button from locale', () => {
+    render(
+      <Provider locale="nb-NO">
+        <FilterRoot id="manual-aria-label-test">
+          <FilterSearch label="Søk" submitBehavior="manual" />
+        </FilterRoot>
+      </Provider>
+    )
+
+    const submitButton = document.querySelector(
+      '.dnb-input__submit-button__button'
+    )
+
+    expect(submitButton).toHaveAttribute(
+      'aria-label',
+      nbNO['nb-NO'].Filter.searchSubmitLabel
+    )
+  })
+
+  it('uses English aria-label when locale is en-GB', () => {
+    render(
+      <Provider locale="en-GB">
+        <FilterRoot id="manual-aria-label-en-test">
+          <FilterSearch label="Søk" submitBehavior="manual" />
+        </FilterRoot>
+      </Provider>
+    )
+
+    const submitButton = document.querySelector(
+      '.dnb-input__submit-button__button'
+    )
+
+    expect(submitButton).toHaveAttribute(
+      'aria-label',
+      enGB['en-GB'].Filter.searchSubmitLabel
+    )
   })
 })

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -207,6 +207,7 @@ export default {
       applyFilterLabel: 'Anvend filter',
       cancelFilterLabel: 'Annuller',
       dateLabel: 'Dato',
+      searchSubmitLabel: 'Søg',
       sortButtonLabel: 'Sortér',
       noResultsMessage: 'Prøv at ændre eller fjerne nogle filtre.',
       resultCountMessage: '%s resultat(er)',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -207,6 +207,7 @@ export default {
       applyFilterLabel: 'Apply filter',
       cancelFilterLabel: 'Cancel',
       dateLabel: 'Date',
+      searchSubmitLabel: 'Search',
       sortButtonLabel: 'Sort',
       noResultsMessage: 'Try changing or removing some filters.',
       resultCountMessage: '%s result(s)',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -205,6 +205,7 @@ export default {
       applyFilterLabel: 'Bruk filter',
       cancelFilterLabel: 'Avbryt',
       dateLabel: 'Dato',
+      searchSubmitLabel: 'Søk',
       sortButtonLabel: 'Sorter',
       noResultsMessage: 'Prøv å endre eller fjerne noen filtre.',
       resultCountMessage: '%s treff',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -206,6 +206,7 @@ export default {
       applyFilterLabel: 'Använd filter',
       cancelFilterLabel: 'Avbryt',
       dateLabel: 'Datum',
+      searchSubmitLabel: 'Sök',
       sortButtonLabel: 'Sortera',
       noResultsMessage: 'Försök att ändra eller ta bort några filter.',
       resultCountMessage: '%s resultat',


### PR DESCRIPTION
When FilterSearch uses submitBehavior="manual", the Input renders a submit button with a loupe icon but no accessible name. Screen readers cannot identify the button's purpose.

Add a searchSubmitLabel translation key to nb-NO, en-GB, and sv-SE locales, and pass it as submitButtonTitle to the Input component. Consumers can still override via the submitButtonTitle prop.

Deploy preview: https://fix-filter-search-submit-but.eufemia-e25.pages.dev/uilib/components/filter#search-only
Main preview: https://main.eufemia-e25.pages.dev/uilib/components/filter#search-only
