### PR TITLE
fix(Tabs): restore page scrolling over tablist

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -21,6 +21,7 @@ import type {
   PropsWithChildren,
   ReactElement,
   ReactNode,
+  WheelEvent,
   SyntheticEvent,
 } from 'react'
 import { clsx } from 'clsx'
@@ -666,6 +667,19 @@ function TabsComponent(ownProps: TabsProps) {
         behavior: 'smooth',
       })
     }
+  }
+
+  const onTablistWheelHandler = (event: WheelEvent<HTMLDivElement>) => {
+    if (
+      event.ctrlKey ||
+      event.shiftKey ||
+      Math.abs(event.deltaY) <= Math.abs(event.deltaX)
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    window.scrollBy({ top: event.deltaY, behavior: 'auto' })
   }
 
   const setFocusOnTabButton = useCallback(() => {
@@ -1362,6 +1376,7 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
         className="dnb-tabs__tabs__tablist"
         tabIndex={0}
         onKeyDown={onTablistKeyDownHandler}
+        onWheelCapture={onTablistWheelHandler}
         ref={tablistRef}
         {...params}
       >

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -405,6 +405,31 @@ describe('TabList component', () => {
     )
   })
 
+  it('passes only vertical wheel gestures to page scrolling', () => {
+    const scrollBy = vi
+      .spyOn(window, 'scrollBy')
+      .mockImplementation(() => undefined)
+
+    render(
+      <Tabs {...props} data={tablistData} selectedKey={startupSelectedKey}>
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const tablist = document.querySelector('.dnb-tabs__tabs__tablist')
+
+    fireEvent.wheel(tablist, { deltaX: 100 })
+    expect(scrollBy).not.toHaveBeenCalled()
+
+    fireEvent.wheel(tablist, { deltaY: 100 })
+    expect(scrollBy).toHaveBeenCalledWith({
+      top: 100,
+      behavior: 'auto',
+    })
+
+    scrollBy.mockRestore()
+  })
+
   it('has to have the right content on a "click event"', () => {
     render(
       <Tabs {...props} data={tablistData} selectedKey={startupSelectedKey}>


### PR DESCRIPTION
Scrolling the page while hovering the Tabs tablist could be trapped by the horizontal tab scroller in Chromium-based browsers, and Firefox could stop page scrolling in the same area.

This keeps horizontal tab scrolling available while letting vertical wheel intent continue to scroll the page, so users do not get stuck when the pointer is over the tablist.

Closes #6827