### PR TITLE
chore: replace lodash.isequal/isequalwith with node:util isDeepStrictEqual

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -202,8 +202,6 @@
     "lebab": "3.2.7",
     "lightningcss": "1.32.0",
     "lockfile-lint": "4.14.1",
-    "lodash.isequal": "4.5.0",
-    "lodash.isequalwith": "4.4.0",
     "mock-match-media": "0.3.0",
     "nodemon": "2.0.15",
     "opentype.js": "1.3.4",

--- a/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
+++ b/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
@@ -8,8 +8,7 @@ import https from 'https'
 import path from 'path'
 import { Client } from 'figma-js'
 import traverse from 'traverse'
-import isEqual from 'lodash.isequal'
-import isEqualWith from 'lodash.isequalwith'
+import { isDeepStrictEqual } from 'node:util'
 import { ErrorHandler, ERROR_HARMLESS } from '../../lib/error'
 import { log } from '../../lib'
 import crypto from 'crypto'
@@ -102,28 +101,24 @@ export const findAll = (
 ) => {
   const objToReturn = []
   if (!tree) return objToReturn
-  const customizer = (objValue, othValue) => {
+  const compareValues = (objValue, othValue) => {
     // is RegExp
     if (String(othValue)[0] === '/') {
       return othValue.test(objValue)
     }
-    return isEqual(objValue, othValue)
+    return isDeepStrictEqual(objValue, othValue)
   }
   const innerFunc = (tree, childrenKey, objToFindBy, objToIgnoreBy) => {
     let ignoreSuccess = false
     const findKeys = Object.keys(objToFindBy)
-    // find the first matching key
-    // const findSuccess = findKeys.some(key =>
-    //   isEqualWith(tree[key], objToFindBy[key], customizer)
-    // )
     // make sure we match all
     const findSuccess = findKeys.every((key) =>
-      isEqualWith(tree[key], objToFindBy[key], customizer)
+      compareValues(tree[key], objToFindBy[key])
     )
     if (objToIgnoreBy) {
       const ignoreKeys = Object.keys(objToIgnoreBy)
       ignoreSuccess = ignoreKeys.some((key) =>
-        isEqualWith(tree[key], objToIgnoreBy[key], customizer)
+        compareValues(tree[key], objToIgnoreBy[key])
       )
     }
     if (findSuccess && !ignoreSuccess) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,8 +2540,6 @@ __metadata:
     lebab: "npm:3.2.7"
     lightningcss: "npm:1.32.0"
     lockfile-lint: "npm:4.14.1"
-    lodash.isequal: "npm:4.5.0"
-    lodash.isequalwith: "npm:4.4.0"
     mock-match-media: "npm:0.3.0"
     nodemon: "npm:2.0.15"
     opentype.js: "npm:1.3.4"
@@ -13393,20 +13391,6 @@ __metadata:
   version: 4.1.2
   resolution: "lodash.escaperegexp@npm:4.1.2"
   checksum: 10/6d99452b1cfd6073175a9b741a9b09ece159eac463f86f02ea3bee2e2092923fce812c8d2bf446309cc52d1d61bf9af51c8118b0d7421388e6cead7bd3798f0f
-  languageName: node
-  linkType: hard
-
-"lodash.isequal@npm:4.5.0":
-  version: 4.5.0
-  resolution: "lodash.isequal@npm:4.5.0"
-  checksum: 10/82fc58a83a1555f8df34ca9a2cd300995ff94018ac12cc47c349655f0ae1d4d92ba346db4c19bbfc90510764e0c00ddcc985a358bdcd4b3b965abf8f2a48a214
-  languageName: node
-  linkType: hard
-
-"lodash.isequalwith@npm:4.4.0":
-  version: 4.4.0
-  resolution: "lodash.isequalwith@npm:4.4.0"
-  checksum: 10/5c79d2f64b7eec9e9d337c347a58c8dda2f83f6da9ec8ff83fb1beab3ae87be3a02ac295e9283b6395673bee363039fca7324a6244bbdb7e6a47e0cd872cc36b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove deprecated [lodash.isequal](https://www.npmjs.com/package/lodash.isequal) (4.5.0) and lodash.isequalwith (4.4.0) in favor of the built-in isDeepStrictEqual from node:util.

These packages were only used in the Figma doc-helpers script.

