### PR TITLE
chore(forms): sync JSDoc comments with Docs definitions for Field components

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -52,19 +52,17 @@ export type FieldArraySelectionProps = FieldProps<
   width?: FieldBlockWidth
 
   /**
-   * The path to the context data (Form.Handler).
-   * The context data object needs to have a `value` and a `title` property.
+   * The path to the context data (Form.Handler). The context data object needs to have a `value` and a `title` property. The generated options will be placed above given JSX based children. When `children` is a function, the generated options are instead provided as `options` to the function.
    */
   dataPath?: Path
 
   /**
-   * Data to be used for the component. The object needs to have a `value` and a `title` property.
-   * The generated options will be placed above given JSX based children.
+   * Data to be used for the component. The object needs to have a `value` and a `title` property. Provide the Dropdown or Autocomplete data in the format documented here: [Dropdown](/uilib/components/dropdown) and [Autocomplete](/uilib/components/autocomplete) documentation.
    */
   data?: Data
 
   /**
-   * The size of the component.
+   * The sizes you can choose are `small` (1.5rem), `default` (2rem), `medium` (2.5rem) and `large` (3rem). Defaults to `default` / `null`. Also, if you define a number like `size="2"` then it will be forwarded as the input element attribute. Consider rather setting field sizes with [Form.Appearance](/uilib/extensions/forms/Form/Appearance/).
    */
   size?: ToggleButtonProps['size'] | CheckboxProps['size']
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -27,8 +27,7 @@ export type FieldBankAccountNumberProps = Omit<
   onBlurValidator?: BankAccountNumberValidator | false
 
   /**
-   * The type of bank account number, used for input mask and formatting.
-   * Defaults to `norwegianBban`.
+   * The type of bank account number, used for input mask, label, and formatting. Can be `norwegianBban`, `swedishBban`, `swedishBankgiro`, `swedishPlusgiro`, or `iban`. Validation is currently only supported for `norwegianBban`. Defaults to `norwegianBban`.
    */
   bankAccountType?: BankAccountType
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Boolean/Boolean.tsx
@@ -5,15 +5,23 @@ import type { FieldProps } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 type BooleanProps = {
-  /** Custom label text shown when the value is `true`. Defaults to localized "Yes". */
+  /**
+   * Text to show in the UI when value is `true`.
+   */
   trueText?: string
-  /** Custom label text shown when the value is `false`. Defaults to localized "No". */
+  /**
+   * Text to show in the UI when value is `false`.
+   */
   falseText?: string
-  /** The visual variant of the toggle field: `checkbox`, `checkbox-button`, `button`, or `buttons`. */
+  /**
+   * Choice of input feature. Can be: `checkbox`, `switch`, `button`, `checkbox-button` or `buttons`.
+   */
   variant?: ToggleFieldProps['variant']
   /** The size of the toggle. Available sizes: `small`, `medium` (default), `large`. */
   size?: ToggleFieldProps['size']
-  /** Callback fired when the toggle is clicked. */
+  /**
+   * Will be called on click.
+   */
   onClick?: ToggleFieldProps['onClick']
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/Currency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/Currency.tsx
@@ -13,8 +13,7 @@ import withComponentMarkers from '../../../../shared/helpers/withComponentMarker
 
 export type FieldCurrencyProps = NumberFieldProps & {
   /**
-   * Will change the currency.
-   * You can also set a path as the value, e.g. `/myCurrencyPath`.
+   * Defines what format to show the currency value in, e.g. `NOK` or `USD`. You can also set a path as the value, e.g. `/myCurrencyPath`.
    */
   currency?: PathStrict | CurrencyISO
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -68,7 +68,7 @@ export type DateProps = Omit<
   showInput?: DatePickerProps['showInput']
 
   /**
-   * If set to `true`, a cancel button will be shown. You can change the default text by using `cancelButtonText="Avbryt"`. Defaults to `true`. If the `range` prop is `true`, then the cancel button is shown.
+   * If set to `true`, a cancel button will be shown. You can change the default text by using `cancelButtonText="Avbryt"`. Defaults to `true`. If the `range` property is `true`, then the cancel button is shown.
    */
   showCancelButton?: DatePickerProps['showCancelButton']
   /**

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/Indeterminate.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/Indeterminate.tsx
@@ -8,15 +8,12 @@ export type FieldIndeterminateProps = Partial<
   Omit<ToggleAllProps, 'textOn' | 'textOff'>
 > & {
   /**
-   * An array of paths to the data object.
+   * Provide an array with the related paths of other [Field.Toggle](/uilib/extensions/forms/base-fields/Toggle/) or [Field.Boolean](/uilib/extensions/forms/base-fields/Boolean/) fields.
    */
   dependencePaths: Array<Path>
 
   /**
-   * When `checked`, the dependent checkboxes will always be set to "checked" when in indeterminate state.
-   * When `unchecked`, the dependent checkboxes will be set to "unchecked" when in indeterminate state.
-   * When "auto", the dependent checkboxes will get the inverted state from where the (this) parent checkbox is in.
-   * Default: `checked`.
+   * When `checked`, the dependent checkboxes will always be set to "checked" when in indeterminate state. When `unchecked`, the dependent checkboxes will be set to "unchecked" when in indeterminate state. When "auto", the dependent checkboxes will get the inverted state from where the (this) parent checkbox is in. Defaults to `checked`.
    */
   propagateIndeterminateState?: 'checked' | 'unchecked' | 'auto'
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -48,64 +48,57 @@ export type FieldMultiSelectionProps = FieldProps<
   Array<number | string> | undefined
 > & {
   /**
-   * Data to be used for the component. Array of objects with `value` and `title` properties.
-   * Supports nested items via `children` property.
+   * Array of objects where each object contains at least `value` and `title`. Can also include `text` for an optional primary extra line, `description` for an optional secondary grey line, plus `disabled`, `help`, and `className`.
    */
   data?: MultiSelectionData
 
   /**
-   * The path to the context data (Form.Handler).
+   * Path to data in Form.Handler context. The context data array should contain objects with `value` and `title` properties.
    */
   dataPath?: Path
 
   /**
-   * Defines the variant of the component.
-   * `popover` renders a trigger button that opens a popover with the item list.
-   * `inline` renders the item list inline as checkboxes.
-   * Default: `popover`
+   * Defines the variant of the component. `popover` renders a trigger button that opens a popover with the item list. `inline` renders the item list inline as checkboxes.
    */
   variant?: 'popover' | 'inline'
 
   /**
-   * The width of the component. Supported values: false, 'medium', 'large', or a custom width.
+   * The width of the component. Supported values: `"medium"` and `"large"`. Defaults to `"large"`.
    */
   width?: MultiSelectionFieldBlockWidth
 
   /**
-   * Show search field to filter options. Defaults to false.
+   * Show a search/filter input field to search through items.
    */
   showSearchField?: boolean
 
   /**
-   * Show "Select all" checkbox at top of list. Defaults to false.
+   * Show a "Select all" checkbox at the top of the list.
    */
   showSelectAll?: boolean
 
   /**
-   * Show selected items as tags inside the popover. When enabled and nothing is
-   * selected a placeholder text is shown. Defaults to false.
+   * Show selected items as removable tags inside the popover. When enabled and nothing is selected, a placeholder text is shown.
    */
   showSelectedTags?: boolean
 
   /**
-   * Threshold for collapsing selected items when showSelectedTags is enabled.
-   * When the number of selected items exceeds this threshold, a toggle button
-   * and "Clear all" button appear, and the tags are hidden by default. Defaults to 10.
+   * When the number of selected items exceeds this threshold, the selected items are hidden by default and can be toggled with a header.
    */
   selectedItemsCollapsibleThreshold?: number
 
   /**
-   * Show confirm/cancel buttons. Defaults to false.
+   * Show confirm and cancel buttons at the bottom of the popover. Selections are only applied when the user confirms.
    */
   showConfirmButton?: boolean
 
   /**
-   * Minimum number of items required to be selected
+   * Minimum number of items required to be selected. Triggers a validation error if fewer items are selected.
    */
   minItems?: number
 
   /**
-   * Maximum number of items allowed to be selected
+   * Maximum number of items allowed to be selected. Triggers a validation error if more items are selected.
    */
   maxItems?: number
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -39,45 +39,81 @@ export type FieldNumberProps = FieldProps<number, undefined | number> & {
   ref?: RefObject<HTMLInputElement>
   /** Additional CSS class applied to the inner input element. */
   inputClassName?: string
-  /** Formats the value as a currency. Pass `true` for locale default or a currency code string. */
+  /**
+   * Currency code (ISO 4217) or `true` to use the default `NOK`. Uses two decimals by default.
+   */
   currency?: InputMaskedProps['asCurrency']
   /** How to display the currency symbol: `code` (e.g., USD), `symbol` (e.g., $), `narrowSymbol`, or `name`. */
   currencyDisplay?: 'code' | 'symbol' | 'narrowSymbol' | 'name' | false
-  /** Formats the value as a percentage. */
+  /**
+   * Format a number as a percentage.
+   */
   percent?: InputMaskedProps['asPercent']
-  /** Input mask configuration for the underlying masked input. */
+  /**
+   * An array or a function returning an array of regexes to use as a mask for the input. If not given, the input will not be masked.
+   */
   mask?: InputMaskedProps['mask']
-  /** Step increment/decrement value for the step controls. Defaults to `1`. */
+  /**
+   * Determines step granularity when increasing/decreasing the value via step control buttons or arrow keys. Defaults to `1`.
+   */
   step?: number
-  /** Initial value when the field is empty and the user clicks a step control. */
+  /**
+   * When no `value` or `defaultValue` is given, start with a given value when increasing/decreasing the value via step control buttons or arrow keys. Defaults to `null`.
+   */
   startWith?: number
-  /** Maximum number of decimal digits allowed. Defaults to `12`. */
+  /**
+   * Max number of decimals. Values with more decimals will be rounded. Defaults to `12`.
+   */
   decimalLimit?: number
-  /** If `true`, allows negative numbers. Defaults to `true`. */
+  /**
+   * Whether or not to allow negative numbers. Defaults to `true`.
+   */
   allowNegative?: boolean
-  /** If `true`, disallows leading zeroes (e.g. `007`). */
+  /**
+   * Whether or not to allow leading zeroes during typing. Defaults to `false`.
+   */
   disallowLeadingZeroes?: boolean
-  /** Text or function returning text to display before the number value. */
+  /**
+   * Text added before the value input.
+   */
   prefix?: string | ((value: number) => string)
-  /** Text or function returning text to display after the number value. */
+  /**
+   * Text added after the value input.
+   */
   suffix?: string | ((value: number) => string)
-  /** Minimum allowed value (inclusive, i.e. greater than or equal to). */
+  /**
+   * Validation for inclusive minimum number value (greater than or equal). Defaults to `Number.MIN_SAFE_INTEGER`.
+   */
   minimum?: number
-  /** Maximum allowed value (inclusive, i.e. less than or equal to). */
+  /**
+   * Validation for inclusive maximum number value (less than or equal). Defaults to `Number.MAX_SAFE_INTEGER`.
+   */
   maximum?: number
-  /** Exclusive minimum (value must be strictly greater than this). */
+  /**
+   * Validation for exclusive minimum number value (greater than).
+   */
   exclusiveMinimum?: number
-  /** Exclusive maximum (value must be strictly less than this). */
+  /**
+   * Validation for exclusive maximum number value (less than).
+   */
   exclusiveMaximum?: number
-  /** Value must be a multiple of this number. */
+  /**
+   * Validation that requires the number to be a multiple of a given value.
+   */
   multipleOf?: number
   /** The size of the input. Available sizes: `small`, `medium` (default), `large`. */
   size?: InputSize
-  /** Defines the width of the field block container. */
+  /**
+   * `false` for no width (use browser default), `small`, `medium` or `large` for predefined standard widths, `stretch` for fill available width.
+   */
   width?: FieldBlockWidth
-  /** Text alignment inside the input: `left`, `center`, or `right`. */
+  /**
+   * Lateral alignment of contents of input field, one of `left` (default), `center`, or `right`.
+   */
   align?: InputAlign
-  /** If `true`, shows increment/decrement step control buttons. */
+  /**
+   * Show buttons that increase/decrease the value by the step amount.
+   */
   showStepControls?: boolean
   /** Text showing in place of the value if no value is given. */
   placeholder?: string

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Option/Option.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Option/Option.tsx
@@ -6,7 +6,9 @@ export type FieldOptionProps = FieldProps<number | string> & {
   title?: ReactNode
   /** Secondary text. */
   text?: ReactNode
-  /** What group index in the `groups` prop this item belongs to. */
+  /**
+   * What group index in the `groups` property ([Field.Selection](/uilib/extensions/forms/base-fields/Selection/)) this item belongs to.
+   */
   groupIndex?: number
   /** Optional way to provide `title`. Will be ignored if `title` is used. */
   children?: ReactNode

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/Password.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/Password.tsx
@@ -26,19 +26,19 @@ export type PasswordVisibilityEvent = MouseEvent<HTMLButtonElement> & {
 
 export type PasswordProps = Omit<StringFieldProps, 'ref'> & {
   /**
-   * Fires when the input toggles to show the password.
+   * Will be called when the user toggles the password to be visible.
    */
   onShowPassword?: (event: PasswordVisibilityEvent) => void
   /**
-   * Fires when the input toggles to hide the password.
+   * Will be called when the user toggles the password to be hidden.
    */
   onHidePassword?: (event: PasswordVisibilityEvent) => void
   /**
-   * The sizes you can choose is small (1.5rem), default (2rem), medium (2.5rem) and large (3rem) are supported component sizes. Defaults to default / null. Also, if you define a number like size="2" then it will be forwarded as the input element attribute.
+   * The sizes you can choose are `small` (1.5rem), `default` (2rem), `medium` (2.5rem) and `large` (3rem). Defaults to `default` / `null`. Also, if you define a number like `size="2"` then it will be forwarded as the input element attribute. Consider rather setting field sizes with [Form.Appearance](/uilib/extensions/forms/Form/Appearance/).
    */
   size?: InputProps['size']
   /**
-   * ElementRef passed on to the password input element.
+   * `ElementRef` passed on to the password `input` element.
    */
   ref?: RefObject<HTMLInputElement>
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -57,13 +57,12 @@ export type FieldPhoneNumberProps = Omit<
   onNumberChange?: (value: string | undefined) => void
 
   /**
-   * Defines the countries to filter. Can be `Scandinavia`, `Nordic`, `Europe` or `Prioritized`.
-   * Defaults to `Prioritized`.
+   * List only a certain set of countries: `Scandinavia`, `Nordic`, `Europe` or `Prioritized` (all countries [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCountry/#filter-or-prioritize-country-listing)). Defaults to `Prioritized`.
    */
   countries?: CountryFilterSet
 
   /**
-   * Use this prop to filter out certain countries. The function receives the country object and should return a boolean. Returning `false` will omit the country.
+   * Use this property to filter out certain countries. The function receives the country object and should return a boolean. Returning `false` will omit the country.
    */
   filterCountries?: (country: CountryType) => boolean
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
@@ -13,7 +13,7 @@ export type FieldProviderProps = FieldProps & {
   children: ReactNode
 
   /**
-   * Locale to use for all nested Eufemia components
+   * Locale (language) to use for all nested Eufemia components.
    */
   locale?: DataContextProps<JsonObject>['locale']
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -37,13 +37,12 @@ export type FieldSelectCountryProps = FieldPropsWithExtraValue<
   undefined | string
 > & {
   /**
-   * Lists only the countries you want to show. Can be `Scandinavia`, `Nordic`, `Europe` or `Prioritized`.
-   * Defaults to `Prioritized`.
+   * List only a certain set of countries: `Scandinavia`, `Nordic`, `Europe` or `Prioritized` (all countries [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCountry/#filter-or-prioritize-country-listing)). Defaults to `Prioritized`.
    */
   countries?: CountryFilterSet
 
   /**
-   * Use this prop to filter out certain countries. The function receives the country object and should return a boolean. Returning `false` will omit the country.
+   * Use this property to filter out certain countries. The function receives the country object and should return a boolean. Returning `false` will omit the country.
    */
   filterCountries?: (country: CountryType) => boolean
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrency.tsx
@@ -35,13 +35,12 @@ export type FieldSelectCurrencyProps = FieldPropsWithExtraValue<
   undefined | string
 > & {
   /**
-   * Lists only the currencies you want to show. Can be `Scandinavia`, `Nordic`, `Europe` or `Prioritized`.
-   * Defaults to `Prioritized`.
+   * List only a certain set of currencies: `Scandinavia`, `Nordic`, `Europe` or `Prioritized` (all currencies [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCurrency/#filter-or-prioritize-currency-listing)). Defaults to `Prioritized`.
    */
   currencies?: CurrencyFilterSet
 
   /**
-   * Use this prop to filter out certain currencies. The function receives the currency object and should return a boolean. Returning `false` will omit the currency.
+   * Use this property to filter out certain currencies. The function receives the currency object and should return a boolean. Returning `false` will omit the currency.
    */
   filterCurrencies?: (currency: CurrencyType) => boolean
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -79,56 +79,51 @@ type DrawerListVisibilityParams = {
 
 export type FieldSelectionProps = FieldProps<IOption['value']> & {
   /**
-   * Defines the variant of the component.
-   * Default: `dropdown`
+   * Choice of UI feature. Can be: `dropdown`, `autocomplete`, `button`, `radio`.
    */
   variant?: 'dropdown' | 'autocomplete' | 'radio' | 'button'
 
   /**
-   * The width of the component.
-   * Default: `large`
+   * `small`, `medium` or `large` for predefined standard widths, `stretch` for fill available width.
    */
   width?: FieldBlockWidth
 
   /**
-   * Defines the layout of the options for radio and button variants.
+   * Layout for the list of options. Can be `horizontal` or `vertical`.
    */
   optionsLayout?: 'horizontal' | 'vertical'
 
   /**
-   * Transform the displayed selection for Dropdown and Autocomplete variant.
-   * Use it to display a different value than the one in the data set.
+   * Transform the displayed selection for Dropdown and Autocomplete variant. Use it to display a different value than the one in the data set. The first parameter is the properties of the Option component or data item. You can return a `React.ReactNode` that will be displayed in the selection.
    */
   transformSelection?: (props: OptionFieldProps) => ReactNode
 
   /**
-   * The path to the context data (Form.Handler).
-   * The context data object needs to have a `value` and a `title` property.
+   * The path to the context data (Form.Handler). The context data object needs to have a `value` and a `title` property. The generated options will be placed above given JSX based children. When `children` is a function, the generated options are instead provided as `options` to the function.
    */
   dataPath?: Path
 
   /**
-   * Data to be used for the component. The object needs to have a `value` and a `title` property.
-   * The generated options will be placed above given JSX based children.
+   * Data to be used for the component. The object needs to have a `value` and a `title` property. Provide the Dropdown or Autocomplete data in the format documented here: [Dropdown](/uilib/components/dropdown) and [Autocomplete](/uilib/components/autocomplete) documentation.
    */
   data?: Data
 
   /**
-   * Array of groups, only the first can be `undefined`
+   * An array of group titles for the list items. Only the first group can be `undefined`.
    */
   groups?: ReactNode[]
   /**
-   * Autocomplete specific props
+   * Forward any additional properties to the [Autocomplete](/uilib/components/autocomplete/) component. `onType` will additionally provide the `value` parameter with `emptyValue` support in addition to the internal `dataContext`.
    */
   autocompleteProps?: AutocompleteAllProps
 
   /**
-   * Dropdown specific props
+   * Forward any additional properties to the [Dropdown](/uilib/components/dropdown/) component.
    */
   dropdownProps?: DropdownAllProps
 
   /**
-   * The size of the component.
+   * The sizes you can choose are `small` (1.5rem), `default` (2rem), `medium` (2.5rem) and `large` (3rem). Defaults to `default` / `null`. Also, if you define a number like `size="2"` then it will be forwarded as the input element attribute. Consider rather setting field sizes with [Form.Appearance](/uilib/extensions/forms/Form/Appearance/).
    */
   size?:
     | ToggleButtonGroupProps['size']
@@ -137,7 +132,7 @@ export type FieldSelectionProps = FieldProps<IOption['value']> & {
     | DropdownAllProps['size']
 
   /**
-   * The content of the component.
+   * For providing [Field.Option](/uilib/extensions/forms/base-fields/Option/) components and other children. Can also be a render function that receives `{ value, options }`, where `options` are from `data` or `dataPath` and may include additional custom properties.
    */
   children?: ReactNode | RenderSelectionChildren
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/Slider.tsx
@@ -22,7 +22,7 @@ export type SliderVisibilityEvent = MouseEvent<HTMLButtonElement> & {
 export type SliderValue = number | Array<number>
 export type FieldSliderProps = FieldProps<SliderValue> & {
   /**
-   * Define an array with JSON Pointers for multiple thumb buttons.
+   * Define an array with JSON Pointer paths for multiple thumb buttons.
    */
   paths?: Array<Path>
   step?: SliderProps['step'] | Path

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -24,13 +24,21 @@ import type { FieldProps, Schema } from '../../types'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type FieldStringProps = FieldProps<string, undefined | string> & {
-  /** Renders a multiline textarea instead of a single-line input. */
+  /**
+   * True to be able to write in multiple lines (switching from input-element to textarea-element).
+   */
   multiline?: boolean
-  /** Additional CSS class applied to the inner input element. */
+  /**
+   * Class name set on the `<input>` DOM element.
+   */
   inputClassName?: string
-  /** Ref to the underlying input or textarea element. */
+  /**
+   * By providing a `React.Ref` we can get the internally used input element (DOM).
+   */
   ref?: RefObject<HTMLInputElement | HTMLTextAreaElement>
-  /** Defines the width of the field block container. */
+  /**
+   * `false` for no width (use browser default), `small`, `medium` or `large` for predefined standard widths, `stretch` to fill available width.
+   */
   width?: FieldBlockWidth
   /** The size of the input. Available sizes: `small`, `medium` (default), `large`. */
   size?: InputProps['size'] | TextareaProps['size']
@@ -38,11 +46,17 @@ export type FieldStringProps = FieldProps<string, undefined | string> & {
   keepPlaceholder?: InputProps['keepPlaceholder']
 
   // - Validation
-  /** Minimum number of characters required. Triggers a validation error if the value is shorter. */
+  /**
+   * Validation for minimum length of the text (number of characters).
+   */
   minLength?: number
-  /** Maximum number of characters allowed. Triggers a validation error if the value is longer. */
+  /**
+   * Validation for maximum length of the text (number of characters).
+   */
   maxLength?: number
-  /** Regex pattern string the value must match. Triggers a validation error on mismatch. */
+  /**
+   * Validation based on regex pattern.
+   */
   pattern?: string
 
   // - Input props
@@ -58,31 +72,53 @@ export type FieldStringProps = FieldProps<string, undefined | string> & {
   mask?: InputMaskedProps['mask']
   /** If `true`, allows typing beyond the defined mask boundaries. */
   allowOverflow?: InputMaskedProps['allowOverflow']
-  /** Icon displayed on the left side of the input. Accepts icon name strings. */
+  /**
+   * For icon at the left side of the text input. Only one of `leftIcon` or `rightIcon` can be used at the same time.
+   */
   leftIcon?: string
-  /** Icon displayed on the right side of the input. Accepts icon name strings. */
+  /**
+   * For icon at the right side of the text input. Only one of `leftIcon` or `rightIcon` can be used at the same time.
+   */
   rightIcon?: string
-  /** Custom React element rendered as a submit button inside the input. */
+  /**
+   * Accepts a React element which will show up where the "submit button" would do.
+   */
   submitElement?: InputProps['submitElement']
-  /** If `true`, capitalizes the first letter of the input value. */
+  /**
+   * When set to `true`, it will capitalize the first letter of every word, transforming the rest to lower case.
+   */
   capitalize?: boolean
-  /** If `true`, trims leading and trailing whitespace from the value on blur. */
+  /**
+   * When `true`, it will trim leading and trailing whitespaces on blur, triggering `onChange` if the value changes.
+   */
   trim?: boolean
 
   // - Textarea props
-  /** Number of visible text rows for the textarea (when `multiline` is true). */
+  /**
+   * To be used together with `multiline`. Set how many rows of text can be shown by default. Defaults to `2`.
+   */
   rows?: TextareaProps['rows']
-  /** Maximum number of rows the textarea can grow to when `autoResize` is enabled. */
+  /**
+   * To be used together with `multiline`. Set how many rows of text can be shown at max. Defaults to `6`.
+   */
   autoResizeMaxRows?: TextareaProps['autoResizeMaxRows']
-  /** If `true`, the textarea height adjusts automatically to its content. */
+  /**
+   * To be used together with `multiline`. Set true to expand when writing longer texts. Defaults to `true`.
+   */
   autoResize?: TextareaProps['autoResize']
-  /** Displays a character counter. Pass a number to set the max count, or a config object. */
+  /**
+   * To be used together with `multiline`. Use a number to define the displayed max length e.g. `40` or `{ max: 40, variant: 'down' }`.
+   */
   characterCounter?: Omit<TextCounterProps, 'text'> | number
 
   // - Html props
-  /** HTML `autocomplete` attribute for browser autofill hints. */
+  /**
+   * For HTML [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attributes.
+   */
   autoComplete?: HTMLInputElement['autocomplete']
-  /** Hint for the virtual keyboard type on touch devices, e.g. `numeric`, `email`, `tel`. */
+  /**
+   * Define an [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
+   */
   inputMode?: HTMLAttributes<HTMLInputElement>['inputMode']
   /** Controls browser autocorrect behavior. */
   autoCorrect?: HTMLAttributes<HTMLInputElement>['autoCorrect']

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Toggle/Toggle.tsx
@@ -44,7 +44,7 @@ export type ToggleProps = {
   size?: ToggleButtonProps['size'] | CheckboxProps['size']
 
   /**
-   * Checkbox props
+   * Will be called on click.
    */
   onClick?: (
     value: unknown,


### PR DESCRIPTION
Align JSDoc property descriptions in forms Field components with the doc strings in their sibling *Docs files, via the docs-types/sync-docs-jsdoc rule.

