### PR TITLE
chore(forms): sync JSDoc comments with Docs definitions for Iterate, Wizard and Value

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/types.ts
@@ -31,39 +31,69 @@ export type IterateArrayProps = Omit<
     | 'validateContinuously'
     | 'schema'
   > & {
-    /** Render function or React nodes for each array item. When a function, receives `(value, index, arrayItems)`. */
+    /**
+     * `React.ReactNode` or a function so you can get the current value as the first function parameter, and the index as the second parameter as well as the array of internal items as the third parameter.
+     */
     children: ElementChild | Array<ElementChild>
-    /** JSON Pointer path to the array data in the form data context. */
+    /**
+     * A path (JSON Pointer) to the array to iterate over.
+     */
     path?: Path
-    /** JSON Pointer sub-path within each array item for value access. */
+    /**
+     * A path (JSON Pointer) to nested array items.
+     */
     itemPath?: Path
-    /** Maximum number of items to render from the array. */
+    /**
+     * Limit the number of rendered items to iterate over. Defaults to `undefined`.
+     */
     limit?: number
-    /** If `true`, renders array items in reverse order. */
+    /**
+     * When `true` it will reverse the order of the items.
+     */
     reverse?: boolean
-    /** JSON Pointer path to a counter value that tracks the number of items. */
+    /**
+     * A path (JSON Pointer) to the array length.
+     */
     countPath?: Path
-    /** Maximum value the counter at `countPath` can reach. */
+    /**
+     * Will limit the iterate amount by given "countPathLimit" value.
+     */
     countPathLimit?: number
-    /** Minimum number of items required. Triggers a validation error if fewer. */
+    /**
+     * The minimum amount of items required to iterate over.
+     */
     minItems?: number
-    /** Maximum number of items allowed. Triggers a validation error if more. */
+    /**
+     * The maximum amount of items to iterate over before showing the error.
+     */
     maxItems?: number
     /** Custom validator function called when the array value changes. */
     onChangeValidator?: Validator<Value>
-    /** If `true`, renders children without a Flex container wrapper. */
+    /**
+     * When `true` it will omit the Flex.Stack wrapper so it can be used for tables and lists.
+     */
     withoutFlex?: boolean
-    /** If `true`, animates item additions and removals. */
+    /**
+     * When `true` it will animate the height of the items.
+     */
     animate?: boolean
-    /** Content to display when the array is empty. */
+    /**
+     * Will be shown if the value or data context value is empty.
+     */
     placeholder?: ReactNode
-    /** Controls the initial display mode for items: `view`, `edit`, or `auto`. */
+    /**
+     * Defines the container mode for all nested containers. Can be `view`, `edit` or `auto`. When using `auto`, it will automatically open if there is an error in the container. When a new item is added, the item before it will change to `view` mode, if it had no validation errors. Defaults to `auto`.
+     */
     containerMode?: ContainerMode
-    /** If `true`, at least one item is required. */
+    /**
+     * If the array is required. It does not automatically inherit the `required` property in the same way that `Field.*` components do. You may provide a custom error message to give the user a more useful message than the default one: `errorMessages={{ 'Field.errorRequired': 'Custom message' }}`.
+     */
     required?: boolean
     /** Custom error messages for validation states. */
     errorMessages?: DefaultErrorMessages
-    /** Transform function applied to each item before updating the count path. */
+    /**
+     * Will transform the current value before it is displayed.
+     */
     countPathTransform?: (params: { value: any; index: number }) => any
 
     // internal

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainer.tsx
@@ -16,27 +16,27 @@ import withComponentMarkers from '../../../../shared/helpers/withComponentMarker
 
 export type IterateEditContainerProps = {
   /**
-   * The title of the EditContainer.
+   * The title of the container.
    */
   title?: ReactNode
 
   /**
-   * The title for a new item show within the EditContainer.
+   * The title for a new item.
    */
   titleWhenNew?: ReactNode
 
   /**
-   * If the EditContainer is open or not.
+   * If the container should be open or not. This is taken care of internally by default.
    */
   open?: boolean
 
   /**
-   * An alternative toolbar to be shown in the EditContainer.
+   * An alternative toolbar to be shown in the container.
    */
   toolbar?: ReactNode
 
   /**
-   * The variant of the toolbar.
+   * Use variants to render the toolbar differently. Currently there are the `minimumOneItem` and `custom` variants. See the info section for more info.
    */
   toolbarVariant?: ArrayItemAreaProps['toolbarVariant']
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -51,7 +51,9 @@ type OnlyPathRequired = {
    */
   path: Path
 
-  /** The sub path to the array to add the new item to. */
+  /**
+   * The path to the item in a nested array, to add the new item to.
+   */
   itemPath?: Path
 }
 
@@ -61,7 +63,9 @@ type OnlyItemPathRequired = {
    */
   path?: Path
 
-  /** The sub path to the array to add the new item to. */
+  /**
+   * The path to the item in a nested array, to add the new item to.
+   */
   itemPath: Path
 }
 
@@ -96,17 +100,17 @@ export type IteratePushContainerProps = (
   showOpenButtonWhen?: (list: unknown[]) => boolean
 
   /**
-   * Prefilled data to add to the fields. The data will be put into this path: "/pushContainerItems/0".
+   * Prefilled data to be used by fields. The data will be put into this path: `/pushContainerItems/0`. Use `defaultData` when possible.
    */
   data?: unknown | Record<string, unknown>
 
   /**
-   * Prefilled data to add to the fields. The data will be put into this path: "/pushContainerItems/0".
+   * Prefilled data to be used by fields. The data will be put into this path: `/pushContainerItems/0`.
    */
   defaultData?: unknown | Record<string, unknown>
 
   /**
-   * Provide additional data that will be put into the root of the isolated data context (parallel to "/pushContainerItems/0").
+   * Provide additional data that will be put into the root of the isolated data context (parallel to `/pushContainerItems/0`).
    */
   isolatedData?: Record<string, unknown>
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainer.tsx
@@ -15,17 +15,17 @@ import withComponentMarkers from '../../../../shared/helpers/withComponentMarker
 
 export type IterateViewContainerProps = {
   /**
-   * The title of the ViewContainer.
+   * The title of the container.
    */
   title?: ReactNode
 
   /**
-   * An alternative toolbar to be shown in the ViewContainer.
+   * An alternative toolbar to be shown in the container.
    */
   toolbar?: ReactNode
 
   /**
-   * The variant of the toolbar.
+   * Use variants to render the toolbar differently. Currently there are the `minimumOneItem` and `custom` variants. See the info section for more info.
    */
   toolbarVariant?: ArrayItemAreaProps['toolbarVariant']
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/BankAccountNumber/BankAccountNumber.tsx
@@ -13,7 +13,7 @@ export type { BankAccountType } from '../../../../components/number-format/utils
 
 export type ValueBankAccountNumberProps = StringValueProps & {
   /**
-   * The type of bank account number for formatting. Defaults to `norwegianBban`.
+   * The type of bank account number, used for label and formatting. Can be `norwegianBban`, `swedishBban`, `swedishBankgiro`, `swedishPlusgiro`, or `iban`. Defaults to `norwegianBban`.
    */
   bankAccountType?: BankAccountType
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -57,32 +57,32 @@ export type WizardContainerProps = ComponentProps & {
   id?: string
 
   /**
-   * The mode of the wizard.
+   * How to show the wizard. Inherited from StepIndicator. Defaults to `strict`.
    */
   mode?: 'static' | 'strict' | 'loose'
 
   /**
-   * If set to `true`, the wizard will not scroll to the first step when the user clicks on the next button.
+   * If set to `true`, the wizard will not scroll to the first step when the user navigates to a different step.
    */
   omitScrollManagement?: boolean
 
   /**
-   * If set to `true`, the wizard will not focus on the next step when the user clicks on the next button.
+   * If set to `true`, the wizard will not set focus on the next step when the user navigates to a different step.
    */
   omitFocusManagement?: boolean
 
   /**
-   * The index of the first step to be rendered.
+   * What step should show initially (defaults to `0` for the first one).
    */
   initialActiveIndex?: StepIndex
 
   /**
-   * The callback function that will be called when the user clicks on the next button.
+   * Will be called when the user navigates to a different step, with step `index` as the first argument and `previous` or `next` (or `stepListModified` when a step gets replaced) as the second argument, and as the third parameter an options object containing `totalSteps`, a `preventNavigation` function, an `id` if given on the `Wizard.Step` and a `previousStep` object containing the previous `index` (and `id` if given on the `Wizard.Step`). When an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for a minimum of 1 second. Related Form.Handler properties: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`.
    */
   onStepChange?: OnStepChange
 
   /**
-   * If set to `true`, the wizard will not animate the steps.
+   * If set to `true`, the height animation on step change and list expansion will be omitted. Inherited from StepIndicator. Defaults to `false`.
    */
   noAnimation?: boolean
   /**
@@ -90,11 +90,11 @@ export type WizardContainerProps = ComponentProps & {
    */
   expandedInitially?: boolean
   /**
-   * If set to `true`, the wizard will not unmount the steps when navigating back and forth.
+   * Determines if all steps should be kept in the DOM. Defaults to `false`.
    */
   keepInDOM?: boolean
   /**
-   * Whether or not to break out (using negative margins) on larger screens. Defaults to `true`.
+   * Whether or not to break out (using negative margins) on larger screens. Same as `outset` in [Card](/uilib/components/card/properties). But defaults to `true`.
    */
   outset?: boolean
   /**
@@ -109,7 +109,7 @@ export type WizardContainerProps = ComponentProps & {
   validationMode?: 'bypassOnNavigation'
 
   /**
-   * The children of the wizard container.
+   * Contents (Step components).
    */
   children: ReactNode
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
@@ -12,12 +12,12 @@ export const WizardContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   omitScrollManagement: {
-    doc: 'True to omit scroll management.',
+    doc: 'If set to `true`, the wizard will not scroll to the first step when the user navigates to a different step.',
     type: 'boolean',
     status: 'optional',
   },
   omitFocusManagement: {
-    doc: 'True to omit focus management.',
+    doc: 'If set to `true`, the wizard will not set focus on the next step when the user navigates to a different step.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/Step.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/Step.tsx
@@ -30,7 +30,7 @@ export type WizardStepProps = ComponentProps &
     index?: number
 
     /**
-     * Will make all the fields inside the step to be required.
+     * Will make all nested form fields required.
      */
     required?: boolean
 
@@ -40,7 +40,7 @@ export type WizardStepProps = ComponentProps &
 
     include?: boolean
     /**
-     * Provide a `path` and a `hasValue` property with the expected value in order to enable the step. You can alternatively provide a `hasValue` function that returns a boolean. The first parameter is the value of the path.
+     * Provide a `path` or `itemPath` together with `hasValue` or `isValid` in order to enable the step. `hasValue` can be a value or a function that returns a boolean. `isValid` uses the validation state of the referenced field.
      */
     includeWhen?: VisibleWhen
 


### PR DESCRIPTION
Align JSDoc property descriptions with the doc strings in their sibling *Docs files, via the docs-types/sync-docs-jsdoc rule.

