### PR TITLE
chore(forms): sync JSDoc comments with Docs definitions for Form, DataContext, FieldBlock and hooks

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/At/At.tsx
@@ -14,7 +14,9 @@ import DataContextRefContext from '../DataContextRefContext'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type DataContextAtProps = ComponentProps & {
-  /** JSON Pointer for where in the source dataset to point at in sub components */
+  /**
+   * JSON Pointer path to where in the outer DataContext source to point at.
+   */
   path?: string
   iterate?: boolean
   children?: ReactNode

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -91,19 +91,19 @@ export type SharedAttachments<Data = unknown> = {
 export type DataContextProviderProps<Data extends JsonObject> =
   IsolationProviderProps<Data> & {
     /**
-     * Unique ID to communicate with the hook Form.useData
+     * Unique id for connecting Form.Handler and helper tools such as Form.useData.
      */
     id?: SharedStateId
     /**
-     * Unique ID to connect with a GlobalStatus
+     * If needed, you can define a custom [GlobalStatus](/uilib/components/global-status) id. Defaults to `main`.
      */
     globalStatusId?: string
     /**
-     * Source data, will be used instead of defaultData, and leading to updates if changed after mount
+     * Dynamic source data used as both initial data, and updates internal data if changed after mount.
      */
     data?: Data
     /**
-     * Default source data, only used if no other source is available, and not leading to updates if changed after mount
+     * Default source data is used only when no other source is provided and does not trigger updates after mount. Initializing fields with an empty value is optional. If you do, use the field's `emptyValue`, which is often `undefined`.
      */
     defaultData?: Data
     /**
@@ -111,32 +111,31 @@ export type DataContextProviderProps<Data extends JsonObject> =
      */
     emptyData?: unknown
     /**
-     * JSON Schema to validate the data against.
+     * JSON Schema for validation of the data set. IMPORTANT: When using JSON Schema validation, you MUST provide an `ajvInstance` property.
      */
     schema?: Schema<Data>
     /**
-     * Custom Ajv instance, if you want to use your own
+     * REQUIRED when using JSON Schema validation. Provide your own custom Ajv instance: `import Ajv from "@dnb/eufemia/extensions/forms"` and pass `ajvInstance={makeAjvInstance()}`. This ensures your bundle only includes AJV when you actually need it. More info in the [Schema validation](/uilib/extensions/forms/Form/schema-validation/#custom-ajv-instance-and-keywords) section.
      */
     ajvInstance?: AjvInstance
     /**
-     * Custom error messages for the whole data set
+     * Object containing error messages by either type of JSON Pointer path and type. The messages can be a `React.ReactNode` or a string.
      */
     errorMessages?: GlobalErrorMessagesWithPaths
     /**
-     * Transform the data context (internally as well) based on your criteria: `({ path, value, data, props, internal }) => 'new value'`. It will iterate on each data entry (/path).
+     * Mutate the data context (internally as well) based on your criteria: `({ path, value, data, properties, internal }) => 'new value'`. It will iterate on each data entry (/path).
      */
     transformIn?: TransformData
     /**
-     * Mutate the data before it enters onSubmit or onChange based on your criteria: `({ path, value, data, props, internal }) => 'new value'`. It will iterate on each data entry (/path).
+     * Mutate the data before it enters `onSubmit` or `onChange` based on your criteria: `({ path, value, data, properties, internal }) => 'new value'`. It will iterate on each data entry (/path).
      */
     transformOut?: TransformData
     /**
-     * Change handler for the whole data set.
-     * You can provide an async function to show an indicator on the current label during a field change.
+     * Will be called when a value of a field was changed by the user, with the data set (including the changed value) as argument. When an async function is provided, it will show an indicator on the current label during a field change. Related properties: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`. You can return an error or an object with these keys `{ info: 'Info message', warning: 'Warning message', error: Error('My error') } as const` in addition to { success: 'saved' } indicate the field was saved. Will emit unvalidated by default and validated when an async function is provided (like `onSubmit`). The second parameter is an object containing the `filterData`, `resetForm` and `clearData` functions.
      */
     onChange?: OnChange<Data>
     /**
-     * Change handler for each value
+     * Will be called when a value of a field was changed by the user, with the `path` (JSON Pointer) and new `value` as arguments. Can be an async function. Will emit unvalidated by default and validated when `onChange` is an async function.
      */
     onPathChange?: (
       path: Path,
@@ -146,16 +145,15 @@ export type DataContextProviderProps<Data extends JsonObject> =
       | void
       | Promise<EventReturnWithStateObject | void>
     /**
-     * Will emit on a form submit – if validation has passed.
-     * You can provide an async function to shows a submit indicator during submit. All form elements will be disabled during the submit.
+     * Will be called (on validation success) when the user submits the form (e.g. by clicking a [Form.SubmitButton](/uilib/extensions/forms/Form/SubmitButton) component inside), with the data set as argument. When an async function is provided, it will show an indicator on the submit button during the form submission. All form elements will be disabled during the submit. The indicator will be shown for a minimum of 1 second. Related properties: `minimumAsyncBehaviorTime` and `asyncSubmitTimeout`. You can return an error or an object with these keys `{ status: 'pending', info: 'Info message', warning: 'Warning message', error: Error('My error') } as const` to be shown in a [FormStatus](/uilib/components/form-status). Will only emit when every validation has passed. The second parameter is an object containing the `filterData`, `reduceToVisibleFields`, `transformData`, `resetForm` and `clearData` functions.
      */
     onSubmit?: OnSubmit<Data>
     /**
-     * Submit was requested, but data was invalid
+     * Will be called when the user tries to submit, but errors stop the data from being submitted. The first parameter is an object containing the `getErrors` method, returning an array with field errors. Each error object contains the `path`, `error` and `properties` of the field. You can use this to log the errors before the form is submitted. You can return an error or an object with these keys `{ info: 'Info message', warning: 'Warning message', error: Error('My error') } as const` to be shown in a [FormStatus](/uilib/components/form-status) at the form level. Supports async functions.
      */
     onSubmitRequest?: OnSubmitRequest
     /**
-     * Will be called when the onSubmit is finished and had not errors
+     * Will be called after onSubmit has finished and had no errors. It supports the same return values as `onSubmit` and will be merged together.
      */
     onSubmitComplete?: (
       data: Data,
@@ -173,19 +171,19 @@ export type DataContextProviderProps<Data extends JsonObject> =
      */
     onUpdateDataValue?: ContextState['updateDataValue']
     /**
-     * Minimum time to display the submit indicator.
+     * Minimum time to display the submit indicator. Defaults to 1s.
      */
     minimumAsyncBehaviorTime?: number
     /**
-     * The maximum time to display the submit indicator before it changes back to normal. In case something went wrong during submission.
+     * The maximum time to display the submit indicator before it changes back to normal. In case something went wrong during submission. Defaults to 30s.
      */
     asyncSubmitTimeout?: number
     /**
-     * Scroll to top on submit
+     * True for the UI to scroll to the top of the page when data is submitted.
      */
     scrollTopOnSubmit?: boolean
     /**
-     * Key for caching the data in session storage
+     * Key for saving active data to session storage and loading it on mount.
      */
     sessionStorageId?: string
     /**
@@ -194,17 +192,15 @@ export type DataContextProviderProps<Data extends JsonObject> =
      */
     countryCode?: ContextState['countryCode']
     /**
-     * Locale to use for all nested Eufemia components
+     * Locale (language) to use for all nested Eufemia components.
      */
     locale?: ContextProps['locale']
     /**
-     * Provide your own translations. Use the same format as defined in the translation files
+     * Provide translation strings. Can be a flat or nested object keyed by locale, e.g. `{ "nb-NO": { MyKey: "value" } }`. See [Localization](/uilib/usage/customisation/localization).
      */
     translations?: ContextProps['translations']
     /**
-     * Async function to load translations for a given locale.
-     * Called on mount and whenever the locale changes.
-     * The returned translations are merged with any existing translations.
+     * Async function that receives the current locale and returns a translations object. Called on mount and when the locale changes. Loaded translations are merged on top of static `translations`. See [Load translations dynamically](/uilib/usage/customisation/localization/#load-translations-dynamically).
      */
     translationsLoader?: ContextProps['translationsLoader']
     /**
@@ -214,11 +210,11 @@ export type DataContextProviderProps<Data extends JsonObject> =
      */
     messageFormatter?: ContextProps['messageFormatter']
     /**
-     * Make all fields required
+     * Make all fields required.
      */
     required?: boolean
     /**
-     * The children of the context provider
+     * Contents.
      */
     children: ReactNode
   }

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -87,17 +87,19 @@ export type FieldBlockHorizontalLabelHeight =
 
 export type SharedFieldBlockProps = {
   /**
-   * The layout of the field block
+   * Layout for the label and input. Can be `horizontal` or `vertical`.
    */
   layout?: 'vertical' | 'horizontal'
-  /** Use this to set additional options for the layout */
+  /**
+   * Use this to set additional options for the `horizontal` layout, e.g. `{ width: "medium" }`. You can also use a custom width `{number}rem`. Instead of a width, you can use a min/max width, e.g. `{ minWidth: "6rem", maxWidth: "12rem" }`.
+   */
   layoutOptions?: {
     width?: FieldBlockHorizontalLabelWidth
     minWidth?: FieldBlockHorizontalLabelWidth
     maxWidth?: FieldBlockHorizontalLabelWidth
   }
   /**
-   * Main label text for the field
+   * Label text displayed above the field. Most fields already have a default label, so check the field translations for an existing label entry. Only set `label` when you need to override the default.
    */
   label?: ReactNode
   /**
@@ -109,35 +111,35 @@ export type SharedFieldBlockProps = {
    */
   labelSuffix?: ReactNode
   /**
-   * A more discreet text displayed beside the label
+   * A more discreet text displayed beside the label (e.g. "(optional)").
    */
   labelDescription?: ReactNode
   /**
-   * If true, the labelDescription will be displayed on the same line as the label.
+   * If `true`, the `labelDescription` will be displayed on the same line as the label.
    */
   labelDescriptionInline?: boolean
   /**
-   * Define the font-size of the label based on the [heading sizes](/uilib/elements/heading/) table.
+   * Define one of the following [heading sizes](/uilib/elements/heading/): `medium` or `large`.
    */
   labelSize?: 'medium' | 'large'
   /**
-   * Width of outer block element
+   * Will set the width for the whole block. Use `small`, `medium`, `large` for predefined standard widths. You can also set a custom width `{number}rem` or use `stretch` or `false`.
    */
   width?: FieldBlockWidth
   /**
-   * Width of contents block, while label etc can be wider if space is available
+   * Will set the width for its contents. Use `small`, `medium`, `large` for predefined standard widths. You can also set a custom width `{number}rem` or use `stretch` or `false`.
    */
   contentWidth?: FieldBlockWidth
   /**
-   * Provide help content for the field.
+   * Provide help content for the field using `title` and `content` as a string or `React.ReactNode`. Additionally, you can set `open` to `true` to display the inline help, set the `breakout` property to `false` to disable the breakout of the inline help content, set `outset` to `false` to display the help text inline (inset) instead of the default outset behavior, or use `renderAs` set to `dialog` to render the content in a [Dialog](/uilib/components/dialog/) (recommended for larger amounts of content).
    */
   help?: HelpProps
   /**
-   * Hide the help button that is normally rendered beside the label.
+   * Set `true` when you render the inline help button outside the label (e.g. inside a checkbox suffix) so FieldBlock skips drawing the default label help button.
    */
   hideHelpButton?: boolean
   /**
-   * Controls where status messages (error, warning, information) are visually shown.
+   * Controls where status messages (`error`, `warning`, `information`) are visually shown. Use `below` (default) or `above`.
    */
   statusPosition?: 'below' | 'above'
 }
@@ -149,19 +151,29 @@ export type FieldBlockProps<Value = unknown> = SharedFieldBlockProps &
   > & {
     /** The id to link an element with */
     forId?: string
-    /** Use true if you have more than one form element */
+    /**
+     * Use `true` when you have several form elements. This way a `fieldset` with a `legend` is used.
+     */
     asFieldset?: boolean
-    /** Defines the layout of nested fields */
+    /**
+     * Use `true` for when you have more than one field wrapped.
+     */
     composition?: FieldBlockContextProps['composition']
-    /** For composition only: Align the contents vertically */
+    /**
+     * `center` or `bottom` for aligning the contents vertically. Defaults to `bottom`.
+     */
     align?: 'center' | 'bottom'
     /** Class name for the contents block */
     contentClassName?: string
     /** To show the SubmitIndicator during async validation */
     fieldState?: SubmitState
-    /** Defines the height of a component (size prop), so the label can be aligned correctly */
+    /**
+     * Defines the height of a component (size property), so the label can be aligned correctly. Can be `default`, `small`, `medium`, `large`.
+     */
     labelHeight?: FieldBlockHorizontalLabelHeight
-    /** Disable the error summary for this field block */
+    /**
+     * Use `true` to disable the error summary.
+     */
     disableStatusSummary?: boolean
     /** For internal use only */
     required?: boolean

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useSubmit.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useSubmit.ts
@@ -13,9 +13,7 @@ const invalidUseSubmitErrorMessage =
 
 export type UseSubmitReturn = {
   /**
-   * Triggers form submit. Runs validation and calls the form's onSubmit when valid.
-   * Use this when the submit button is rendered outside Form.Element (e.g. in a modal footer).
-   * Resolves with the submit result or undefined.
+   * Triggers form submit. Runs validation and calls the form's `onSubmit` when valid. Use when the submit button is rendered outside Form.Element (e.g. in a modal footer). Returns a Promise that resolves with the submit result or `undefined`.
    */
   submit: () => Promise<EventStateObject | undefined>
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Handler/Handler.tsx
@@ -9,7 +9,7 @@ import type { ContextState } from '../../DataContext'
 
 export type FormHandlerProps = FormElementProps & {
   /**
-   * Will enable autoComplete for all nested Field.String fields
+   * Will set `autoComplete="on"` on all nested [Field.String](/uilib/extensions/forms/base-fields/String/)-fields.
    */
   autoComplete?: boolean
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
@@ -35,7 +35,7 @@ import withComponentMarkers from '../../../../shared/helpers/withComponentMarker
 
 export type IsolationProviderProps<Data extends JsonObject> = {
   /**
-   * Form.Isolation: Will be called when the isolated context is committed.
+   * Will be called on a nested form context commit – if validation has passed. The first parameter is the committed data object. The second parameter is an object containing a method to clear the internal data `{ clearData }`.
    */
   onCommit?: OnCommit<Data>
   /**
@@ -43,9 +43,7 @@ export type IsolationProviderProps<Data extends JsonObject> = {
    */
   onClear?: () => void
   /**
-   * Form.Isolation: A function that will be called when the isolated context is committed.
-   * It will receive the data from the isolated context and the data from the outer context.
-   * You can use this to transform the data before it is committed.
+   * Transform the data before it gets committed to the form. The first parameter is the isolated data object. The second parameter is the outer context data object (Form.Handler).
    */
   transformOnCommit?: (isolatedData: Data, handlerData: Data) => JsonObject
   /**
@@ -61,11 +59,11 @@ export type IsolationProviderProps<Data extends JsonObject> = {
    */
   resetDataAfterCommit?: boolean
   /**
-   * Provide a reference by using Form.Isolation.createDataReference.
+   * Provide a reference by using `Form.Isolation.createDataReference`.
    */
   dataReference?: IsolationDataReference
   /**
-   * Used internally by the Form.Isolation component
+   * JSON Pointer to define the object key for all the generated nested field data. When provided, Form.Isolation will inherit schema validation from the parent Form.Handler for fields within this path.
    */
   path?: Path
   /**
@@ -86,7 +84,7 @@ export type IsolationProps<Data extends JsonObject> = Omit<
   | 'globalStatusId'
 > & {
   /**
-   * A ref (function) that you can call in order to commit the data programmatically to the outer context.
+   * Provide a ref to a function that can be called from any location to commit the data to the form.
    */
   commitHandleRef?: RefObject<() => void>
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/MainHeading/MainHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/MainHeading/MainHeading.tsx
@@ -11,7 +11,9 @@ import type { ComponentProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FormMainHeadingProps = ComponentProps & {
-  /** The heading level to render (h2–h6). Defaults to `2`. */
+  /**
+   * Define a specific level value to ensure correct level hierarchy. Defaults to `2`.
+   */
   level?: HeadingLevel
   /** Configuration for an inline help button shown next to the heading. */
   help?: HelpProps

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Section.tsx
@@ -30,13 +30,12 @@ export type SectionBaseProps<
   Data extends JsonObject = JsonObject,
 > = {
   /**
-   * Path to the section.
-   * When defined, fields inside the section will get this path as a prefix of their own path.
+   * A path to the section (JSON Pointer). When defined, fields inside the section will get this path as a prefix of their own path.
    */
   path?: Path
 
   /**
-   * Overwrite field props for the section.
+   * Overwrite field properties for the section.
    */
   overwriteProps?: overwriteProps | OverwritePropsDefaults
 
@@ -57,9 +56,7 @@ export type SectionBaseProps<
    */
   containerMode?: ContainerMode
   /**
-   * Disables editing for the section.
-   * When set to `true`, the section will stay in view mode even if an EditContainer is provided.
-   * Defaults to `false`.
+   * If set to `true`, the section will stay in view mode and hide the edit toolbar.
    */
   disableEditing?: boolean
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubHeading/SubHeading.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubHeading/SubHeading.tsx
@@ -11,7 +11,9 @@ import type { ComponentProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FormSubHeadingProps = ComponentProps & {
-  /** The heading level to render (h2–h6). Defaults to `3`. */
+  /**
+   * Define a specific level value to ensure correct level hierarchy. Defaults to `3`.
+   */
   level?: HeadingLevel
   /** Configuration for an inline help button shown next to the heading. */
   help?: HelpProps

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitButton/SubmitButton.tsx
@@ -13,7 +13,7 @@ import withComponentMarkers from '../../../../shared/helpers/withComponentMarker
 
 export type FormSubmitButtonProps = {
   /**
-   * Show the submit indicator
+   * Show the submit indicator.
    */
   showIndicator?: boolean
 } & ComponentProps &

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/Visibility.tsx
@@ -40,30 +40,52 @@ export type FormVisibilityProps = {
   /** A unique identifier for the component's wrapper element. */
   id?: string
   visible?: boolean
-  /** Given data context path must be defined to show children */
+  /**
+   * Given data context path must be defined to show children.
+   */
   pathDefined?: Path
-  /** Given data context path must be undefined to show children */
+  /**
+   * Given data context path must be `undefined` to show children.
+   */
   pathUndefined?: Path
-  /** Given data context path must be truthy to show children */
+  /**
+   * Given data context path must be truthy to show children.
+   */
   pathTruthy?: Path
-  /** Given data context path must be falsy to show children */
+  /**
+   * Given data context path must be falsy to show children.
+   */
   pathFalsy?: Path
-  /** Given data context path must be true to show children */
+  /**
+   * Given data context path must be `true` to show children.
+   */
   pathTrue?: Path
-  /** Given data context path must be false to show children */
+  /**
+   * Given data context path must be `false` to show children.
+   */
   pathFalse?: Path
-  /** Provide a `path` or `itemPath` and a `hasValue` method that returns a boolean or the expected value in order to show children. The first parameter is the value of the path. */
+  /**
+   * Provide a `path` or `itemPath`, and a `hasValue` function that returns either a boolean or the expected value to determine whether the children should be shown. The first parameter passed to `hasValue` is the value at the given `path`. If the `path` does not exist, the value will be `undefined`. Alternatively, you can use `isValid` instead of `hasValue` to show the children only when the field has no validation errors and has been blurred (lost focus). You can change this behavior by setting the `validateContinuously` property.
+   */
   visibleWhen?: VisibleWhen
   /** Same as `visibleWhen`, but with inverted logic. */
   visibleWhenNot?: VisibleWhen
-  /** Infer visibility calling given derivative function with the whole data set. Should return true/false for visibility.   */
+  /**
+   * Will be called to decide by external logic, and show/hide contents based on the return value.
+   */
   inferData?: (data: unknown) => boolean
-  /** Filter data based on provided criteria. The first parameter is the path, the second is the value, and the third is the props, and the fourth is the internal. Return false to filter out the data. */
+  /**
+   * Filter data based on provided criteria. More info about `filterData` can be found in the [Getting Started](/uilib/extensions/forms/getting-started/#filter-data) documentation.
+   */
   filterData?: FilterData
-  /** Callback for when the content gets visible. */
+  /**
+   * Callback for when the content gets visible. Returns a boolean as the first parameter.
+   */
   onVisible?: HeightAnimationAllProps['onOpen']
 
-  /** When visibility is hidden, and `keepInDOM` is true, pass these props to the children */
+  /**
+   * When visibility is hidden, and `keepInDOM` is `true`, pass these properties to the children.
+   */
   fieldPropsWhenHidden?: UseFieldProps & DataAttributes & AriaAttributes
   children: ReactNode
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/VisibilityDocs.ts
@@ -3,7 +3,7 @@ import { HeightAnimationEvents } from '../../../../components/height-animation/H
 
 export const VisibilityProperties: PropertiesTableProps = {
   visibleWhen: {
-    doc: 'Provide a `path` or `itemPath`, and a `hasValue` function that returns either a boolean or the expected value to determine whether the children should be shown. The first parameter passed to `hasValue` is the value at the given `path`. If the `path` does not exist, the value will be `undefined`. \nAlternatively, you can use `isValid` instead of `hasValue` to show the children only when the field has no validation errors and has been blurred (lost focus). You can change this behavior by setting the `validateContinuously` property.',
+    doc: 'Provide a `path` or `itemPath`, and a `hasValue` function that returns either a boolean or the expected value to determine whether the children should be shown. The first parameter passed to `hasValue` is the value at the given `path`. If the `path` does not exist, the value will be `undefined`. Alternatively, you can use `isValid` instead of `hasValue` to show the children only when the field has no validation errors and has been blurred (lost focus). You can change this behavior by setting the `validateContinuously` property.',
     type: 'object',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1939,7 +1939,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 }
 
 export type ReturnAdditional<Value> = {
-  /** Documented APIs */
+  /**
+   * The transformed value ready for display, or `undefined` if the associated field is not visible.
+   */
   value: Value
   isChanged: boolean
   htmlAttributes: AriaAttributes | DataAttributes
@@ -1965,7 +1967,9 @@ export type ReturnAdditional<Value> = {
   forceUpdate: () => void
   hasError?: boolean
 
-  /** Internal */
+  /**
+   * The DataContext state object, providing access to form-level data and methods.
+   */
   dataContext: ContextState
   fieldState: SubmitState
   additionalArgs: ReceiveAdditionalEventArgs<Value>


### PR DESCRIPTION
Align JSDoc property descriptions with the doc strings in their sibling *Docs files, via the docs-types/sync-docs-jsdoc rule. Also collapsed a stray embedded newline in VisibilityDocs visibleWhen.

