### PR TITLE
fix(Autocomplete): keep open button open when no-results is shown

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -2340,7 +2340,8 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
 
   const { id, hidden, selectedItem, direction, open } = drawerList
 
-  const isExpanded = Boolean(open) && hasValidData()
+  const hasVisibleListContent = drawerList.data.length > 0
+  const isExpanded = Boolean(open) && hasVisibleListContent
 
   attributesRef.current = validateDOMAttributes(null, attributes)
   Object.assign(drawerList.attributes, attributesRef.current)

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1971,6 +1971,38 @@ describe('Autocomplete component', () => {
     ).toBeInTheDocument()
   })
 
+  it('should keep submit button open when no-options is shown', async () => {
+    render(
+      <Autocomplete data={mockData} showSubmitButton {...mockProps} />
+    )
+
+    toggle()
+
+    const submitButton = document.querySelector(
+      'button.dnb-input__submit-button__button:not(.dnb-input__clear-button)'
+    )
+
+    const openIcon = submitButton.querySelector(
+      'svg[data-icon-state="open"]'
+    )
+    const closedIcon = submitButton.querySelector(
+      'svg[data-icon-state="closed"]'
+    )
+
+    expect(submitButton).toHaveAttribute('aria-expanded', 'true')
+    expect(openIcon).toHaveClass('dnb-icon__state--active')
+    expect(closedIcon).not.toHaveClass('dnb-icon__state--active')
+
+    await userEvent.type(document.querySelector('input'), 'invalid')
+
+    expect(
+      document.querySelector('.dnb-autocomplete__no-options')
+    ).toBeInTheDocument()
+    expect(submitButton).toHaveAttribute('aria-expanded', 'true')
+    expect(openIcon).toHaveClass('dnb-icon__state--active')
+    expect(closedIcon).not.toHaveClass('dnb-icon__state--active')
+  })
+
   it('should not show "no-options" during async mode', async () => {
     const mockData = [
       { selectedKey: 'a', content: 'AA c' },


### PR DESCRIPTION
The Autocomplete submit button used selectable result data to decide whether the popup was expanded. When filtering produced only the no-options message, the list was still visible but the toggle icon switched to the closed direction.

This keeps the expanded state tied to visible list content, so the button remains open while the no-options message is shown.

Example: https://eufemia.dnb.no/uilib/components/autocomplete/demos#with-a-button-to-toggle-the-open--close-state


https://github.com/user-attachments/assets/64ca2702-554c-46de-bbec-9b5b431beeb4

