### PR TITLE
chore(InputMasked): use reduce generic instead of casting initial value

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/hooks/useSegmentedFieldValues.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/hooks/useSegmentedFieldValues.ts
@@ -53,9 +53,9 @@ export function useSegmentedFieldValues<T extends string>({
 }
 
 function createDefaultValues(inputs: SegmentedFieldDefinition<string>[]) {
-  return inputs.reduce((values, input) => {
+  return inputs.reduce<SegmentedFieldValue<string>>((values, input) => {
     values[input.id] = ''
 
     return values
-  }, {} as SegmentedFieldValue<string>)
+  }, {})
 }


### PR DESCRIPTION
Replace `{} as SegmentedFieldValue<string>` with
`reduce<SegmentedFieldValue<string>>` generic.

