### PR TITLE
chore(DrawerList): do not forward deprecated arrowPosition prop to the DOM

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -422,6 +422,7 @@ const DrawerListInstance = memo(function DrawerListInstance(
     ignoreEvents,
     optionsRender,
     className,
+    arrowPosition: _arrowPosition,
     cacheHash: _cacheHash,
     wrapperElement: _wrapperElement,
     direction: _direction,

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -152,7 +152,7 @@ export type DrawerListProps = {
   cacheHash?: string
   /**
    * Position of the arrow on the popup drawer. Set to `left` or `right`. Defaults to `left` if not set.
-   * @deprecated does nothing as there is no longer any arrow.
+   * @deprecated does nothing as there is no longer any arrow, and will be removed in v12.
    */
   arrowPosition?: string
   /**

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -95,6 +95,22 @@ describe('DrawerList component', () => {
     ).toBeInTheDocument()
   })
 
+  it('does not forward the deprecated arrowPosition prop to the DOM', () => {
+    render(
+      <DrawerList
+        {...props}
+        data={mockData}
+        skipPortal
+        arrowPosition="left"
+      />
+    )
+
+    const element = document.querySelector('.dnb-drawer-list')
+    expect(element).toBeInTheDocument()
+    expect(element.hasAttribute('arrowposition')).toBe(false)
+    expect(element.hasAttribute('arrowPosition')).toBe(false)
+  })
+
   it('should skip portal when skipPortal is set', () => {
     render(<DrawerList {...props} data={mockData} skipPortal />)
     expect(

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -95,6 +95,7 @@ describe('DrawerList component', () => {
     ).toBeInTheDocument()
   })
 
+  // TODO: remove this test in v12 when the deprecated arrowPosition prop is removed
   it('does not forward the deprecated arrowPosition prop to the DOM', () => {
     render(
       <DrawerList


### PR DESCRIPTION
Follow-up to https://github.com/dnbexperience/eufemia/pull/7767

The deprecated arrowPosition prop was no longer destructured out of the props, so it leaked onto the DOM element and triggered a React 'does not recognize the prop' warning. Strip it before spreading attributes.

