### PR TITLE
chore(VisibilityByTheme): remove unnecessary JSX.Element cast

### DIFF
--- a/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
+++ b/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
@@ -1,4 +1,4 @@
-import type { JSX, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import useTheme from './useTheme'
 import type { ThemeNames, ThemeProps } from './Theme'
 
@@ -45,7 +45,7 @@ export default function VisibilityByTheme({
     }
   }
 
-  return children as JSX.Element
+  return children
 
   function match(theme: ThemeProps) {
     return (themeItem: ThemeItem) => {


### PR DESCRIPTION
React 19 supports ReactNode as a valid component return type, making the 'as JSX.Element' cast and JSX import unnecessary.

