### PR TITLE
chore(ci): remove duplicate scope in dependabot commit titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
-      include: 'scope'
     # Groups apply to scheduled updates (not security updates). Ready for when
     # open-pull-requests-limit is raised above 0.
     groups:
@@ -61,7 +60,6 @@ updates:
       - 'dependencies'
     commit-message:
       prefix: 'chore(ci)'
-      include: 'scope'
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Why

After enabling Conventional-Commit-style prefixes for Dependabot, PR titles came out with the scope duplicated:

```
chore(deps-dev)(deps-dev): bump @babel/core from 7.28.5 to 7.29.6
```

That is caused by combining `prefix` / `prefix-development` (which already contains a parenthesized scope like `chore(deps-dev)`) with `include: scope`, which appends the dep category (`deps` / `deps-dev`) as a second scope. This is a long-standing Dependabot behavior — see [dependabot/dependabot-core#1666](https://github.com/dependabot/dependabot-core/issues/1666).

## What

Drop `include: scope` from both the npm and github-actions entries. The prefixes already carry the scope.

## Result

- dev dep bump → `chore(deps-dev): bump @babel/core from 7.28.5 to 7.29.6`
- prod dep bump → `chore(deps): bump react from 18.x to 19.x`
- action bump → `chore(ci): bump actions/checkout from 4 to 5`

Existing open Dependabot PRs keep their old titles until recreated (`@dependabot recreate`).