### PR TITLE
fix(Filter): let search input own manual icon

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/filter/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/filter/Examples.tsx
@@ -2,7 +2,7 @@
  * Filter component examples for the portal docs.
  */
 
-import { useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
 import {
   Button,
@@ -1067,25 +1067,58 @@ export const SearchOnly = () => {
     <ComponentBox hideCode>
       {() => {
         const Example = () => {
-          const items = [
-            { id: 1, name: 'Rema 1000', amount: -245 },
-            { id: 2, name: 'Kiwi', amount: -189 },
-            { id: 3, name: 'Salary', amount: 35000 },
-          ]
+          const items = useMemo(
+            () => [
+              { id: 1, name: 'Rema 1000', amount: -245 },
+              { id: 2, name: 'Kiwi', amount: -189 },
+              { id: 3, name: 'Salary', amount: 35000 },
+            ],
+            []
+          )
+
+          const getFilteredItems = useCallback(
+            (searchValue: string) => {
+              return items.filter((item) => {
+                if (
+                  searchValue &&
+                  !item.name
+                    .toLowerCase()
+                    .includes(searchValue.toLowerCase()) &&
+                  !String(item.amount).includes(searchValue)
+                ) {
+                  return false
+                }
+
+                return true
+              })
+            },
+            [items]
+          )
 
           const { search } = Filter.useFilter('search-only-demo')
+          const previousSearchRef = useRef(search)
+          const [showSkeleton, setShowSkeleton] = useState(false)
+          const [filtered, setFiltered] = useState(() =>
+            getFilteredItems(search)
+          )
 
-          const filtered = items.filter((item) => {
-            if (
-              search &&
-              !item.name.toLowerCase().includes(search.toLowerCase()) &&
-              !String(item.amount).includes(search)
-            ) {
-              return false
+          useEffect(() => {
+            if (previousSearchRef.current === search) {
+              return // stop here
             }
 
-            return true
-          })
+            previousSearchRef.current = search
+            setShowSkeleton(true)
+
+            const timeout = setTimeout(() => {
+              setFiltered(getFilteredItems(search))
+              setShowSkeleton(false)
+            }, 1000)
+
+            return () => clearTimeout(timeout)
+          }, [getFilteredItems, search])
+
+          const visibleItems = showSkeleton ? items : filtered
 
           return (
             <>
@@ -1106,9 +1139,9 @@ export const SearchOnly = () => {
               </Filter.Root>
 
               <Filter.Content connectedTo="search-only-demo">
-                <List.Container>
-                  <Filter.NoResults />
-                  {filtered.map((item) => (
+                <List.Container skeleton={showSkeleton}>
+                  {!showSkeleton && <Filter.NoResults />}
+                  {visibleItems.map((item) => (
                     <List.Item.Action
                       key={item.id}
                       title={

--- a/packages/dnb-eufemia/src/components/filter/FilterSearch.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterSearch.tsx
@@ -10,7 +10,6 @@ import Input from '../input/Input'
 import type { InputProps } from '../input/Input'
 import ProgressIndicator from '../progress-indicator/ProgressIndicator'
 import { FilterContext } from './FilterContext'
-import { loupe as searchIcon } from '../../icons'
 
 export type FilterSearchProps = {
   label: string
@@ -124,9 +123,7 @@ function FilterSearch({
         icon={
           showIndicator ? (
             <ProgressIndicator type="circular" size="small" />
-          ) : (
-            searchIcon
-          )
+          ) : undefined
         }
         stretch
         size="medium"

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterSearch.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterSearch.test.tsx
@@ -290,6 +290,21 @@ describe('Filter.Search submitBehavior="manual"', () => {
     ).toBe('world')
   })
 
+  it('does not render a separate search icon when submit button is shown', () => {
+    render(
+      <FilterRoot>
+        <FilterSearch label="Søk" submitBehavior="manual" />
+      </FilterRoot>
+    )
+
+    expect(
+      document.querySelector('.dnb-input__submit-button .dnb-icon')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('.dnb-input__icon')
+    ).not.toBeInTheDocument()
+  })
+
   it('clears search state when clear button is clicked', () => {
     function SearchState() {
       const ctx = useFilterContext()

--- a/packages/dnb-eufemia/src/components/filter/style/dnb-filter.scss
+++ b/packages/dnb-eufemia/src/components/filter/style/dnb-filter.scss
@@ -137,6 +137,11 @@
     border-top-right-radius: 0;
   }
 
+  &__content .dnb-list__container:has(.dnb-list__item.dnb-skeleton) {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
   &__highlighting {
     font-weight: var(--font-weight-bold);
     background-color: transparent;


### PR DESCRIPTION
This keeps `Filter.Search` aligned with the `Input` search behavior by letting `type="search"` provide the manual submit icon instead of forcing a separate loupe icon.

This is fine because async cannot be used with `submitBehavior="manual"`, so the manual submit button can rely on the default search icon while the loading indicator remains scoped to typing/loading state.

Closes #8560