### PR TITLE
fix(Forms): ensure PushContainer resolves section paths and validates schema correctly

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -15,6 +15,7 @@ import * as z from 'zod'
 import { isZodSchema } from '../../utils/zod'
 import pointer from '../../utils/json-pointer'
 import useHandleStatus from '../../Form/Isolation/useHandleStatus'
+import SectionContext from '../../Form/Section/SectionContext'
 import PushContainerContext from './PushContainerContext'
 import IterateItemContext from '../IterateItemContext'
 import DataContext from '../../DataContext/Context'
@@ -147,6 +148,7 @@ export type IteratePushContainerAllProps = IteratePushContainerProps &
 function PushContainer(props: IteratePushContainerAllProps) {
   const [, forceUpdate] = useReducer(() => ({}), {})
   const outerContext = useContext(DataContext)
+  const sectionContext = useContext(SectionContext)
   const { required: requiredInherited } = outerContext
   const { value: outerData } = useDataValue<JsonObject>('//')
 
@@ -172,6 +174,33 @@ function PushContainer(props: IteratePushContainerAllProps) {
 
   const { absolutePath } = useItemPath(itemPath)
   const { path: relativePath } = usePath({ path, itemPath })
+  const targetPath = useMemo(() => {
+    if (absolutePath) {
+      return absolutePath
+    }
+
+    if (!path) {
+      return relativePath
+    }
+
+    const sectionPath = sectionContext?.path
+    if (
+      sectionPath &&
+      !path.startsWith('//') &&
+      (path === sectionPath || path.startsWith(`${sectionPath}/`))
+    ) {
+      return path
+    }
+
+    return relativePath
+  }, [absolutePath, path, relativePath, sectionContext?.path])
+  const rootRelativeTargetPath = useMemo(() => {
+    if (!targetPath || targetPath === '/') {
+      return targetPath
+    }
+
+    return `//${targetPath.slice(1)}` as Path
+  }, [targetPath])
   const commitHandleRef = useRef<() => void>(undefined)
   const switchContainerModeRef =
     useRef<(mode: ContainerMode) => void>(undefined)
@@ -180,14 +209,10 @@ function PushContainer(props: IteratePushContainerAllProps) {
     value: entries = [],
     moveValueToPath,
     getValueByPath,
-  } = useDataValue<Array<unknown>>(path || absolutePath)
+  } = useDataValue<Array<unknown>>(rootRelativeTargetPath)
 
-  const { setNextContainerMode } = useSwitchContainerMode(
-    path || absolutePath
-  )
-  const { hasReachedLimit, setShowStatus } = useArrayLimit(
-    path || absolutePath
-  )
+  const { setNextContainerMode } = useSwitchContainerMode(targetPath)
+  const { hasReachedLimit, setShowStatus } = useArrayLimit(targetPath)
   const cancelHandler = useCallback(() => {
     if (hasReachedLimit) {
       setShowStatus(false)
@@ -252,7 +277,6 @@ function PushContainer(props: IteratePushContainerAllProps) {
   // so that fields inside PushContainer validate against the target array's item schema.
   const isolationSchema = useMemo(() => {
     const parentSchema = outerContext?.props?.schema as unknown
-    const targetPath = absolutePath || relativePath
 
     if (!parentSchema || !targetPath) {
       return undefined // stop here
@@ -290,7 +314,7 @@ function PushContainer(props: IteratePushContainerAllProps) {
         },
       }
     }
-  }, [outerContext?.props?.schema, absolutePath, relativePath])
+  }, [outerContext?.props?.schema, targetPath])
 
   return (
     <Isolation
@@ -306,7 +330,7 @@ function PushContainer(props: IteratePushContainerAllProps) {
       schema={isolationSchema}
       transformOnCommit={({ pushContainerItems }) => {
         return moveValueToPath(
-          absolutePath || relativePath,
+          targetPath,
           typeof insertAt === 'number'
             ? [
                 ...entries.slice(0, insertAt),
@@ -314,7 +338,9 @@ function PushContainer(props: IteratePushContainerAllProps) {
                 ...entries.slice(insertAt),
               ]
             : [...entries, ...pushContainerItems],
-          absolutePath ? structuredClone(getValueByPath('/')) : {}
+          targetPath && targetPath !== '/'
+            ? structuredClone(getValueByPath('/'))
+            : {}
         )
       }}
       onCommit={(data, options) => {
@@ -331,29 +357,37 @@ function PushContainer(props: IteratePushContainerAllProps) {
       }}
     >
       <PushContainerContext value={newItemContextProps}>
-        <IterateArray
-          path="/pushContainerItems"
-          containerMode={showOpenButton ? 'view' : 'edit'}
-          withoutFlex
-          omitSectionPath
+        <SectionContext
+          value={
+            sectionContext
+              ? { ...sectionContext, path: undefined }
+              : undefined
+          }
         >
-          <NewContainer
-            title={title}
-            openButton={openButton}
-            switchContainerModeRef={switchContainerModeRef}
-            showOpenButton={showOpenButton}
-            cancelHandler={cancelHandler}
-            containerModeRef={containerModeRef}
-            rerenderPushContainer={forceUpdate}
-            preventUncommittedChanges={preventUncommittedChanges}
-            showResetButton={showResetButton}
-            outerContext={outerContext}
-            required={required}
-            {...rest}
+          <IterateArray
+            path="/pushContainerItems"
+            containerMode={showOpenButton ? 'view' : 'edit'}
+            withoutFlex
+            omitSectionPath
           >
-            {children}
-          </NewContainer>
-        </IterateArray>
+            <NewContainer
+              title={title}
+              openButton={openButton}
+              switchContainerModeRef={switchContainerModeRef}
+              showOpenButton={showOpenButton}
+              cancelHandler={cancelHandler}
+              containerModeRef={containerModeRef}
+              rerenderPushContainer={forceUpdate}
+              preventUncommittedChanges={preventUncommittedChanges}
+              showResetButton={showResetButton}
+              outerContext={outerContext}
+              required={required}
+              {...rest}
+            >
+              {children}
+            </NewContainer>
+          </IterateArray>
+        </SectionContext>
       </PushContainerContext>
     </Isolation>
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -3234,6 +3234,214 @@ describe('PushContainer', () => {
         expect.anything()
       )
     })
+
+    it('should apply Form.Section schema validation when PushContainer has relative path', async () => {
+      const onChange = vi.fn()
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          section: {
+            type: 'object',
+            properties: {
+              items: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', minLength: 4 },
+                  },
+                  required: ['name'],
+                },
+              },
+            },
+          },
+        },
+      }
+
+      render(
+        <Form.Handler
+          schema={schema}
+          ajvInstance={makeAjvInstance()}
+          onChange={onChange}
+        >
+          <Form.Section path="/section">
+            <Iterate.Array path="/items">...</Iterate.Array>
+
+            <Iterate.PushContainer path="/items">
+              <Field.String itemPath="/name" />
+            </Iterate.PushContainer>
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      const doneButton = document.querySelector(
+        '.dnb-forms-iterate__done-button'
+      )
+
+      await userEvent.type(input, 'foo')
+      await userEvent.click(doneButton)
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).toBeInTheDocument()
+      expect(onChange).toHaveBeenCalledTimes(0)
+    })
+
+    it('should not duplicate Form.Section path when PushContainer has an absolute path', async () => {
+      const onSubmit = vi.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Form.Section path="/section">
+            <Iterate.PushContainer path="/section/component">
+              <Field.String itemPath="/name" />
+            </Iterate.PushContainer>
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      const doneButton = document.querySelector(
+        '.dnb-forms-iterate__done-button'
+      )
+
+      await userEvent.type(input, 'bar')
+      await userEvent.click(doneButton)
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenLastCalledWith(
+        {
+          section: {
+            component: [{ name: 'bar' }],
+          },
+        },
+        expect.anything()
+      )
+    })
+
+    it('should apply Form.Section Zod schema validation when PushContainer has relative path', async () => {
+      const onChange = vi.fn()
+      const schema = z.object({
+        section: z.object({
+          items: z.array(z.object({ name: z.string().min(4) })),
+        }),
+      })
+
+      render(
+        <Form.Handler schema={schema} onChange={onChange}>
+          <Form.Section path="/section">
+            <Iterate.Array path="/items">...</Iterate.Array>
+
+            <Iterate.PushContainer path="/items">
+              <Field.String itemPath="/name" />
+            </Iterate.PushContainer>
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      const doneButton = document.querySelector(
+        '.dnb-forms-iterate__done-button'
+      )
+
+      await userEvent.type(input, 'foo')
+      await userEvent.click(doneButton)
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).toBeInTheDocument()
+      expect(onChange).toHaveBeenCalledTimes(0)
+    })
+
+    it('should preserve Form.Section errorPrioritization in isolated fields', async () => {
+      const onChange = vi.fn()
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          section: {
+            type: 'object',
+            properties: {
+              items: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', minLength: 4 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      render(
+        <Form.Handler
+          schema={schema}
+          ajvInstance={makeAjvInstance()}
+          onChange={onChange}
+        >
+          <Form.Section
+            path="/section"
+            errorPrioritization={['contextSchema']}
+          >
+            <Iterate.Array path="/items">...</Iterate.Array>
+
+            <Iterate.PushContainer path="/items">
+              <Field.String itemPath="/name" />
+            </Iterate.PushContainer>
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      const doneButton = document.querySelector(
+        '.dnb-forms-iterate__done-button'
+      )
+
+      await userEvent.type(input, 'foo')
+      await userEvent.click(doneButton)
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).toBeInTheDocument()
+      expect(onChange).toHaveBeenCalledTimes(0)
+    })
+
+    it('should handle root-relative path //items under Form.Section', async () => {
+      const onSubmit = vi.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Form.Section path="/section">
+            <Iterate.PushContainer path="//items">
+              <Field.String itemPath="/name" />
+            </Iterate.PushContainer>
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      const doneButton = document.querySelector(
+        '.dnb-forms-iterate__done-button'
+      )
+
+      await userEvent.type(input, 'bar')
+      await userEvent.click(doneButton)
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenLastCalledWith(
+        {
+          items: [{ name: 'bar' }],
+        },
+        expect.anything()
+      )
+    })
   })
 
   it('should clear Field.Currency value when opening PushContainer again after committing', async () => {


### PR DESCRIPTION
## Why
PushContainer could behave incorrectly inside Form.Section when certain path combinations were used:
- Relative paths could miss schema validation in the isolated context.
- Absolute paths could be committed with duplicated section segments.

This caused inconsistent validation behavior and incorrect submitted data shapes for nested form structures.

Closes #8609.