### PR TITLE
fix(Wizard): improve routed step history

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useNextRouter.test.tsx
@@ -40,13 +40,12 @@ describe('useNextRouter', () => {
     const forceUpdateRef: RefObject<(() => void) | null> = {
       current: null,
     }
+    const push = vi.fn((href) => {
+      window.history.replaceState({}, '', href)
+      forceUpdateRef.current?.()
+    })
 
     const useRouter = vi.fn(() => {
-      const push = useCallback((href) => {
-        window.history.replaceState({}, '', href)
-        forceUpdateRef.current()
-      }, [])
-
       return useMemo(() => {
         return { push }
       }, [push])
@@ -71,6 +70,7 @@ describe('useNextRouter', () => {
       useSearchParams,
       useRouter,
       forceUpdateRef,
+      push,
     }
   }
 
@@ -78,6 +78,11 @@ describe('useNextRouter', () => {
     const url = new URL(window.location.href)
     url.searchParams.set(`${identifier}-step`, String(index))
     window.history.pushState({}, '', url.toString())
+  }
+  const removeStep = () => {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(`${identifier}-step`)
+    window.history.replaceState({}, '', url.toString())
   }
 
   it('should not throw when using an id that has never been mounted', () => {
@@ -150,7 +155,7 @@ describe('useNextRouter', () => {
     mockUrl()
 
     const onStepChange = vi.fn()
-    const { useRouter, usePathname, useSearchParams } = getHookMock()
+    const { useRouter, usePathname, useSearchParams, push } = getHookMock()
 
     const Step = () => {
       const { activeIndex } = useStep(identifier)
@@ -198,6 +203,7 @@ describe('useNextRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+    expect(push).toHaveBeenCalledTimes(1)
 
     await userEvent.click(previousButton())
 
@@ -209,6 +215,7 @@ describe('useNextRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=0`
     )
+    expect(push).toHaveBeenCalledTimes(2)
 
     await userEvent.click(nextButton())
 
@@ -220,6 +227,58 @@ describe('useNextRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+    expect(push).toHaveBeenCalledTimes(3)
+  })
+
+  it('should write one history entry when multiple hooks listen to the same wizard', async () => {
+    mockUrl()
+
+    const { useRouter, usePathname, useSearchParams, push } = getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useNextRouter(identifier, {
+        useRouter,
+        usePathname,
+        useSearchParams,
+      })
+      useNextRouter(identifier, {
+        useRouter,
+        usePathname,
+        useSearchParams,
+      })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+    expect(push).toHaveBeenCalledTimes(1)
   })
 
   it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
@@ -300,31 +359,36 @@ describe('useNextRouter', () => {
     const { useRouter, usePathname, useSearchParams, forceUpdateRef } =
       getHookMock()
 
-    const Step = () => {
-      const { activeIndex } = useStep(identifier)
+    const MyForm = () => {
       const { getIndex } = useNextRouter(identifier, {
         useRouter,
         usePathname,
         useSearchParams,
       })
+
+      const Step = () => {
+        const { activeIndex } = useStep(identifier)
+        return (
+          <Wizard.Step>
+            <output>
+              {JSON.stringify({ activeIndex, index: getIndex() })}
+            </output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+        )
+      }
+
       return (
-        <Wizard.Step>
-          <output>
-            {JSON.stringify({ activeIndex, index: getIndex() })}
-          </output>
-          <Wizard.Buttons />
-        </Wizard.Step>
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
       )
     }
 
-    render(
-      <Form.Handler>
-        <Wizard.Container mode="loose" id={identifier}>
-          <Step />
-          <Step />
-        </Wizard.Container>
-      </Form.Handler>
-    )
+    render(<MyForm />)
 
     expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
     expect(window.location.search).toBe('?existing-query=foo&bar=baz')
@@ -346,7 +410,7 @@ describe('useNextRouter', () => {
     visitStep(0)
     act(forceUpdateRef.current)
 
-    expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
+    expect(output()).toHaveTextContent('{"activeIndex":0,"index":0}')
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=0`
     )
@@ -355,6 +419,59 @@ describe('useNextRouter', () => {
       '',
       `http://localhost/?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should restore the first step when the routed step is removed from the URL', async () => {
+    mockUrl()
+
+    const { useRouter, usePathname, useSearchParams, forceUpdateRef } =
+      getHookMock()
+
+    const MyForm = () => {
+      const { getIndex } = useNextRouter(identifier, {
+        useRouter,
+        usePathname,
+        useSearchParams,
+      })
+
+      const Step = () => {
+        const { activeIndex } = useStep(identifier)
+        return (
+          <Wizard.Step>
+            <output>
+              {JSON.stringify({ activeIndex, index: getIndex() })}
+            </output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+        )
+      }
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
+    })
+
+    removeStep()
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
+    })
+
+    expect(window.location.search).toBe('?existing-query=foo&bar=baz')
   })
 
   it('should handle and show try/catch errors', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useQueryLocator.test.tsx
@@ -59,6 +59,15 @@ describe('useQueryLocator', () => {
       popstateListener()
     })
   }
+  const removeStep = () => {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(`${identifier}-step`)
+    window.history.replaceState({}, '', url.toString())
+
+    act(() => {
+      popstateListener()
+    })
+  }
   const Step = () => {
     const { activeIndex } = useStep(identifier)
     const { getIndex } = useQueryLocator(identifier)
@@ -205,6 +214,47 @@ describe('useQueryLocator', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should write one history entry when multiple hooks listen to the same wizard', async () => {
+    mockUrl()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useQueryLocator(identifier)
+      useQueryLocator(identifier)
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+    expect(window.history.pushState).toHaveBeenCalledTimes(1)
   })
 
   it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
@@ -390,6 +440,51 @@ describe('useQueryLocator', () => {
       '',
       `http://localhost/?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should restore the first step when the routed step is removed from the URL', async () => {
+    mockUrl()
+
+    const MyForm = () => {
+      const { getIndex } = useQueryLocator(identifier)
+
+      const Step = () => {
+        const { activeIndex } = useStep(identifier)
+        return (
+          <Wizard.Step>
+            <output>
+              {JSON.stringify({ activeIndex, index: getIndex() })}
+            </output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+        )
+      }
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
+    })
+
+    removeStep()
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
+    })
+
+    expect(window.location.search).toBe('?existing-query=foo&bar=baz')
   })
 
   it('should handle and show try/catch errors', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReachRouter.test.tsx
@@ -64,6 +64,11 @@ describe('useReachRouter', () => {
     url.searchParams.set(`${identifier}-step`, String(index))
     window.history.pushState({}, '', url.toString())
   }
+  const removeStep = () => {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(`${identifier}-step`)
+    window.history.replaceState({}, '', url.toString())
+  }
 
   it('should not throw when using an id that has never been mounted', () => {
     mockUrl()
@@ -182,6 +187,7 @@ describe('useReachRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+    expect(navigate).toHaveBeenCalledTimes(1)
 
     await userEvent.click(previousButton())
 
@@ -193,6 +199,7 @@ describe('useReachRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=0`
     )
+    expect(navigate).toHaveBeenCalledTimes(2)
 
     await userEvent.click(nextButton())
 
@@ -204,6 +211,50 @@ describe('useReachRouter', () => {
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+    expect(navigate).toHaveBeenCalledTimes(3)
+  })
+
+  it('should write one history entry when multiple hooks listen to the same wizard', async () => {
+    mockUrl()
+
+    const { useLocation, navigate } = getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useReachRouter(identifier, { useLocation, navigate })
+      useReachRouter(identifier, { useLocation, navigate })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+    expect(navigate).toHaveBeenCalledTimes(1)
   })
 
   it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
@@ -346,6 +397,52 @@ describe('useReachRouter', () => {
       '',
       `http://localhost/?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should restore the first step when the routed step is removed from the URL', async () => {
+    mockUrl()
+
+    const { useLocation, navigate, forceUpdateRef } = getHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      const { getIndex } = useReachRouter(identifier, {
+        useLocation,
+        navigate,
+      })
+      return (
+        <Wizard.Step>
+          <output>
+            {JSON.stringify({ activeIndex, index: getIndex() })}
+          </output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    render(
+      <Form.Handler>
+        <Wizard.Container mode="loose" id={identifier}>
+          <Step />
+          <Step />
+        </Wizard.Container>
+      </Form.Handler>
+    )
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
+    })
+
+    removeStep()
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
+    })
+
+    expect(window.location.search).toBe('?existing-query=foo&bar=baz')
   })
 
   it('should handle and show try/catch errors', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
@@ -118,6 +118,12 @@ describe('useReactRouter', () => {
     url.searchParams.set(`${identifier}-step`, String(index))
     window.history.pushState({}, '', url.toString())
   }
+  const removeStep = () => {
+    stepIndex = null
+    const url = new URL(window.location.href)
+    url.searchParams.delete(`${identifier}-step`)
+    window.history.replaceState({}, '', url.toString())
+  }
 
   it('should not throw when using an id that has never been mounted', () => {
     mockUrl()
@@ -271,6 +277,49 @@ describe('useReactRouter', () => {
     )
   })
 
+  it('should write one history entry when multiple hooks listen to the same wizard', async () => {
+    mockUrl()
+
+    const { useSearchParams, setSearchParams } = getRerenderingHookMock()
+
+    const Step = () => {
+      const { activeIndex } = useStep(identifier)
+      return (
+        <Wizard.Step>
+          <output>{JSON.stringify({ activeIndex })}</output>
+          <Wizard.Buttons />
+        </Wizard.Step>
+      )
+    }
+
+    const MyForm = () => {
+      useReactRouter(identifier, { useSearchParams })
+      useReactRouter(identifier, { useSearchParams })
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1}')
+    })
+
+    expect(window.location.search).toBe(
+      `?existing-query=foo&bar=baz&${identifier}-step=1`
+    )
+    expect(setSearchParams).toHaveBeenCalledTimes(1)
+  })
+
   it('should call Wizard.Container onStepChange when reacting to url changes after button navigation', async () => {
     mockUrl()
 
@@ -408,6 +457,54 @@ describe('useReactRouter', () => {
       '',
       `http://localhost/?existing-query=foo&bar=baz&${identifier}-step=1`
     )
+  })
+
+  it('should restore the first step when the routed step is removed from the URL', async () => {
+    mockUrl()
+
+    const { useSearchParams, forceUpdateRef } = getRerenderingHookMock()
+
+    const MyForm = () => {
+      const { getIndex } = useReactRouter(identifier, { useSearchParams })
+
+      const Step = () => {
+        const { activeIndex } = useStep(identifier)
+        return (
+          <Wizard.Step>
+            <output>
+              {JSON.stringify({ activeIndex, index: getIndex() })}
+            </output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+        )
+      }
+
+      return (
+        <Form.Handler>
+          <Wizard.Container mode="loose" id={identifier}>
+            <Step />
+            <Step />
+          </Wizard.Container>
+        </Form.Handler>
+      )
+    }
+
+    render(<MyForm />)
+
+    await userEvent.click(nextButton())
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
+    })
+
+    removeStep()
+    act(forceUpdateRef.current)
+
+    await waitFor(() => {
+      expect(output()).toHaveTextContent('{"activeIndex":0,"index":null}')
+    })
+
+    expect(window.location.search).toBe('?existing-query=foo&bar=baz')
   })
 
   it('should handle and show try/catch errors', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
@@ -3,6 +3,8 @@ import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
 
+const routerStepChanges = new Map<string, number>()
+
 export default function useNextRouter(
   id: string = null,
   { useRouter, usePathname, useSearchParams }
@@ -22,19 +24,37 @@ export default function useNextRouter(
   const searchParamsRef = useRef(searchParams)
   searchParamsRef.current = searchParams
   const routerStepChangeRef = useRef<number>(undefined)
+  const hasRouterStepRef = useRef(false)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
-        routerStepChangeRef.current = index
         const params = new URLSearchParams(
           searchParamsRef.current.toString()
         )
+        const currentParams = new URLSearchParams(
+          typeof window !== 'undefined'
+            ? window.location.search
+            : params.toString()
+        )
+
+        if (
+          parseFloat(currentParams.get(name)) === index ||
+          routerStepChangeRef.current === index ||
+          routerStepChanges.get(name) === index
+        ) {
+          return
+        }
+
+        routerStepChangeRef.current = index
+        routerStepChanges.set(name, index)
+        hasRouterStepRef.current = true
         params.set(name, String(index))
         routerRef.current.push(
           `${pathnameRef.current}?${params.toString()}`
         )
       } catch (error) {
+        routerStepChanges.delete(name)
         setFormError(error as Error)
       }
     },
@@ -43,6 +63,14 @@ export default function useNextRouter(
 
   const { setActiveIndex } = useStep(id, { onStepChange })
 
+  useLayoutEffect(() => {
+    return () => {
+      if (routerStepChanges.get(name) === routerStepChangeRef.current) {
+        routerStepChanges.delete(name)
+      }
+    }
+  }, [name])
+
   const getIndex = useCallback(
     () => parseFloat(searchParams.get(name)),
     [name, searchParams]
@@ -50,20 +78,26 @@ export default function useNextRouter(
 
   useLayoutEffect(() => {
     const routerIndex = getIndex()
-    if (!isNaN(routerIndex)) {
-      const skipStepChangeCall =
-        routerIndex === routerStepChangeRef.current
-      if (skipStepChangeCall) {
-        routerStepChangeRef.current = undefined
-      }
+    const hasRouterIndex = !isNaN(routerIndex)
 
-      setActiveIndex?.(routerIndex, {
+    if (hasRouterIndex) {
+      hasRouterStepRef.current = true
+    }
+
+    if (hasRouterIndex || hasRouterStepRef.current) {
+      const activeIndex = hasRouterIndex ? routerIndex : 0
+      const skipStepChangeCall =
+        hasRouterIndex && activeIndex === routerStepChangeRef.current
+      routerStepChangeRef.current = undefined
+      routerStepChanges.delete(name)
+
+      setActiveIndex?.(activeIndex, {
         skipStepChangeCall,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })
     }
-  }, [getIndex, id, searchParams, setActiveIndex, setFormError])
+  }, [getIndex, id, name, searchParams, setActiveIndex, setFormError])
 
   return { getIndex }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
@@ -61,7 +61,10 @@ export default function useNextRouter(
     [name, setFormError]
   )
 
-  const { setActiveIndex } = useStep(id, { onStepChange })
+  const { setActiveIndex } = useStep(id, {
+    onStepChange,
+    unregisterOnUnmount: true,
+  })
 
   useLayoutEffect(() => {
     return () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useNextRouter.ts
@@ -61,9 +61,8 @@ export default function useNextRouter(
     [name, setFormError]
   )
 
-  const { setActiveIndex } = useStep(id, {
+  const { setActiveIndex, onStepChangeEventsRef } = useStep(id, {
     onStepChange,
-    unregisterOnUnmount: true,
   })
 
   useLayoutEffect(() => {
@@ -73,6 +72,12 @@ export default function useNextRouter(
       }
     }
   }, [name])
+
+  useLayoutEffect(() => {
+    return () => {
+      onStepChangeEventsRef?.current?.delete(onStepChange)
+    }
+  }, [onStepChange, onStepChangeEventsRef])
 
   const getIndex = useCallback(
     () => parseFloat(searchParams.get(name)),

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useQueryLocator.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useQueryLocator.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
@@ -6,11 +6,18 @@ import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared
 export default function useQueryLocator(id: string = undefined) {
   const { setFormError } = useStep(id)
   const name = id ? `${id}-step` : 'step'
+  const hasRouterStepRef = useRef(false)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
         const url = new URL(window.location.href)
+
+        if (parseFloat(url.searchParams.get(name)) === index) {
+          return
+        }
+
+        hasRouterStepRef.current = true
         url.searchParams.set(name, String(index))
         window.history.pushState({}, '', url.toString())
       } catch (error) {
@@ -37,8 +44,14 @@ export default function useQueryLocator(id: string = undefined) {
     try {
       const popstateListener = () => {
         const routerIndex = getIndex()
-        if (!isNaN(routerIndex)) {
-          setActiveIndex?.(routerIndex, {
+        const hasRouterIndex = !isNaN(routerIndex)
+
+        if (hasRouterIndex) {
+          hasRouterStepRef.current = true
+        }
+
+        if (hasRouterIndex || hasRouterStepRef.current) {
+          setActiveIndex?.(hasRouterIndex ? routerIndex : 0, {
             skipStepChangeCallFromHook: true,
             skipStepChangeCallBeforeMounted: true,
           })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useQueryLocator.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useQueryLocator.ts
@@ -27,7 +27,10 @@ export default function useQueryLocator(id: string = undefined) {
     [name, setFormError]
   )
 
-  const { setActiveIndex } = useStep(id, { onStepChange })
+  const { setActiveIndex } = useStep(id, {
+    onStepChange,
+    unregisterOnUnmount: true,
+  })
 
   const getIndex = useCallback(() => {
     try {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useQueryLocator.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useQueryLocator.ts
@@ -27,10 +27,15 @@ export default function useQueryLocator(id: string = undefined) {
     [name, setFormError]
   )
 
-  const { setActiveIndex } = useStep(id, {
+  const { setActiveIndex, onStepChangeEventsRef } = useStep(id, {
     onStepChange,
-    unregisterOnUnmount: true,
   })
+
+  useLayoutEffect(() => {
+    return () => {
+      onStepChangeEventsRef?.current?.delete(onStepChange)
+    }
+  }, [onStepChange, onStepChangeEventsRef])
 
   const getIndex = useCallback(() => {
     try {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
@@ -51,7 +51,10 @@ export default function useReachRouter(
     [name, setFormError]
   )
 
-  const { setActiveIndex } = useStep(id, { onStepChange })
+  const { setActiveIndex } = useStep(id, {
+    onStepChange,
+    unregisterOnUnmount: true,
+  })
 
   useLayoutEffect(() => {
     return () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
@@ -3,6 +3,8 @@ import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
 
+const routerStepChanges = new Map<string, number>()
+
 export default function useReachRouter(
   id: string = null,
   { useLocation, navigate }
@@ -17,15 +19,32 @@ export default function useReachRouter(
   const navigateRef = useRef(navigate)
   navigateRef.current = navigate
   const routerStepChangeRef = useRef<number>(undefined)
+  const hasRouterStepRef = useRef(false)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
+        const locationUrl = new URL(locationRef.current.href)
+        const url =
+          typeof window !== 'undefined'
+            ? new URL(window.location.href)
+            : locationUrl
+
+        if (
+          parseFloat(url.searchParams.get(name)) === index ||
+          routerStepChangeRef.current === index ||
+          routerStepChanges.get(name) === index
+        ) {
+          return
+        }
+
         routerStepChangeRef.current = index
-        const url = new URL(locationRef.current.href)
+        routerStepChanges.set(name, index)
+        hasRouterStepRef.current = true
         url.searchParams.set(name, String(index))
         navigateRef.current(url.href)
       } catch (error) {
+        routerStepChanges.delete(name)
         setFormError(error as Error)
       }
     },
@@ -33,6 +52,14 @@ export default function useReachRouter(
   )
 
   const { setActiveIndex } = useStep(id, { onStepChange })
+
+  useLayoutEffect(() => {
+    return () => {
+      if (routerStepChanges.get(name) === routerStepChangeRef.current) {
+        routerStepChanges.delete(name)
+      }
+    }
+  }, [name])
 
   const getIndex = useCallback(() => {
     try {
@@ -47,20 +74,26 @@ export default function useReachRouter(
 
   useLayoutEffect(() => {
     const routerIndex = getIndex()
-    if (!isNaN(routerIndex)) {
-      const skipStepChangeCall =
-        routerIndex === routerStepChangeRef.current
-      if (skipStepChangeCall) {
-        routerStepChangeRef.current = undefined
-      }
+    const hasRouterIndex = !isNaN(routerIndex)
 
-      setActiveIndex?.(routerIndex, {
+    if (hasRouterIndex) {
+      hasRouterStepRef.current = true
+    }
+
+    if (hasRouterIndex || hasRouterStepRef.current) {
+      const activeIndex = hasRouterIndex ? routerIndex : 0
+      const skipStepChangeCall =
+        hasRouterIndex && activeIndex === routerStepChangeRef.current
+      routerStepChangeRef.current = undefined
+      routerStepChanges.delete(name)
+
+      setActiveIndex?.(activeIndex, {
         skipStepChangeCall,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })
     }
-  }, [getIndex, setActiveIndex])
+  }, [getIndex, name, setActiveIndex])
 
   return { getIndex }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReachRouter.ts
@@ -51,9 +51,8 @@ export default function useReachRouter(
     [name, setFormError]
   )
 
-  const { setActiveIndex } = useStep(id, {
+  const { setActiveIndex, onStepChangeEventsRef } = useStep(id, {
     onStepChange,
-    unregisterOnUnmount: true,
   })
 
   useLayoutEffect(() => {
@@ -63,6 +62,12 @@ export default function useReachRouter(
       }
     }
   }, [name])
+
+  useLayoutEffect(() => {
+    return () => {
+      onStepChangeEventsRef?.current?.delete(onStepChange)
+    }
+  }, [onStepChange, onStepChangeEventsRef])
 
   const getIndex = useCallback(() => {
     try {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
@@ -49,9 +49,8 @@ export default function useReactRouter(
     [name, setFormError, setSearchParams]
   )
 
-  const { setActiveIndex } = useStep(id, {
+  const { setActiveIndex, onStepChangeEventsRef } = useStep(id, {
     onStepChange,
-    unregisterOnUnmount: true,
   })
 
   useLayoutEffect(() => {
@@ -61,6 +60,12 @@ export default function useReactRouter(
       }
     }
   }, [name])
+
+  useLayoutEffect(() => {
+    return () => {
+      onStepChangeEventsRef?.current?.delete(onStepChange)
+    }
+  }, [onStepChange, onStepChangeEventsRef])
 
   const getIndex = useCallback(
     () => parseFloat(searchParams.get(name)),

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
@@ -3,6 +3,8 @@ import useStep from './useStep'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
 
+const routerStepChanges = new Map<string, number>()
+
 export default function useReactRouter(
   id: string = null,
   { useSearchParams }
@@ -14,15 +16,33 @@ export default function useReactRouter(
   const searchParamsRef = useRef(searchParams)
   searchParamsRef.current = searchParams
   const routerStepChangeRef = useRef<number>(undefined)
+  const hasRouterStepRef = useRef(false)
 
   const onStepChange = useCallback(
     (index: number) => {
       try {
         const searchParams = searchParamsRef.current
+        const currentSearchParams = new URLSearchParams(
+          typeof window !== 'undefined'
+            ? window.location.search
+            : searchParams.toString()
+        )
+
+        if (
+          parseFloat(currentSearchParams.get(name)) === index ||
+          routerStepChangeRef.current === index ||
+          routerStepChanges.get(name) === index
+        ) {
+          return
+        }
+
         routerStepChangeRef.current = index
+        routerStepChanges.set(name, index)
+        hasRouterStepRef.current = true
         searchParams.set(name, index)
         setSearchParams(searchParams)
       } catch (error) {
+        routerStepChanges.delete(name)
         setFormError(error as Error)
       }
     },
@@ -31,6 +51,14 @@ export default function useReactRouter(
 
   const { setActiveIndex } = useStep(id, { onStepChange })
 
+  useLayoutEffect(() => {
+    return () => {
+      if (routerStepChanges.get(name) === routerStepChangeRef.current) {
+        routerStepChanges.delete(name)
+      }
+    }
+  }, [name])
+
   const getIndex = useCallback(
     () => parseFloat(searchParams.get(name)),
     [name, searchParams]
@@ -38,20 +66,26 @@ export default function useReactRouter(
 
   useLayoutEffect(() => {
     const routerIndex = getIndex()
-    if (!isNaN(routerIndex)) {
-      const skipStepChangeCall =
-        routerIndex === routerStepChangeRef.current
-      if (skipStepChangeCall) {
-        routerStepChangeRef.current = undefined
-      }
+    const hasRouterIndex = !isNaN(routerIndex)
 
-      setActiveIndex?.(routerIndex, {
+    if (hasRouterIndex) {
+      hasRouterStepRef.current = true
+    }
+
+    if (hasRouterIndex || hasRouterStepRef.current) {
+      const activeIndex = hasRouterIndex ? routerIndex : 0
+      const skipStepChangeCall =
+        hasRouterIndex && activeIndex === routerStepChangeRef.current
+      routerStepChangeRef.current = undefined
+      routerStepChanges.delete(name)
+
+      setActiveIndex?.(activeIndex, {
         skipStepChangeCall,
         skipStepChangeCallFromHook: true,
         skipStepChangeCallBeforeMounted: true,
       })
     }
-  }, [getIndex, id, searchParams, setActiveIndex, setFormError])
+  }, [getIndex, id, name, searchParams, setActiveIndex, setFormError])
 
   return { getIndex }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
@@ -49,7 +49,10 @@ export default function useReactRouter(
     [name, setFormError, setSearchParams]
   )
 
-  const { setActiveIndex } = useStep(id, { onStepChange })
+  const { setActiveIndex } = useStep(id, {
+    onStepChange,
+    unregisterOnUnmount: true,
+  })
 
   useLayoutEffect(() => {
     return () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.ts
@@ -83,12 +83,20 @@ export default function useStep(
 
   useLayoutEffect(() => {
     const { onStepChangeEventsRef } = context
+    const onStepChangeEvents = onStepChangeEventsRef?.current
+
     if (
       onStepChange &&
-      onStepChangeEventsRef?.current &&
-      !onStepChangeEventsRef.current.has(onStepChange)
+      onStepChangeEvents &&
+      !onStepChangeEvents.has(onStepChange)
     ) {
-      onStepChangeEventsRef?.current.add(onStepChange)
+      onStepChangeEvents.add(onStepChange)
+    }
+
+    return () => {
+      if (onStepChange) {
+        onStepChangeEvents?.delete(onStepChange)
+      }
     }
   }, [context, onStepChange])
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.ts
@@ -16,10 +16,7 @@ type SetActiveIndexHandler = NonNullable<
 
 export default function useStep(
   id: SharedStateId = null,
-  {
-    onStepChange,
-    unregisterOnUnmount,
-  }: { onStepChange?: OnStepChange; unregisterOnUnmount?: boolean } = {}
+  { onStepChange }: { onStepChange?: OnStepChange } = {}
 ) {
   const setFormError = useCallback(() => null, [])
   const wizardContext = useContext(WizardContext) || { setFormError }
@@ -95,13 +92,7 @@ export default function useStep(
     ) {
       onStepChangeEvents.add(onStepChange)
     }
-
-    return () => {
-      if (unregisterOnUnmount && onStepChange) {
-        onStepChangeEvents?.delete(onStepChange)
-      }
-    }
-  }, [context, onStepChange, unregisterOnUnmount])
+  }, [context, onStepChange])
 
   useLayoutEffect(() => {
     if (id) {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useStep.ts
@@ -16,7 +16,10 @@ type SetActiveIndexHandler = NonNullable<
 
 export default function useStep(
   id: SharedStateId = null,
-  { onStepChange }: { onStepChange?: OnStepChange } = {}
+  {
+    onStepChange,
+    unregisterOnUnmount,
+  }: { onStepChange?: OnStepChange; unregisterOnUnmount?: boolean } = {}
 ) {
   const setFormError = useCallback(() => null, [])
   const wizardContext = useContext(WizardContext) || { setFormError }
@@ -94,11 +97,11 @@ export default function useStep(
     }
 
     return () => {
-      if (onStepChange) {
+      if (unregisterOnUnmount && onStepChange) {
         onStepChangeEvents?.delete(onStepChange)
       }
     }
-  }, [context, onStepChange])
+  }, [context, onStepChange, unregisterOnUnmount])
 
   useLayoutEffect(() => {
     if (id) {


### PR DESCRIPTION
Wizard route hooks could leave browser history awkward when the same routed step change was observed more than once, and returning to the original URL without a step parameter could keep the UI on the later step.

This improves the routed step synchronization so browser Back/Forward behaves predictably across the supported router integrations. It keeps step navigation as real history, while avoiding duplicate same-step entries and restoring the first step when the routed step parameter is removed after route state has been used.

Reprod with fix: https://stackblitz.com/edit/7kxrnnv5
(Navigating with browser back/forth buttons (history) should with this change work instantly.)