### PR TITLE
chore(elements): sync JSDoc comments with Docs definitions

### DIFF
--- a/packages/dnb-eufemia/src/elements/blockquote/Blockquote.tsx
+++ b/packages/dnb-eufemia/src/elements/blockquote/Blockquote.tsx
@@ -13,12 +13,11 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 type BlockquoteProps = SpacingProps &
   HTMLAttributes<HTMLElement> & {
     /**
-     * Hides the blockquote background by making it transparent
+     * Hides the blockquote background by making it transparent.
      */
     noBackground?: boolean
     /**
-     * Determines the flow direction of the content inside of blockquote. Can be either `horizontal` or `vertical`
-     * Default: `horizontal`
+     * Determines the flow direction of the content inside of blockquote. Can be either `horizontal` or `vertical`. Defaults to `horizontal`.
      */
     direction?: 'horizontal' | 'vertical'
   }

--- a/packages/dnb-eufemia/src/elements/lists/Dl.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Dl.tsx
@@ -14,7 +14,7 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type DlProps = {
   /**
-   * Use "true" to horizontally align both the term and the description
+   * Sets the layout of the list. Can be `vertical`, `horizontal` or `grid`. Defaults to `vertical`.
    */
   layout?: 'vertical' | 'horizontal' | 'grid'
 }

--- a/packages/dnb-eufemia/src/elements/lists/Ol.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Ol.tsx
@@ -13,17 +13,17 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type OlProps = {
   /**
-   * Defines the position of the marker
+   * Defines the position of the marker.
    */
   inside?: boolean
 
   /**
-   * Defines the position of the marker (default)
+   * Defines the position of the marker (default).
    */
   outside?: boolean
 
   /**
-   * Will ensure a nested structure of several lists
+   * Will ensure a nested structure of several lists.
    */
   nested?: boolean
 }

--- a/packages/dnb-eufemia/src/elements/lists/Ul.tsx
+++ b/packages/dnb-eufemia/src/elements/lists/Ul.tsx
@@ -13,17 +13,17 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type UlProps = {
   /**
-   * Defines the position of the marker
+   * Defines the position of the marker.
    */
   inside?: boolean
 
   /**
-   * Defines the position of the marker (default)
+   * Defines the position of the marker (default).
    */
   outside?: boolean
 
   /**
-   * Will ensure a nested structure of several lists
+   * Will ensure a nested structure of several lists.
    */
   nested?: boolean
 }

--- a/packages/dnb-eufemia/src/elements/typography/Typography.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/Typography.tsx
@@ -41,11 +41,11 @@ export type TypographyProps<
 > = SpacingProps &
   HTMLAttributes<ElementType> & {
     /**
-     * Defines the Element Type, like "p".
+     * Defines the Element Type, like `p`.
      */
     element?: DynamicElement
     /**
-     * Sets the font size, also sets the line-height if `line` prop is not set
+     * Sets the font size, also sets the line-height if `lineHeight` property is not set.
      */
     size?: TypographySize
     /**
@@ -53,27 +53,27 @@ export type TypographyProps<
      */
     lineHeight?: TypographySize
     /**
-     * Sets the text alignment
+     * Sets the text alignment.
      */
     align?: TypographyAlign
     /**
-     * Sets the font family
+     * Sets the font family.
      */
     family?: TypographyFamily
     /**
-     * Sets the font weight
+     * Sets the font weight.
      */
     weight?: TypographyWeight
     /**
-     * Sets the font decoration
+     * Sets the font decoration.
      */
     decoration?: TypographyDecoration
     /**
-     * Sets the font style
+     * Sets the font style.
      */
     slant?: TypographySlant
     /**
-     * Sets the maximum width based on character count. This will limit the text width to approximately the specified number of characters. Use `true` for a default value of 60ch.
+     * Sets the maximum width based on character count for all Typography children. This will limit the text width to approximately the specified number of characters. Use `true` for a default value of 60ch.
      */
     proseMaxWidth?: number | boolean
   }

--- a/packages/dnb-eufemia/src/elements/typography/TypographyDocs.ts
+++ b/packages/dnb-eufemia/src/elements/typography/TypographyDocs.ts
@@ -58,7 +58,7 @@ export const TypographyProperties: PropertiesTableProps = {
     status: 'optional',
   },
   proseMaxWidth: {
-    doc: 'Sets the maximum width based on character count. This will limit the text width to approximately the specified number of characters. Use `true` for a default value of 60ch.',
+    doc: 'Sets the maximum width based on character count for all Typography children. This will limit the text width to approximately the specified number of characters. Use `true` for a default value of 60ch.',
     type: ['number', 'boolean'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -53,7 +53,9 @@ const propsToFilterOut: Record<string, null> = {
 export type DrawerListContent = string | ReactNode | (string | ReactNode)[]
 
 export type DrawerListDataArrayObjectStrict = {
-  /** index of group supplied in the `groups` prop */
+  /**
+   * What group index in the `groups` property this item belongs to.
+   */
   groupIndex?: number
   selectedValue?: string | ReactNode
   selectedKey?: string | number
@@ -66,7 +68,9 @@ export type DrawerListDataArrayObjectStrict = {
   style?: CSSProperties
   /** classname added to the html list item */
   className?: string
-  /** set to true to disable mouse events selected style. Keyboard can still select. */
+  /**
+   * If set to `true`, mouse events selected style will be disabled. Keyboard can still select.
+   */
   ignoreEvents?: boolean
   /** internal use only */
   render?: (children: ReactNode, id: string) => ReactNode
@@ -151,7 +155,7 @@ export type DrawerListProps = {
    */
   cacheHash?: string
   /**
-   * Position of the arrow on the popup drawer. Set to `left` or `right`. Defaults to `left` if not set.
+   * Does nothing as there is no longer any arrow. Legacy docs: Position of the arrow on the popup drawer. Set to `left` or `right`. Defaults to `left` if not set.
    * @deprecated does nothing as there is no longer any arrow, and will be removed in v13.
    */
   arrowPosition?: string
@@ -202,15 +206,15 @@ export type DrawerListProps = {
    */
   optionsRender?: DrawerListOptionsRender
   /**
-   * Has to be an HTML Element, ideally a parent element, used to calculate sizes and distances. Also used for the 'click outside' detection. Clicking on the `wrapperElement` will not trigger an outside click.
+   * Has to be an HTML Element, or a selector for one, ideally a parent element, used to calculate sizes and distances. Also used for the 'click outside' detection. Clicking on the `wrapperElement` will not trigger an outside click.
    */
   wrapperElement?: string | HTMLElement
   /**
-   * Define a startup value or handle a re-render without handling the state during the re-render by yourself. Defaults to null.
+   * Define a startup value or handle a re-render without handling the state during the re-render by yourself. Defaults to `null`.
    */
   defaultValue?: DrawerListValue
   /**
-   * Define a preselected `data` entry. In order of priority, `value` can be set to: object key (if `data` is an object), `selectedKey` prop (if `data` is an array), array index (if no `selectedKey`) or content (if `value` is a non-integer string).
+   * Define a preselected `data` entry. In order of priority, `value` can be set to: object key (if `data` is an object), `selectedKey` property (if `data` is an array), array index (if no `selectedKey`) or content (if `value` is a non-integer string).
    */
   value?: DrawerListValue
   /**


### PR DESCRIPTION
Align JSDoc property descriptions in elements and fragments with the doc strings in their sibling *Docs files, via the docs-types/sync-docs-jsdoc rule.

