### PR TITLE
chore: rename upcoming major v12 to v13

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'v12'
+title: 'v13'
 description: 'TBA'
-order: -12
+order: -13
 draft: true
 ---
 
-# v12
+# v13
 
-- [v12](#v12)
+- [v13](#v13)
   - [Migration](#migration)
   - [Install](#install)
   - [Component changes](#component-changes)
@@ -16,18 +16,20 @@ draft: true
     - [InfoCard](#infocard)
     - [Popover](#popover)
 
+> **Note:** There is no `v12` release. The version `v12` was accidentally published to NPM and has since been removed. Because a published version number cannot be safely reused, `v12` has been skipped entirely, and these breaking changes are released as `v13` instead.
+
 ## Migration
 
-v12 of @dnb/eufemia contains _breaking changes_. As a migration process, you can simply search and replace:
+v13 of @dnb/eufemia contains _breaking changes_. As a migration process, you can simply search and replace:
 
 ## Install
 
-To upgrade to @dnb/eufemia v12 with NPM, use:
+To upgrade to @dnb/eufemia v13 with NPM, use:
 
 ```bash
-$ npm i @dnb/eufemia@12
+$ npm i @dnb/eufemia@13
 # or
-$ yarn add @dnb/eufemia@12
+$ yarn add @dnb/eufemia@13
 ```
 
 ## Component changes

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -161,7 +161,7 @@ describe('Drawer', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  // Deprecated: closeButtonAttributes – remove this test in v12
+  // Deprecated: closeButtonAttributes – remove this test in v13
   it('sends along closeButtonAttributes to close button', () => {
     render(
       <Drawer

--- a/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/__tests__/InfoCard.test.tsx
@@ -230,7 +230,7 @@ describe('InfoCard', () => {
     ).toBeInTheDocument()
   })
 
-  // Deprecated: acceptButtonAttributes – remove this test in v12
+  // Deprecated: acceptButtonAttributes – remove this test in v13
   it('renders the accept button with additional props', () => {
     const href = 'href'
 
@@ -284,7 +284,7 @@ describe('InfoCard', () => {
     expect(buttonElement.getAttribute('data-testid')).toBe('new-prop')
   })
 
-  // Deprecated: closeButtonAttributes – remove this test in v12
+  // Deprecated: closeButtonAttributes – remove this test in v13
   it('renders the close button with additional props', () => {
     const href = 'href'
 

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1564,7 +1564,7 @@ describe('Modal component', () => {
     ).toBe('dnb-modal-modal_id-content')
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('should have no icon', () => {
     render(<Modal triggerAttributes={{ text: 'Open Modal' }} />)
     expect(document.querySelector('.dnb-icon')).not.toBeInTheDocument()
@@ -1581,7 +1581,7 @@ describe('Modal component', () => {
     expect(document.querySelector('.dnb-icon')).not.toBeInTheDocument()
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('should have an icon', () => {
     render(
       <Modal
@@ -1595,7 +1595,7 @@ describe('Modal component', () => {
     expect(document.querySelector('.dnb-icon')).toBeInTheDocument()
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('should render props', () => {
     const customText = 'Custom text in camelcase'
     render(
@@ -1611,7 +1611,7 @@ describe('Modal component', () => {
     ).toBe(customText)
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('should call triggerAttributes onClick', () => {
     const onClick = vi.fn()
 
@@ -1824,7 +1824,7 @@ describe('Modal component', () => {
 describe('Modal trigger', () => {
   const roledescription = 'Hjelp-knapp'
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('will act by default as a HelpButton', () => {
     render(<Modal {...props} triggerAttributes={{ text: '' }} />)
     expect(
@@ -1834,7 +1834,7 @@ describe('Modal trigger', () => {
     ).toBe(roledescription)
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('will have a aria-label', () => {
     render(
       <Modal {...props} triggerAttributes={{ 'aria-label': 'label' }} />
@@ -1851,7 +1851,7 @@ describe('Modal trigger', () => {
     ).toBe('label')
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('will not act as a HelpButton if only triggerText was given', () => {
     render(<Modal {...props} triggerAttributes={{ text: 'text' }} />)
     expect(
@@ -1869,7 +1869,7 @@ describe('Modal trigger', () => {
     ).toBe('text')
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('will not act as a HelpButton if a different icon was given', () => {
     render(<Modal {...props} triggerAttributes={{ icon: 'bell' }} />)
     expect(
@@ -1882,7 +1882,7 @@ describe('Modal trigger', () => {
     ).toBeInTheDocument()
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('will not act as a HelpButton if trigger text was given', () => {
     render(<Modal {...props} triggerAttributes={{ text: 'text' }} />)
     expect(

--- a/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
+++ b/packages/dnb-eufemia/src/components/popover/__tests__/Popover.test.tsx
@@ -1447,7 +1447,7 @@ describe('Popover', () => {
     expect(popoverElement).toHaveClass('dnb-popover--no-inner-space')
   })
 
-  // Deprecated: triggerAttributes – remove this test in v12
+  // Deprecated: triggerAttributes – remove this test in v13
   it('merges triggerAttributes with defaults and triggerClassName', async () => {
     const triggerOnClick = vi.fn()
     renderWithTrigger({

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -152,7 +152,7 @@ export type DrawerListProps = {
   cacheHash?: string
   /**
    * Position of the arrow on the popup drawer. Set to `left` or `right`. Defaults to `left` if not set.
-   * @deprecated does nothing as there is no longer any arrow, and will be removed in v12.
+   * @deprecated does nothing as there is no longer any arrow, and will be removed in v13.
    */
   arrowPosition?: string
   /**

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -95,7 +95,7 @@ describe('DrawerList component', () => {
     ).toBeInTheDocument()
   })
 
-  // TODO: remove this test in v12 when the deprecated arrowPosition prop is removed
+  // TODO: remove this test in v13 when the deprecated arrowPosition prop is removed
   it('does not forward the deprecated arrowPosition prop to the DOM', () => {
     render(
       <DrawerList


### PR DESCRIPTION
v12 was accidentally published to NPM and removed, so the version number cannot be reused. Skip v12 and release the changes as v13 instead. Renames v12-info.mdx to v13-info.mdx, updates all v12 references in docs and deprecation comments, and adds a note explaining why v12 is skipped.

