### PR TITLE
chore(Forms): fix handlePathChange return type and remove `as any` cast

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -8,6 +8,7 @@ import type {
   Path,
   EventStateObject,
   EventReturnWithStateObject,
+  EventReturnWithStateObjectAndSuccess,
   FieldProps,
   ValueProps,
   OnChange,
@@ -135,8 +136,15 @@ export type ContextState = {
     value?: any
   ) =>
     | EventReturnWithStateObject
-    | unknown
-    | Promise<EventReturnWithStateObject | unknown>
+    | EventReturnWithStateObjectAndSuccess
+    | void
+    | null
+    | Promise<
+        | EventReturnWithStateObject
+        | EventReturnWithStateObjectAndSuccess
+        | void
+        | null
+      >
   handlePathChangeUnvalidated: (path: Path, value: any) => void
   updateDataValue: (
     path: Path,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldAsync.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldAsync.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import type { RefObject } from 'react'
 import type {
+  EventReturnWithStateObject,
   EventReturnWithStateObjectAndSuccess,
   EventStateObjectWithSuccess,
   Identifier,
@@ -54,8 +55,16 @@ export type UseFieldAsyncParams<Value> = {
   handlePathChangeDataContext: (
     identifier: Identifier
   ) =>
+    | EventReturnWithStateObject
     | EventReturnWithStateObjectAndSuccess
-    | Promise<EventReturnWithStateObjectAndSuccess>
+    | void
+    | null
+    | Promise<
+        | EventReturnWithStateObject
+        | EventReturnWithStateObjectAndSuccess
+        | void
+        | null
+      >
 }
 
 export default function useFieldAsync<Value>({

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -531,7 +531,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     hasPath,
     identifier,
     executeOnChangeRegardlessOfError,
-    handlePathChangeDataContext: handlePathChangeDataContext as any,
+    handlePathChangeDataContext,
   })
 
   // ─── useFieldValidation ──────────────────────────────────────────────


### PR DESCRIPTION
Replace meaningless `| unknown` in ContextState's handlePathChange return type with the actual types (EventReturnWithStateObjectAndSuccess, void, null). Widen the matching param type in UseFieldAsyncParams to accept the broader return, removing the `as any` cast in useFieldProps.

