### PR TITLE
chore(Autocomplete): cover show-all numeric crash across more triggers

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1303,6 +1303,79 @@ describe('Autocomplete component', () => {
     ).toHaveLength(4)
   })
 
+  it('does not crash with disableFilter when searching a full number with whitespace', () => {
+    const mockData = [
+      formatBankAccountNumber(20001234567),
+      formatBankAccountNumber(22233344425),
+      formatCurrency(1234.5),
+      formatPhoneNumber('+47116000'),
+    ] as DrawerListData
+
+    render(
+      <Autocomplete
+        data={mockData}
+        searchNumbers
+        disableFilter
+        showSubmitButton
+        {...mockProps}
+      />
+    )
+
+    toggle()
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '2000 12 34567' },
+    })
+
+    expect(
+      document.querySelectorAll(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+    ).toHaveLength(4)
+  })
+
+  it('does not crash when showing all with nested content after searching a full number with whitespace', () => {
+    const mockData = [
+      {
+        selectedKey: 'a',
+        content: <span>{formatBankAccountNumber(20001234567)}</span>,
+      },
+      {
+        selectedKey: 'b',
+        content: <span>{formatBankAccountNumber(22233344425)}</span>,
+      },
+    ] as DrawerListData
+
+    render(
+      <Autocomplete
+        data={mockData}
+        searchNumbers
+        showSubmitButton
+        {...mockProps}
+      />
+    )
+
+    toggle()
+
+    fireEvent.change(document.querySelector('.dnb-input__input'), {
+      target: { value: '2000 12 34567' },
+    })
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(2)
+
+    fireEvent.click(
+      document.querySelector('li.dnb-autocomplete__show-all')
+    )
+
+    expect(
+      document.querySelectorAll(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+    ).toHaveLength(2)
+  })
+
   it('has correct options when using searchNumbers, and searching with æøå', () => {
     const mockData = [
       ['Åge Ørn Ærlig', formatNumber('12345678901')],


### PR DESCRIPTION
PR #8605 fixed the 'Objects are not valid as a React child' crash for spaced numeric searches, but only tested the show-all button path. The same fix also guards other triggers that previously crashed:

- disableFilter + searchNumbers, which crashes on every keystroke with no user interaction
- options with nested React content on show-all

Add regression tests for these to lock in the fixed behavior.

