### PR TITLE
fix(Stat.Currency): fix missing space between currency and suffix in flex layout

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/Amount.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Amount.tsx
@@ -76,10 +76,6 @@ const renderAffix = (
     resolved = resolved()
   }
 
-  if (typeof resolved === 'string' && resolved.startsWith(' ')) {
-    resolved = `\u00A0${resolved.slice(1)}`
-  }
-
   return <span className={className}>{resolved as ReactNode}</span>
 }
 
@@ -287,10 +283,7 @@ function AmountBase(props: AmountProps) {
         resolvedAuxWeight && `dnb-t__weight--${resolvedAuxWeight}`
       )
     )
-    const suffixStartsWithSlashOrSpace =
-      typeof suffix === 'string' &&
-      (suffix.startsWith('/') || suffix.startsWith(' '))
-    const suffixSpace = suffixStartsWithSlashOrSpace ? '' : ' '
+    const suffixSpace = suffixStartsWithSlash ? '' : '\u00A0'
     content = (
       <>
         {content}
@@ -298,14 +291,7 @@ function AmountBase(props: AmountProps) {
         {suffixElement}
       </>
     )
-
-    const ariaSpace =
-      typeof suffix === 'string' && suffix.startsWith('/') ? '' : ' '
-    const ariaSuffix = convertJsxToString(suffixElement).replace(
-      /^\u00A0/,
-      ''
-    )
-    aria = `${aria}${ariaSpace}${ariaSuffix}`
+    aria = `${aria}${suffixStartsWithSlash ? '' : ' '}${convertJsxToString(suffixElement)}`
   }
 
   const srText = srLabel

--- a/packages/dnb-eufemia/src/components/stat/Amount.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Amount.tsx
@@ -76,6 +76,10 @@ const renderAffix = (
     resolved = resolved()
   }
 
+  if (typeof resolved === 'string' && resolved.startsWith(' ')) {
+    resolved = `\u00A0${resolved.slice(1)}`
+  }
+
   return <span className={className}>{resolved as ReactNode}</span>
 }
 
@@ -283,8 +287,10 @@ function AmountBase(props: AmountProps) {
         resolvedAuxWeight && `dnb-t__weight--${resolvedAuxWeight}`
       )
     )
-    const suffixSpace =
-      typeof suffix === 'string' && suffix.startsWith('/') ? '' : ' '
+    const suffixStartsWithSlashOrSpace =
+      typeof suffix === 'string' &&
+      (suffix.startsWith('/') || suffix.startsWith(' '))
+    const suffixSpace = suffixStartsWithSlashOrSpace ? '' : ' '
     content = (
       <>
         {content}
@@ -292,7 +298,14 @@ function AmountBase(props: AmountProps) {
         {suffixElement}
       </>
     )
-    aria = `${aria}${suffixSpace}${convertJsxToString(suffixElement)}`
+
+    const ariaSpace =
+      typeof suffix === 'string' && suffix.startsWith('/') ? '' : ' '
+    const ariaSuffix = convertJsxToString(suffixElement).replace(
+      /^\u00A0/,
+      ''
+    )
+    aria = `${aria}${ariaSpace}${ariaSuffix}`
   }
 
   const srText = srLabel

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
@@ -176,14 +176,14 @@ describe('Stat.Currency', () => {
     expect(srOnly.getAttribute('data-text')).toContain('kroner')
   })
 
-  it('renders non-breaking space between currency and suffix with leading space', () => {
-    render(<Stat.Currency value={1234} suffix=" per mnd" />)
+  it('renders space between currency and suffix without slash', () => {
+    render(<Stat.Currency value={1234} suffix="per mnd" />)
 
     const suffix = document.querySelector('.dnb-stat__suffix')
     const content = document.querySelector('.dnb-stat__content')
     const sr = document.querySelector('.dnb-stat .dnb-sr-only')
 
-    expect(suffix.textContent).toBe('\u00A0per mnd')
+    expect(suffix.textContent).toBe('per mnd')
     expect(content.textContent).toContain('kr\u00A0per mnd')
     expect(sr.getAttribute('data-text')).toContain('kroner per mnd')
   })

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Currency.test.tsx
@@ -175,4 +175,16 @@ describe('Stat.Currency', () => {
     expect(srOnly.getAttribute('data-text')).toContain('12,346')
     expect(srOnly.getAttribute('data-text')).toContain('kroner')
   })
+
+  it('renders non-breaking space between currency and suffix with leading space', () => {
+    render(<Stat.Currency value={1234} suffix=" per mnd" />)
+
+    const suffix = document.querySelector('.dnb-stat__suffix')
+    const content = document.querySelector('.dnb-stat__content')
+    const sr = document.querySelector('.dnb-stat .dnb-sr-only')
+
+    expect(suffix.textContent).toBe('\u00A0per mnd')
+    expect(content.textContent).toContain('kr\u00A0per mnd')
+    expect(sr.getAttribute('data-text')).toContain('kroner per mnd')
+  })
 })


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1781770298695429