### PR TITLE
fix(NumberFormat): preserve formatted part boundaries

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v11-info.mdx
@@ -2204,7 +2204,7 @@ const formatted = useNumberFormatWithParts(value, formatCurrency, {
 | `useNumberFormatWithParts(value, { percent: true })`                  | `useNumberFormatWithParts(value, formatPercent)`                                 |
 | `useNumberFormatWithParts(value, { forceCurrencyAfterAmount: true })` | `useNumberFormatWithParts(value, formatCurrency, { currencyPosition: 'after' })` |
 
-The returned `parts` shape is unchanged. `parts` are now derived from the formatter's display string, so any formatter returning a `NumberFormatReturnValue` (including custom ones) can be passed in.
+The returned `parts` shape is unchanged. Standard Eufemia formatters preserve semantic formatter parts, while custom formatter objects fall back to parsing the returned display string.
 
 #### Behavioral changes
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
@@ -41,7 +41,7 @@ Good reasons for why we have this:
 
 ### Defaults
 
-It uses the browser APIs `number.toLocaleString` or `Intl.NumberFormat.format` under the hood. As well as some custom formatter. The locale defaults to:
+It uses the browser API `Intl.NumberFormat` under the hood, as well as some custom formatters. The locale defaults to:
 
 - Locale: `nb-NO`
 - Currency: `NOK`

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatDocs.ts
@@ -92,7 +92,7 @@ const presentationProps: PropertiesTableProps = {
     status: 'optional',
   },
   options: {
-    doc: "Accepts all [number.toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) or [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) options as an object - can also be a JSON given as the parameter e.g. `options={{ 'minimumFractionDigits': 2 }}`.",
+    doc: "Accepts all [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) options as an object - can also be a JSON given as the parameter e.g. `options={{ 'minimumFractionDigits': 2 }}`.",
     type: 'object',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
@@ -6,6 +6,7 @@
 import { renderHook } from '@testing-library/react'
 import useNumberFormatWithParts from '../useNumberFormatWithParts'
 import { formatCurrency, formatPercent, formatNumber } from '../utils'
+import { getReturnValueParts } from '../utils/formatCore'
 import type {
   NumberFormatOptionParams,
   NumberFormatReturnValue,
@@ -13,6 +14,9 @@ import type {
 } from '../NumberUtils'
 import type { NumberFormatter } from '../useNumberFormat'
 import Provider from '../../../shared/Provider'
+
+const joinParts = (parts: Array<{ value: string }>) =>
+  parts.reduce((acc, { value }) => acc + value, '')
 
 describe('useNumberFormatWithParts', () => {
   it('will return object with parts by default', () => {
@@ -47,6 +51,86 @@ describe('useNumberFormatWithParts', () => {
           number: '1\u00A0234,00',
           currency: 'kr',
           currencyPosition: 'after',
+        }),
+      })
+    )
+  })
+
+  it('will preserve semantic parts for negative Norwegian currency', () => {
+    const formatted = formatCurrency(-1234, {
+      locale: 'nb-NO',
+      returnAria: true,
+    })
+    const parts = getReturnValueParts(formatted) ?? []
+
+    expect(parts.length).toBeGreaterThan(0)
+    expect(joinParts(parts)).toBe(formatted.number)
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'minusSign', value: '-' }),
+        expect.objectContaining({ type: 'currency', value: 'kr' }),
+      ])
+    )
+  })
+
+  it('will preserve semantic parts for negative Norwegian numbers', () => {
+    const formatted = formatNumber(-1234, {
+      locale: 'nb-NO',
+      returnAria: true,
+    })
+    const parts = getReturnValueParts(formatted) ?? []
+
+    expect(parts.length).toBeGreaterThan(0)
+    expect(joinParts(parts)).toBe(formatted.number)
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'minusSign', value: '-' }),
+      ])
+    )
+  })
+
+  it('will expose normalized sign parts for negative Norwegian numbers', () => {
+    const { result } = renderHook(() =>
+      useNumberFormatWithParts(-1234, formatNumber, {
+        locale: 'nb-NO',
+      })
+    )
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        number: '-1\u00A0234',
+        parts: expect.objectContaining({
+          sign: '-',
+          signedNumber: '-1\u00A0234',
+          number: '1\u00A0234',
+          currency: null,
+          currencyPosition: null,
+        }),
+      })
+    )
+  })
+
+  it('will not treat accounting literals as currency spacing', () => {
+    const { result } = renderHook(() =>
+      useNumberFormatWithParts(-1234, formatCurrency, {
+        currency: 'USD',
+        currencyDisplay: 'symbol',
+        locale: 'en-US',
+        options: { currencySign: 'accounting' },
+      })
+    )
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        number: '($1,234.00)',
+        parts: expect.objectContaining({
+          sign: null,
+          signedNumber: '1,234.00',
+          number: '1,234.00',
+          currency: '$',
+          currencyPosition: 'before',
+          spaceAfterCurrency: false,
+          spaceBeforeCurrency: false,
         }),
       })
     )

--- a/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/useNumberFormatWithParts.test.tsx
@@ -6,6 +6,11 @@
 import { renderHook } from '@testing-library/react'
 import useNumberFormatWithParts from '../useNumberFormatWithParts'
 import { formatCurrency, formatPercent, formatNumber } from '../utils'
+import type {
+  NumberFormatOptionParams,
+  NumberFormatReturnValue,
+  NumberFormatValue,
+} from '../NumberUtils'
 import type { NumberFormatter } from '../useNumberFormat'
 import Provider from '../../../shared/Provider'
 
@@ -116,6 +121,39 @@ describe('useNumberFormatWithParts', () => {
           })
         )
       })
+
+      it('will parse compact suffix from custom formatter objects', () => {
+        const formatCustomCurrency = ((
+          value: NumberFormatValue,
+          options: NumberFormatOptionParams
+        ): NumberFormatReturnValue => ({
+          value,
+          cleanedValue: String(value),
+          number: '1,3 mill. kr',
+          aria: '1,3 million kroner',
+          locale: options.locale ?? 'nb-NO',
+          type: 'currency',
+        })) as NumberFormatter
+
+        const { result } = renderHook(() =>
+          useNumberFormatWithParts(1300000, formatCustomCurrency, {
+            compact: true,
+          })
+        )
+
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            number: '1,3 mill. kr',
+            parts: expect.objectContaining({
+              signedNumber: '1,3 mill.',
+              number: '1,3 mill.',
+              currency: 'kr',
+              currencyPosition: 'after',
+              spaceBeforeCurrency: true,
+            }),
+          })
+        )
+      })
     })
 
     describe('number', () => {
@@ -204,6 +242,29 @@ describe('useNumberFormatWithParts', () => {
           currency: 'NOK',
           spaceAfterCurrency: true,
           spaceBeforeCurrency: false,
+        }),
+      })
+    )
+  })
+
+  it('will keep the sign separate when currency is before the sign', () => {
+    const { result } = renderHook(() =>
+      useNumberFormatWithParts(-123456789.5, formatCurrency, {
+        currency: 'CHF',
+        locale: 'de-CH',
+      })
+    )
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        number: "CHF-123'456'789.50",
+        parts: expect.objectContaining({
+          sign: '-',
+          signedNumber: "-123'456'789.50",
+          number: "123'456'789.50",
+          currency: 'CHF',
+          currencyPosition: 'before',
+          spaceAfterCurrency: false,
         }),
       })
     )

--- a/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
+++ b/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
@@ -97,6 +97,10 @@ const NUMBER_PART_TYPES = new Set([
 ])
 const SIGN_PART_TYPES = new Set(['minusSign', 'plusSign'])
 
+function isSpacingLiteral(value: string): boolean {
+  return value.trim() === ''
+}
+
 function parseFormatParts(
   parts: FormatPartItem[] | undefined,
   type: NumberFormatReturnValue['type'] = 'number'
@@ -148,6 +152,10 @@ function parseFormatParts(
 
       if (hasNumber && parts[index + 1]?.type === 'compact') {
         number += part.value
+        return
+      }
+
+      if (!isSpacingLiteral(part.value)) {
         return
       }
 

--- a/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
+++ b/packages/dnb-eufemia/src/components/number-format/useNumberFormatWithParts.ts
@@ -8,6 +8,8 @@ import type {
 } from './NumberUtils'
 import { cleanNumber, formatNumber } from './utils'
 import { canHandleCompact } from './utils/compact'
+import { getReturnValueParts } from './utils/formatCore'
+import type { FormatPartItem } from './utils/types'
 import type { NumberFormatter } from './useNumberFormat'
 
 export type NumberFormatParts = {
@@ -32,9 +34,9 @@ export type NumberFormatReturnWithParts = NumberFormatReturnValue & {
  * percent) so consumers can style each piece independently.
  *
  * `formatter` defaults to `formatNumber`. Pass `formatCurrency` or
- * `formatPercent` for currency/percent output. The returned `parts` are
- * derived from the formatter's display string, so any formatter that
- * returns a `NumberFormatReturnValue` works.
+ * `formatPercent` for currency/percent output. Standard Eufemia formatters
+ * preserve semantic formatter parts; custom formatter objects fall back to
+ * parsing the returned display string.
  */
 function useNumberFormatWithParts(
   value: NumberFormatValue,
@@ -71,16 +73,125 @@ function useNumberFormatWithParts(
     value: compactValue ?? '',
     compact: params.compact ?? null,
   })
+  const formatParts = getReturnValueParts(result)
 
   return {
     ...result,
-    parts: parseParts(result.number, result.type, compact),
+    parts:
+      parseFormatParts(formatParts, result.type) ??
+      parseParts(result.number, result.type, compact),
   }
 }
 
 const SIGN_RE = /^[\u200e\u200f\u061c\s]*([+\-\u2212])?\s*/
 const NUMBER_RE = /[0-9](?:[0-9.,]|[\s\u00A0\u202F](?=[0-9]))*/
 const PERCENT_RE = /^([\u00A0\u202F\s]*)([%٪])\s*$/
+const NUMBER_PART_TYPES = new Set([
+  'integer',
+  'group',
+  'decimal',
+  'fraction',
+  'compact',
+  'nan',
+  'infinity',
+])
+const SIGN_PART_TYPES = new Set(['minusSign', 'plusSign'])
+
+function parseFormatParts(
+  parts: FormatPartItem[] | undefined,
+  type: NumberFormatReturnValue['type'] = 'number'
+): NumberFormatParts | null {
+  if (!parts?.length) {
+    return null
+  }
+
+  let sign: string | null = null
+  let number = ''
+  let currencyBefore = ''
+  let currencyAfter = ''
+  let spacingBeforeNumber = ''
+  let spacingAfterNumber = ''
+  let percent = ''
+  let percentSpacing = ''
+  let hasNumber = false
+
+  parts.forEach((part, index) => {
+    if (SIGN_PART_TYPES.has(part.type)) {
+      sign = part.value
+      return
+    }
+
+    if (NUMBER_PART_TYPES.has(part.type)) {
+      hasNumber = true
+      number += part.value
+      return
+    }
+
+    if (part.type === 'currency') {
+      if (hasNumber) {
+        currencyAfter += part.value
+      } else {
+        currencyBefore += part.value
+      }
+      return
+    }
+
+    if (part.type === 'percentSign') {
+      percent += part.value
+      return
+    }
+
+    if (part.type === 'literal') {
+      if (percent) {
+        return
+      }
+
+      if (hasNumber && parts[index + 1]?.type === 'compact') {
+        number += part.value
+        return
+      }
+
+      if (hasNumber) {
+        spacingAfterNumber += part.value
+      } else {
+        spacingBeforeNumber += part.value
+      }
+    }
+  })
+
+  if (!hasNumber) {
+    return null
+  }
+
+  const currency =
+    type === 'currency' ? currencyBefore || currencyAfter || null : null
+
+  if (percent) {
+    const percentIndex = parts.findIndex(
+      ({ type }) => type === 'percentSign'
+    )
+    const previousPart = parts[percentIndex - 1]
+    if (previousPart?.type === 'literal') {
+      percentSpacing = previousPart.value
+    }
+  }
+
+  return {
+    sign,
+    signedNumber: sign ? `${sign}${number}` : number,
+    number,
+    currency,
+    currencyPosition: currencyBefore
+      ? 'before'
+      : currencyAfter
+        ? 'after'
+        : null,
+    spaceAfterCurrency: Boolean(currencyBefore && spacingBeforeNumber),
+    spaceBeforeCurrency: Boolean(currencyAfter && spacingAfterNumber),
+    percent: percent || null,
+    percentSpacing,
+  }
+}
 
 function parseParts(
   input: string,
@@ -108,8 +219,9 @@ function parseParts(
   }
 
   let number = numberMatch[0].trim()
-  const before = afterSign.slice(0, numberMatch.index).trim()
-  let after = afterSign.slice(numberMatch.index! + numberMatch[0].length)
+  const numberIndex = numberMatch.index ?? 0
+  const before = afterSign.slice(0, numberIndex).trim()
+  let after = afterSign.slice(numberIndex + numberMatch[0].length)
 
   if (compact && !PERCENT_RE.test(after)) {
     const compactMatch = after.match(

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
@@ -10,6 +10,7 @@ import { cleanNumber } from './cleanNumber'
 import { formatDecimals } from './decimals'
 import {
   formatNumberCore,
+  formatNumberCoreParts,
   prepareMinus,
   enhanceSR,
 } from './formatNumberCore'
@@ -29,6 +30,17 @@ import type {
   FormatPartItem,
   FormattedParts,
 } from './types'
+
+const returnValueParts = new WeakMap<
+  NumberFormatReturnValue,
+  FormatPartItem[]
+>()
+
+export function getReturnValueParts(
+  value: NumberFormatReturnValue
+): FormatPartItem[] | undefined {
+  return returnValueParts.get(value)
+}
 
 /**
  * Normalises locale (handles `null` + `auto`).
@@ -90,6 +102,7 @@ export function buildReturn({
   opts,
   cleanCopyValue,
   invalidAriaText,
+  parts,
 }: {
   value: NumberFormatValue
   locale: string
@@ -99,6 +112,7 @@ export function buildReturn({
   opts: InternalNumberFormatOptions
   cleanCopyValue: boolean | null
   invalidAriaText: string | null
+  parts?: FormatPartItem[]
 }): NumberFormatReturnValue {
   let cleanedValue
 
@@ -135,7 +149,20 @@ export function buildReturn({
       'N/A'
   }
 
-  return { value, cleanedValue, number: display, aria, locale, type }
+  const result = {
+    value,
+    cleanedValue,
+    number: display,
+    aria,
+    locale,
+    type,
+  }
+
+  if (parts) {
+    returnValueParts.set(result, parts)
+  }
+
+  return result
 }
 
 /**
@@ -156,7 +183,7 @@ export function applyDecimalsForPlain({
     return formatDecimals(value, decimals, rounding, opts)
   } else if (typeof opts.maximumFractionDigits === 'undefined') {
     // if no decimals are set, opts.maximumFractionDigits is set
-    // why do we this? because the ".toLocaleString" will else use 3 as the default
+    // because Intl.NumberFormat otherwise uses 3 as the default
     opts.maximumFractionDigits = 20
   }
   return value
@@ -166,6 +193,7 @@ export {
   cleanNumber,
   formatDecimals,
   formatNumberCore,
+  formatNumberCoreParts,
   prepareMinus,
   enhanceSR,
   handleCompactBeforeDisplay,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCore.ts
@@ -12,6 +12,7 @@ import {
   formatNumberCore,
   formatNumberCoreParts,
   prepareMinus,
+  prepareMinusParts,
   enhanceSR,
 } from './formatNumberCore'
 import { getThousandsSeparator } from './separators'
@@ -195,6 +196,7 @@ export {
   formatNumberCore,
   formatNumberCoreParts,
   prepareMinus,
+  prepareMinusParts,
   enhanceSR,
   handleCompactBeforeDisplay,
   handleCompactBeforeAria,

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
@@ -16,6 +16,7 @@ import {
   cleanNumber,
   formatDecimals,
   formatNumberCore,
+  formatNumberCoreParts,
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
@@ -26,6 +27,33 @@ import {
 import { currencyPositionFormatter } from './currencyPosition'
 import { getFallbackCurrencyDisplay, CURRENCY } from './currencyDisplay'
 import { alignCurrencySymbol } from './formatNumberCore'
+
+function joinParts(parts: FormatPartItem[]): string {
+  return parts.reduce((acc, { value }) => acc + value, '')
+}
+
+function trimBoundaryLiterals(parts: FormatPartItem[]): FormatPartItem[] {
+  const nextParts = parts.filter((item) => item.value)
+
+  while (
+    nextParts[0]?.type === 'literal' &&
+    nextParts[0].value.trim() === ''
+  ) {
+    nextParts.shift()
+  }
+
+  while (nextParts.length > 0) {
+    const lastPart = nextParts[nextParts.length - 1]
+
+    if (lastPart.type !== 'literal' || lastPart.value.trim() !== '') {
+      break
+    }
+
+    nextParts.pop()
+  }
+
+  return nextParts
+}
 
 export function formatCurrency(
   value: NumberFormatValue | null | undefined,
@@ -143,15 +171,35 @@ export function formatCurrency(
     )
   }
 
-  let display = formatNumberCore(cleanedNumber, locale, opts, formatter)
-  display = prepareMinus(display, locale)
+  const formatted = formatNumberCoreParts(
+    cleanedNumber,
+    locale,
+    opts,
+    formatter
+  )
+  let display = prepareMinus(formatted.number, locale)
+  let parts = display === formatted.number ? formatted.parts : undefined
 
   if (resolvedPosition && currencySuffix) {
     if (resolvedPosition === 'after') {
       display = `${display.trim()} ${currencySuffix}`
+      parts = parts && [
+        ...trimBoundaryLiterals(parts),
+        { type: 'literal', value: ' ' },
+        { type: 'currency', value: currencySuffix },
+      ]
     } else if (resolvedPosition === 'before') {
       display = `${currencySuffix} ${display.trim()}`
+      parts = parts && [
+        { type: 'currency', value: currencySuffix },
+        { type: 'literal', value: ' ' },
+        ...trimBoundaryLiterals(parts),
+      ]
     }
+  }
+
+  if (parts && joinParts(parts) !== display) {
+    parts = undefined
   }
 
   handleCompactBeforeAria({ value, compact, opts })
@@ -178,5 +226,6 @@ export function formatCurrency(
     opts,
     cleanCopyValue,
     invalidAriaText,
+    parts,
   })
 }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatCurrency.ts
@@ -20,7 +20,7 @@ import {
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
-  prepareMinus,
+  prepareMinusParts,
   resolveLocale,
   enhanceSR,
 } from './formatCore'
@@ -177,8 +177,13 @@ export function formatCurrency(
     opts,
     formatter
   )
-  let display = prepareMinus(formatted.number, locale)
-  let parts = display === formatted.number ? formatted.parts : undefined
+  const prepared = prepareMinusParts(
+    formatted.number,
+    formatted.parts,
+    locale
+  )
+  let display = prepared.number
+  let parts = prepared.parts.length ? prepared.parts : undefined
 
   if (resolvedPosition && currencySuffix) {
     if (resolvedPosition === 'after') {

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
@@ -14,6 +14,7 @@ import {
   buildReturn,
   cleanNumber,
   formatNumberCore,
+  formatNumberCoreParts,
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
@@ -58,8 +59,9 @@ export function formatNumber(
 
   handleCompactBeforeDisplay({ value, locale, compact, decimals, opts })
 
-  let display = formatNumberCore(value, locale, opts)
-  display = prepareMinus(display, locale)
+  const formatted = formatNumberCoreParts(value, locale, opts)
+  const display = prepareMinus(formatted.number, locale)
+  const parts = display === formatted.number ? formatted.parts : undefined
 
   handleCompactBeforeAria({ value, compact, opts })
 
@@ -80,5 +82,6 @@ export function formatNumber(
     opts,
     cleanCopyValue,
     invalidAriaText,
+    parts,
   })
 }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumber.ts
@@ -18,7 +18,7 @@ import {
   handleCompactBeforeAria,
   handleCompactBeforeDisplay,
   prepareFormatOptions,
-  prepareMinus,
+  prepareMinusParts,
   resolveLocale,
   enhanceSR,
 } from './formatCore'
@@ -60,8 +60,11 @@ export function formatNumber(
   handleCompactBeforeDisplay({ value, locale, compact, decimals, opts })
 
   const formatted = formatNumberCoreParts(value, locale, opts)
-  const display = prepareMinus(formatted.number, locale)
-  const parts = display === formatted.number ? formatted.parts : undefined
+  const { number: display, parts } = prepareMinusParts(
+    formatted.number,
+    formatted.parts,
+    locale
+  )
 
   handleCompactBeforeAria({ value, compact, opts })
 
@@ -82,6 +85,6 @@ export function formatNumber(
     opts,
     cleanCopyValue,
     invalidAriaText,
-    parts,
+    parts: parts.length ? parts : undefined,
   })
 }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
@@ -154,6 +154,36 @@ export const prepareMinus = (
   return display
 }
 
+export function prepareMinusParts(
+  display: string,
+  parts: FormatPartItem[] | undefined,
+  locale: string | null
+): FormatNumberCoreResult {
+  const number = prepareMinus(display, locale)
+
+  if (!parts || number === display) {
+    return { number, parts: parts ?? [] }
+  }
+
+  const nextParts = parts.map((part) => {
+    if (
+      part.type === 'minusSign' &&
+      display.startsWith(part.value) &&
+      number.startsWith('-')
+    ) {
+      return { ...part, value: '-' }
+    }
+
+    return part
+  })
+
+  if (joinParts(nextParts) === number) {
+    return { number, parts: nextParts }
+  }
+
+  return { number, parts: [] }
+}
+
 /**
  * Enhance VoiceOver support on mobile devices.
  * Numbers under 99.999 are read out correctly, but only if we remove the spaces.

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
@@ -25,12 +25,7 @@ function toIntlOptions({
   return rest
 }
 
-/**
- * For internal usage.
- * Returns an array that contains all the parts of the given number
- * `[{ value, type }]`.
- */
-export function formatToParts({
+function getFormatParts({
   number,
   locale = null,
   options = null,
@@ -43,25 +38,64 @@ export function formatToParts({
     typeof Intl !== 'undefined' &&
     typeof Intl.NumberFormat === 'function'
   ) {
-    try {
-      const inst = new Intl.NumberFormat(
-        locale || LOCALE,
-        toIntlOptions(options || {})
-      )
-      if (typeof inst.formatToParts === 'function') {
-        return inst.formatToParts(Number(number))
-      } else {
-        return [{ value: inst.format(Number(number)), type: 'unknown' }]
-      }
-    } catch (e) {
-      warn(
-        'NumberFormat: Failed to format number with Intl.NumberFormat:',
-        e
-      )
+    const inst = new Intl.NumberFormat(
+      locale || LOCALE,
+      toIntlOptions(options || {})
+    )
+    if (typeof inst.formatToParts === 'function') {
+      return inst.formatToParts(Number(number))
     }
+    return [{ value: inst.format(Number(number)), type: 'unknown' }]
   }
 
   return [{ value: String(number), type: 'unknown' }]
+}
+
+/**
+ * For internal usage.
+ * Returns an array that contains all the parts of the given number
+ * `[{ value, type }]`.
+ */
+export function formatToParts(args: {
+  number: NumberFormatValue
+  locale?: string | null
+  options?: InternalNumberFormatOptions | null
+}): FormatPartItem[] {
+  try {
+    return getFormatParts(args)
+  } catch (e) {
+    warn(
+      'NumberFormat: Failed to format number with Intl.NumberFormat:',
+      e
+    )
+  }
+
+  return [{ value: String(args.number), type: 'unknown' }]
+}
+
+export type FormatNumberCoreResult = {
+  number: string
+  parts: FormatPartItem[]
+}
+
+function joinParts(parts: FormatPartItem[]): string {
+  return parts.reduce((acc, { value }) => acc + value, '')
+}
+
+function alignParts(
+  parts: FormatPartItem[],
+  currencyDisplay: InternalNumberFormatOptions['currencyDisplay']
+): FormatPartItem[] {
+  return parts.map((item) => {
+    if (item.type === 'currency') {
+      return {
+        ...item,
+        value: alignCurrencySymbol(item.value, currencyDisplay),
+      }
+    }
+
+    return item
+  })
 }
 
 /**
@@ -155,7 +189,7 @@ function replaceNaNWithDash(number: string | number): string {
 
 /**
  * The main number formatter function.
- * Calls the browser/Node.js `Intl.NumberFormat` or `Number.toLocaleString` APIs.
+ * Calls the browser/Node.js `Intl.NumberFormat` API.
  */
 export const formatNumberCore = (
   number: NumberFormatValue,
@@ -163,6 +197,17 @@ export const formatNumberCore = (
   options: InternalNumberFormatOptions = {},
   formatter: PartFormatter | null = null
 ): string => {
+  return formatNumberCoreParts(number, locale, options, formatter).number
+}
+
+export const formatNumberCoreParts = (
+  number: NumberFormatValue,
+  locale: string | null,
+  options: InternalNumberFormatOptions = {},
+  formatter: PartFormatter | null = null
+): FormatNumberCoreResult => {
+  let parts: FormatPartItem[] = []
+
   try {
     if (options.currencyDisplay) {
       options.currencyDisplay = getFallbackCurrencyDisplay(
@@ -174,19 +219,14 @@ export const formatNumberCore = (
     // remove unsupported decimals
     delete options.decimals
 
-    if (formatter) {
-      number = formatToParts({ number, locale, options })
-        .map(formatter)
-        .reduce((acc: string, { value }) => acc + value, '')
-    } else if (
-      typeof Number !== 'undefined' &&
-      typeof Number.toLocaleString === 'function'
-    ) {
-      number = parseFloat(String(number)).toLocaleString(
-        locale || LOCALE,
-        toIntlOptions(options)
-      )
-    }
+    parts = getFormatParts({
+      number: formatter ? Number(number) : parseFloat(String(number)),
+      locale,
+      options,
+    }).map((item) => (formatter ? formatter(item) : item))
+    parts = alignParts(parts, options.currencyDisplay)
+    number = joinParts(parts)
+
     if (
       new RegExp(`^(${NUMBER_MINUS})(0|0[^\\d]|0\\s.*)$`).test(
         String(number)
@@ -208,7 +248,13 @@ export const formatNumberCore = (
     )
   }
 
-  return replaceNaNWithDash(
+  number = replaceNaNWithDash(
     alignCurrencySymbol(number, options.currencyDisplay)
   )
+
+  if (joinParts(parts) !== String(number)) {
+    parts = []
+  }
+
+  return { number: String(number), parts }
 }

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatPercent.ts
@@ -19,7 +19,7 @@ import {
   buildReturn,
   cleanNumber,
   formatDecimals,
-  formatNumberCore,
+  formatNumberCoreParts,
   prepareFormatOptions,
   resolveLocale,
 } from './formatCore'
@@ -71,7 +71,11 @@ export function formatPercent(
     opts.style = 'percent'
   }
 
-  const display = formatNumberCore(Number(value) / 100, locale, opts)
+  const { number: display, parts } = formatNumberCoreParts(
+    Number(value) / 100,
+    locale,
+    opts
+  )
   const aria = display
 
   if (!returnAria) {
@@ -89,5 +93,6 @@ export function formatPercent(
     opts,
     cleanCopyValue,
     invalidAriaText,
+    parts,
   })
 }


### PR DESCRIPTION
NumberFormat's parts hook relied on parsing the finished display string, which made compact suffixes, currency placement, and signs fragile across locales.

This PR carries semantic formatter parts through the standard Eufemia number, currency, and percent formatters so consumers can style number, currency, and percent segments without losing the formatter boundaries. Custom formatter objects still fall back to display-string parsing, keeping the existing hook contract and public return shape intact.