### PR TITLE
chore(Portal): cache static query results

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/shims/portal-query.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/portal-query.test.ts
@@ -308,5 +308,31 @@ describe('portal-query', () => {
       expect(result.categories).toBeDefined()
       expect(result.categories.edges.length).toBeGreaterThan(0)
     })
+
+    it('caches results by query string', () => {
+      const query = `
+        query { allMdx(filter: { frontmatter: { title: { ne: null } } }) {
+          edges { node { frontmatter { title } } }
+        }}
+      `
+
+      const firstResult = runQuery(query)
+      const secondResult = runQuery(query)
+
+      expect(secondResult).toBe(firstResult)
+      expect(
+        secondResult.allMdx.edges.map(
+          (edge: { node: { frontmatter: { title: string } } }) =>
+            edge.node.frontmatter.title
+        )
+      ).not.toContain(null)
+
+      const differentQuery = `
+        query { allMdx(filter: { frontmatter: { draft: { ne: true } } }) {
+          edges { node { frontmatter { draft } } }
+        }}
+      `
+      expect(runQuery(differentQuery)).not.toBe(firstResult)
+    })
   })
 })

--- a/packages/dnb-design-system-portal/vite/client/shims/portal-query.tsx
+++ b/packages/dnb-design-system-portal/vite/client/shims/portal-query.tsx
@@ -14,6 +14,10 @@ export function graphql(strings: TemplateStringsArray) {
   return strings.join('')
 }
 
+// Cache for useStaticQuery results. Since allMdxNodes is static, consumers
+// should treat the returned result for a given query string as read-only.
+const staticQueryCache = new Map<string, unknown>()
+
 // useStaticQuery returns the pre-computed allMdx data.
 // Gatsby's GraphQL layer filters (e.g. title != null, draft != true) –
 // replicate the most common filters here so portal code that relies on
@@ -21,6 +25,11 @@ export function graphql(strings: TemplateStringsArray) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useStaticQuery(query: unknown): any {
   const queryStr = typeof query === 'string' ? query : ''
+
+  const cached = staticQueryCache.get(queryStr)
+  if (cached) {
+    return cached
+  }
 
   const siteData = {
     pathPrefix: '/',
@@ -57,6 +66,8 @@ export function useStaticQuery(query: unknown): any {
   for (const { alias, filterStr } of allMdxQueries) {
     result[alias] = { edges: buildFilteredEdges(queryStr, filterStr) }
   }
+
+  staticQueryCache.set(queryStr, result)
 
   return result
 }


### PR DESCRIPTION
Caches repeated Portal static query lookups so navigation and menu rendering avoid rebuilding the same MDX query result over and over.

The cache is keyed by the query string and keeps the existing filtering behavior intact.
