### PR TITLE
fix(Autocomplete): disable submit button while the loading indicator is shown

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -1594,7 +1594,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
       if (typeof args.hasFilter === 'undefined') {
         args.hasFilter = false
       }
-      if (disabled) {
+      if (disabled || visibleIndicator) {
         return undefined // stop here
       }
       if (
@@ -1610,6 +1610,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
     },
     [
       disabled,
+      visibleIndicator,
       preventClose,
       drawerList.hidden,
       drawerList.isOpen,
@@ -2419,7 +2420,9 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
   let submitButton: ReactNode = false
   const triggerParams = {
     id: id + '-submit-button',
-    disabled,
+    // Disable the submit button while the loading indicator is shown,
+    // so it can't be used to open the drawer over loading or stale data.
+    disabled: disabled || visibleIndicator,
     status: status ? statusState : null,
     onKeyDown: onTriggerKeyDownHandler,
     onSubmit: toggleVisible as any as InputSubmitButtonProps['onSubmit'],

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1961,6 +1961,56 @@ describe('Autocomplete component', () => {
     ).toHaveTextContent('No options')
   })
 
+  it('disables the submit button while the loading indicator is shown', async () => {
+    const onTypeHandler = ({ value, showIndicator, hideIndicator }) => {
+      if (value === 'x') {
+        showIndicator()
+      } else {
+        hideIndicator()
+      }
+    }
+
+    render(
+      <Autocomplete
+        {...mockProps}
+        mode="async"
+        showSubmitButton
+        data={mockData}
+        onType={onTypeHandler}
+      />
+    )
+
+    const submitButton = document.querySelector(
+      'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+    )
+
+    expect(submitButton).not.toHaveAttribute('disabled')
+
+    const inputElement = document.querySelector('input')
+
+    // Trigger the loading indicator
+    await userEvent.type(inputElement, 'x')
+
+    await waitFor(() => {
+      expect(submitButton).toHaveAttribute('disabled')
+    })
+
+    expect(
+      document.querySelector('.dnb-autocomplete--show-indicator')
+    ).toBeInTheDocument()
+
+    // Remove the value to hide the loading indicator again
+    await userEvent.clear(inputElement)
+
+    await waitFor(() => {
+      expect(submitButton).not.toHaveAttribute('disabled')
+    })
+
+    expect(
+      document.querySelector('.dnb-autocomplete--show-indicator')
+    ).not.toBeInTheDocument()
+  })
+
   it('should support inline styling', () => {
     render(<Autocomplete data={[]} style={{ color: 'red' }} />)
 


### PR DESCRIPTION
This is meant to improve the experience for a user when pressing a "async" autocomplete which has noe loaded any data yet.

TODO: I've not really thought about the experience of removing/disabling opening/closing of the drawer list when searching in a autocomplete that already has previous data 🤔 

From:

https://github.com/user-attachments/assets/f4b2d76f-3893-4568-b4d0-0655b1e7c399

To:


https://github.com/user-attachments/assets/727b07b9-b01f-4ca0-a2e4-3a9943a123ff

