### PR TITLE
chore(Wizard): use String(index) in useReactRouter for consistency

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/__tests__/useReactRouter.test.tsx
@@ -176,7 +176,7 @@ describe('useReactRouter', () => {
     await userEvent.click(nextButton())
 
     expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
-    expect(set).toHaveBeenLastCalledWith(`${identifier}-step`, 1)
+    expect(set).toHaveBeenLastCalledWith(`${identifier}-step`, '1')
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )
@@ -184,7 +184,7 @@ describe('useReactRouter', () => {
     await userEvent.click(nextButton())
 
     expect(output()).toHaveTextContent('{"activeIndex":2,"index":2}')
-    expect(set).toHaveBeenLastCalledWith(`${identifier}-step`, 2)
+    expect(set).toHaveBeenLastCalledWith(`${identifier}-step`, '2')
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=2`
     )
@@ -192,7 +192,7 @@ describe('useReactRouter', () => {
     await userEvent.click(previousButton())
 
     expect(output()).toHaveTextContent('{"activeIndex":1,"index":1}')
-    expect(set).toHaveBeenLastCalledWith(`${identifier}-step`, 1)
+    expect(set).toHaveBeenLastCalledWith(`${identifier}-step`, '1')
     expect(window.location.search).toBe(
       `?existing-query=foo&bar=baz&${identifier}-step=1`
     )

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/hooks/useReactRouter.ts
@@ -39,7 +39,7 @@ export default function useReactRouter(
         routerStepChangeRef.current = index
         routerStepChanges.set(name, index)
         hasRouterStepRef.current = true
-        searchParams.set(name, index)
+        searchParams.set(name, String(index))
         setSearchParams(searchParams)
       } catch (error) {
         routerStepChanges.delete(name)


### PR DESCRIPTION
Align useReactRouter with useNextRouter, useReachRouter, and useQueryLocator by explicitly converting the step index to a string before passing it to URLSearchParams.set().

