### PR TITLE
chore(Autocomplete): do not show loading spinner when icon is null

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/methods.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/methods.mdx
@@ -12,7 +12,7 @@ You can manipulate the used data dynamically, either by changing the `data` prop
 - `setInputValue` update the input value.
 - `clearInputValue` will set the current input value to an empty string.
 - `focusInput` will set focus on the input element.
-- `showIndicator` shows a progress indicator instead of the icon (inside the input).
+- `showIndicator` shows a progress indicator instead of the icon (inside the input). When `icon={null}` is set, no progress indicator is shown.
 - `hideIndicator` hides the progress indicator inside the input.
 - `showIndicatorItem` shows an item with a [ProgressIndicator](/uilib/components/progress-indicator) status as a data option item.
 - `showNoOptionsItem` shows the "no entries found" status as a data option item.

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -2546,7 +2546,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
             ) : (
               <Input
                 icon={
-                  visibleIndicator ? (
+                  visibleIndicator && icon ? (
                     <ProgressIndicator
                       size={size === 'large' ? 'medium' : 'small'}
                     />

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -77,7 +77,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     status: 'optional',
   },
   icon: {
-    doc: 'To be included in the autocomplete input.',
+    doc: 'To be included in the autocomplete input. Defaults to `loupe`. Set to `null` to remove the icon entirely – no progress indicator will then be shown while loading.',
     type: ['string', 'React.ReactNode'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -3037,6 +3037,67 @@ describe('Autocomplete component', () => {
     ).toBe('c value')
   })
 
+  describe('indicator', () => {
+    const onTypeHandler = ({ showIndicator }) => {
+      showIndicator()
+    }
+
+    it('shows a ProgressIndicator as the input icon while loading', async () => {
+      render(
+        <Autocomplete
+          {...mockProps}
+          mode="async"
+          data={mockData}
+          onType={onTypeHandler}
+          showSubmitButton
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'aa' },
+      })
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-input__icon .dnb-progress-indicator'
+          )
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('does not show a ProgressIndicator while loading when icon is null', async () => {
+      render(
+        <Autocomplete
+          {...mockProps}
+          mode="async"
+          data={mockData}
+          icon={null}
+          onType={onTypeHandler}
+          showSubmitButton
+        />
+      )
+
+      toggle()
+
+      fireEvent.change(document.querySelector('.dnb-input__input'), {
+        target: { value: 'aa' },
+      })
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-autocomplete--show-indicator')
+        ).toBeInTheDocument()
+      })
+
+      expect(
+        document.querySelector('.dnb-progress-indicator')
+      ).not.toBeInTheDocument()
+    })
+  })
+
   it('will filter items with current value after data prop has changed', async () => {
     const mockDataA = ['first', 'foo']
     const mockDataB = ['second', 'bar', 'baz']


### PR DESCRIPTION
Can be experienced by passing `icon={null}` (icon={null} is used in an other example as well, and seems to be something we support) in [this example](https://eufemia.dnb.no/uilib/components/autocomplete/#async-usage-dynamically-update-data-during-typing):


https://github.com/user-attachments/assets/aaf8105d-9c26-4fbe-9c93-01907e4ed588

