### PR TITLE
docs(PortalRoot): mention Google Translate in BrowserTranslate headings

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
@@ -123,4 +123,4 @@ You can also set the width directly, but then it has to be defined like so (incl
 
 ## Root Element (React Portal)
 
-The Autocomplete component uses [PortalRoot](/uilib/components/portal-root) internally to render its option list. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Autocomplete component uses [PortalRoot](/uilib/components/portal-root) internally to render its option list. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
@@ -133,4 +133,4 @@ Additional event return object properties:
 
 ## Root Element (React Portal)
 
-The DatePicker component uses [PortalRoot](/uilib/components/portal-root) internally to render its calendar. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The DatePicker component uses [PortalRoot](/uilib/components/portal-root) internally to render its calendar. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/info.mdx
@@ -57,4 +57,4 @@ For more details regarding the component functionality, check out the [Modal doc
 
 ## Root Element (React Portal)
 
-The Dialog component uses [PortalRoot](/uilib/components/portal-root) internally through Modal to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Dialog component uses [PortalRoot](/uilib/components/portal-root) internally through Modal to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/info.mdx
@@ -32,4 +32,4 @@ For more details regarding the component functionality, check out the [Modal doc
 
 ## Root Element (React Portal)
 
-The Drawer component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Drawer component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/info.mdx
@@ -67,4 +67,4 @@ You can also set the width directly, but then it has to be defined like so (incl
 
 ## Root Element (React Portal)
 
-The Dropdown component uses [PortalRoot](/uilib/components/portal-root) internally to render its option list. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Dropdown component uses [PortalRoot](/uilib/components/portal-root) internally to render its option list. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
@@ -44,4 +44,4 @@ For inline expandable groups, use `Menu.Accordion` instead of a nested `Menu.Roo
 
 ## Root Element (React Portal)
 
-The Menu component uses [PortalRoot](/uilib/components/portal-root) internally through Popover to render its top-level menu. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Menu component uses [PortalRoot](/uilib/components/portal-root) internally through Popover to render its top-level menu. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.mdx
@@ -96,4 +96,4 @@ html[data-dnb-modal-active='MODAL-ID'] {
 
 ## Root Element (React Portal)
 
-The Modal component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Modal component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/popover/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/popover/info.mdx
@@ -33,4 +33,4 @@ It is used in the [Tooltip](/uilib/components/tooltip) and [DatePicker](/uilib/c
 
 ## Root Element (React Portal)
 
-The Popover component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Popover component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/demos.mdx
@@ -10,7 +10,7 @@ import * as Examples from './Examples'
 
 <Examples.PortalRootExample />
 
-### BrowserTranslate
+### BrowserTranslate (Google Translate)
 
 The `BrowserTranslate` helper prevents browser translation tools (e.g. Google Translate) from modifying form component content. It sets `translate="no"` on both the component itself and any portal-rendered content like dropdown lists.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
@@ -149,7 +149,7 @@ render(
 
 In this example, every portal element will receive `data-my-need="something"` for content rendered outside the main React tree.
 
-### BrowserTranslate helper
+### BrowserTranslate helper (Google Translate)
 
 The `BrowserTranslate` helper component prevents browser translation tools (such as Google Translate) from modifying the content of form components. It works by combining the Eufemia Provider's `formElement` context with `PortalRoot.Provider`, so both the visible component (e.g. a button) and its portal-rendered content (e.g. a dropdown list) receive `translate="no"`.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition/info.mdx
@@ -35,4 +35,4 @@ To ensure that the TermDefinition component is accessible, it uses semantic HTML
 
 ## Root Element (React Portal)
 
-The TermDefinition component uses [PortalRoot](/uilib/components/portal-root) internally to render its explanation content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The TermDefinition component uses [PortalRoot](/uilib/components/portal-root) internally to render its explanation content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/info.mdx
@@ -47,4 +47,4 @@ To use the built-in hover/focus/touch behavior, omit the `open` property and let
 
 ## Root Element (React Portal)
 
-The Tooltip component uses [PortalRoot](/uilib/components/portal-root) internally through Popover to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+The Tooltip component uses [PortalRoot](/uilib/components/portal-root) internally through Popover to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.


### PR DESCRIPTION
Developers looking for Google Translate behavior need to be able to find the BrowserTranslate helper without already knowing its exact name.

This makes the PortalRoot BrowserTranslate headings searchable for Google Translate and keeps related component docs pointing to the updated section hash.