### PR TITLE
chore(Flex): replace spaceStyles type cast with annotation

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/Item.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Item.tsx
@@ -64,7 +64,7 @@ function FlexItem(props: FlexItemAllProps) {
     return typeof span === 'number' || span === 'auto'
   }, [])
 
-  const spaceStyles = {} as CSSProperties
+  const spaceStyles: CSSProperties = {}
 
   if (span) {
     if (isValidSpan(span as FlexSpans)) {


### PR DESCRIPTION
Replace `{} as CSSProperties` with a CSSProperties type annotation.

