### PR TITLE
chore(Filter): remove redundant test ids

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/FilterContent.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterContent.tsx
@@ -30,7 +30,7 @@ function FilterContent({
     sharedContext.getTranslation({}).Filter
   const resolvedId = connectedTo ?? context?.id
 
-  if (!resolvedId) {
+  if (!resolvedId && !context) {
     throw new Error(
       'Filter.Content requires a connectedTo prop or must be used inside a Filter.Root.'
     )
@@ -38,8 +38,8 @@ function FilterContent({
 
   const { data } = useSharedState<FilterState>(resolvedId)
 
-  const isLoading = data?.resultLoading ?? false
-  const resultCount = data?.resultCount
+  const isLoading = data?.resultLoading ?? context?.resultLoading ?? false
+  const resultCount = data?.resultCount ?? context?.resultCount
 
   const hadLoading = useRef(false)
   if (isLoading) {

--- a/packages/dnb-eufemia/src/components/filter/FilterContext.ts
+++ b/packages/dnb-eufemia/src/components/filter/FilterContext.ts
@@ -18,7 +18,7 @@ export type FilterState = FilterChangeState & {
 }
 
 export type FilterContextValue = {
-  id: string
+  id?: string
   behavior: 'realtime' | 'manual'
   state: FilterState
   appliedState: FilterState

--- a/packages/dnb-eufemia/src/components/filter/FilterResultCount.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterResultCount.tsx
@@ -37,7 +37,8 @@ function FilterResultCount({
   const resultCount =
     resultCountProp ?? sharedData?.resultCount ?? context?.resultCount
 
-  const isLoading = sharedData?.resultLoading ?? false
+  const isLoading =
+    sharedData?.resultLoading ?? context?.resultLoading ?? false
 
   const hasActiveFilters =
     context?.behavior === 'manual'

--- a/packages/dnb-eufemia/src/components/filter/FilterRoot.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterRoot.tsx
@@ -21,7 +21,7 @@ import type { SpacingProps } from '../../shared/types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type FilterRootProps = {
-  id: string
+  id?: string
   behavior?: 'realtime' | 'manual'
   defaultFilters?: Record<string, FilterValue>
   defaultPanelOpen?: boolean
@@ -95,9 +95,11 @@ function FilterRoot({
     return deriveAccordionState(defaultFilters)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const accordionStateId = id ? `${id}__accordion` : undefined
+
   const { data: savedAccordionState, extend: extendAccordionState } =
     useSharedState<Record<string, boolean>>(
-      `${id}__accordion`,
+      accordionStateId,
       defaultAccordionState
     )
 
@@ -105,9 +107,13 @@ function FilterRoot({
     savedAccordionState ?? defaultAccordionState
   )
 
-  const defaultState: FilterState = defaultFilters
-    ? { search: '', filters: defaultFilters }
-    : initialState
+  const defaultState = useMemo<FilterState>(
+    () =>
+      defaultFilters
+        ? { search: '', filters: defaultFilters }
+        : initialState,
+    [defaultFilters]
+  )
 
   const { data, get, extend } = useSharedState<FilterState>(
     id,
@@ -115,6 +121,28 @@ function FilterRoot({
   )
 
   const isManual = behavior === 'manual'
+  const [localState, setLocalState] = useState<FilterState>(defaultState)
+
+  const committedState = id ? (data ?? defaultState) : localState
+  const committedStateRef = useRef(committedState)
+  committedStateRef.current = committedState
+
+  const getCommittedState = useCallback(() => {
+    return id ? (get() ?? defaultState) : committedStateRef.current
+  }, [defaultState, get, id])
+
+  const updateCommittedState = useCallback(
+    (nextState: FilterState | Partial<FilterState>) => {
+      if (id) {
+        extend(nextState)
+      } else {
+        const next = { ...committedStateRef.current, ...nextState }
+        committedStateRef.current = next
+        setLocalState(next)
+      }
+    },
+    [extend, id]
+  )
 
   const [draftState, setDraftState] = useState<FilterState>(
     () => data ?? defaultState
@@ -126,7 +154,7 @@ function FilterRoot({
   // useFilter initializes the shared state to empty before FilterRoot renders.
   useEffect(() => {
     if (hasDefaultFilters) {
-      extend({ filters: defaultFilters })
+      updateCommittedState({ filters: defaultFilters })
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -142,27 +170,27 @@ function FilterRoot({
     }
 
     if (Object.keys(updates).length > 0) {
-      extend(updates)
+      updateCommittedState(updates)
     }
-  }, [extend, resultLoading, resultCount])
+  }, [resultLoading, resultCount, updateCommittedState])
 
-  const state = isManual ? draftState : (data ?? initialState)
+  const state = isManual ? draftState : committedState
 
   const setSearch = useCallback(
     (search: string) => {
       if (isManual) {
-        const filters = (get() ?? initialState).filters
+        const filters = getCommittedState().filters
 
         setDraftState((prev) => ({ ...prev, search }))
-        extend({ search })
+        updateCommittedState({ search })
         onChangeRef.current?.({ search, filters })
       } else {
-        extend({ search })
-        const filters = (get() ?? initialState).filters
+        updateCommittedState({ search })
+        const filters = getCommittedState().filters
         onChangeRef.current?.({ search, filters })
       }
     },
-    [isManual, extend, get]
+    [getCommittedState, isManual, updateCommittedState]
   )
 
   const setFilter = useCallback(
@@ -180,7 +208,7 @@ function FilterRoot({
           return { ...prev, filters: next }
         })
       } else {
-        const latest = get() ?? initialState
+        const latest = getCommittedState()
         const next = { ...latest.filters }
 
         if (value === undefined) {
@@ -189,11 +217,11 @@ function FilterRoot({
           next[filterKey] = value
         }
 
-        extend({ filters: next })
+        updateCommittedState({ filters: next })
         onChangeRef.current?.(toChangeState({ ...latest, filters: next }))
       }
     },
-    [isManual, extend, get]
+    [getCommittedState, isManual, updateCommittedState]
   )
 
   const getFilter = useCallback(
@@ -205,7 +233,7 @@ function FilterRoot({
 
   const submitFilterRemoval = useCallback(
     (filterKey: string) => {
-      const committed = get() ?? initialState
+      const committed = getCommittedState()
       const nextAppliedFilters = { ...committed.filters }
       delete nextAppliedFilters[filterKey]
 
@@ -224,16 +252,16 @@ function FilterRoot({
       }
 
       setDraftState(nextDraftState)
-      extend(nextAppliedState)
+      updateCommittedState(nextAppliedState)
       onChangeRef.current?.(toChangeState(nextAppliedState))
     },
-    [extend, get]
+    [getCommittedState, updateCommittedState]
   )
 
   const removeFilter = useCallback(
     (filterKey: string) => {
       if (isManual) {
-        const appliedFilters = (get() ?? initialState).filters
+        const appliedFilters = getCommittedState().filters
 
         if (Object.hasOwn(appliedFilters, filterKey)) {
           submitFilterRemoval(filterKey)
@@ -244,7 +272,7 @@ function FilterRoot({
         setFilter(filterKey, undefined)
       }
     },
-    [get, isManual, setFilter, submitFilterRemoval]
+    [getCommittedState, isManual, setFilter, submitFilterRemoval]
   )
 
   const removeAppliedFilter = useCallback(
@@ -259,28 +287,31 @@ function FilterRoot({
   )
 
   const clearFilters = useCallback(() => {
-    const latest = isManual ? draftRef.current : (get() ?? initialState)
+    const latest = isManual ? draftRef.current : getCommittedState()
     const nextState = { ...latest, filters: {} }
 
     if (isManual) {
       setDraftState(nextState)
     }
 
-    extend({ search: nextState.search, filters: nextState.filters })
+    updateCommittedState({
+      search: nextState.search,
+      filters: nextState.filters,
+    })
     onChangeRef.current?.(toChangeState(nextState))
-  }, [extend, get, isManual])
+  }, [getCommittedState, isManual, updateCommittedState])
 
   const replaceFilters = useCallback(
     (filters: Record<string, FilterValue>) => {
       if (isManual) {
         setDraftState((prev) => ({ ...prev, filters }))
       } else {
-        extend({ filters })
-        const latest = get() ?? initialState
+        updateCommittedState({ filters })
+        const latest = getCommittedState()
         onChangeRef.current?.(toChangeState({ ...latest, filters }))
       }
     },
-    [isManual, extend, get]
+    [getCommittedState, isManual, updateCommittedState]
   )
 
   const resetFilters = useCallback(() => {
@@ -288,27 +319,26 @@ function FilterRoot({
 
     if (isManual) {
       setDraftState(next)
-      extend(next)
-    } else {
-      extend(next)
     }
 
+    updateCommittedState(next)
+
     onChangeRef.current?.(next)
-  }, [isManual, extend])
+  }, [isManual, updateCommittedState])
 
   const commitFilters = useCallback(() => {
     const draft = draftRef.current
-    extend({ search: draft.search, filters: draft.filters })
+    updateCommittedState({ search: draft.search, filters: draft.filters })
     onChangeRef.current?.(toChangeState(draft))
-  }, [extend])
+  }, [updateCommittedState])
 
   const revertFilters = useCallback(() => {
-    const committed = get() ?? initialState
+    const committed = getCommittedState()
     setDraftState({
       search: committed.search,
       filters: committed.filters,
     })
-  }, [get])
+  }, [getCommittedState])
 
   const hasActiveFilters =
     state.search.length > 0 || Object.keys(state.filters).length > 0
@@ -325,7 +355,7 @@ function FilterRoot({
       return // stop here — explicit defaultPanelOpen or defaultFilters already handles this
     }
 
-    const current = get()
+    const current = getCommittedState()
     const filters = current?.filters ?? {}
 
     if (Object.keys(filters).length > 0) {
@@ -352,12 +382,11 @@ function FilterRoot({
     [extendAccordionState]
   )
 
-  const sharedState = data ?? initialState
-
   // The applied state is the committed shared state, separate from the local draft in manual mode
-  const appliedState = sharedState
-  const resolvedResultCount = resultCount ?? sharedState.resultCount
-  const resolvedResultLoading = resultLoading ?? sharedState.resultLoading
+  const appliedState = committedState
+  const resolvedResultCount = resultCount ?? committedState.resultCount
+  const resolvedResultLoading =
+    resultLoading ?? committedState.resultLoading
 
   const contextValue = useMemo(
     () => ({

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterActiveFilters.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterActiveFilters.test.tsx
@@ -11,7 +11,7 @@ import { useFilterContext } from '../hooks/useFilter'
 describe('Filter.ActiveFilters', () => {
   it('is hidden when no filters are active', () => {
     render(
-      <FilterRoot id="empty-active">
+      <FilterRoot>
         <FilterActiveFilters />
       </FilterRoot>
     )
@@ -39,7 +39,7 @@ describe('Filter.ActiveFilters', () => {
     }
 
     render(
-      <FilterRoot id="active-tags-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters />
       </FilterRoot>
@@ -72,7 +72,7 @@ describe('Filter.ActiveFilters', () => {
     }
 
     render(
-      <FilterRoot id="show-filter-label-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters showCategoryLabel />
       </FilterRoot>
@@ -104,7 +104,7 @@ describe('Filter.ActiveFilters', () => {
     }
 
     render(
-      <FilterRoot id="hide-filter-label-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters />
       </FilterRoot>
@@ -139,7 +139,7 @@ describe('Filter.ActiveFilters', () => {
     }
 
     render(
-      <FilterRoot id="remove-tag-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters />
         <FilterState />
@@ -164,7 +164,7 @@ describe('Filter.ActiveFilters', () => {
 
   it('shows tags when FilterSelection checkbox is checked', () => {
     render(
-      <FilterRoot id="active-via-selection">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterSelection
@@ -211,7 +211,7 @@ describe('Filter.ActiveFilters events', () => {
     }
 
     render(
-      <FilterRoot id="on-remove-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters onRemove={onRemove} />
       </FilterRoot>
@@ -248,7 +248,7 @@ describe('Filter.ActiveFilters accessibility', () => {
     }
 
     render(
-      <FilterRoot id="a11y-label-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters />
       </FilterRoot>
@@ -281,7 +281,7 @@ describe('Filter.ActiveFilters accessibility', () => {
     }
 
     const { container } = render(
-      <FilterRoot id="a11y-active-test">
+      <FilterRoot>
         <SetFilter />
         <FilterActiveFilters />
       </FilterRoot>
@@ -315,7 +315,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('does not show collapsible when below threshold', () => {
     render(
-      <FilterRoot id="collapse-below-test">
+      <FilterRoot>
         <SetManyFilters count={3} />
         <FilterActiveFilters collapsibleThreshold={5} />
       </FilterRoot>
@@ -333,7 +333,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('shows a clear all button without collapsibleThreshold', () => {
     render(
-      <FilterRoot id="non-collapse-clear-test">
+      <FilterRoot>
         <SetManyFilters count={2} />
         <FilterActiveFilters />
       </FilterRoot>
@@ -360,7 +360,7 @@ describe('Filter.ActiveFilters collapsible', () => {
     }
 
     render(
-      <FilterRoot id="non-collapse-clear-action-test">
+      <FilterRoot>
         <SetManyFilters count={3} />
         <FilterActiveFilters />
         <FilterState />
@@ -400,7 +400,7 @@ describe('Filter.ActiveFilters collapsible', () => {
     }
 
     render(
-      <FilterRoot id="clear-action-preserve-search-test">
+      <FilterRoot>
         <FilterSearch label="Søk" />
         <SetManyFilters count={3} />
         <FilterPanelButton>Filters</FilterPanelButton>
@@ -445,7 +445,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('shows collapsible accordion when above threshold', () => {
     render(
-      <FilterRoot id="collapse-above-test">
+      <FilterRoot>
         <SetManyFilters count={6} />
         <FilterActiveFilters collapsibleThreshold={5} />
       </FilterRoot>
@@ -461,7 +461,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('shows filter count in the accordion title', () => {
     render(
-      <FilterRoot id="collapse-count-test">
+      <FilterRoot>
         <SetManyFilters count={6} />
         <FilterActiveFilters collapsibleThreshold={5} />
       </FilterRoot>
@@ -476,7 +476,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('shows a clear all button', () => {
     render(
-      <FilterRoot id="collapse-clear-test">
+      <FilterRoot>
         <SetManyFilters count={6} />
         <FilterActiveFilters collapsibleThreshold={5} />
       </FilterRoot>
@@ -503,7 +503,7 @@ describe('Filter.ActiveFilters collapsible', () => {
     }
 
     render(
-      <FilterRoot id="collapse-clear-action-test">
+      <FilterRoot>
         <SetManyFilters count={6} />
         <FilterActiveFilters collapsibleThreshold={5} />
         <FilterState />
@@ -531,7 +531,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('wraps tags in a scroll view when accordion is expanded', () => {
     render(
-      <FilterRoot id="collapse-scroll-test">
+      <FilterRoot>
         <SetManyFilters count={6} />
         <FilterActiveFilters collapsibleThreshold={5} />
       </FilterRoot>
@@ -553,7 +553,7 @@ describe('Filter.ActiveFilters collapsible', () => {
 
   it('renders tags inside the accordion content when expanded', () => {
     render(
-      <FilterRoot id="collapse-tags-test">
+      <FilterRoot>
         <SetManyFilters count={6} />
         <FilterActiveFilters collapsibleThreshold={5} />
       </FilterRoot>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterContent.test.tsx
@@ -1,17 +1,17 @@
 import { render, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import FilterRoot from '../FilterRoot'
 import FilterContent from '../FilterContent'
 import FilterNoResults from '../FilterNoResults'
 import ListContainer from '../../list/Container'
-import { useSharedState } from '../../../shared/helpers/useSharedState'
 import userEvent from '@testing-library/user-event'
 
 describe('Filter.Content', () => {
   it('renders children', () => {
     render(
-      <FilterRoot id="results-render-test">
-        <FilterContent connectedTo="results-render-test">
+      <FilterRoot>
+        <FilterContent>
           <p>Result content</p>
         </FilterContent>
       </FilterRoot>
@@ -27,8 +27,8 @@ describe('Filter.Content', () => {
 
   it('shows skeleton when resultLoading is true', () => {
     render(
-      <FilterRoot id="results-skeleton-test" resultLoading>
-        <FilterContent connectedTo="results-skeleton-test">
+      <FilterRoot resultLoading>
+        <FilterContent>
           <p>Loading content</p>
         </FilterContent>
       </FilterRoot>
@@ -43,8 +43,8 @@ describe('Filter.Content', () => {
 
   it('does not show skeleton when resultLoading is false', () => {
     render(
-      <FilterRoot id="results-no-skeleton-test" resultLoading={false}>
-        <FilterContent connectedTo="results-no-skeleton-test">
+      <FilterRoot resultLoading={false}>
+        <FilterContent>
           <p>Normal content</p>
         </FilterContent>
       </FilterRoot>
@@ -76,8 +76,8 @@ describe('Filter.Content', () => {
 
   it('supports spacing props', () => {
     render(
-      <FilterRoot id="results-spacing-test">
-        <FilterContent connectedTo="results-spacing-test" top="large">
+      <FilterRoot>
+        <FilterContent top="large">
           <p>Content</p>
         </FilterContent>
       </FilterRoot>
@@ -88,9 +88,9 @@ describe('Filter.Content', () => {
     expect(element.className).toContain('dnb-space__top--large')
   })
 
-  it('uses context id when connectedTo is omitted', () => {
+  it('uses context when connectedTo is omitted', () => {
     render(
-      <FilterRoot id="results-context-test" resultLoading>
+      <FilterRoot resultLoading>
         <FilterContent>
           <p>Content</p>
         </FilterContent>
@@ -106,8 +106,8 @@ describe('Filter.Content', () => {
 
   it('does not wrap children in HeightAnimation on initial render', () => {
     render(
-      <FilterRoot id="results-no-anim-test">
-        <FilterContent connectedTo="results-no-anim-test">
+      <FilterRoot>
+        <FilterContent>
           <p>Content</p>
         </FilterContent>
       </FilterRoot>
@@ -119,27 +119,22 @@ describe('Filter.Content', () => {
   })
 
   it('wraps children in HeightAnimation after loading has occurred', async () => {
-    function Trigger({ id }) {
-      const { extend } = useSharedState(id)
+    function FilterWithLoading() {
+      const [loading, setLoading] = useState(true)
 
       return (
-        <button
-          onClick={() => extend({ resultLoading: false })}
-          data-testid="trigger"
-        >
-          Done
-        </button>
+        <FilterRoot resultLoading={loading}>
+          <FilterContent>
+            <p>Content</p>
+          </FilterContent>
+          <button onClick={() => setLoading(false)} data-testid="trigger">
+            Done
+          </button>
+        </FilterRoot>
       )
     }
 
-    render(
-      <FilterRoot id="results-anim-test" resultLoading>
-        <FilterContent connectedTo="results-anim-test">
-          <p>Content</p>
-        </FilterContent>
-        <Trigger id="results-anim-test" />
-      </FilterRoot>
-    )
+    render(<FilterWithLoading />)
 
     expect(
       document.querySelector('.dnb-height-animation')
@@ -178,7 +173,7 @@ describe('Filter.Content error handling', () => {
 describe('Filter.NoResults', () => {
   it('shows message when resultCount is 0', () => {
     render(
-      <FilterRoot id="no-results-zero-test" resultCount={0}>
+      <FilterRoot resultCount={0}>
         <FilterNoResults />
       </FilterRoot>
     )
@@ -190,7 +185,7 @@ describe('Filter.NoResults', () => {
 
   it('returns nothing when resultCount is greater than 0', () => {
     render(
-      <FilterRoot id="no-results-positive-test" resultCount={5}>
+      <FilterRoot resultCount={5}>
         <FilterNoResults />
       </FilterRoot>
     )
@@ -215,7 +210,7 @@ describe('Filter.NoResults', () => {
 
   it('shows custom children text', () => {
     render(
-      <FilterRoot id="no-results-custom-test" resultCount={0}>
+      <FilterRoot resultCount={0}>
         <FilterNoResults>Custom no results text</FilterNoResults>
       </FilterRoot>
     )
@@ -242,7 +237,7 @@ describe('Filter.NoResults', () => {
 
   it('renders as a list item when inside List.Container', () => {
     render(
-      <FilterRoot id="no-results-list-test" resultCount={0}>
+      <FilterRoot resultCount={0}>
         <ListContainer>
           <FilterNoResults />
         </ListContainer>
@@ -257,7 +252,7 @@ describe('Filter.NoResults', () => {
 
   it('renders as a paragraph when outside List.Container', () => {
     render(
-      <FilterRoot id="no-results-paragraph-test" resultCount={0}>
+      <FilterRoot resultCount={0}>
         <FilterNoResults />
       </FilterRoot>
     )
@@ -269,7 +264,7 @@ describe('Filter.NoResults', () => {
 
   it('supports spacing props', () => {
     render(
-      <FilterRoot id="no-results-spacing-test" resultCount={0}>
+      <FilterRoot resultCount={0}>
         <FilterNoResults top="large" />
       </FilterRoot>
     )
@@ -283,8 +278,8 @@ describe('Filter.NoResults', () => {
 describe('Filter.Content aria-live', () => {
   it('announces result count to screen readers', async () => {
     render(
-      <FilterRoot id="aria-count-test" resultCount={3}>
-        <FilterContent connectedTo="aria-count-test">
+      <FilterRoot resultCount={3}>
+        <FilterContent>
           <p>Results</p>
         </FilterContent>
       </FilterRoot>
@@ -302,8 +297,8 @@ describe('Filter.Content aria-live', () => {
 
   it('announces no results message when resultCount is 0', async () => {
     render(
-      <FilterRoot id="aria-no-results-test" resultCount={0}>
-        <FilterContent connectedTo="aria-no-results-test">
+      <FilterRoot resultCount={0}>
+        <FilterContent>
           <p>Results</p>
         </FilterContent>
       </FilterRoot>
@@ -320,8 +315,8 @@ describe('Filter.Content aria-live', () => {
 
   it('does not announce when resultCount is undefined', () => {
     render(
-      <FilterRoot id="aria-no-count-test">
-        <FilterContent connectedTo="aria-no-count-test">
+      <FilterRoot>
+        <FilterContent>
           <p>Results</p>
         </FilterContent>
       </FilterRoot>
@@ -335,8 +330,8 @@ describe('Filter.Content aria-live', () => {
 
   it('does not announce while loading', () => {
     render(
-      <FilterRoot id="aria-loading-test" resultCount={3} resultLoading>
-        <FilterContent connectedTo="aria-loading-test">
+      <FilterRoot resultCount={3} resultLoading>
+        <FilterContent>
           <p>Results</p>
         </FilterContent>
       </FilterRoot>
@@ -351,8 +346,8 @@ describe('Filter.Content aria-live', () => {
 describe('Filter.Content accessibility', () => {
   it('has no axe violations', async () => {
     const { container } = render(
-      <FilterRoot id="content-a11y-test">
-        <FilterContent connectedTo="content-a11y-test">
+      <FilterRoot>
+        <FilterContent>
           <p>Result content</p>
         </FilterContent>
       </FilterRoot>
@@ -363,8 +358,8 @@ describe('Filter.Content accessibility', () => {
 
   it('has no axe violations when loading', async () => {
     const { container } = render(
-      <FilterRoot id="content-loading-a11y-test" resultLoading>
-        <FilterContent connectedTo="content-loading-a11y-test">
+      <FilterRoot resultLoading>
+        <FilterContent>
           <p>Loading content</p>
         </FilterContent>
       </FilterRoot>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterDate.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterDate.test.tsx
@@ -12,7 +12,7 @@ import { useFilterContext } from '../hooks/useFilter'
 describe('Filter.Date', () => {
   it('renders accordion open when defaultOpen is true', () => {
     render(
-      <FilterRoot id="date-open-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterDate label="Dato" defaultOpen />
@@ -41,7 +41,7 @@ describe('Filter.Date filter values', () => {
     }
 
     render(
-      <FilterRoot id="date-value-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterDate label="Dato" />
@@ -78,7 +78,7 @@ describe('Filter.Date filter values', () => {
 
   it('uses custom filterKey when provided', () => {
     render(
-      <FilterRoot id="date-custom-key-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterDate label="Period" filterKey="/period" defaultOpen />
@@ -99,7 +99,7 @@ describe('Filter.Date filter values', () => {
 describe('Filter.Date outside panel', () => {
   it('renders as a popover trigger when outside FilterPanel', () => {
     render(
-      <FilterRoot id="date-popover-test">
+      <FilterRoot>
         <FilterDate label="Dato" />
       </FilterRoot>
     )
@@ -133,7 +133,7 @@ describe('Filter.Date clearing', () => {
     }
 
     render(
-      <FilterRoot id="date-clear-test">
+      <FilterRoot>
         <FilterDate label="Dato" />
         <FilterActiveFilters />
         <SetDateFilter />
@@ -170,7 +170,7 @@ describe('Filter.Date inline behavior', () => {
     setMedia({ width: '60em' })
 
     render(
-      <FilterRoot id="date-inline-large">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterDate label="Dato" defaultOpen />
@@ -190,7 +190,7 @@ describe('Filter.Date inline behavior', () => {
     setMedia({ width: '30em' })
 
     render(
-      <FilterRoot id="date-inline-small">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterDate label="Dato" defaultOpen />
@@ -210,7 +210,7 @@ describe('Filter.Date inline behavior', () => {
 describe('Filter.Date accessibility', () => {
   it('has no axe violations', async () => {
     const { container } = render(
-      <FilterRoot id="date-a11y-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterDate label="Dato" defaultOpen />

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterHeader.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterHeader.test.tsx
@@ -6,7 +6,7 @@ import FilterToolbar from '../FilterToolbar'
 describe('Filter.Header', () => {
   it('renders with dnb-filter__header class', () => {
     render(
-      <FilterRoot id="header-test">
+      <FilterRoot>
         <FilterHeader>
           <p>Header content</p>
         </FilterHeader>
@@ -21,7 +21,7 @@ describe('Filter.Header', () => {
 
   it('merges custom className', () => {
     render(
-      <FilterRoot id="header-class-test">
+      <FilterRoot>
         <FilterHeader className="my-header">
           <p>Content</p>
         </FilterHeader>
@@ -38,7 +38,7 @@ describe('Filter.Header', () => {
 describe('Filter.Toolbar.Actions', () => {
   it('renders children', () => {
     render(
-      <FilterRoot id="toolbar-actions-test">
+      <FilterRoot>
         <FilterToolbar>
           <FilterToolbar.Actions>
             <button>Action</button>
@@ -55,7 +55,7 @@ describe('Filter.Toolbar.Actions', () => {
 
   it('merges custom className', () => {
     render(
-      <FilterRoot id="toolbar-actions-class-test">
+      <FilterRoot>
         <FilterToolbar>
           <FilterToolbar.Actions className="my-actions">
             <button>Action</button>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterHighlighting.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterHighlighting.test.tsx
@@ -2,13 +2,22 @@ import { render, act, fireEvent } from '@testing-library/react'
 import FilterRoot from '../FilterRoot'
 import FilterContent from '../FilterContent'
 import FilterHighlighting from '../FilterHighlighting'
+import FilterSearch from '../FilterSearch'
 import { useSharedState } from '../../../shared/helpers/useSharedState'
+
+function changeSearch(search: string) {
+  act(() => {
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: search },
+    })
+  })
+}
 
 describe('Filter.Highlighting', () => {
   it('renders plain text when there is no search', () => {
     render(
-      <FilterRoot id="highlight-no-search">
-        <FilterContent connectedTo="highlight-no-search">
+      <FilterRoot>
+        <FilterContent>
           <FilterHighlighting>Hello World</FilterHighlighting>
         </FilterContent>
       </FilterRoot>
@@ -22,32 +31,16 @@ describe('Filter.Highlighting', () => {
   })
 
   it('highlights matching text from the search term', () => {
-    function SetSearch() {
-      const { extend } = useSharedState('highlight-match')
-      return (
-        <button
-          onClick={() => extend({ search: 'World' })}
-          data-testid="set-search"
-        >
-          Search
-        </button>
-      )
-    }
-
     render(
-      <>
-        <SetSearch />
-        <FilterRoot id="highlight-match">
-          <FilterContent connectedTo="highlight-match">
-            <FilterHighlighting>Hello World</FilterHighlighting>
-          </FilterContent>
-        </FilterRoot>
-      </>
+      <FilterRoot>
+        <FilterSearch label="Search" />
+        <FilterContent>
+          <FilterHighlighting>Hello World</FilterHighlighting>
+        </FilterContent>
+      </FilterRoot>
     )
 
-    act(() => {
-      fireEvent.click(document.querySelector('[data-testid="set-search"]'))
-    })
+    changeSearch('World')
 
     const mark = document.querySelector('.dnb-filter__highlighting')
     expect(mark).toBeInTheDocument()
@@ -56,32 +49,16 @@ describe('Filter.Highlighting', () => {
   })
 
   it('highlights case-insensitively', () => {
-    function SetSearch() {
-      const { extend } = useSharedState('highlight-case')
-      return (
-        <button
-          onClick={() => extend({ search: 'hello' })}
-          data-testid="set-search"
-        >
-          Search
-        </button>
-      )
-    }
-
     render(
-      <>
-        <SetSearch />
-        <FilterRoot id="highlight-case">
-          <FilterContent connectedTo="highlight-case">
-            <FilterHighlighting>Hello World</FilterHighlighting>
-          </FilterContent>
-        </FilterRoot>
-      </>
+      <FilterRoot>
+        <FilterSearch label="Search" />
+        <FilterContent>
+          <FilterHighlighting>Hello World</FilterHighlighting>
+        </FilterContent>
+      </FilterRoot>
     )
 
-    act(() => {
-      fireEvent.click(document.querySelector('[data-testid="set-search"]'))
-    })
+    changeSearch('hello')
 
     const mark = document.querySelector('.dnb-filter__highlighting')
     expect(mark).toBeInTheDocument()
@@ -89,64 +66,32 @@ describe('Filter.Highlighting', () => {
   })
 
   it('highlights multiple occurrences', () => {
-    function SetSearch() {
-      const { extend } = useSharedState('highlight-multi')
-      return (
-        <button
-          onClick={() => extend({ search: 'a' })}
-          data-testid="set-search"
-        >
-          Search
-        </button>
-      )
-    }
-
     render(
-      <>
-        <SetSearch />
-        <FilterRoot id="highlight-multi">
-          <FilterContent connectedTo="highlight-multi">
-            <FilterHighlighting>banana</FilterHighlighting>
-          </FilterContent>
-        </FilterRoot>
-      </>
+      <FilterRoot>
+        <FilterSearch label="Search" />
+        <FilterContent>
+          <FilterHighlighting>banana</FilterHighlighting>
+        </FilterContent>
+      </FilterRoot>
     )
 
-    act(() => {
-      fireEvent.click(document.querySelector('[data-testid="set-search"]'))
-    })
+    changeSearch('a')
 
     const marks = document.querySelectorAll('.dnb-filter__highlighting')
     expect(marks).toHaveLength(3)
   })
 
   it('escapes regex special characters in search', () => {
-    function SetSearch() {
-      const { extend } = useSharedState('highlight-escape')
-      return (
-        <button
-          onClick={() => extend({ search: '(test)' })}
-          data-testid="set-search"
-        >
-          Search
-        </button>
-      )
-    }
-
     render(
-      <>
-        <SetSearch />
-        <FilterRoot id="highlight-escape">
-          <FilterContent connectedTo="highlight-escape">
-            <FilterHighlighting>foo (test) bar</FilterHighlighting>
-          </FilterContent>
-        </FilterRoot>
-      </>
+      <FilterRoot>
+        <FilterSearch label="Search" />
+        <FilterContent>
+          <FilterHighlighting>foo (test) bar</FilterHighlighting>
+        </FilterContent>
+      </FilterRoot>
     )
 
-    act(() => {
-      fireEvent.click(document.querySelector('[data-testid="set-search"]'))
-    })
+    changeSearch('(test)')
 
     const mark = document.querySelector('.dnb-filter__highlighting')
     expect(mark).toBeInTheDocument()
@@ -154,32 +99,16 @@ describe('Filter.Highlighting', () => {
   })
 
   it('returns plain text when search does not match', () => {
-    function SetSearch() {
-      const { extend } = useSharedState('highlight-no-match')
-      return (
-        <button
-          onClick={() => extend({ search: 'xyz' })}
-          data-testid="set-search"
-        >
-          Search
-        </button>
-      )
-    }
-
     render(
-      <>
-        <SetSearch />
-        <FilterRoot id="highlight-no-match">
-          <FilterContent connectedTo="highlight-no-match">
-            <FilterHighlighting>Hello World</FilterHighlighting>
-          </FilterContent>
-        </FilterRoot>
-      </>
+      <FilterRoot>
+        <FilterSearch label="Search" />
+        <FilterContent>
+          <FilterHighlighting>Hello World</FilterHighlighting>
+        </FilterContent>
+      </FilterRoot>
     )
 
-    act(() => {
-      fireEvent.click(document.querySelector('[data-testid="set-search"]'))
-    })
+    changeSearch('xyz')
 
     expect(
       document.querySelector('.dnb-filter__highlighting')

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterItem.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterItem.test.tsx
@@ -5,7 +5,7 @@ import FilterItem from '../FilterItem'
 describe('Filter.Item', () => {
   it('renders accordion closed by default', () => {
     render(
-      <FilterRoot id="item-default">
+      <FilterRoot>
         <FilterItem label="Category" filterKey="/category">
           <p>Item content</p>
         </FilterItem>
@@ -25,7 +25,7 @@ describe('Filter.Item', () => {
 
   it('renders accordion open when defaultOpen is true', () => {
     render(
-      <FilterRoot id="item-accordion-test">
+      <FilterRoot>
         <FilterItem label="Category" filterKey="/category" defaultOpen>
           <p>Content</p>
         </FilterItem>
@@ -41,7 +41,7 @@ describe('Filter.Item', () => {
 
   it('opens and closes accordion on click', () => {
     render(
-      <FilterRoot id="item-toggle-test">
+      <FilterRoot>
         <FilterItem label="Category" filterKey="/category">
           <p>Content</p>
         </FilterItem>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterManualBehavior.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterManualBehavior.test.tsx
@@ -43,11 +43,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot
-        id="manual-no-emit"
-        behavior="manual"
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" onChange={onChange}>
         <TestInner />
       </FilterRoot>
     )
@@ -61,11 +57,7 @@ describe('behavior="manual"', () => {
     const onChange = vi.fn()
 
     render(
-      <FilterRoot
-        id="manual-search-emit"
-        behavior="manual"
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" onChange={onChange}>
         <FilterSearch label="Søk" />
       </FilterRoot>
     )
@@ -85,11 +77,7 @@ describe('behavior="manual"', () => {
     const onChange = vi.fn()
 
     render(
-      <FilterRoot
-        id="manual-search-no-apply"
-        behavior="manual"
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" onChange={onChange}>
         <FilterSearch label="Søk" />
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
@@ -124,7 +112,6 @@ describe('behavior="manual"', () => {
 
     render(
       <FilterRoot
-        id="manual-remove-tag-with-pending-draft"
         behavior="manual"
         defaultFilters={{
           '/status/active': {
@@ -207,7 +194,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-internal-state" behavior="manual">
+      <FilterRoot behavior="manual">
         <FilterSearch label="Søk" />
         <StateReader />
       </FilterRoot>
@@ -248,12 +235,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot
-        id="manual-commit"
-        behavior="manual"
-        resultCount={5}
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" resultCount={5} onChange={onChange}>
         <TestInner />
       </FilterRoot>
     )
@@ -299,7 +281,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-revert" behavior="manual">
+      <FilterRoot behavior="manual">
         <TestInner />
       </FilterRoot>
     )
@@ -319,7 +301,7 @@ describe('behavior="manual"', () => {
 
   it('renders apply and cancel buttons in the panel', () => {
     render(
-      <FilterRoot id="manual-panel-buttons" behavior="manual">
+      <FilterRoot behavior="manual">
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -342,7 +324,7 @@ describe('behavior="manual"', () => {
 
   it('does not render apply/cancel in realtime mode', () => {
     render(
-      <FilterRoot id="realtime-panel-no-apply">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -379,11 +361,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot
-        id="manual-apply-click"
-        behavior="manual"
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" onChange={onChange}>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <SetFilter />
@@ -433,7 +411,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-cancel-click" behavior="manual">
+      <FilterRoot behavior="manual">
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <SetFilter />
@@ -482,7 +460,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-active-committed" behavior="manual">
+      <FilterRoot behavior="manual">
         <SetFilter />
         <FilterActiveFilters />
       </FilterRoot>
@@ -523,11 +501,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot
-        id="manual-result-count-committed"
-        behavior="manual"
-        resultCount={5}
-      >
+      <FilterRoot behavior="manual" resultCount={5}>
         <SetFilter />
         <FilterResultCount />
       </FilterRoot>
@@ -549,11 +523,7 @@ describe('behavior="manual"', () => {
 
   it('shows result count when search is typed', () => {
     render(
-      <FilterRoot
-        id="manual-result-count-search"
-        behavior="manual"
-        resultCount={5}
-      >
+      <FilterRoot behavior="manual" resultCount={5}>
         <FilterSearch label="Søk" />
         <FilterResultCount />
       </FilterRoot>
@@ -577,7 +547,6 @@ describe('behavior="manual"', () => {
 
     render(
       <FilterRoot
-        id="manual-remove-active-filter"
         behavior="manual"
         defaultFilters={defaultFilters}
         onChange={onChange}
@@ -605,7 +574,6 @@ describe('behavior="manual"', () => {
 
     render(
       <FilterRoot
-        id="manual-remove-one-active-filter"
         behavior="manual"
         defaultFilters={defaultFiltersMultiple}
         resultCount={5}
@@ -655,7 +623,6 @@ describe('behavior="manual"', () => {
 
     render(
       <FilterRoot
-        id="manual-clear-applied-filters"
         behavior="manual"
         defaultFilters={defaultFiltersMultiple}
         resultCount={5}
@@ -705,7 +672,6 @@ describe('behavior="manual"', () => {
 
     render(
       <FilterRoot
-        id="manual-uncheck-applied-filter"
         behavior="manual"
         defaultFilters={defaultFilters}
         onChange={onChange}
@@ -737,7 +703,6 @@ describe('behavior="manual"', () => {
 
     render(
       <FilterRoot
-        id="manual-uncheck-applied-filter-in-panel"
         behavior="manual"
         defaultFilters={defaultFilters}
         onChange={onChange}
@@ -770,11 +735,7 @@ describe('behavior="manual"', () => {
     const onChange = vi.fn()
 
     render(
-      <FilterRoot
-        id="manual-uncheck-unapplied-filter"
-        behavior="manual"
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" onChange={onChange}>
         <FilterSelection
           label="Type"
           filterKey="/type"
@@ -846,11 +807,7 @@ describe('behavior="manual"', () => {
     }
 
     render(
-      <FilterRoot
-        id="manual-reset-onchange"
-        behavior="manual"
-        onChange={onChange}
-      >
+      <FilterRoot behavior="manual" onChange={onChange}>
         <FilterSearch label="Search" />
         <Controls />
       </FilterRoot>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterMultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterMultiSelection.test.tsx
@@ -11,7 +11,7 @@ describe('Filter.MultiSelection', () => {
 
   it('renders inside an accordion', () => {
     render(
-      <FilterRoot id="multi-sel-test">
+      <FilterRoot>
         <FilterMultiSelection
           label="Client"
           filterKey="/client"
@@ -56,7 +56,7 @@ describe('Filter.MultiSelection state', () => {
     }
 
     render(
-      <FilterRoot id="multi-sel-state-test">
+      <FilterRoot>
         <FilterMultiSelection
           label="Client"
           filterKey="client"
@@ -91,7 +91,7 @@ describe('Filter.MultiSelection state', () => {
     }
 
     render(
-      <FilterRoot id="multi-sel-remove-test">
+      <FilterRoot>
         <FilterMultiSelection
           label="Client"
           filterKey="client"

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterPanel.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterPanel.test.tsx
@@ -10,7 +10,7 @@ import FilterToolbar from '../FilterToolbar'
 describe('Filter.Panel', () => {
   it('is hidden by default', () => {
     render(
-      <FilterRoot id="panel-hidden-test">
+      <FilterRoot>
         <FilterPanel>
           <FilterSelection
             label="Type"
@@ -28,7 +28,7 @@ describe('Filter.Panel', () => {
 
   it('becomes visible when panelOpen is toggled via PanelButton', () => {
     render(
-      <FilterRoot id="panel-toggle-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterSelection
@@ -51,7 +51,7 @@ describe('Filter.Panel', () => {
 
   it('renders filter children as tertiary accordions', () => {
     render(
-      <FilterRoot id="panel-children-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterSelection
@@ -74,7 +74,7 @@ describe('Filter.Panel', () => {
 
   it('renders a close button with hide label', () => {
     render(
-      <FilterRoot id="panel-close-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -92,7 +92,7 @@ describe('Filter.Panel', () => {
 
   it('closes the panel when close button is clicked', () => {
     render(
-      <FilterRoot id="panel-close-click-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -115,7 +115,7 @@ describe('Filter.Panel', () => {
 
   it('moves focus to the panel button when close button is clicked', () => {
     render(
-      <FilterRoot id="panel-close-focus-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -135,7 +135,7 @@ describe('Filter.Panel', () => {
 
   it('moves focus to the panel button when apply is clicked in manual mode', () => {
     render(
-      <FilterRoot id="panel-apply-focus-test" behavior="manual">
+      <FilterRoot behavior="manual">
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -157,7 +157,7 @@ describe('Filter.Panel', () => {
 
   it('renders cancel button without icon in manual mode', () => {
     render(
-      <FilterRoot id="panel-cancel-icon-test" behavior="manual">
+      <FilterRoot behavior="manual">
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -178,7 +178,7 @@ describe('Filter.Panel', () => {
 
   it('moves focus to the panel button when cancel is clicked in manual mode', () => {
     render(
-      <FilterRoot id="panel-cancel-focus-test" behavior="manual">
+      <FilterRoot behavior="manual">
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Content</p>
@@ -200,7 +200,7 @@ describe('Filter.Panel', () => {
 
   it('merges custom className', () => {
     render(
-      <FilterRoot id="panel-class-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel className="my-panel">
           <p>Content</p>
@@ -228,7 +228,7 @@ describe('Filter.Panel', () => {
 
   it('has no axe violations', async () => {
     const { container } = render(
-      <FilterRoot id="panel-a11y-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterSelection
@@ -249,7 +249,7 @@ describe('Filter.Panel', () => {
 describe('Filter.PanelButton', () => {
   it('renders a tertiary button', () => {
     render(
-      <FilterRoot id="accordion-btn-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
       </FilterRoot>
     )
@@ -262,7 +262,7 @@ describe('Filter.PanelButton', () => {
 
   it('toggles aria-expanded on click', () => {
     render(
-      <FilterRoot id="accordion-btn-expanded-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
       </FilterRoot>
     )
@@ -288,7 +288,7 @@ describe('Filter.PanelButton', () => {
 
   it('renders the translated default label when no children are given', () => {
     render(
-      <FilterRoot id="default-label-test">
+      <FilterRoot>
         <FilterPanelButton />
       </FilterRoot>
     )
@@ -302,7 +302,7 @@ describe('Filter.PanelButton', () => {
 describe('Filter.Toolbar', () => {
   it('renders children inside toolbar', () => {
     render(
-      <FilterRoot id="toolbar-test">
+      <FilterRoot>
         <FilterToolbar>
           <FilterSearch label="Søk" />
         </FilterToolbar>
@@ -319,7 +319,7 @@ describe('Filter.Toolbar', () => {
 
   it('merges custom className', () => {
     render(
-      <FilterRoot id="toolbar-class-test">
+      <FilterRoot>
         <FilterToolbar className="my-toolbar">
           <p>Content</p>
         </FilterToolbar>
@@ -336,7 +336,7 @@ describe('Filter.Toolbar', () => {
 describe('Filter.Toolbar.Actions', () => {
   it('renders children inside actions container', () => {
     render(
-      <FilterRoot id="tools-test">
+      <FilterRoot>
         <FilterToolbar>
           <FilterToolbar.Actions>
             <FilterPanelButton>Filters</FilterPanelButton>
@@ -353,7 +353,7 @@ describe('Filter.Toolbar.Actions', () => {
 
   it('merges custom className', () => {
     render(
-      <FilterRoot id="toolbar-actions-class">
+      <FilterRoot>
         <FilterToolbar>
           <FilterToolbar.Actions className="my-actions">
             <FilterPanelButton>Filters</FilterPanelButton>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterResultCount.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterResultCount.test.tsx
@@ -14,11 +14,7 @@ const defaultFilters = {
 describe('Filter.ResultCount', () => {
   it('renders the result count when filters are active', () => {
     render(
-      <FilterRoot
-        id="count-render-test"
-        resultCount={5}
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot resultCount={5} defaultFilters={defaultFilters}>
         <FilterResultCount />
       </FilterRoot>
     )
@@ -31,10 +27,7 @@ describe('Filter.ResultCount', () => {
 
   it('returns null when resultCount is undefined', () => {
     render(
-      <FilterRoot
-        id="count-undefined-test"
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot defaultFilters={defaultFilters}>
         <FilterResultCount />
       </FilterRoot>
     )
@@ -46,7 +39,7 @@ describe('Filter.ResultCount', () => {
 
   it('hides when no filters are active', () => {
     render(
-      <FilterRoot id="count-no-active-test" resultCount={5}>
+      <FilterRoot resultCount={5}>
         <FilterResultCount />
       </FilterRoot>
     )
@@ -58,7 +51,7 @@ describe('Filter.ResultCount', () => {
 
   it('shows without active filters when alwaysVisible is true', () => {
     render(
-      <FilterRoot id="count-always-test" resultCount={5}>
+      <FilterRoot resultCount={5}>
         <FilterResultCount alwaysVisible />
       </FilterRoot>
     )
@@ -71,11 +64,7 @@ describe('Filter.ResultCount', () => {
 
   it('shows 0 results when resultCount is 0 and filters are active', () => {
     render(
-      <FilterRoot
-        id="count-zero-test"
-        resultCount={0}
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot resultCount={0} defaultFilters={defaultFilters}>
         <FilterResultCount />
       </FilterRoot>
     )
@@ -88,11 +77,7 @@ describe('Filter.ResultCount', () => {
 
   it('uses the resultCount prop to override context', () => {
     render(
-      <FilterRoot
-        id="count-override-test"
-        resultCount={10}
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot resultCount={10} defaultFilters={defaultFilters}>
         <FilterResultCount resultCount={42} />
       </FilterRoot>
     )
@@ -105,11 +90,7 @@ describe('Filter.ResultCount', () => {
 
   it('renders custom children instead of the default message', () => {
     render(
-      <FilterRoot
-        id="count-children-test"
-        resultCount={3}
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot resultCount={3} defaultFilters={defaultFilters}>
         <FilterResultCount>Showing 3 items</FilterResultCount>
       </FilterRoot>
     )
@@ -159,11 +140,7 @@ describe('Filter.ResultCount', () => {
 
   it('supports spacing props', () => {
     render(
-      <FilterRoot
-        id="count-spacing-test"
-        resultCount={1}
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot resultCount={1} defaultFilters={defaultFilters}>
         <FilterResultCount top="large" />
       </FilterRoot>
     )
@@ -175,11 +152,7 @@ describe('Filter.ResultCount', () => {
 
   it('supports custom className', () => {
     render(
-      <FilterRoot
-        id="count-classname-test"
-        resultCount={2}
-        defaultFilters={defaultFilters}
-      >
+      <FilterRoot resultCount={2} defaultFilters={defaultFilters}>
         <FilterResultCount className="my-custom-class" />
       </FilterRoot>
     )

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterResultCountClosing.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterResultCountClosing.test.tsx
@@ -51,11 +51,7 @@ describe('Filter.ResultCount closing state', () => {
       const [count, setCount] = useState(3)
 
       return (
-        <FilterRoot
-          id="count-close-freeze-test"
-          resultCount={count}
-          defaultFilters={defaultFilters}
-        >
+        <FilterRoot resultCount={count} defaultFilters={defaultFilters}>
           <Controls onClear={() => setCount(10)} />
           <FilterResultCount />
         </FilterRoot>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterRoot.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterRoot.test.tsx
@@ -16,7 +16,7 @@ import { useSharedState } from '../../../shared/helpers/useSharedState'
 describe('Filter.Root', () => {
   it('renders with dnb-filter class', () => {
     render(
-      <FilterRoot id="test-filter">
+      <FilterRoot>
         <p>Content</p>
       </FilterRoot>
     )
@@ -28,7 +28,7 @@ describe('Filter.Root', () => {
 
   it('renders with role="search"', () => {
     render(
-      <FilterRoot id="test-filter">
+      <FilterRoot>
         <p>Content</p>
       </FilterRoot>
     )
@@ -40,7 +40,7 @@ describe('Filter.Root', () => {
 
   it('merges custom className', () => {
     render(
-      <FilterRoot id="test-filter" className="my-custom">
+      <FilterRoot className="my-custom">
         <p>Content</p>
       </FilterRoot>
     )
@@ -53,7 +53,7 @@ describe('Filter.Root', () => {
 
   it('renders children', () => {
     render(
-      <FilterRoot id="test-filter">
+      <FilterRoot>
         <p>Hello</p>
       </FilterRoot>
     )
@@ -80,7 +80,7 @@ describe('Filter.Root', () => {
     }
 
     render(
-      <FilterRoot id="on-change-test" onChange={onChange}>
+      <FilterRoot onChange={onChange}>
         <TestInner />
       </FilterRoot>
     )
@@ -97,7 +97,7 @@ describe('Filter.Root', () => {
 
   it('has no axe violations', async () => {
     const { container } = render(
-      <FilterRoot id="a11y-test">
+      <FilterRoot>
         <p>Accessible</p>
       </FilterRoot>
     )
@@ -107,7 +107,7 @@ describe('Filter.Root', () => {
 
   it('supports spacing props', () => {
     render(
-      <FilterRoot id="container-spacing-test" top="large">
+      <FilterRoot top="large">
         <p>Content</p>
       </FilterRoot>
     )
@@ -173,7 +173,6 @@ describe('defaultFilters', () => {
 
     render(
       <FilterRoot
-        id="default-filters-test"
         defaultFilters={{
           '/status': { value: 'active', label: 'Active' },
         }}
@@ -190,7 +189,6 @@ describe('defaultFilters', () => {
   it('shows defaultFilters in active filters', () => {
     render(
       <FilterRoot
-        id="default-filters-active-test"
         defaultFilters={{
           '/status': { value: 'active', label: 'Active' },
         }}
@@ -207,7 +205,6 @@ describe('defaultFilters', () => {
   it('opens the panel by default', () => {
     render(
       <FilterRoot
-        id="default-filters-panel-test"
         defaultFilters={{
           '/type/card': {
             value: 'card',
@@ -232,7 +229,6 @@ describe('defaultFilters', () => {
   it('opens the relevant filter accordion', () => {
     render(
       <FilterRoot
-        id="default-filters-accordion-test"
         defaultFilters={{
           '/type/card': {
             value: 'card',
@@ -273,7 +269,7 @@ describe('defaultFilters', () => {
 
   it('does not open the panel when defaultFilters is not set', () => {
     render(
-      <FilterRoot id="no-default-filters-panel-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Panel content</p>
@@ -289,7 +285,6 @@ describe('defaultFilters', () => {
   it('checks the matching checkboxes in FilterSelection', () => {
     render(
       <FilterRoot
-        id="default-filters-checked-test"
         defaultFilters={{
           '/type/card': {
             value: 'card',
@@ -374,7 +369,6 @@ describe('defaultFilters', () => {
 
     render(
       <FilterRoot
-        id="default-filters-onchange-test"
         onChange={onChange}
         defaultFilters={{
           '/type/card': {
@@ -599,7 +593,7 @@ describe('URL-restored filters', () => {
 describe('defaultPanelOpen', () => {
   it('opens the panel initially when set to true', () => {
     render(
-      <FilterRoot id="default-open-true" defaultPanelOpen>
+      <FilterRoot defaultPanelOpen>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <p>Panel content</p>
@@ -616,7 +610,6 @@ describe('defaultPanelOpen', () => {
   it('keeps the panel closed when set to false with defaultFilters', () => {
     render(
       <FilterRoot
-        id="default-open-false-filters"
         defaultPanelOpen={false}
         defaultFilters={{
           '/type/card': {

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterSearch.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterSearch.test.tsx
@@ -7,7 +7,7 @@ import { useFilterContext } from '../hooks/useFilter'
 describe('Filter.Search', () => {
   it('renders a search input', () => {
     render(
-      <FilterRoot id="search-test">
+      <FilterRoot>
         <FilterSearch label="Søk" placeholder="Søk..." />
       </FilterRoot>
     )
@@ -24,7 +24,7 @@ describe('Filter.Search', () => {
     }
 
     render(
-      <FilterRoot id="search-input-test">
+      <FilterRoot>
         <FilterSearch label="Søk" />
         <SearchValue />
       </FilterRoot>
@@ -41,7 +41,7 @@ describe('Filter.Search', () => {
 
   it('shows progress indicator when typing and resultLoading is true', () => {
     render(
-      <FilterRoot id="search-loading-test" resultLoading>
+      <FilterRoot resultLoading>
         <FilterSearch label="Søk" />
       </FilterRoot>
     )
@@ -59,7 +59,7 @@ describe('Filter.Search', () => {
 
   it('does not show progress indicator when resultLoading is true but not typing', () => {
     render(
-      <FilterRoot id="search-no-typing-test" resultLoading>
+      <FilterRoot resultLoading>
         <FilterSearch label="Søk" />
       </FilterRoot>
     )
@@ -73,7 +73,7 @@ describe('Filter.Search', () => {
 
   it('does not show progress indicator when resultLoading is false', () => {
     render(
-      <FilterRoot id="search-no-loading-test">
+      <FilterRoot>
         <FilterSearch label="Søk" />
       </FilterRoot>
     )
@@ -91,7 +91,7 @@ describe('Filter.Search events', () => {
     const onChange = vi.fn()
 
     render(
-      <FilterRoot id="search-on-change-test">
+      <FilterRoot>
         <FilterSearch label="Søk" onChange={onChange} />
       </FilterRoot>
     )
@@ -113,7 +113,7 @@ describe('Filter.Search clear button', () => {
     }
 
     render(
-      <FilterRoot id="clear-btn-test">
+      <FilterRoot>
         <FilterSearch label="Søk" />
         <SearchState />
       </FilterRoot>
@@ -139,7 +139,7 @@ describe('Filter.Search clear button', () => {
 describe('Filter.Search accessibility', () => {
   it('has no axe violations', async () => {
     const { container } = render(
-      <FilterRoot id="a11y-search-test">
+      <FilterRoot>
         <FilterSearch label="Search" placeholder="Search..." />
       </FilterRoot>
     )
@@ -151,7 +151,7 @@ describe('Filter.Search accessibility', () => {
 describe('Filter.Search prop forwarding', () => {
   it('forwards type prop to the input element', () => {
     render(
-      <FilterRoot id="search-type-test">
+      <FilterRoot>
         <FilterSearch label="Søk" type="search" />
       </FilterRoot>
     )
@@ -163,7 +163,7 @@ describe('Filter.Search prop forwarding', () => {
 
   it('has autocomplete off by default', () => {
     render(
-      <FilterRoot id="search-autocomplete-default-test">
+      <FilterRoot>
         <FilterSearch label="Søk" />
       </FilterRoot>
     )
@@ -175,7 +175,7 @@ describe('Filter.Search prop forwarding', () => {
 
   it('disables autoCorrect, autoCapitalize and spellCheck by default', () => {
     render(
-      <FilterRoot id="search-browser-features-test">
+      <FilterRoot>
         <FilterSearch label="Søk" />
       </FilterRoot>
     )
@@ -189,7 +189,7 @@ describe('Filter.Search prop forwarding', () => {
 
   it('forwards autoComplete prop to the input element', () => {
     render(
-      <FilterRoot id="search-autocomplete-test">
+      <FilterRoot>
         <FilterSearch label="Søk" autoComplete="name" />
       </FilterRoot>
     )
@@ -201,7 +201,7 @@ describe('Filter.Search prop forwarding', () => {
 
   it('forwards disabled prop to the input element', () => {
     render(
-      <FilterRoot id="search-disabled-test">
+      <FilterRoot>
         <FilterSearch label="Søk" disabled />
       </FilterRoot>
     )
@@ -220,7 +220,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-no-update-test">
+      <FilterRoot>
         <FilterSearch label="Søk" submitBehavior="manual" />
         <SearchState />
       </FilterRoot>
@@ -242,7 +242,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-enter-test">
+      <FilterRoot>
         <FilterSearch label="Søk" submitBehavior="manual" />
         <SearchState />
       </FilterRoot>
@@ -265,7 +265,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-submit-btn-test">
+      <FilterRoot>
         <FilterSearch label="Søk" submitBehavior="manual" />
         <SearchState />
       </FilterRoot>
@@ -297,7 +297,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-clear-test">
+      <FilterRoot>
         <FilterSearch label="Søk" submitBehavior="manual" />
         <SearchState />
       </FilterRoot>
@@ -324,7 +324,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     const onChange = vi.fn()
 
     render(
-      <FilterRoot id="manual-onchange-test">
+      <FilterRoot>
         <FilterSearch
           label="Søk"
           submitBehavior="manual"
@@ -350,7 +350,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-empty-commit-test">
+      <FilterRoot>
         <FilterSearch label="Søk" submitBehavior="manual" />
         <SearchState />
       </FilterRoot>
@@ -383,7 +383,7 @@ describe('Filter.Search submitBehavior="manual"', () => {
     }
 
     render(
-      <FilterRoot id="manual-reset-test">
+      <FilterRoot>
         <FilterSearch label="Søk" submitBehavior="manual" />
         <Controls />
       </FilterRoot>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterSelection.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterSelection.test.tsx
@@ -14,7 +14,7 @@ describe('Filter.Selection', () => {
 
   it('renders checkboxes for each option', () => {
     render(
-      <FilterRoot id="selection-test">
+      <FilterRoot>
         <FilterSelection label="Type" filterKey="type" data={options} />
       </FilterRoot>
     )
@@ -39,7 +39,7 @@ describe('Filter.Selection', () => {
     }
 
     render(
-      <FilterRoot id="selection-check-test">
+      <FilterRoot>
         <FilterSelection label="Type" filterKey="type" data={options} />
         <FilterState />
       </FilterRoot>
@@ -88,7 +88,7 @@ describe('Filter.Selection', () => {
     }
 
     render(
-      <FilterRoot id="selection-uncheck-test">
+      <FilterRoot>
         <FilterSelection label="Type" filterKey="type" data={options} />
         <FilterState />
       </FilterRoot>
@@ -118,7 +118,7 @@ describe('Filter.Selection', () => {
 
   it('renders accordion open when defaultOpen is true', () => {
     render(
-      <FilterRoot id="selection-open-test">
+      <FilterRoot>
         <FilterSelection
           label="Type"
           filterKey="type"
@@ -139,7 +139,7 @@ describe('Filter.Selection', () => {
 describe('Filter.Selection accessibility', () => {
   it('has no axe violations', async () => {
     const { container } = render(
-      <FilterRoot id="a11y-selection-test">
+      <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
         <FilterPanel>
           <FilterSelection


### PR DESCRIPTION
Removes redundant `FilterRoot` ids and nested `connectedTo` props from filter tests where context can be inherited directly.

Also keeps id-less `FilterRoot` local state synchronously readable so local-only tests behave like the shared-state path when multiple updates happen in one interaction.
