### PR TITLE
chore(DatePicker): replace pickerParams type cast with typed declaration

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -624,7 +624,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
 
   const showStatus = getStatusState(status)
 
-  const pickerParams = {} as HTMLProps<HTMLSpanElement>
+  const pickerParams: Partial<HTMLProps<HTMLSpanElement>> = {}
 
   if (showStatus || suffix) {
     pickerParams['aria-describedby'] = combineDescribedBy(


### PR DESCRIPTION
Replace `{} as HTMLProps<HTMLSpanElement>` with a
`Partial<HTMLProps<HTMLSpanElement>>` type annotation.

