### PR TITLE
fix(Forms): improve shared attachment render cascade

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -898,9 +898,11 @@ export default function Provider<Data extends JsonObject>(
     preSeedSharedState<Data>(id, initialData)
   }
   const sharedData = useSharedState<Data>(id)
-  const sharedAttachments = useSharedState<SharedAttachments<Data>>(
-    id ? createReferenceKey(id, 'attachments') : undefined
-  )
+  const sharedAttachments = id
+    ? createSharedState<SharedAttachments<Data>>(
+        createReferenceKey(id, 'attachments')
+      )
+    : null
   // Use createSharedState (non-reactive) instead of useSharedState here
   // because the Provider only writes to this store during render.
   // Using useSharedState (which subscribes via useSyncExternalStore)
@@ -915,21 +917,33 @@ export default function Provider<Data extends JsonObject>(
 
   const setSharedData = sharedData.set
   const extendSharedData = sharedData.extend
-  const extendAttachment = sharedAttachments.extend
-  const rerenderUseDataHook = sharedAttachments.data?.rerenderUseDataHook
+  const extendAttachment = sharedAttachments?.extend
+  const bumpValidationPendingRef = useRef(false)
   bumpValidationVersionRef.current = () => {
     if (id) {
       validationVersionRef.current += 1
-      extendAttachment(
-        { validationVersion: validationVersionRef.current },
-        { preventSyncOfSameInstance: true }
-      )
+
+      if (!bumpValidationPendingRef.current) {
+        bumpValidationPendingRef.current = true
+        const schedule =
+          typeof queueMicrotask === 'function'
+            ? queueMicrotask
+            : (callback: () => void) => Promise.resolve().then(callback)
+
+        schedule(() => {
+          bumpValidationPendingRef.current = false
+          extendAttachment?.(
+            { validationVersion: validationVersionRef.current },
+            { preventSyncOfSameInstance: true }
+          )
+        })
+      }
     }
   }
   const hasHydratedFieldErrorRef = useRef(false)
 
   if (!hasHydratedFieldErrorRef.current) {
-    const sharedFieldErrorRef = sharedAttachments.data?.fieldErrorRef
+    const sharedFieldErrorRef = sharedAttachments?.data?.fieldErrorRef
     if (sharedFieldErrorRef?.current) {
       fieldErrorRef.current = sharedFieldErrorRef.current
       hasHydratedFieldErrorRef.current = true
@@ -1706,7 +1720,7 @@ export default function Provider<Data extends JsonObject>(
 
   useLayoutEffect(() => {
     if (id) {
-      extendAttachment(
+      extendAttachment?.(
         {
           visibleDataHandler,
           filterDataHandler,
@@ -1733,7 +1747,6 @@ export default function Provider<Data extends JsonObject>(
     hasErrors,
     hasFieldError,
     id,
-    rerenderUseDataHook,
     setData,
     setShowAllErrors,
     setSubmitState,

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -77,7 +77,6 @@ export type SharedAttachments<Data = unknown> = {
   hasFieldError?: ContextState['hasFieldError']
   setShowAllErrors?: ContextState['setShowAllErrors']
   setSubmitState?: ContextState['setSubmitState']
-  rerenderUseDataHook?: () => void
   updateDataValue?: ContextState['updateDataValue']
   clearData?: () => void
   setData?: ContextState['setData']

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -52,7 +52,10 @@ import type {
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
-type OnChangeValue = DataValueWriteProps<any>['onChange']
+type OnChangeValue = DataValueWriteProps<
+  string,
+  undefined | string
+>['onChange']
 
 function TestField(props: StringFieldProps) {
   return <Field.String {...props} validateInitially validateContinuously />
@@ -4689,8 +4692,10 @@ describe('DataContext.Provider', { retry: isCI ? 5 : 0 }, () => {
         </DataContext.Provider>
       )
 
-      expect(nestedMockData).toHaveLength(2)
-      expect(nestedMockData).toEqual([initialData, initialData])
+      expect(nestedMockData.length).toBeGreaterThanOrEqual(1)
+      expect(nestedMockData.length).toBeLessThanOrEqual(2)
+      expect(nestedMockData[0]).toEqual(initialData)
+      expect(nestedMockData.at(-1)).toEqual(initialData)
 
       const inputElement = document.querySelector('input')
       expect(inputElement).toHaveValue('bar')
@@ -4727,8 +4732,10 @@ describe('DataContext.Provider', { retry: isCI ? 5 : 0 }, () => {
       expect(sidecarMockData).toHaveLength(2)
       expect(sidecarMockData).toEqual([undefined, initialData])
 
-      expect(nestedMockData).toHaveLength(2)
-      expect(nestedMockData).toEqual([initialData, initialData])
+      expect(nestedMockData.length).toBeGreaterThanOrEqual(1)
+      expect(nestedMockData.length).toBeLessThanOrEqual(2)
+      expect(nestedMockData[0]).toEqual(initialData)
+      expect(nestedMockData.at(-1)).toEqual(initialData)
 
       const [sidecar, nested] = Array.from(
         document.querySelectorAll('input')
@@ -4772,6 +4779,7 @@ describe('DataContext.Provider', { retry: isCI ? 5 : 0 }, () => {
       )
 
       expect(sidecarMockData.length).toBeGreaterThanOrEqual(2)
+      expect(sidecarMockData.length).toBeLessThanOrEqual(4)
       expect(sidecarMockData[0]).toBeUndefined()
       expect(sidecarMockData.at(-1)).toEqual({
         fieldA: 'updated A',
@@ -4779,6 +4787,7 @@ describe('DataContext.Provider', { retry: isCI ? 5 : 0 }, () => {
       })
 
       expect(nestedMockData.length).toBeGreaterThanOrEqual(2)
+      expect(nestedMockData.length).toBeLessThanOrEqual(4)
       expect(nestedMockData[0]).toBeUndefined()
       expect(nestedMockData.at(-1)).toEqual({
         fieldA: 'updated A',
@@ -4823,18 +4832,16 @@ describe('DataContext.Provider', { retry: isCI ? 5 : 0 }, () => {
       )
 
       expect(sidecarMockData.length).toBeGreaterThanOrEqual(2)
+      expect(sidecarMockData.length).toBeLessThanOrEqual(4)
       expect(sidecarMockData[0]).toBeUndefined()
       expect(sidecarMockData[1]).toBeUndefined()
       // With useSyncExternalStore, SidecarMock receives the Provider's data
       // via React's torn-snapshot detection after Provider mounts and seeds the shared state.
 
-      expect(nestedMockData).toHaveLength(4)
-      expect(nestedMockData).toEqual([
-        initialData,
-        initialData,
-        initialData,
-        initialData,
-      ])
+      expect(nestedMockData.length).toBeGreaterThanOrEqual(2)
+      expect(nestedMockData.length).toBeLessThanOrEqual(4)
+      expect(nestedMockData[0]).toEqual(initialData)
+      expect(nestedMockData.at(-1)).toEqual(initialData)
 
       const [sidecar, nested] = Array.from(
         document.querySelectorAll('input')


### PR DESCRIPTION
Fixes the Form.Appearance demo slowdown caused by reactive shared attachment updates after #8009.

The Provider does not need to subscribe to the id-based attachment store it owns. Keeping that path imperative avoids repeated synchronous re-renders while still notifying external subscribers when validation state changes.

Closes #8342
