### PR TITLE
fix(Stat): align font-size when `compact` and `auxiliarySize` is used

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
@@ -6,6 +6,7 @@
 import { renderHook } from '@testing-library/react'
 import useNumberFormatWithParts from '../useNumberFormatWithParts'
 import { formatCurrency, formatPercent, formatNumber } from '../utils'
+import type { NumberFormatter } from '../useNumberFormat'
 import Provider from '../../../shared/Provider'
 
 describe('useNumberFormatWithParts', () => {
@@ -44,6 +45,148 @@ describe('useNumberFormatWithParts', () => {
         }),
       })
     )
+  })
+
+  describe('compact', () => {
+    describe('currency', () => {
+      it('will include compact suffix in the number part', () => {
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1300000, formatCurrency, {
+            compact: true,
+            decimals: 1,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1,3 mill. kr',
+            parts: expect.objectContaining({
+              signedNumber: '1,3 mill.',
+              number: '1,3 mill.',
+              currency: 'kr',
+              currencyPosition: 'after',
+              spaceBeforeCurrency: true,
+            }),
+          })
+        )
+      })
+
+      it('will include compact suffix in the number part for before-position currency', () => {
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1300000, formatCurrency, {
+            compact: true,
+            currency: 'NOK',
+            decimals: 1,
+            locale: 'en-GB',
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: 'NOK 1.3m',
+            parts: expect.objectContaining({
+              signedNumber: '1.3m',
+              number: '1.3m',
+              currency: 'NOK',
+              currencyPosition: 'before',
+              spaceAfterCurrency: true,
+            }),
+          })
+        )
+      })
+
+      it('will include compact suffix when value is cleaned', () => {
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts('1 300 000', formatCurrency, {
+            clean: true,
+            compact: true,
+            decimals: 1,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1,3 mill. kr',
+            parts: expect.objectContaining({
+              signedNumber: '1,3 mill.',
+              number: '1,3 mill.',
+              currency: 'kr',
+              currencyPosition: 'after',
+            }),
+          })
+        )
+      })
+    })
+
+    describe('number', () => {
+      it('will include compact suffix in the number part', () => {
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1300000, formatNumber, {
+            compact: true,
+            decimals: 1,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1,3 mill.',
+            parts: expect.objectContaining({
+              signedNumber: '1,3 mill.',
+              number: '1,3 mill.',
+              currency: null,
+              currencyPosition: null,
+            }),
+          })
+        )
+      })
+
+      it('will include compact suffix when formatter wraps formatNumber', () => {
+        const formatWrappedNumber: NumberFormatter = ((value, options) =>
+          formatNumber(value, options)) as NumberFormatter
+
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1300000, formatWrappedNumber, {
+            compact: true,
+            decimals: 1,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1,3 mill.',
+            parts: expect.objectContaining({
+              signedNumber: '1,3 mill.',
+              number: '1,3 mill.',
+              currency: null,
+              currencyPosition: null,
+            }),
+          })
+        )
+      })
+    })
+
+    describe('percent', () => {
+      it('will not include percent sign in the number part', () => {
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1300, formatPercent, {
+            compact: true,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1 300 %',
+            parts: expect.objectContaining({
+              signedNumber: '1 300',
+              number: '1 300',
+              currency: null,
+              currencyPosition: null,
+              percent: '%',
+            }),
+          })
+        )
+      })
+    })
   })
 
   it('will derive before-position and after-currency space for en-GB currency', () => {

--- a/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
+++ b/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
@@ -6,7 +6,8 @@ import type {
   NumberFormatReturnValue,
   NumberFormatValue,
 } from './NumberUtils'
-import { formatNumber } from './utils'
+import { cleanNumber, formatNumber } from './utils'
+import { canHandleCompact } from './utils/compact'
 import type { NumberFormatter } from './useNumberFormat'
 
 export type NumberFormatParts = {
@@ -65,9 +66,15 @@ function useNumberFormatWithParts(
     return result
   }
 
+  const compactValue = params.clean ? cleanNumber(value) : value
+  const compact = canHandleCompact({
+    value: compactValue ?? '',
+    compact: params.compact ?? null,
+  })
+
   return {
     ...result,
-    parts: parseParts(result.number),
+    parts: parseParts(result.number, result.type, compact),
   }
 }
 
@@ -75,7 +82,11 @@ const SIGN_RE = /^[\u200e\u200f\u061c\s]*([+\-\u2212])?\s*/
 const NUMBER_RE = /[0-9](?:[0-9.,]|[\s\u00A0\u202F](?=[0-9]))*/
 const PERCENT_RE = /^([\u00A0\u202F\s]*)([%٪])\s*$/
 
-function parseParts(input: string): NumberFormatParts {
+function parseParts(
+  input: string,
+  type: NumberFormatReturnValue['type'] = 'number',
+  compact = false
+): NumberFormatParts {
   const source = String(input ?? '')
   const signMatch = source.match(SIGN_RE) as RegExpMatchArray
   const sign = signMatch[1] ?? null
@@ -96,26 +107,52 @@ function parseParts(input: string): NumberFormatParts {
     }
   }
 
-  const number = numberMatch[0].trim()
-  const signedNumber = sign ? `${sign}${number}` : number
+  let number = numberMatch[0].trim()
   const before = afterSign.slice(0, numberMatch.index).trim()
-  const after = afterSign.slice(numberMatch.index! + numberMatch[0].length)
+  let after = afterSign.slice(numberMatch.index! + numberMatch[0].length)
+
+  if (compact && !PERCENT_RE.test(after)) {
+    const compactMatch = after.match(
+      /^([\s\u00A0\u202F]*[^\d\s\u00A0\u202F]+)/
+    )
+
+    if (compactMatch) {
+      number += compactMatch[1]
+      after = after.slice(compactMatch[1].length)
+    }
+  }
+
+  const signedNumber = sign ? `${sign}${number}` : number
   const percentMatch = after.match(PERCENT_RE)
   const percent = percentMatch ? percentMatch[2] : null
   const percentSpacing = percentMatch ? percentMatch[1] : ''
   const trailing = percentMatch ? '' : after.trim()
   const hasBefore = before.length > 0
   const hasAfter = trailing.length > 0
-  const currency = hasBefore ? before : hasAfter ? trailing : null
+  const currency =
+    type === 'currency'
+      ? hasBefore
+        ? before
+        : hasAfter
+          ? trailing
+          : null
+      : null
 
   return {
     sign,
     signedNumber,
     number,
     currency,
-    currencyPosition: hasBefore ? 'before' : hasAfter ? 'after' : null,
-    spaceAfterCurrency: hasBefore,
-    spaceBeforeCurrency: hasAfter,
+    currencyPosition:
+      type === 'currency'
+        ? hasBefore
+          ? 'before'
+          : hasAfter
+            ? 'after'
+            : null
+        : null,
+    spaceAfterCurrency: type === 'currency' && hasBefore,
+    spaceBeforeCurrency: type === 'currency' && hasAfter,
     percent,
     percentSpacing,
   }

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
@@ -42,6 +42,40 @@ describe('Stat.Currency', () => {
     expect(currency.textContent).toBe('EUR')
   })
 
+  describe('compact', () => {
+    it('renders currency suffix and symbol', () => {
+      render(<Stat.Currency value={1300000} compact decimals={1} />)
+
+      const content = document.querySelector('.dnb-stat__content')
+      const amount = document.querySelector('.dnb-stat__amount')
+      const currency = document.querySelector('.dnb-stat__currency')
+
+      expect(content.textContent).toBe('1,3 mill. kr')
+      expect(amount.textContent).toBe('1,3 mill.')
+      expect(currency.textContent).toBe('kr')
+    })
+
+    it('keeps compact suffix in the amount when auxiliarySize is set', () => {
+      render(
+        <Stat.Currency
+          value={1300000}
+          compact
+          decimals={1}
+          mainSize="x-large"
+          auxiliarySize="basis"
+        />
+      )
+
+      const amount = document.querySelector('.dnb-stat__amount')
+      const currency = document.querySelector('.dnb-stat__currency')
+
+      expect(amount.textContent).toBe('1,3 mill.')
+      expect(amount.classList).toContain('dnb-t__size--x-large')
+      expect(currency.textContent).toBe('kr')
+      expect(currency.classList).toContain('dnb-t__size--basis')
+    })
+  })
+
   it('supports sign tone colorization', () => {
     render(
       <Stat.Currency

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Percent.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Percent.test.tsx
@@ -33,6 +33,20 @@ describe('Stat.Percent', () => {
     expect(sr.getAttribute('data-text')).toContain('+0 %')
   })
 
+  describe('compact', () => {
+    it('keeps percent sign separate', () => {
+      render(<Stat.Percent value={1300} compact />)
+
+      const content = document.querySelector('.dnb-stat__content')
+      const amount = document.querySelector('.dnb-stat__amount')
+      const percentSign = document.querySelector('.dnb-stat__percent')
+
+      expect(content.textContent).toBe('1 300 %')
+      expect(amount.textContent).toBe('1 300')
+      expect(percentSign.textContent).toBe('%')
+    })
+  })
+
   it('supports sign tone colorization', () => {
     render(<Stat.Percent value={-12.3} colorizeBySign />)
 


### PR DESCRIPTION
Align Stat.Currency with ` compact` and `auxiliarySize`.


Preview: https://chore-stat-currency-compact.eufemia-e25.pages.dev/uilib/components/stat/demos

The version to the right is the one of this PR.
<img width="718" height="310" alt="Screenshot 2026-06-18 at 13 55 21" src="https://github.com/user-attachments/assets/d97d39e8-064c-4dbc-afe9-4fc08a6b3160" />
