### PR TITLE
chore(docs): use named starter for issue reports

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/issue.mdx
+++ b/packages/dnb-design-system-portal/src/docs/issue.mdx
@@ -6,6 +6,6 @@ title: 'Reproduce an issue'
 
 When reporting a bug, a minimal reproduction helps us identify and fix the problem faster. Use the starter template below to get started:
 
-- [StackBlitz Starter](https://stackblitz.com/edit/u6dlg7ok?file=src%2FApp.tsx)
+- [StackBlitz Starter](https://stackblitz.com/edit/eufemia-starter?file=src%2FApp.tsx)
 
 You can also open any code example from the documentation directly in StackBlitz by clicking the **Open in StackBlitz** button in the code example toolbar. This creates a new project pre-configured with the example code and all necessary dependencies.


### PR DESCRIPTION
The issue reproduction page should point reporters to the named Eufemia starter project instead of an opaque StackBlitz project id. That makes the reproduction path easier to recognize, share, and maintain when people report bugs.