### PR TITLE
feat(MultiSelection): highlight filtered options to be easier to scan

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback } from 'react'
+import { cloneElement, Fragment, isValidElement, useCallback } from 'react'
 import type { ReactNode, MouseEvent } from 'react'
 import { clsx } from 'clsx'
 import { Checkbox } from '../../../../components'
@@ -34,6 +34,76 @@ export type MultiSelectionItemListProps = {
   selectableFilteredFlat: MultiSelectionItem[]
   allFilteredSelected: boolean
   someFilteredSelected: boolean
+}
+
+function highlightText(
+  text: string,
+  searchValue: string,
+  keyPrefix: string
+): ReactNode {
+  if (!searchValue || !text) {
+    return text
+  }
+
+  const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(`(${escapedSearch})`, 'gi')
+  const exactRegex = new RegExp(`^${escapedSearch}$`, 'i')
+  const parts = text.split(regex)
+
+  if (parts.length === 1) {
+    return text
+  }
+
+  return parts.map((part, index) => {
+    if (exactRegex.test(part)) {
+      return (
+        <mark
+          key={`${keyPrefix}-${index}`}
+          className="dnb-forms-field-multi-selection__highlighting"
+        >
+          {part}
+        </mark>
+      )
+    }
+
+    return part
+  })
+}
+
+function highlightSearchValue(
+  node: ReactNode,
+  searchValue: string,
+  keyPrefix: string
+): ReactNode {
+  if (!searchValue) {
+    return node
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((child, index) =>
+      highlightSearchValue(child, searchValue, `${keyPrefix}-${index}`)
+    )
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return highlightText(String(node), searchValue, keyPrefix)
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    const children = node.props.children
+
+    if (typeof children === 'undefined') {
+      return node
+    }
+
+    return cloneElement(
+      node,
+      undefined,
+      highlightSearchValue(children, searchValue, `${keyPrefix}-children`)
+    )
+  }
+
+  return node
 }
 
 export function MultiSelectionItemList({
@@ -120,7 +190,11 @@ export function MultiSelectionItemList({
                   : onToggleItem(item.value)
               }
               disabled={disabled || item.disabled}
-              label={item.title}
+              label={highlightSearchValue(
+                item.title,
+                searchValue,
+                `${itemPath}-title`
+              )}
               className="dnb-forms-field-multi-selection__checkbox"
               {...htmlAttributes}
             />
@@ -128,12 +202,20 @@ export function MultiSelectionItemList({
               <div className="dnb-forms-field-multi-selection__item-details">
                 {item.text && (
                   <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-text">
-                    {item.text}
+                    {highlightSearchValue(
+                      item.text,
+                      searchValue,
+                      `${itemPath}-text`
+                    )}
                   </span>
                 )}
                 {item.description && (
                   <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-description">
-                    {item.description}
+                    {highlightSearchValue(
+                      item.description,
+                      searchValue,
+                      `${itemPath}-description`
+                    )}
                   </span>
                 )}
               </div>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -873,6 +873,85 @@ describe('MultiSelection', () => {
       expect(screen.queryByText('Option 2')).not.toBeInTheDocument()
     })
 
+    it('highlights search matches in item titles', async () => {
+      const data = [
+        { value: 'option1', title: 'Savings account' },
+        { value: 'option2', title: 'Daily card' },
+      ]
+
+      render(<Field.MultiSelection data={data} showSearchField />)
+
+      fireEvent.click(document.querySelector('button'))
+
+      const input = document.querySelector(
+        '.dnb-forms-field-multi-selection__search input'
+      ) as HTMLInputElement
+      fireEvent.change(input, { target: { value: 'account' } })
+
+      await waitFor(
+        () => {
+          const highlight = document.querySelector(
+            '.dnb-forms-field-multi-selection__highlighting'
+          )
+
+          expect(highlight).toBeInTheDocument()
+          expect(highlight?.tagName).toBe('MARK')
+          expect(highlight).toHaveTextContent('account')
+        },
+        { timeout: 3000 }
+      )
+
+      expect(screen.queryByText('Daily card')).not.toBeInTheDocument()
+    })
+
+    it('highlights search matches in item text and description', async () => {
+      const data = [
+        {
+          value: 'option1',
+          title: 'Account',
+          text: 'Daily banking',
+          description: 'Norwegian customer',
+        },
+        { value: 'option2', title: 'Card' },
+      ]
+
+      render(<Field.MultiSelection data={data} showSearchField />)
+
+      fireEvent.click(document.querySelector('button'))
+
+      const input = document.querySelector(
+        '.dnb-forms-field-multi-selection__search input'
+      ) as HTMLInputElement
+
+      fireEvent.change(input, { target: { value: 'bank' } })
+
+      await waitFor(
+        () => {
+          const textHighlight = document.querySelector(
+            '.dnb-forms-field-multi-selection__item-text .dnb-forms-field-multi-selection__highlighting'
+          )
+
+          expect(textHighlight).toBeInTheDocument()
+          expect(textHighlight).toHaveTextContent('bank')
+        },
+        { timeout: 3000 }
+      )
+
+      fireEvent.change(input, { target: { value: 'customer' } })
+
+      await waitFor(
+        () => {
+          const descriptionHighlight = document.querySelector(
+            '.dnb-forms-field-multi-selection__item-description .dnb-forms-field-multi-selection__highlighting'
+          )
+
+          expect(descriptionHighlight).toBeInTheDocument()
+          expect(descriptionHighlight).toHaveTextContent('customer')
+        },
+        { timeout: 3000 }
+      )
+    })
+
     it('focuses the search input when pressing ArrowDown on the trigger with showSearchField', async () => {
       const data = [
         { value: 'option1', title: 'Option 1' },
@@ -1092,19 +1171,30 @@ describe('MultiSelection', () => {
 
       await waitFor(
         () => {
-          expect(screen.getByText(/Bold Title/)).toBeInTheDocument()
+          expect(
+            document.querySelector('.dnb-form-label strong')
+          ).toHaveTextContent('Bold Title')
         },
         { timeout: 3000 }
       )
 
-      const input = document.querySelector('input') as HTMLInputElement
+      const input = document.querySelector(
+        '.dnb-forms-field-multi-selection__search input'
+      ) as HTMLInputElement
 
       // Search for text within JSX title
       fireEvent.change(input, { target: { value: 'bold' } })
 
       await waitFor(
         () => {
-          expect(screen.getByText(/Bold Title/)).toBeInTheDocument()
+          const title = document.querySelector('.dnb-form-label strong')
+
+          expect(title).toHaveTextContent('Bold Title')
+          expect(
+            title?.querySelector(
+              '.dnb-forms-field-multi-selection__highlighting'
+            )
+          ).toHaveTextContent('Bold')
         },
         { timeout: 3000 }
       )
@@ -1116,7 +1206,16 @@ describe('MultiSelection', () => {
 
       await waitFor(
         () => {
-          expect(screen.getByText(/Span description/)).toBeInTheDocument()
+          const description = document.querySelector(
+            '.dnb-forms-field-multi-selection__item-description'
+          )
+
+          expect(description).toHaveTextContent('Span description')
+          expect(
+            description?.querySelector(
+              '.dnb-forms-field-multi-selection__highlighting'
+            )
+          ).toHaveTextContent('Span')
         },
         { timeout: 3000 }
       )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
@@ -55,6 +55,12 @@
     color: var(--token-color-text-neutral-alternative);
   }
 
+  &__highlighting {
+    font-weight: var(--font-weight-bold);
+    background-color: transparent;
+    color: inherit;
+  }
+
   &__item {
     position: relative;
     display: flex;


### PR DESCRIPTION
MultiSelection filtering narrows the option list, but users still have to visually parse each remaining item to find the matching text. Highlighting the matched part makes the search results quicker to scan and aligns the experience with Filter and Autocomplete.

Preview: https://chore-multi-selection-search.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection/demos#with-search