### PR TITLE
fix(Tabs): prevent vertical wheel scroll trapping on tab strip

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -902,10 +902,64 @@ function TabsComponent(ownProps: TabsProps) {
       resizeObserver.observe(tabsRef.current)
     }
 
+    // Prevent vertical wheel events from being translated into horizontal
+    // scrolling of the tab strip (Chromium behavior). Instead, forward
+    // them to the nearest scrollable ancestor so the page scrolls normally.
+    const handleWheel = (event: WheelEvent) => {
+      if (!hasScrollbarRef.current) {
+        return
+      }
+
+      if (
+        Math.abs(event.deltaX) > Math.abs(event.deltaY) ||
+        event.shiftKey
+      ) {
+        return
+      }
+
+      event.preventDefault()
+
+      let deltaY = event.deltaY
+      if (event.deltaMode === 1) {
+        deltaY *= 16
+      } else if (event.deltaMode === 2) {
+        deltaY *= window.innerHeight
+      }
+
+      let scrollTarget: Element | null =
+        tablistRef.current?.parentElement ?? null
+      while (scrollTarget) {
+        const style = window.getComputedStyle(scrollTarget)
+        if (
+          (style.overflowY === 'auto' || style.overflowY === 'scroll') &&
+          scrollTarget.scrollHeight > scrollTarget.clientHeight
+        ) {
+          break
+        }
+        scrollTarget = scrollTarget.parentElement
+      }
+
+      const el =
+        scrollTarget ||
+        document.scrollingElement ||
+        document.documentElement
+      el.scrollBy({ top: deltaY })
+    }
+
+    const tablistEl = tablistRef.current
+    if (tablistEl) {
+      tablistEl.addEventListener('wheel', handleWheel, {
+        passive: false,
+      })
+    }
+
     return () => {
       isMounted = false
       sharedStateRef.current = null
       resizeObserver?.disconnect()
+      if (tablistEl) {
+        tablistEl.removeEventListener('wheel', handleWheel)
+      }
       if (typeof window !== 'undefined') {
         window.removeEventListener('load', init)
       }

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -855,6 +855,180 @@ describe('A single Tab component', () => {
   })
 })
 
+describe('Tabs wheel scrolling', () => {
+  function setupScrollableTabs() {
+    let triggerResize: ResizeObserverCallback
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        triggerResize = callback
+      }
+      observe() {
+        /* noop */
+      }
+      unobserve() {
+        /* noop */
+      }
+      disconnect() {
+        /* noop */
+      }
+    } as unknown as typeof ResizeObserver
+
+    render(
+      <Tabs {...props} data={tablistData}>
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const tablist = document.querySelector('.dnb-tabs__tabs__tablist')
+
+    Object.defineProperty(tablist, 'scrollWidth', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(tablist, 'offsetWidth', {
+      value: 100,
+      configurable: true,
+    })
+
+    act(() => {
+      triggerResize([] as unknown as ResizeObserverEntry[], null)
+    })
+
+    return tablist
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as Record<string, unknown>).ResizeObserver
+  })
+
+  it('should preventDefault on vertical wheel and scroll the page instead', () => {
+    const tablist = setupScrollableTabs()
+
+    expect(document.querySelector('.dnb-tabs__tabs')).toHaveClass(
+      'dnb-tabs--has-scrollbar'
+    )
+
+    document.documentElement.scrollBy =
+      document.documentElement.scrollBy || (() => undefined)
+    const scrollBySpy = vi
+      .spyOn(document.documentElement, 'scrollBy')
+      .mockImplementation(() => undefined)
+
+    const wheelEvent = new WheelEvent('wheel', {
+      deltaX: 0,
+      deltaY: 120,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const preventDefaultSpy = vi.spyOn(wheelEvent, 'preventDefault')
+
+    tablist.dispatchEvent(wheelEvent)
+
+    expect(preventDefaultSpy).toHaveBeenCalledTimes(1)
+    expect(scrollBySpy).toHaveBeenCalledWith({ top: 120 })
+  })
+
+  it('should not preventDefault on horizontal-dominant wheel', () => {
+    const tablist = setupScrollableTabs()
+
+    const wheelEvent = new WheelEvent('wheel', {
+      deltaX: 120,
+      deltaY: 10,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const preventDefaultSpy = vi.spyOn(wheelEvent, 'preventDefault')
+
+    tablist.dispatchEvent(wheelEvent)
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  it('should not preventDefault when shiftKey is pressed', () => {
+    const tablist = setupScrollableTabs()
+
+    const wheelEvent = new WheelEvent('wheel', {
+      deltaX: 0,
+      deltaY: 120,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const preventDefaultSpy = vi.spyOn(wheelEvent, 'preventDefault')
+
+    tablist.dispatchEvent(wheelEvent)
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  it('should be a no-op when there is no horizontal overflow', () => {
+    let triggerResize: ResizeObserverCallback
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        triggerResize = callback
+      }
+      observe() {
+        /* noop */
+      }
+      unobserve() {
+        /* noop */
+      }
+      disconnect() {
+        /* noop */
+      }
+    } as unknown as typeof ResizeObserver
+
+    render(
+      <Tabs {...props} data={tablistData}>
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const tablist = document.querySelector('.dnb-tabs__tabs__tablist')
+
+    Object.defineProperty(tablist, 'scrollWidth', {
+      value: 100,
+      configurable: true,
+    })
+    Object.defineProperty(tablist, 'offsetWidth', {
+      value: 100,
+      configurable: true,
+    })
+
+    act(() => {
+      triggerResize([] as unknown as ResizeObserverEntry[], null)
+    })
+
+    expect(document.querySelector('.dnb-tabs__tabs')).not.toHaveClass(
+      'dnb-tabs--has-scrollbar'
+    )
+
+    document.documentElement.scrollBy =
+      document.documentElement.scrollBy || (() => undefined)
+    const scrollBySpy = vi
+      .spyOn(document.documentElement, 'scrollBy')
+      .mockImplementation(() => undefined)
+
+    const wheelEvent = new WheelEvent('wheel', {
+      deltaX: 0,
+      deltaY: 120,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const preventDefaultSpy = vi.spyOn(wheelEvent, 'preventDefault')
+
+    tablist.dispatchEvent(wheelEvent)
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+    expect(scrollBySpy).not.toHaveBeenCalled()
+  })
+})
+
 describe('Tabs scss', () => {
   it('has to match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))


### PR DESCRIPTION
Chromium translates vertical wheel events into horizontal scrolling on the tab strip, trapping page scroll. Add a wheel listener that detects vertical-dominant gestures, calls preventDefault, and forwards the scroll to the nearest scrollable ancestor.

Intentional horizontal scrolling (deltaX-dominant or Shift+wheel) is left untouched. The handler is a no-op when the strip has no overflow.

Closes #6827

