### PR TITLE
chore(DatePicker): type filterOutNonAttributes reduce accumulator

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -951,12 +951,15 @@ const NonAttributes = [
 ]
 
 function filterOutNonAttributes(props: DatePickerProps) {
-  return Object.keys(props).reduce((attributes, key) => {
-    if (!NonAttributes.includes(key)) {
-      attributes[key] = props[key]
-    }
-    return attributes
-  }, {})
+  return Object.keys(props).reduce<Record<string, unknown>>(
+    (attributes, key) => {
+      if (!NonAttributes.includes(key)) {
+        attributes[key] = props[key]
+      }
+      return attributes
+    },
+    {}
+  )
 }
 
 withComponentMarkers(DatePicker, {


### PR DESCRIPTION
The reduce call in filterOutNonAttributes used an untyped {} accumulator, causing the return type to be inferred as {}. Added an explicit Record<string, unknown> generic to give the accumulator and return value a proper type.

