### PR TITLE
chore(StepIndicator): remove unnecessary type casts

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -165,9 +165,9 @@ function StepIndicatorItem({
 
   const usedIsCurrent = currentItemNum === activeStep
 
-  const element = (<StepItemWrapper>{title}</StepItemWrapper>) as ReactNode
+  const element = <StepItemWrapper>{title}</StepItemWrapper>
 
-  const itemParams = {} as HTMLProps<HTMLLIElement>
+  const itemParams: Partial<HTMLProps<HTMLLIElement>> = {}
   const buttonParams = {
     status,
     statusState,


### PR DESCRIPTION
- Replace `{} as HTMLProps<HTMLLIElement>` with typed declaration
- Remove redundant `as ReactNode` cast on JSX element

