### PR TITLE
fix(NumberFormat): preserve formatted part boundaries

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
@@ -7,6 +7,11 @@ import { renderHook } from '@testing-library/react'
 import useNumberFormatWithParts from '../useNumberFormatWithParts'
 import { formatCurrency, formatPercent, formatNumber } from '../utils'
 import type { NumberFormatter } from '../useNumberFormat'
+import {
+  numberFormatDisplayPartsSymbol,
+  type NumberFormatInternalOptionParams,
+  type NumberFormatReturnValueWithDisplayParts,
+} from '../utils/displayParts'
 import Provider from '../../../shared/Provider'
 
 describe('useNumberFormatWithParts', () => {
@@ -114,6 +119,83 @@ describe('useNumberFormatWithParts', () => {
               currencyPosition: 'after',
             }),
           })
+        )
+      })
+
+      it('will use display parts when fallback parsing cannot split joined compact currency output', () => {
+        const formatJoinedCurrency = (() => {
+          const result: NumberFormatReturnValueWithDisplayParts = {
+            value: 1000000,
+            cleanedValue: '1000000',
+            number: '1Mkr',
+            aria: '1 million kroner',
+            locale: 'nb-NO',
+            type: 'currency',
+          }
+
+          Object.defineProperty(result, numberFormatDisplayPartsSymbol, {
+            value: [
+              { type: 'integer', value: '1' },
+              { type: 'compact', value: 'M' },
+              { type: 'currency', value: 'kr' },
+            ],
+          })
+
+          return result
+        }) as unknown as NumberFormatter
+
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1000000, formatJoinedCurrency, {
+            compact: true,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1Mkr',
+            parts: expect.objectContaining({
+              signedNumber: '1M',
+              number: '1M',
+              currency: 'kr',
+              currencyPosition: 'after',
+              spaceBeforeCurrency: false,
+            }),
+          })
+        )
+      })
+
+      it('will keep display parts internal and opt-in for formatters', () => {
+        const regularResult = formatCurrency(1300000, {
+          compact: true,
+          decimals: 1,
+          returnAria: true,
+        })
+
+        expect(numberFormatDisplayPartsSymbol in regularResult).toBe(false)
+
+        const internalResult = formatCurrency(1300000, {
+          compact: true,
+          decimals: 1,
+          returnAria: true,
+          returnDisplayParts: true,
+        } as NumberFormatInternalOptionParams & {
+          returnAria: true
+        }) as NumberFormatReturnValueWithDisplayParts
+        const descriptor = Object.getOwnPropertyDescriptor(
+          internalResult,
+          numberFormatDisplayPartsSymbol
+        )
+        const displayParts = internalResult[numberFormatDisplayPartsSymbol]
+
+        expect(descriptor?.enumerable).toBe(false)
+        expect(displayParts).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: 'compact', value: 'mill.' }),
+            expect.objectContaining({ type: 'currency', value: 'kr' }),
+          ])
+        )
+        expect(displayParts.map(({ value }) => value).join('')).toBe(
+          internalResult.number
         )
       })
     })

--- a/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
+++ b/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
@@ -8,6 +8,12 @@ import type {
 } from './NumberUtils'
 import { cleanNumber, formatNumber } from './utils'
 import { canHandleCompact } from './utils/compact'
+import {
+  numberFormatDisplayPartsSymbol,
+  type NumberFormatInternalOptionParams,
+  type NumberFormatReturnValueWithDisplayParts,
+} from './utils/displayParts'
+import type { FormatPartItem } from './utils/types'
 import type { NumberFormatter } from './useNumberFormat'
 
 export type NumberFormatParts = {
@@ -58,9 +64,12 @@ function useNumberFormatWithParts(
     context.NumberFormat
   ) as NumberFormatOptionParams
 
-  const result = formatter(value, params) as
-    | NumberFormatReturnValue
-    | string
+  const result = formatter(value, {
+    ...params,
+    returnDisplayParts: true,
+  } as NumberFormatInternalOptionParams & {
+    returnAria: true
+  }) as NumberFormatReturnValueWithDisplayParts | string
 
   if (typeof result === 'string') {
     return result
@@ -74,13 +83,127 @@ function useNumberFormatWithParts(
 
   return {
     ...result,
-    parts: parseParts(result.number, result.type, compact),
+    parts:
+      parseDisplayParts(
+        result[numberFormatDisplayPartsSymbol],
+        result.number,
+        result.type
+      ) ?? parseParts(result.number, result.type, compact),
   }
 }
 
 const SIGN_RE = /^[\u200e\u200f\u061c\s]*([+\-\u2212])?\s*/
 const NUMBER_RE = /[0-9](?:[0-9.,]|[\s\u00A0\u202F](?=[0-9]))*/
 const PERCENT_RE = /^([\u00A0\u202F\s]*)([%٪])\s*$/
+const NUMBER_PART_TYPES = new Set([
+  'integer',
+  'group',
+  'decimal',
+  'fraction',
+  'compact',
+  'nan',
+  'infinity',
+])
+const SIGN_PART_TYPES = new Set(['minusSign', 'plusSign'])
+
+function joinParts(parts: FormatPartItem[]): string {
+  return parts.reduce((acc, { value }) => acc + value, '')
+}
+
+function findLastIndex(
+  parts: FormatPartItem[],
+  callback: (part: FormatPartItem) => boolean
+): number {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (callback(parts[i])) {
+      return i
+    }
+  }
+
+  return -1
+}
+
+function isNumberPart(part: FormatPartItem): boolean {
+  return NUMBER_PART_TYPES.has(part.type)
+}
+
+function isSignPart(part: FormatPartItem): boolean {
+  return SIGN_PART_TYPES.has(part.type)
+}
+
+function hasSpacingBetween(
+  parts: FormatPartItem[],
+  fromIndex: number,
+  toIndex: number
+): boolean {
+  return parts
+    .slice(fromIndex + 1, toIndex)
+    .some(({ type, value }) => type === 'literal' && value.length > 0)
+}
+
+function parseDisplayParts(
+  displayParts: FormatPartItem[] | undefined,
+  input: string,
+  type: NumberFormatReturnValue['type'] = 'number'
+): NumberFormatParts | null {
+  if (!displayParts?.length || joinParts(displayParts) !== input) {
+    return null
+  }
+
+  const firstNumberIndex = displayParts.findIndex(isNumberPart)
+  const lastNumberIndex = findLastIndex(displayParts, isNumberPart)
+
+  if (firstNumberIndex === -1 || lastNumberIndex === -1) {
+    return null
+  }
+
+  const sign = displayParts.find(isSignPart)?.value ?? null
+  const number = joinParts(
+    displayParts.slice(firstNumberIndex, lastNumberIndex + 1)
+  ).trim()
+  const signedNumber = sign ? `${sign}${number}` : number
+  const percentIndex = displayParts.findIndex(
+    ({ type }) => type === 'percentSign'
+  )
+  const percentPart = displayParts[percentIndex]
+  const percent = percentPart?.value ?? null
+  const percentSpacing = percent
+    ? joinParts(displayParts.slice(lastNumberIndex + 1, percentIndex))
+    : ''
+  const firstCurrencyIndex = displayParts.findIndex(
+    ({ type }) => type === 'currency'
+  )
+  const lastCurrencyIndex = findLastIndex(
+    displayParts,
+    ({ type }) => type === 'currency'
+  )
+  const currency =
+    type === 'currency' && firstCurrencyIndex !== -1
+      ? joinParts(displayParts.filter(({ type }) => type === 'currency'))
+      : null
+  const currencyPosition =
+    currency && firstCurrencyIndex < firstNumberIndex
+      ? 'before'
+      : currency
+        ? 'after'
+        : null
+
+  return {
+    sign,
+    signedNumber,
+    number,
+    currency,
+    currencyPosition,
+    spaceAfterCurrency:
+      currencyPosition === 'before' &&
+      hasSpacingBetween(displayParts, lastCurrencyIndex, firstNumberIndex),
+    spaceBeforeCurrency:
+      currencyPosition === 'after' &&
+      hasSpacingBetween(displayParts, lastNumberIndex, firstCurrencyIndex),
+    percent,
+    percentSpacing,
+  }
+}
 
 function parseParts(
   input: string,
@@ -108,8 +231,9 @@ function parseParts(
   }
 
   let number = numberMatch[0].trim()
-  const before = afterSign.slice(0, numberMatch.index).trim()
-  let after = afterSign.slice(numberMatch.index! + numberMatch[0].length)
+  const numberIndex = numberMatch.index ?? 0
+  const before = afterSign.slice(0, numberIndex).trim()
+  let after = afterSign.slice(numberIndex + numberMatch[0].length)
 
   if (compact && !PERCENT_RE.test(after)) {
     const compactMatch = after.match(

--- a/packages/dnb-eufemia/src/components/number-format/utils/displayParts.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/displayParts.ts
@@ -1,0 +1,23 @@
+import type {
+  FormatPartItem,
+  NumberFormatOptionParams,
+  NumberFormatReturnValue,
+} from './types'
+
+/**
+ * Internal metadata for consumers that need semantic display boundaries.
+ * Public formatter calls keep their return shape unchanged unless this
+ * opt-in flag is set by an internal caller.
+ */
+export const numberFormatDisplayPartsSymbol = Symbol(
+  'NumberFormat.displayParts'
+)
+
+export type NumberFormatInternalOptionParams = NumberFormatOptionParams & {
+  returnDisplayParts?: boolean
+}
+
+export type NumberFormatReturnValueWithDisplayParts =
+  NumberFormatReturnValue & {
+    [numberFormatDisplayPartsSymbol]?: FormatPartItem[]
+  }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
@@ -10,6 +10,7 @@ import { cleanNumber } from './cleanNumber'
 import { formatDecimals } from './decimals'
 import {
   formatNumberCore,
+  formatNumberCoreWithParts,
   prepareMinus,
   enhanceSR,
 } from './formatNumberCore'
@@ -19,6 +20,7 @@ import {
   handleCompactBeforeAria,
 } from './compact'
 import locales from '../../../shared/locales'
+import { numberFormatDisplayPartsSymbol } from './displayParts'
 import type {
   NumberFormatType,
   NumberFormatValue,
@@ -85,6 +87,7 @@ export function buildReturn({
   value,
   locale,
   display,
+  displayParts,
   aria,
   type,
   opts,
@@ -94,6 +97,7 @@ export function buildReturn({
   value: NumberFormatValue
   locale: string
   display: string
+  displayParts?: FormatPartItem[] | null
   aria: string
   type: NumberFormatType
   opts: InternalNumberFormatOptions
@@ -135,7 +139,22 @@ export function buildReturn({
       'N/A'
   }
 
-  return { value, cleanedValue, number: display, aria, locale, type }
+  const result = {
+    value,
+    cleanedValue,
+    number: display,
+    aria,
+    locale,
+    type,
+  }
+
+  if (displayParts) {
+    Object.defineProperty(result, numberFormatDisplayPartsSymbol, {
+      value: displayParts,
+    })
+  }
+
+  return result
 }
 
 /**
@@ -166,6 +185,7 @@ export {
   cleanNumber,
   formatDecimals,
   formatNumberCore,
+  formatNumberCoreWithParts,
   prepareMinus,
   enhanceSR,
   handleCompactBeforeDisplay,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
@@ -5,6 +5,7 @@ import type {
   FormatPartItem,
   PartFormatter,
 } from './types'
+import type { NumberFormatInternalOptionParams } from './displayParts'
 /**
  * Formatter for currency numbers.
  */
@@ -16,6 +17,7 @@ import {
   cleanNumber,
   formatDecimals,
   formatNumberCore,
+  formatNumberCoreWithParts,
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
@@ -26,6 +28,30 @@ import {
 import { currencyPositionFormatter } from './currencyPosition'
 import { getFallbackCurrencyDisplay, CURRENCY } from './currencyDisplay'
 import { alignCurrencySymbol } from './formatNumberCore'
+
+function trimDisplayParts(parts: FormatPartItem[]): FormatPartItem[] {
+  const displayParts = parts.map((part) => ({ ...part }))
+
+  while (displayParts[0]?.value.length === 0) {
+    displayParts.shift()
+  }
+
+  while (displayParts.at(-1)?.value.length === 0) {
+    displayParts.pop()
+  }
+
+  const firstPart = displayParts[0]
+  if (firstPart) {
+    firstPart.value = firstPart.value.trimStart()
+  }
+
+  const lastPart = displayParts.at(-1)
+  if (lastPart) {
+    lastPart.value = lastPart.value.trimEnd()
+  }
+
+  return displayParts.filter(({ value }) => value.length > 0)
+}
 
 export function formatCurrency(
   value: NumberFormatValue | null | undefined,
@@ -50,9 +76,10 @@ export function formatCurrency(
     signDisplay = null,
     options = null,
     returnAria = false,
+    returnDisplayParts = false,
     invalidAriaText = null,
     cleanCopyValue = null,
-  }: NumberFormatOptionParams = {}
+  }: NumberFormatInternalOptionParams = {}
 ): string | NumberFormatReturnValue {
   value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
@@ -143,14 +170,38 @@ export function formatCurrency(
     )
   }
 
-  let display = formatNumberCore(cleanedNumber, locale, opts, formatter)
-  display = prepareMinus(display, locale)
+  const displayResult = formatNumberCoreWithParts(
+    cleanedNumber,
+    locale,
+    opts,
+    formatter,
+    returnDisplayParts
+  )
+  let display = prepareMinus(displayResult.display, locale)
+  let displayParts =
+    returnDisplayParts && display === displayResult.display
+      ? displayResult.displayParts
+      : null
 
   if (resolvedPosition && currencySuffix) {
     if (resolvedPosition === 'after') {
       display = `${display.trim()} ${currencySuffix}`
+      displayParts = displayParts
+        ? [
+            ...trimDisplayParts(displayParts),
+            { type: 'literal', value: ' ' },
+            { type: 'currency', value: currencySuffix },
+          ]
+        : null
     } else if (resolvedPosition === 'before') {
       display = `${currencySuffix} ${display.trim()}`
+      displayParts = displayParts
+        ? [
+            { type: 'currency', value: currencySuffix },
+            { type: 'literal', value: ' ' },
+            ...trimDisplayParts(displayParts),
+          ]
+        : null
     }
   }
 
@@ -173,6 +224,7 @@ export function formatCurrency(
     value,
     locale,
     display,
+    displayParts,
     aria,
     type: 'currency',
     opts,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
@@ -3,6 +3,7 @@ import type {
   NumberFormatReturnValue,
   NumberFormatValue,
 } from './types'
+import type { NumberFormatInternalOptionParams } from './displayParts'
 /**
  * Formatter for plain (non-currency / non-percent) numbers. Supports `compact`.
  */
@@ -14,6 +15,7 @@ import {
   buildReturn,
   cleanNumber,
   formatNumberCore,
+  formatNumberCoreWithParts,
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
@@ -41,9 +43,10 @@ export function formatNumber(
     signDisplay = null,
     options = null,
     returnAria = false,
+    returnDisplayParts = false,
     invalidAriaText = null,
     cleanCopyValue = null,
-  }: NumberFormatOptionParams = {}
+  }: NumberFormatInternalOptionParams = {}
 ): string | NumberFormatReturnValue {
   value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
@@ -58,8 +61,18 @@ export function formatNumber(
 
   handleCompactBeforeDisplay({ value, locale, compact, decimals, opts })
 
-  let display = formatNumberCore(value, locale, opts)
-  display = prepareMinus(display, locale)
+  const displayResult = formatNumberCoreWithParts(
+    value,
+    locale,
+    opts,
+    null,
+    returnDisplayParts
+  )
+  const display = prepareMinus(displayResult.display, locale)
+  const displayParts =
+    returnDisplayParts && display === displayResult.display
+      ? displayResult.displayParts
+      : null
 
   handleCompactBeforeAria({ value, compact, opts })
 
@@ -75,6 +88,7 @@ export function formatNumber(
     value,
     locale,
     display,
+    displayParts,
     aria,
     type: 'number',
     opts,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
@@ -14,6 +14,11 @@ import type {
   InternalNumberFormatOptions,
 } from './types'
 
+export type FormatNumberCoreResult = {
+  display: string
+  displayParts: FormatPartItem[] | null
+}
+
 /**
  * Strips custom properties (e.g. `decimals`) so the object
  * is compatible with the native `Intl.NumberFormatOptions` type.
@@ -163,6 +168,20 @@ export const formatNumberCore = (
   options: InternalNumberFormatOptions = {},
   formatter: PartFormatter | null = null
 ): string => {
+  return formatNumberCoreWithParts(number, locale, options, formatter)
+    .display
+}
+
+export const formatNumberCoreWithParts = (
+  number: NumberFormatValue,
+  locale: string | null,
+  options: InternalNumberFormatOptions = {},
+  formatter: PartFormatter | null = null,
+  returnDisplayParts = false
+): FormatNumberCoreResult => {
+  const sourceNumber = number
+  let displayParts: FormatPartItem[] | null = null
+
   try {
     if (options.currencyDisplay) {
       options.currencyDisplay = getFallbackCurrencyDisplay(
@@ -175,9 +194,16 @@ export const formatNumberCore = (
     delete options.decimals
 
     if (formatter) {
-      number = formatToParts({ number, locale, options })
-        .map(formatter)
-        .reduce((acc: string, { value }) => acc + value, '')
+      const formattedParts = formatToParts({
+        number,
+        locale,
+        options,
+      }).map(formatter)
+      number = formattedParts.reduce(
+        (acc: string, { value }) => acc + value,
+        ''
+      )
+      displayParts = returnDisplayParts ? formattedParts : null
     } else if (
       typeof Number !== 'undefined' &&
       typeof Number.toLocaleString === 'function'
@@ -186,7 +212,16 @@ export const formatNumberCore = (
         locale || LOCALE,
         toIntlOptions(options)
       )
+
+      if (returnDisplayParts) {
+        displayParts = formatToParts({
+          number: sourceNumber,
+          locale,
+          options,
+        })
+      }
     }
+
     if (
       new RegExp(`^(${NUMBER_MINUS})(0|0[^\\d]|0\\s.*)$`).test(
         String(number)
@@ -208,7 +243,9 @@ export const formatNumberCore = (
     )
   }
 
-  return replaceNaNWithDash(
+  const display = replaceNaNWithDash(
     alignCurrencySymbol(number, options.currencyDisplay)
   )
+
+  return { display, displayParts }
 }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
@@ -3,6 +3,7 @@ import type {
   NumberFormatReturnValue,
   NumberFormatValue,
 } from './types'
+import type { NumberFormatInternalOptionParams } from './displayParts'
 /**
  * Formatter for percent numbers.
  *
@@ -19,7 +20,7 @@ import {
   buildReturn,
   cleanNumber,
   formatDecimals,
-  formatNumberCore,
+  formatNumberCoreWithParts,
   prepareFormatOptions,
   resolveLocale,
 } from './formatCore'
@@ -43,9 +44,10 @@ export function formatPercent(
     signDisplay = null,
     options = null,
     returnAria = false,
+    returnDisplayParts = false,
     invalidAriaText = null,
     cleanCopyValue = null,
-  }: NumberFormatOptionParams = {}
+  }: NumberFormatInternalOptionParams = {}
 ): string | NumberFormatReturnValue {
   value = isAbsent(value) ? ABSENT_VALUE_FORMAT : value
 
@@ -71,7 +73,14 @@ export function formatPercent(
     opts.style = 'percent'
   }
 
-  const display = formatNumberCore(Number(value) / 100, locale, opts)
+  const displayResult = formatNumberCoreWithParts(
+    Number(value) / 100,
+    locale,
+    opts,
+    null,
+    returnDisplayParts
+  )
+  const display = displayResult.display
   const aria = display
 
   if (!returnAria) {
@@ -82,6 +91,7 @@ export function formatPercent(
     value,
     locale,
     display,
+    displayParts: returnDisplayParts ? displayResult.displayParts : null,
     aria,
     // Original `format()` only assigns `type = 'currency'` – percent keeps
     // the default "number" type.


### PR DESCRIPTION
This improves how formatted number output is split into semantic parts for consumers that style the number, currency, and percent pieces separately.

The previous fallback parser had to infer boundaries from the final display string. That works for common spaced output, but it is fragile for compact notation where the compact suffix and currency can be adjacent or locale-dependent. The formatter pipeline now keeps Intl display parts available through an internal opt-in path, so `useNumberFormatWithParts` can use the same formatted output with more reliable part boundaries while regular formatter calls keep their existing public shape and cost profile.