### PR TITLE
chore(Filter): remove type casts in router hooks

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/hooks/useNextRouter.ts
+++ b/packages/dnb-eufemia/src/components/filter/hooks/useNextRouter.ts
@@ -108,9 +108,12 @@ export default function useFilterNextRouter(
   }, [readFromUrl, extend])
 
   // Write state to URL when filters or search change
-  const prevRef = useRef({
+  const prevRef = useRef<{
+    search: string
+    filters: Record<string, FilterValue>
+  }>({
     search: '',
-    filters: {} as Record<string, FilterValue>,
+    filters: {},
   })
   useLayoutEffect(() => {
     const prev = prevRef.current

--- a/packages/dnb-eufemia/src/components/filter/hooks/useQueryLocator.ts
+++ b/packages/dnb-eufemia/src/components/filter/hooks/useQueryLocator.ts
@@ -105,9 +105,12 @@ export default function useFilterQueryLocator(
   }, [restoreFromUrl])
 
   // Write state to URL when filters or search change
-  const prevRef = useRef({
+  const prevRef = useRef<{
+    search: string
+    filters: Record<string, FilterValue>
+  }>({
     search: '',
-    filters: {} as Record<string, FilterValue>,
+    filters: {},
   })
   useLayoutEffect(() => {
     const prev = prevRef.current

--- a/packages/dnb-eufemia/src/components/filter/hooks/useReactRouter.ts
+++ b/packages/dnb-eufemia/src/components/filter/hooks/useReactRouter.ts
@@ -101,9 +101,12 @@ export default function useFilterReactRouter(
   }, [readFromUrl, extend])
 
   // Write state to URL when filters or search change
-  const prevRef = useRef({
+  const prevRef = useRef<{
+    search: string
+    filters: Record<string, FilterValue>
+  }>({
     search: '',
-    filters: {} as Record<string, FilterValue>,
+    filters: {},
   })
   useLayoutEffect(() => {
     const prev = prevRef.current


### PR DESCRIPTION
Replace `{} as Record<string, FilterValue>` inside useRef initial values with explicit useRef generic types in useNextRouter, useReactRouter, and useQueryLocator.

