### PR TITLE
chore(Wizard): add explicit types to syncStepsState parameters

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -191,7 +191,10 @@ function WizardContainer(props: WizardContainerProps) {
    * If an index is given, it will check if the step, with the given index, has an invalid state.
    */
   const syncStepsState = useCallback(
-    (index = undefined, forStates = ['unknown', 'error']) => {
+    (
+      index: StepIndex | undefined = undefined,
+      forStates: Array<InternalStepStatus> = ['unknown', 'error']
+    ) => {
       const checkUnknown = forStates.includes('unknown')
       const checkError = forStates.includes('error')
 


### PR DESCRIPTION
The syncStepsState callback parameters were untyped (index inferred as undefined, forStates inferred as string[]). Added explicit StepIndex and Array<InternalStepStatus> types to match the already-typed hasInvalidStepsState on WizardContextState.

