### PR TITLE
chore(eslint): elevate docs-types/sync-docs-jsdoc to error

### DIFF
--- a/packages/dnb-eufemia/eslint.config.mjs
+++ b/packages/dnb-eufemia/eslint.config.mjs
@@ -527,7 +527,7 @@ export default [
       'docs-types': docsTypesPlugin,
     },
     rules: {
-      'docs-types/sync-docs-jsdoc': 'warn',
+      'docs-types/sync-docs-jsdoc': 'error',
     },
   },
   {


### PR DESCRIPTION
Enforce that JSDoc comments stay in sync with the sibling *Docs definitions by failing the lint step instead of only warning.

