### PR TITLE
feat(ListFormat): support `locale` prop

### DIFF
--- a/packages/dnb-eufemia/src/components/list-format/ListFormat.tsx
+++ b/packages/dnb-eufemia/src/components/list-format/ListFormat.tsx
@@ -12,6 +12,12 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ListFormatProps = {
   /**
+   * Locale used to format the value when variant is `text`.
+   * Defaults to the shared Provider locale.
+   */
+  locale?: InternalLocale
+
+  /**
    * Formatting options for the value when variant is `text`.
    * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat
    */
@@ -57,12 +63,13 @@ function ListFormat(
     Omit<OlAllProps, 'value'> &
     ListFormatProps
 ) {
-  const { locale, ListFormat } = useContext(SharedContext)
+  const { locale: contextLocale, ListFormat } = useContext(SharedContext)
 
   // Extract additional props from global context
   const allProps = extendPropsWithContext(localProps, {}, ListFormat)
   const {
     value,
+    locale = contextLocale,
     format,
     variant = 'text',
     listType,

--- a/packages/dnb-eufemia/src/components/list-format/ListFormatDocs.ts
+++ b/packages/dnb-eufemia/src/components/list-format/ListFormatDocs.ts
@@ -16,6 +16,11 @@ export const ListFormatProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
+  locale: {
+    doc: 'Locale used to format the value when variant is `text`. Defaults to the shared Provider locale.',
+    type: 'string',
+    status: 'optional',
+  },
   format: {
     doc: 'Formatting options for the value when variant is `text`. See the [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat) documentation.',
     type: 'Intl.ListFormatOptions',

--- a/packages/dnb-eufemia/src/components/list-format/__tests__/ListFormat.test.tsx
+++ b/packages/dnb-eufemia/src/components/list-format/__tests__/ListFormat.test.tsx
@@ -478,6 +478,16 @@ describe('ListFormat', () => {
     expect(container).toHaveTextContent('Baz, Bar and Foo')
   })
 
+  it('formats value in different locale using locale prop', () => {
+    const { container } = render(
+      <Provider locale="nb-NO">
+        <ListFormat locale="en-GB" value={['Baz', 'Bar', 'Foo']} />
+      </Provider>
+    )
+
+    expect(container).toHaveTextContent('Baz, Bar and Foo')
+  })
+
   it('formats value in different locale using children', () => {
     const { container } = render(
       <Provider locale="en-GB">


### PR DESCRIPTION
ListFormat currently follows the shared Provider locale, which makes one-off list formatting awkward when a specific text locale is needed.

This adds a component-level locale override so consumers can format text lists with a specific Intl locale while keeping the Provider locale as the default.

Preview: https://chore-list-format-locale.eufemia-e25.pages.dev/uilib/components/list-format/properties