### PR TITLE
feat(DatePicker): add `onlyMonth="without-label"` variant to hide month label

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -152,9 +152,9 @@ export type DatePickerProps = {
    */
   hideDays?: boolean
   /**
-   * If set to `true`, the calendar only displays days belonging to the currently displayed month, and month navigation via buttons and keyboard is disabled. The displayed month is determined by the `month` or `startMonth` prop, and ultimately defaults to the current month. Defaults to `false`.
+   * If set to `true`, the calendar only displays days belonging to the currently displayed month, and month navigation via buttons and keyboard is disabled. The displayed month is determined by the `month` or `startMonth` prop, and ultimately defaults to the current month. Use `'without-label'` to also hide the month label. Defaults to `false`.
    */
-  onlyMonth?: boolean
+  onlyMonth?: boolean | 'without-label'
   /**
    * Use `true` to only show the last week in the current month if it needs to be shown. The result is that mainly five (5) weeks (rows) will be shown instead of six (6). Defaults to `false`.
    */
@@ -762,7 +762,8 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   isSync={sync}
                   hideDays={hideDays}
                   hideNavigation={hideNavigation}
-                  onlyMonth={onlyMonth}
+                  onlyMonth={Boolean(onlyMonth)}
+                  hideMonthLabel={onlyMonth === 'without-label'}
                   hideNextMonthWeek={hideLastWeek}
                   onPickerChange={onPickerChange}
                   locale={context.locale}
@@ -857,7 +858,8 @@ function DatePicker(externalProps: DatePickerAllProps) {
                       isSync={sync}
                       hideDays={hideDays}
                       hideNavigation={hideNavigation}
-                      onlyMonth={onlyMonth}
+                      onlyMonth={Boolean(onlyMonth)}
+                      hideMonthLabel={onlyMonth === 'without-label'}
                       hideNextMonthWeek={hideLastWeek}
                       onPickerChange={onPickerChange}
                       locale={context.locale}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -83,6 +83,7 @@ export type DatePickerCalendarProps = Omit<
   hideNavigation?: boolean
   hideDays?: boolean
   onlyMonth?: boolean
+  hideMonthLabel?: boolean
   hideNextMonthWeek?: boolean
   onSelect?: (
     event: DatePickerChangeEvent<
@@ -123,6 +124,7 @@ const defaultProps: DatePickerCalendarProps = {
   hideNavigation: false,
   hideDays: false,
   onlyMonth: false,
+  hideMonthLabel: false,
   hideNextMonthWeek: false,
   rtl: false,
   resetDate: true,
@@ -169,6 +171,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     resetDate,
     hideNextMonthWeek,
     onlyMonth,
+    hideMonthLabel,
   } = props
 
   const tableRef = useRef<ElementRef<'table'> | null>(null)
@@ -643,7 +646,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
           )}
         </div>
       )}
-      {onlyMonth && (
+      {onlyMonth && !hideMonthLabel && (
         <div className="dnb-date-picker__header dnb-date-picker__header--only-month-label">
           <label
             id={`${id}--title`}
@@ -668,7 +671,9 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
         role="grid"
         className="dnb-no-focus"
         tabIndex={0}
-        aria-labelledby={`${id}--title`}
+        aria-labelledby={
+          onlyMonth && hideMonthLabel ? undefined : `${id}--title`
+        }
         onKeyDown={onKeyDownHandler}
         onMouseLeave={onMouseLeaveHandler}
         ref={tableRef}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -194,8 +194,8 @@ export const DatePickerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   onlyMonth: {
-    doc: 'If set to `true`, the calendar only displays days belonging to the currently displayed month, and month navigation via buttons and keyboard is disabled. The displayed month is determined by the `month` or `startMonth` prop, and ultimately defaults to the current month. Defaults to `false`.',
-    type: 'boolean',
+    doc: "If set to `true`, the calendar only displays days belonging to the currently displayed month, and month navigation via buttons and keyboard is disabled. The displayed month is determined by the `month` or `startMonth` prop, and ultimately defaults to the current month. Use `'without-label'` to also hide the month label. Defaults to `false`.",
+    type: ['boolean', `'without-label'`],
     status: 'optional',
   },
   hideLastWeek: {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5151,6 +5151,30 @@ describe('DatePicker component', () => {
       calendar.querySelector('.dnb-date-picker__labels')
     ).not.toBeInTheDocument()
   })
+
+  it('should hide month label when onlyMonth is "without-label"', async () => {
+    render(<DatePicker onlyMonth="without-label" />)
+
+    await userEvent.click(screen.getByLabelText('Åpne datovelger'))
+
+    const header = document.querySelector(
+      '.dnb-date-picker__header--only-month-label'
+    )
+
+    expect(header).not.toBeInTheDocument()
+  })
+
+  it('should show month label when onlyMonth is true', async () => {
+    render(<DatePicker onlyMonth />)
+
+    await userEvent.click(screen.getByLabelText('Åpne datovelger'))
+
+    const header = document.querySelector(
+      '.dnb-date-picker__header--only-month-label'
+    )
+
+    expect(header).toBeInTheDocument()
+  })
 })
 
 // for the unit calc tests


### PR DESCRIPTION
Deploy preview: https://feat-date-picker-hide-month.eufemia-e25.pages.dev/uilib/components/date-picker#show-days-in-a-specific-month-without-month-label

Not sure if we actually need a demo/example for this? 🤔 