### PR TITLE
fix(Form.useTranslation): cache in sync

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useTranslation.test.tsx
@@ -251,6 +251,58 @@ describe('Form.useTranslation', () => {
         )
       )
     })
+
+    it('should update custom translation when translations object changes', () => {
+      type CustomTranslation = {
+        Custom: {
+          translation: string
+        }
+      }
+
+      const initialTranslations = {
+        'nb-NO': {
+          Custom: {
+            translation: 'Initial translation with a {myKey}',
+          },
+        },
+      }
+      const updatedTranslations = {
+        'nb-NO': {
+          Custom: {
+            translation: 'Updated translation with a {myKey}',
+          },
+        },
+      }
+
+      const MockComponent = () => {
+        const { formatMessage } = useTranslation<CustomTranslation>()
+        return (
+          <>
+            {formatMessage('Custom.translation', {
+              myKey: 'value!',
+            })}
+          </>
+        )
+      }
+
+      const { rerender } = render(
+        <Provider locale="nb-NO" translations={initialTranslations}>
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        'Initial translation with a value!'
+      )
+
+      rerender(
+        <Provider locale="nb-NO" translations={updatedTranslations}>
+          <MockComponent />
+        </Provider>
+      )
+      expect(document.body.textContent).toBe(
+        'Updated translation with a value!'
+      )
+    })
   })
 
   it('should support typing for flat translations', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useTranslation.ts
@@ -11,6 +11,15 @@ import type { DeepPartial } from '../../../shared/types'
 import { LOCALE } from '../../../shared/defaults'
 import formsLocales from '../constants/locales'
 
+// Module-level cache for the merged base translation.
+// It is keyed by the SharedContext translation object and resolved locale,
+// avoiding a deep clone for every field while those inputs stay stable.
+let baseCache: {
+  globalTranslation: unknown
+  locale: string
+  result: unknown
+} | null = null
+
 export type FormsTranslationDefaultLocales = typeof formsLocales
 export type FormsTranslationLocale = keyof FormsTranslationDefaultLocales
 export type FormsTranslationKeys =
@@ -81,11 +90,22 @@ export default function useTranslation<T = FormsTranslation>(
   }
 
   const base = useMemo(() => {
-    return extendDeep(
+    const localeKey = translationLocale || LOCALE
+    if (
+      baseCache &&
+      baseCache.globalTranslation === globalTranslation &&
+      baseCache.locale === localeKey
+    ) {
+      return baseCache.result
+    }
+
+    const result = extendDeep(
       {},
-      formsLocales[translationLocale] || formsLocales[LOCALE],
+      formsLocales[localeKey] || formsLocales[LOCALE],
       globalTranslation
     )
+    baseCache = { globalTranslation, locale: localeKey, result }
+    return result
   }, [globalTranslation, translationLocale])
 
   return sharedUseTranslation<


### PR DESCRIPTION
Caches the merged forms translation base without letting same-locale translation prop changes go stale.

This keeps large forms from deep-cloning locale data for every field while preserving the expected behavior when a provider receives a new translations object.
