### PR TITLE
chore(DatePicker): avoid extra container surface

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2737,13 +2737,8 @@ html:not([data-whatinput=touch]) .dnb-toggle-button__button:focus-visible:not([d
   height: inherit;
 }
 .dnb-date-picker__container {
-  border-radius: var(--token-radius-lg);
-  background-color: var(--token-color-background-neutral);
   position: relative;
   top: auto;
-}
-.dnb-date-picker--inline .dnb-date-picker__container {
-  background-color: transparent;
 }
 .dnb-date-picker__container table {
   position: relative;

--- a/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
+++ b/packages/dnb-eufemia/src/components/date-picker/style/dnb-date-picker.scss
@@ -44,17 +44,10 @@
   }
 
   &__container {
-    border-radius: var(--token-radius-lg);
-    background-color: var(--token-color-background-neutral);
-
     // Supports backwards compatibility with Nucleus and scenarios,
     // where both unscoped and scoped styles are imported together (both position and top).
     position: relative;
     top: auto;
-
-    .dnb-date-picker--inline & {
-      background-color: transparent;
-    }
 
     table {
       position: relative;


### PR DESCRIPTION
Removes the DatePicker container's own surface styling so it does not add an extra neutral background and radius around the calendar.

This keeps the visual surface controlled by the surrounding DatePicker structure and avoids special-casing inline mode to undo the container background.