### PR TITLE
docs(Avatar): add grouped CountryFlag example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.tsx
@@ -292,6 +292,34 @@ export const GroupedAvatarsXLarge = () => (
   </ComponentBox>
 )
 
+export const GroupedAvatarsCountryFlag = () => (
+  <ComponentBox hideCode>
+    <Avatar.Group label="Markets" size="small">
+      <Avatar>
+        <CountryFlag iso="NO" size="medium" />
+      </Avatar>
+      <Avatar>
+        <CountryFlag iso="FI" size="medium" />
+      </Avatar>
+      <Avatar>
+        <CountryFlag iso="SE" size="medium" />
+      </Avatar>
+    </Avatar.Group>
+
+    <Avatar.Group label="Markets">
+      <Avatar>
+        <CountryFlag iso="NO" size="large" />
+      </Avatar>
+      <Avatar>
+        <CountryFlag iso="FI" size="large" />
+      </Avatar>
+      <Avatar>
+        <CountryFlag iso="SE" size="large" />
+      </Avatar>
+    </Avatar.Group>
+  </ComponentBox>
+)
+
 export const GroupedAvatarsImg = () => (
   <ComponentBox hideCode data-visual-test="avatar-grouped-image">
     <Avatar.Group

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/demos.mdx
@@ -104,3 +104,7 @@ A single `<Icon>` or `<IconPrimary>` component sent as a child will also follow 
 ### Avatar with a [CountryFlag](/uilib/components/country-flag) as a [Badge](/uilib/components/badge)
 
 <Examples.AvatarCountryFlagBadge />
+
+### Avatar with [CountryFlag](/uilib/components/country-flag) children
+
+<Examples.GroupedAvatarsCountryFlag />


### PR DESCRIPTION
Deploy preview: https://feat-avatar-country-flag-exa.eufemia-e25.pages.dev/uilib/components/avatar/demos/#avatar-with-countryflag-children
Motivation: I got a request from @thaytharma who was curious to know if one could use countryflags in avatars

I could perhaps remove one of the examples? I just wanted to see how it looks combining different sizes of Avatar and CountryFlag.