### PR TITLE
fix(Forms): show Wizard required errors during async validation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -133,6 +133,7 @@ function WizardContainer(props: WizardContainerProps) {
     setShowAllErrors,
     setSubmitState,
     hasFieldState,
+    hasErrors,
   } = dataContext
 
   const id = useId(idProp)
@@ -407,6 +408,7 @@ function WizardContainer(props: WizardContainerProps) {
             // because the form contains errors. Thats why onSubmit will not be called via handleSubmitCall.
             if (
               !hasInvalidStepsState(activeIndexRef.current) &&
+              !hasErrors?.() &&
               !hasFieldState?.('pending')
             ) {
               await onSubmit()
@@ -421,6 +423,7 @@ function WizardContainer(props: WizardContainerProps) {
       getStepChangeOptions,
       handleLayoutEffect,
       handleSubmitCall,
+      hasErrors,
       hasFieldState,
       hasInvalidStepsState,
       isInteractionRef,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -1601,6 +1601,64 @@ describe('Wizard.Container', () => {
       })
     })
 
+    it('should show required error when another async onChangeValidator is pending', async () => {
+      const asyncValidator = async () => undefined
+
+      render(
+        <Form.Handler>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Field.String
+                path="/field1"
+                label="Required field with async validator"
+                required
+                onChangeValidator={asyncValidator}
+              />
+              <Field.String
+                path="/field2"
+                label="Field with async validator"
+                onChangeValidator={asyncValidator}
+              />
+              <Form.ButtonRow>
+                <Wizard.PreviousButton />
+                <Wizard.NextButton />
+              </Form.ButtonRow>
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+              <Form.ButtonRow>
+                <Wizard.PreviousButton />
+                <Wizard.NextButton />
+              </Form.ButtonRow>
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      const [, fieldWithAsyncValidator] = Array.from(
+        document.querySelectorAll('input')
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+      expect(screen.queryAllByRole('alert')).toHaveLength(0)
+
+      await wait(1)
+
+      fireEvent.change(fieldWithAsyncValidator, {
+        target: { value: 'value' },
+      })
+      fireEvent.click(nextButton())
+
+      await waitFor(() => {
+        expect(output()).toHaveTextContent('Step 1')
+        expect(
+          screen.queryByText(nb.Field.errorRequired)
+        ).toBeInTheDocument()
+      })
+    })
+
     it('should handle async onChangeValidator', async () => {
       const asyncValidator = async () => null
 


### PR DESCRIPTION
Required fields in a Wizard can stay hidden when another field's async validator is pending, allowing users to leave the step without correcting the missing required value.

This keeps Wizard fallback navigation aligned with the form error registry so pending async validation does not bypass known errors.

Fixes #6048