### PR TITLE
chore: make dark mode token swatches responsive on small screens

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/design-tokens/Examples.tsx
@@ -172,10 +172,9 @@ const darkModeSwatchRows: DarkModeSwatch[] = [
 ]
 
 const darkModeGridStyle: CSSProperties = {
-  display: 'inline-grid',
+  display: 'grid',
   gap: '1rem',
-  gridTemplateColumns: 'repeat(2, auto)',
-  placeItems: 'start',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 20rem), 1fr))',
 }
 
 const darkModeCardInnerStyle: CSSProperties = {


### PR DESCRIPTION
Change the grid layout from a fixed 2-column layout to auto-fit with minmax so the cards stack vertically on narrow viewports like iPhone.

[From](https://eufemia.dnb.no/uilib/usage/customisation/theming/design-tokens/dark-mode#color-token-swatches): 
<img width="402" height="850" alt="Screenshot 2026-06-12 at 09 55 02" src="https://github.com/user-attachments/assets/f40b56cb-4944-4e8c-9079-c4b642d27515" />

[To](https://fix-dark-mode-swatches-mobil.eufemia-e25.pages.dev/uilib/usage/customisation/theming/design-tokens/dark-mode#color-token-swatches):

<img width="447" height="856" alt="image" src="https://github.com/user-attachments/assets/030bf008-1fd5-4371-a6ff-f21c40a988b3" />
