### PR TITLE
chore(Forms): remove unnecessary double cast in isSupportedCountryCode

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
@@ -216,7 +216,7 @@ export function isSupportedCountryCode(
   if (!countryCode) {
     return false
   }
-  return (supportedCountryCodes as unknown as Array<string>).includes(
+  return supportedCountryCodes.includes(
     String(countryCode).toUpperCase()
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
@@ -216,7 +216,5 @@ export function isSupportedCountryCode(
   if (!countryCode) {
     return false
   }
-  return supportedCountryCodes.includes(
-    String(countryCode).toUpperCase()
-  )
+  return supportedCountryCodes.includes(String(countryCode).toUpperCase())
 }


### PR DESCRIPTION
`readonly string[]` already has `.includes()`, making the `as unknown as Array<string>` cast unnecessary.

