### PR TITLE
fix(Wizard): prevent duplicate route step changes

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
@@ -1,6 +1,7 @@
 import { act, useCallback, useMemo, useReducer, useRef } from 'react'
 import type { RefObject } from 'react'
 import { render, renderHook, waitFor } from '@testing-library/react'
+import { wait } from '../../../../../core/test-utils/testSetup'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useNextRouter from '../useNextRouter'
 import useStep from '../useStep'
@@ -219,6 +220,78 @@ describe('useNextRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+    const { useRouter, usePathname, useSearchParams, forceUpdateRef } =
+      getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useNextRouter(identifier, {
+        useRouter,
+        usePathname,
+        useSearchParams,
+      })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+
+    await wait(10)
+
+    visitStep(0)
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+
+    visitStep(1)
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
   })
 
   it('should react to url change', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
@@ -1,6 +1,6 @@
 import { act, useCallback, useMemo, useReducer, useRef } from 'react'
 import type { RefObject } from 'react'
-import { render, renderHook } from '@testing-library/react'
+import { render, renderHook, waitFor } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useNextRouter from '../useNextRouter'
 import useStep from '../useStep'
@@ -142,6 +142,82 @@ describe('useNextRouter', () => {
     expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=0`
+    )
+  })
+
+  it('should call Wizard.Container onStepChange once for each button navigation when updating the URL query parameter', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+    const { useRouter, usePathname, useSearchParams } = getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useNextRouter(identifier, {
+        useRouter,
+        usePathname,
+        useSearchParams,
+      })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+
+    await userEvent.click(previousButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=0`
+    )
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
@@ -1,5 +1,6 @@
 import { act } from 'react'
 import { render, renderHook, waitFor } from '@testing-library/react'
+import { wait } from '../../../../../core/test-utils/testSetup'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useQueryLocator from '../useQueryLocator'
 import useStep from '../useStep'
@@ -204,6 +205,70 @@ describe('useQueryLocator', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useQueryLocator(identifier)
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+
+    await wait(10)
+
+    visitStep(0)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+
+    visitStep(1)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
   })
 
   it('should work without id', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
@@ -1,5 +1,5 @@
 import { act } from 'react'
-import { render, renderHook } from '@testing-library/react'
+import { render, renderHook, waitFor } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useQueryLocator from '../useQueryLocator'
 import useStep from '../useStep'
@@ -132,6 +132,77 @@ describe('useQueryLocator', () => {
       {},
       '',
       `http://localhost/?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+  })
+
+  it('should call Wizard.Container onStepChange once for each button navigation when updating the URL query parameter', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useQueryLocator(identifier)
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+
+    await userEvent.click(previousButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=0`
+    )
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
@@ -1,6 +1,7 @@
 import { act, useCallback, useReducer } from 'react'
 import type { RefObject } from 'react'
 import { render, renderHook, waitFor } from '@testing-library/react'
+import { wait } from '../../../../../core/test-utils/testSetup'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useReachRouter from '../useReachRouter'
 import useStep from '../useStep'
@@ -203,6 +204,73 @@ describe('useReachRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+    const { useLocation, navigate, forceUpdateRef } = getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useReachRouter(identifier, { useLocation, navigate })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+
+    await wait(10)
+
+    visitStep(0)
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+
+    visitStep(1)
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
   })
 
   it('should react to url change', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
@@ -1,6 +1,6 @@
 import { act, useCallback, useReducer } from 'react'
 import type { RefObject } from 'react'
-import { render, renderHook } from '@testing-library/react'
+import { render, renderHook, waitFor } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useReachRouter from '../useReachRouter'
 import useStep from '../useStep'
@@ -42,6 +42,7 @@ describe('useReachRouter', () => {
 
     const navigate = vi.fn((href) => {
       window.history.replaceState({}, '', href)
+      forceUpdateRef.current?.()
     })
     const useLocation = vi.fn(() => {
       const [, fU] = useReducer(() => ({}), {})
@@ -127,6 +128,78 @@ describe('useReachRouter', () => {
     await userEvent.click(previousButton())
 
     expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+  })
+
+  it('should call Wizard.Container onStepChange once for each button navigation when updating the URL query parameter', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+    const { useLocation, navigate } = getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useReachRouter(identifier, { useLocation, navigate })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+
+    await userEvent.click(previousButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=0`
+    )
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
@@ -1,6 +1,7 @@
 import { act, useCallback, useReducer, useRef } from 'react'
 import type { RefObject } from 'react'
 import { render, renderHook, waitFor } from '@testing-library/react'
+import { wait } from '../../../../../core/test-utils/testSetup'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useReactRouter from '../useReactRouter'
 import useStep from '../useStep'
@@ -107,6 +108,7 @@ describe('useReactRouter', () => {
     return {
       useSearchParams,
       setSearchParams,
+      forceUpdateRef,
     }
   }
 
@@ -267,6 +269,73 @@ describe('useReactRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+    const { useSearchParams, forceUpdateRef } = getRerenderingHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useReactRouter(identifier, { useSearchParams })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+
+    await wait(10)
+
+    visitStep(0)
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+
+    visitStep(1)
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(onStepChange).toHaveBeenCalledTimes(3)
   })
 
   it('should react to url change', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
@@ -1,6 +1,6 @@
 import { act, useCallback, useReducer, useRef } from 'react'
 import type { RefObject } from 'react'
-import { render, renderHook } from '@testing-library/react'
+import { render, renderHook, waitFor } from '@testing-library/react'
 import { makeUniqueId } from '../../../../../shared/component-helper'
 import useReactRouter from '../useReactRouter'
 import useStep from '../useStep'
@@ -77,6 +77,36 @@ describe('useReactRouter', () => {
       set,
       searchParams,
       forceUpdateRef,
+    }
+  }
+
+  const getRerenderingHookMock = () => {
+    const forceUpdateRef: RefObject<(() => void) | null> = {
+      current: null,
+    }
+
+    const setSearchParams = vi.fn((searchParams: URLSearchParams) => {
+      const url = new URL(window.location.href)
+      url.search = searchParams.toString()
+      window.history.replaceState({}, '', url.toString())
+      forceUpdateRef.current?.()
+    })
+
+    const useSearchParams = vi.fn(() => {
+      const [, fU] = useReducer(() => ({}), {})
+      const paramsRef = useRef(new URLSearchParams(window.location.search))
+
+      forceUpdateRef.current = useCallback(() => {
+        paramsRef.current = new URLSearchParams(window.location.search)
+        fU()
+      }, [])
+
+      return [paramsRef.current, setSearchParams] as const
+    })
+
+    return {
+      useSearchParams,
+      setSearchParams,
     }
   }
 
@@ -162,6 +192,81 @@ describe('useReactRouter', () => {
     expect(setSearchParams).toHaveBeenCalledTimes(3)
     expect(setSearchParams).toHaveBeenLastCalledWith(searchParams)
     expect(set).toHaveBeenCalledTimes(3)
+  })
+
+  it('should call Wizard.Container onStepChange once for each button navigation when updating the URL query parameter', async () => {
+    mockUrl()
+
+    const onStepChange = vi.fn()
+    const { useSearchParams, setSearchParams } = getRerenderingHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useReactRouter(identifier, { useSearchParams })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container
+            mode="loose"
+            id={identifier}
+            onStepChange={onStepChange}
+          >
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    expect(output()).toHaveTextContent('{"activeIndex":0}')
+    expect(onStepChange).toHaveBeenCalledTimes(0)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(setSearchParams).toHaveBeenCalledTimes(1)
+    expect(onStepChange).toHaveBeenCalledTimes(1)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+
+    await userEvent.click(previousButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0}')
+    })
+
+    expect(setSearchParams).toHaveBeenCalledTimes(2)
+    expect(onStepChange).toHaveBeenCalledTimes(2)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=0`
+    )
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(setSearchParams).toHaveBeenCalledTimes(3)
+    expect(onStepChange).toHaveBeenCalledTimes(3)
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
   })
 
   it('should react to url change', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
@@ -21,10 +21,12 @@ export default function useNextRouter(
 
   const searchParamsRef = useRef(searchParams)
   searchParamsRef.current = searchParams
+  const routerStepChangeRef = useRef<number>(undefined)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
+        routerStepChangeRef.current = index
         const params = new URLSearchParams(
           searchParamsRef.current.toString()
         )
@@ -49,8 +51,14 @@ export default function useNextRouter(
   useLayoutEffect(() => {
     const routerIndex = getIndex()
     if (!isNaN(routerIndex)) {
+      const skipStepChangeCall =
+        routerIndex === routerStepChangeRef.current
+      if (skipStepChangeCall) {
+        routerStepChangeRef.current = undefined
+      }
+
       setActiveIndex?.(routerIndex, {
-        skipStepChangeCall: true,
+        skipStepChangeCall,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
@@ -13,17 +13,30 @@ export default function useNextRouter(
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
+  const routerRef = useRef(router)
+  routerRef.current = router
+
+  const pathnameRef = useRef(pathname)
+  pathnameRef.current = pathname
+
+  const searchParamsRef = useRef(searchParams)
+  searchParamsRef.current = searchParams
+
   const onStepChange = useCallback(
     (index: number) => {
       try {
-        const params = new URLSearchParams(searchParams.toString())
+        const params = new URLSearchParams(
+          searchParamsRef.current.toString()
+        )
         params.set(name, String(index))
-        router.push(`${pathname}?${params.toString()}`)
+        routerRef.current.push(
+          `${pathnameRef.current}?${params.toString()}`
+        )
       } catch (error) {
         setFormError(error as Error)
       }
     },
-    [name, pathname, router, searchParams, setFormError]
+    [name, setFormError]
   )
 
   const { setActiveIndex } = useStep(id, { onStepChange })
@@ -37,6 +50,7 @@ export default function useNextRouter(
     const routerIndex = getIndex()
     if (!isNaN(routerIndex)) {
       setActiveIndex?.(routerIndex, {
+        skipStepChangeCall: true,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
@@ -16,10 +16,12 @@ export default function useReachRouter(
 
   const navigateRef = useRef(navigate)
   navigateRef.current = navigate
+  const routerStepChangeRef = useRef<number>(undefined)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
+        routerStepChangeRef.current = index
         const url = new URL(locationRef.current.href)
         url.searchParams.set(name, String(index))
         navigateRef.current(url.href)
@@ -46,8 +48,14 @@ export default function useReachRouter(
   useLayoutEffect(() => {
     const routerIndex = getIndex()
     if (!isNaN(routerIndex)) {
+      const skipStepChangeCall =
+        routerIndex === routerStepChangeRef.current
+      if (skipStepChangeCall) {
+        routerStepChangeRef.current = undefined
+      }
+
       setActiveIndex?.(routerIndex, {
-        skipStepChangeCall: true,
+        skipStepChangeCall,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
@@ -11,17 +11,23 @@ export default function useReachRouter(
   const { setFormError } = useStep(id)
   const location = useLocation()
 
+  const locationRef = useRef(location)
+  locationRef.current = location
+
+  const navigateRef = useRef(navigate)
+  navigateRef.current = navigate
+
   const onStepChange = useCallback(
     (index: number) => {
       try {
-        const url = new URL(location.href)
+        const url = new URL(locationRef.current.href)
         url.searchParams.set(name, String(index))
-        navigate(url.href)
+        navigateRef.current(url.href)
       } catch (error) {
         setFormError(error as Error)
       }
     },
-    [location.href, name, navigate, setFormError]
+    [name, setFormError]
   )
 
   const { setActiveIndex } = useStep(id, { onStepChange })
@@ -41,6 +47,7 @@ export default function useReachRouter(
     const routerIndex = getIndex()
     if (!isNaN(routerIndex)) {
       setActiveIndex?.(routerIndex, {
+        skipStepChangeCall: true,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
@@ -11,16 +11,20 @@ export default function useReactRouter(
   const { setFormError } = useStep(id)
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const searchParamsRef = useRef(searchParams)
+  searchParamsRef.current = searchParams
+
   const onStepChange = useCallback(
     (index: number) => {
       try {
+        const searchParams = searchParamsRef.current
         searchParams.set(name, index)
         setSearchParams(searchParams)
       } catch (error) {
         setFormError(error as Error)
       }
     },
-    [name, searchParams, setFormError, setSearchParams]
+    [name, setFormError, setSearchParams]
   )
 
   const { setActiveIndex } = useStep(id, { onStepChange })
@@ -34,6 +38,7 @@ export default function useReactRouter(
     const routerIndex = getIndex()
     if (!isNaN(routerIndex)) {
       setActiveIndex?.(routerIndex, {
+        skipStepChangeCall: true,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
@@ -13,11 +13,13 @@ export default function useReactRouter(
 
   const searchParamsRef = useRef(searchParams)
   searchParamsRef.current = searchParams
+  const routerStepChangeRef = useRef<number>(undefined)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
         const searchParams = searchParamsRef.current
+        routerStepChangeRef.current = index
         searchParams.set(name, index)
         setSearchParams(searchParams)
       } catch (error) {
@@ -37,8 +39,14 @@ export default function useReactRouter(
   useLayoutEffect(() => {
     const routerIndex = getIndex()
     if (!isNaN(routerIndex)) {
+      const skipStepChangeCall =
+        routerIndex === routerStepChangeRef.current
+      if (skipStepChangeCall) {
+        routerStepChangeRef.current = undefined
+      }
+
       setActiveIndex?.(routerIndex, {
-        skipStepChangeCall: true,
+        skipStepChangeCall,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })


### PR DESCRIPTION
Route-backed Wizard steps could call the public step-change handler twice when a button navigation was followed by router state syncing the same step back into the Wizard.

This keeps the router callbacks stable across URL updates and ensures router-to-Wizard sync does not re-emit the public step-change event after the button navigation has already done so.

Closes #6047

Reprod with fix: https://stackblitz.com/edit/7kxrnnv5?file=src%2FApp.tsx,src%2Fmain.tsx,src%2FFormEntry.tsx,src%2FWizardContainer.tsx