### PR TITLE
fix(Autocomplete): prevent show all crash for spaced numbers

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -1220,6 +1220,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
           searchWords.length > 1 &&
           allWordsAreNumeric
         if (
+          !skipFilterRef.current &&
+          !skipFilter &&
           hasMultipleNumericTerms &&
           listOfFoundWords.length !== searchWords.length
         ) {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1265,6 +1265,44 @@ describe('Autocomplete component', () => {
     ).toContain('Vis alt')
   })
 
+  it('does not crash when showing all after searching a full number with whitespace', () => {
+    const mockData = [
+      formatBankAccountNumber(20001234567),
+      formatBankAccountNumber(22233344425),
+      formatCurrency(1234.5),
+      formatPhoneNumber('+47116000'),
+    ] as DrawerListData
+
+    render(
+      <Autocomplete
+        data={mockData}
+        searchNumbers
+        showSubmitButton
+        {...mockProps}
+      />
+    )
+
+    toggle()
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '2000 12 34567' },
+    })
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(2)
+
+    fireEvent.click(
+      document.querySelector('li.dnb-autocomplete__show-all')
+    )
+
+    expect(
+      document.querySelectorAll(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+    ).toHaveLength(4)
+  })
+
   it('has correct options when using searchNumbers, and searching with æøå', () => {
     const mockData = [
       ['Åge Ørn Ærlig', formatNumber('12345678901')],


### PR DESCRIPTION
Autocomplete should not crash when users search for a formatted number with spaces and then reveal all options.

The issue came from the numeric multi-term filtering path returning internal scoring objects during the show-all highlight pass, which React then attempted to render. This keeps that scoring-only branch limited to active filtering so the full option list can render normally.

Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1781696314165249
Preview: https://chore-autocomplete-show-all.eufemia-e25.pages.dev/uilib/components/autocomplete/