### PR TITLE
chore(components): sync JSDoc comments with Docs definitions

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -59,7 +59,7 @@ export type AccordionIcon =
   | {
       closed?: IconIcon
       /**
-       * If set to `true` the accordion will be expanded as its initial state.
+       * Use `true` or `false` to control the expanded/collapsed state of the accordion.
        */
       expanded?: IconIcon
     }
@@ -105,7 +105,7 @@ export type AccordionProps = Omit<
      */
     rememberState?: boolean
     /**
-     * Send along a custom React Ref for `.dnb-accordion__content`.
+     * Send along a custom `React.Ref` for `.dnb-accordion__content`.
      */
     contentRef?: RefObject<HTMLElement | null>
     /**
@@ -164,7 +164,7 @@ export type AccordionProps = Omit<
     className?: string
     children?: ReactNode
     /**
-     * Will be called by user click interaction. Returns an object with a boolean state `expanded` inside `{ expanded, id, event, ...event }`.
+     * Will be called by user click interaction. Returns an object with a boolean state `expanded` inside `{ expanded, event }`.
      */
     onChange?: (event: AccordionChangeEvent) => void
   }

--- a/packages/dnb-eufemia/src/components/accordion/types.ts
+++ b/packages/dnb-eufemia/src/components/accordion/types.ts
@@ -10,20 +10,21 @@ export type AccordionInstance = {
 }
 
 export type AccordionGroupProps = AccordionProps & {
-  /** If `true`, all accordions can be collapsed at once (none expanded). Defaults to `false`. */
+  /**
+   * If set to `true`, the group of accordions will allow all to close.
+   */
   allowCloseAll?: boolean
   /**
-   * Determines how many accordions can be expanded at once.
-   * Default: `single`
+   * Determines how many accordions can be expanded at once. Defaults to `single`.
    */
   expandBehavior?: 'single' | 'multiple'
   /**
-   * ref handle to collapse all expanded accordions. Send in a ref and use `.current()` to collapse all accordions.
-   *
-   * Default: `undefined`
+   * Define an `id` of a nested accordion that will get expanded.
    */
   expandedId?: string
-  /** Ref that exposes a function to programmatically collapse all expanded accordions. Call `.current()` to trigger. */
+  /**
+   * Ref handle to collapse all expanded accordions. Send in a ref and use `.current()` to collapse all accordions. Defaults to `undefined`.
+   */
   collapseAllHandleRef?: RefObject<() => void>
 }
 

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -51,38 +51,31 @@ export type AnchorProps = {
   ref?: Ref<HTMLAnchorElement>
 
   /**
-   * Removes default animation.
-   * Default: `false`
+   * Removes animations if set to `true`. Defaults to `false`.
    */
   noAnimation?: boolean
   /**
-   * Removes default styling.
-   * Default: `false`
+   * Removes styling if set to `true`. Defaults to `false`.
    */
   noStyle?: boolean
   /**
-   * Removes default hover style.
-   * Default: `false`
+   * Removes hover effects if set to `true`. Defaults to `false`.
    */
   noHover?: boolean
   /**
-   * Removes underline.
-   * Default: `false`
+   * Removes underline if set to `true`. Defaults to `false`.
    */
   noUnderline?: boolean
   /**
-   * Removes Icon.
-   * Default: `false`
+   * Removes icons if set to `true`. Defaults to `false`.
    */
   noIcon?: boolean
   /**
-   * Removes Launch Icon.
-   * Default: `false`
+   * Removes launch icon if set to `true`. Defaults to `false`.
    */
   noLaunchIcon?: boolean
   /**
-   * Disables the Anchor element.
-   * Default: `false`
+   * Disables the Anchor (no navigation, no hover). Keep a short reason nearby (e.g. using the `tooltip` property).
    */
   disabled?: boolean
 }

--- a/packages/dnb-eufemia/src/components/aria-live/AriaLiveDocs.ts
+++ b/packages/dnb-eufemia/src/components/aria-live/AriaLiveDocs.ts
@@ -27,7 +27,7 @@ export const AriaLiveProperties: PropertiesTableProps = {
     status: 'optional',
   },
   politeness: {
-    doc: 'The politeness setting for the announcement. Can be `polite` or `assertive`.',
+    doc: 'The politeness level of the announcement. Can be `off`, `polite`, or `assertive`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/aria-live/types.ts
+++ b/packages/dnb-eufemia/src/components/aria-live/types.ts
@@ -3,12 +3,12 @@ export type AriaLiveProps = {
   element?: ElementType
 
   /**
-   * The variant of the announcement. Can be `text` or `content`. Defaults to `text`.
+   * Can be `text` for text messages or `content` for whole application content. Defaults to `text`.
    */
   variant?: 'text' | 'content'
 
   /**
-   * The priority level of the announcement. Can be `low`, or `high`.
+   * Priority of the announcement. Can be `low` or `high`. Defaults to `low`.
    */
   priority?: 'low' | 'high'
 
@@ -23,28 +23,27 @@ export type AriaLiveProps = {
   disabled?: boolean
 
   /**
-   * The politeness level of the announcement. Can be 'off', 'polite', or 'assertive'.
+   * The politeness level of the announcement. Can be `off`, `polite`, or `assertive`.
    */
   politeness?: HTMLAttributes<HTMLElement>['aria-live']
 
   /**
-   * Whether the entire region should be considered as a whole when communicating updates.
+   * If `true`, assistive technologies will present the entire region as a whole. If `false`, only additions will be announced.
    */
   atomic?: HTMLAttributes<HTMLElement>['aria-atomic']
 
   /**
-   * What types of changes should be presented to the user. Can be 'additions', 'removals', 'text', or 'all'.
+   * A space-separated list of the types of changes that should be announced. Can be `additions`, `removals`, `text`, or `all`.
    */
   relevant?: HTMLAttributes<HTMLElement>['aria-relevant']
 
   /**
-   * Whether to show the children or not.
-   * Default: `false`
+   * Whether to show the children or not. Defaults to `false`.
    */
   showAnnouncement?: boolean
 
   /**
-   * The content to be announced.
+   * The content that will be announced to the user.
    */
   children: ReactNode
 }

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -180,152 +180,152 @@ export type AutocompleteProps = {
    */
   mode?: AutocompleteMode
   /**
-   * Give a title to let the user know what they have to do.
+   * Give a title to let the user know what they have to do. Defaults to `Skriv og få alternativer`.
    */
   title?: AutocompleteTitle
   /**
-   * Pre-filled placeholder text in the input.
+   * Use this to define the pre-filled placeholder text in the input. Defaults to `title="Skriv og velg"`.
    */
   placeholder?: AutocompletePlaceholder
   /**
-   * Text shown in the "no options" item. If set to `false`, the list will not be rendered when there are no options.
+   * Text shown in the "no options" item. If set to `false`, the list will not be rendered when there are no options available. Defaults to `Ingen alternativer`.
    */
   noOptions?: AutocompleteNoOptions
   /**
-   * Text that lets a user unravel all the available options.
+   * Text that lets a user unravel all the available options. Defaults to `Vis alt`.
    */
   showAll?: AutocompleteShowAll
   /**
-   * Text read out by screen readers to announce number of options.
+   * Text read out by screen readers. This way users with screen readers know how many options they got during typing. Defaults to `%s alternativer`.
    */
   ariaLiveOptions?: AutocompleteAriaLiveOptions
   /**
-   * Text shown on indicator item.
+   * Text shown on indicator "options" item. Defaults to `Henter data ...`.
    */
   indicatorLabel?: AutocompleteIndicatorLabel
   /**
-   * Screen-reader title for the button that opens options.
+   * Only for screen readers. Title of the button to show the suggestions / options. It is always present and when activating, it opens the DrawerList and sets the focus on it. Defaults to `Bla gjennom alternativer`.
    */
   showOptionsSr?: string
   /**
-   * Label used to announce the selected item for screen readers.
+   * Only for screen readers (VoiceOver). The label used to announce the selected item. Defaults to `Valgt:`.
    */
   selectedSr?: string
   /**
-   * If set to `true`, the whole input value gets selected on focus.
+   * If set to `true`, then the whole input value gets selected on the entry focus. A second click will place the cursor on the wanted position.
    */
   selectAll?: boolean
   /**
-   * Title on submit button.
+   * Title on submit button. Defaults to `Vis alternativer`.
    */
   submitButtonTitle?: string
   /**
-   * The icon used in the submit button.
+   * The icon used in the submit button. Defaults to `chevron_down`.
    */
   submitButtonIcon?: AutocompleteSubmitButtonIcon
   /**
-   * React ref for access to the input DOM element.
+   * Use a `React.Ref` to get access to the `input` DOM element.
    */
   inputRef?: AutocompleteInputRef
   /**
-   * Icon to be included in the autocomplete input. Defaults to `'loupe'`.
+   * To be included in the autocomplete input. Defaults to `loupe`. Set to `null` to remove the icon entirely – no progress indicator will then be shown while loading.
    */
   icon?: IconIcon | ReactNode | (() => ReactNode)
   /**
-   * Change icon size.
+   * Change the size of the icon programmatically.
    */
   iconSize?: IconSize
   /**
-   * Icon position inside autocomplete.
+   * Position of the icon inside the autocomplete. Set to `left` or `right`. Defaults to `left`.
    */
   iconPosition?: ButtonIconPosition
   /**
-   * Prepends the form label.
+   * Prepends the Form Label component. If no ID is provided, a random ID is created.
    */
   label?: ReactNode
   /**
-   * Set `vertical` to change label layout direction.
+   * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
    */
   labelDirection?: FormLabelLabelDirection
   /**
-   * Makes label readable by screen readers only.
+   * Use `true` to make the label only readable by screen readers.
    */
   labelSrOnly?: boolean
   /**
-   * Keep typed value on blur even when invalid.
+   * Use `true` to not remove the typed value on input blur, if it is invalid. By default, the typed value will disappear / be replaced by a selected value from the data list during the input field blur. Defaults to `false`.
    */
   keepValue?: boolean
   /**
-   * Keep selected item on blur when input value is empty.
+   * Use `true` to not remove selected item on input blur, when the input value is empty. Defaults to `false`.
    */
   keepSelection?: boolean
   /**
-   * Keep typed value and selected item on blur.
+   * Like `keepValue` – but would not reset to the selected value during input field blur. Also, the selected value would still be kept. Defaults to `false`.
    */
   keepValueAndSelection?: boolean
   /**
-   * Show clear button inside input.
+   * If set to `true`, a clear button is shown inside the input field. Defaults to `false`.
    */
   showClearButton?: boolean
   /**
-   * Keep highlighting but disable filtering.
+   * If set to `true`, word highlighting will still be active, but no options will be filtered out. Defaults to `false`.
    */
   disableFilter?: boolean
   /**
-   * Disable reordering of search results.
+   * If set to `true`, reordering of search results will be disabled. Defaults to `false`.
    */
   disableReorder?: boolean
   /**
-   * Disable highlighting but keep filtering.
+   * If set to `true`, word highlighting will be disabled, but the options will still get filtered. Defaults to `false`.
    */
   disableHighlighting?: boolean
   /**
-   * Show autocomplete submit/toggle button.
+   * Use `true` to show an Autocomplete button to toggle the [DrawerList](/uilib/components/fragments/drawer-list). Defaults to `false`.
    */
   showSubmitButton?: boolean
   /**
-   * Replace submit button with a custom element.
+   * Replace the dropdown / submit button with a custom React element. Defaults to the input SubmitButton `import { SubmitButton } from '@dnb/eufemia/components/input/Input'`.
    */
   submitElement?: ReactNode
   /**
-   * Change options alignment.
+   * Use `right` to change the options alignment direction. Defaults to `left`.
    */
   align?: AutocompleteAlign
   /**
-   * Provide a custom input element.
+   * Lets you provide a custom React element as the input HTML element.
    */
   inputElement?: AutocompleteInputElement
   /**
-   * Threshold deciding from which word to search inside words.
+   * This gives you the possibility to change the threshold number, which defines from what word on we search "inside words". Defaults to `3`.
    */
   searchInWordIndex?: AutocompleteSearchInWordIndex
   /**
-   * Search matching mode.
+   * Defines how search matching is performed. Use `starts-with` to only match items that begin with the first typed word. Defaults to `word`.
    */
   searchMatch?: AutocompleteSearchMatch
   /**
-   * Better number searching/filtering behavior.
+   * If set to `true` and `searchInWordIndex` is not set, the user will be able to more easily search and filter e.g. bank account numbers. Defaults to `false`.
    */
   searchNumbers?: boolean
   /**
-   * Auto-open list on focus.
+   * Use `true` to auto open the list once the user is entering the input field with the keyboard.
    */
   openOnFocus?: boolean
   disabled?: boolean
   /**
-   * Stretch to full available width.
+   * If set to `true`, then the autocomplete will be 100% in available `width`.
    */
   stretch?: boolean
   /**
-   * Show skeleton loading overlay.
+   * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow
   /**
-   * Additional content rendered as suffix.
+   * Text describing the content of the Autocomplete more than the label. You can also send in a React component, so it gets wrapped inside the Autocomplete component.
    */
   suffix?: DrawerListSuffix
   /**
-   * Custom class for internal drawer list.
+   * Define a custom class for the internal drawer-list. This makes it possible more easily customize the drawer-list style with styled-components and the `css` style method. Defaults to `null`.
    */
   drawerClass?: string
   /**
@@ -337,17 +337,17 @@ export type AutocompleteProps = {
    */
   defaultValue?: string | number
   /**
-   * Controlled input value.
+   * Lets you define a custom input value. Setting it to an empty string `""` will reset the input value.
    */
   inputValue?: string
   size?: DrawerListProps['size']
   data?: DrawerListData
   /**
-   * Will be called once the Autocomplete shows up.
+   * Will be called once the user presses the autocomplete. Returns the data item `{ data, attributes }`.
    */
   onOpen?: (event: AutocompleteOnTypeParams) => void
   /**
-   * Will be called once the Autocomplete gets closed.
+   * Will be called once the user presses the autocomplete again, or clicks somewhere else. Returns the data item `{ data, attributes }`.
    */
   onClose?: (event: AutocompleteOnTypeParams) => void
   onType?: (event: AutocompleteOnTypeParams) => void
@@ -357,7 +357,7 @@ export type AutocompleteProps = {
   onSelect?: (event: AutocompleteOnSelectParams) => void
   onClear?: (event: AutocompleteOnClearParams) => void
   /**
-   * Will be called when the user presses Enter in the input field without selecting an item from the list. Returns an object with the input `value` and the `event`.
+   * Will be called when the user presses Enter in the input field without selecting an item from the list. Useful for triggering custom actions like navigating to a search results page. Returns `{ value, event, attributes }` including [these methods](/uilib/components/autocomplete/events#dynamically-change-data).
    */
   onSubmit?: (event: AutocompleteOnSubmitParams) => void
 }

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -45,7 +45,6 @@ export type AvatarImgProps = ImgProps
 export type AvatarProps = Omit<HTMLProps<HTMLElement>, 'size'> & {
   /**
    * Used in combination with `src` to provide an alt attribute for the `img` element.
-   * Default: `null`
    */
   alt?: string
 
@@ -56,63 +55,53 @@ export type AvatarProps = Omit<HTMLProps<HTMLElement>, 'size'> & {
   className?: string
 
   /**
-   * Skeleton should be applied when loading content
-   * Default: `null`
+   * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow
 
   /**
-   * The content of the component. Can be used instead of prop "data".
-   * Default: `null`
+   * Content of the component.
    */
   children?: ReactNode
 
   /**
-   * The size of the component.
-   * Default: `medium`
+   * Size of the Avatar. Options: `small` | `medium` | `large` | `x-large`. Defaults to `medium`.
    */
   size?: AvatarSizes
 
   /**
-   * Specifies the path to the image
-   * Default: `null`
+   * Specifies the path to the image.
    */
   src?: string
 
   /**
-   * Props applied to the `img` element if the component is used to display an image.
-   * Default: `null`
+   * [Image properties](/uilib/elements/image) applied to the `img` element if the component is used to display an image.
    */
   imgProps?: ImgProps
 
   /**
-   * An icon name or component
+   * An icon name or component. (Will override the `src` property.)
    */
 
   icon?: IconIcon
 
   /**
-   * The variant of the component.
-   * Default: `primary`
+   * Override the variant of the component. Options: `primary` | `secondary` | `tertiary`. Defaults to `primary`.
    */
   variant?: AvatarVariants
 
   /**
-   * If an avatar is hidden from the screen reader (by setting aria-hidden={true}) or if label is given, typical inside a table or dl (definition list), then you can disable Avatar.Group as a dependent of Avatar.
-   * Use `true` to omit the `Avatar group required:` warning.
-   * Default: `null`
+   * If `aria-hidden` is set to `true` or if a label is given, typically inside a table or dl (definition list), then you can disable Avatar.Group as a dependent of Avatar. Use `true` to omit the `Avatar group required:` warning.
    */
   hasLabel?: boolean
 
   /**
    * Define a custom background color, instead of a variant. Use a Eufemia color.
-   * Default: `undefined`
    */
   backgroundColor?: string
 
   /**
    * Define a custom color to complement the backgroundColor. Use a Eufemia color.
-   * Default: `undefined`
    */
   color?: string
 }

--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -26,60 +26,50 @@ export type BadgeProps = {
   label?: ReactNode
 
   /**
-   * Custom className on the component root
-   * Default: `null`
+   * Custom `className` for the component.
    */
   className?: string
 
   /**
    * Applies loading skeleton.
-   * Default: `false`
    */
   skeleton?: SkeletonShow
 
   /**
-   * The content to display the badge on top of.
-   * Default: `null`
+   * Content to display the badge on top of.
    */
   children?: ReactNode
 
   /**
-   * The content of the component.
-   * Default: `null`
+   * Content of the component.
    */
   content?: string | number | ReactNode
 
   /**
-   * The vertical positioning of the component.
-   * Default: `null`
+   * Vertical positioning of the component. Options: `bottom` | `top`.
    */
   vertical?: 'bottom' | 'top'
 
   /**
-   * The horizontal positioning of the component.
-   * Default: `null`
+   * Horizontal positioning of the component. Options: `left` | `right`.
    */
   horizontal?: 'left' | 'right'
 
   /**
-   * The variant of the component.
-   * Default: `information`
+   * Defines the visual appearance of the badge. There are two main variants `notification` and `information`. The `content` variant is just for placement purposes, and will require you to style the `content` all by yourself. Default variant is `information`.
    */
   variant?: 'information' | 'notification' | 'content'
 
   /**
-   * Defines the status color of the `"information"` variant. Has no effect on other variants.
-   * Default: `default`
+   * Defines the status color of the `"information"` variant. Has no effect on other variants. Defaults to `"default"`.
    */
   status?: 'default' | 'neutral' | 'positive' | 'warning' | 'negative'
   /**
-   * Applies subtle style to `"information"` variant. Has no effect on other variants.
-   * Default: `false`
+   * Applies subtle style to `"information"` variant. Has no effect on other variants. Defaults to `false`.
    */
   subtle?: boolean
   /**
-   * Removes the badge without removing children. Useful when Badge wraps content.
-   * Default: `false`
+   * Removes the badge without removing children. Useful when Badge wraps content. Defaults to `false`.
    */
   hideBadge?: boolean
 }

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -53,8 +53,7 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type BreadcrumbProps = {
   /**
-   * Custom className on the component root
-   * Default: `null`
+   * Custom `className` for the component root.
    */
   className?: string
 
@@ -64,76 +63,64 @@ export type BreadcrumbProps = {
   skeleton?: SkeletonShow
 
   /**
-   * Pass in a list of your pages as objects of breadcrumbitem to render them as breadcrumbitems.
-   * Default: `null`
+   * List of pages to render as breadcrumb items. Each object in data can include all properties from [BreadcrumbItem properties](/uilib/components/breadcrumb/properties#breadcrumbitem-properties).
    */
   data?: Array<BreadcrumbItemProps>
 
   /**
-   * The content of the component. Can be used instead of prop "data".
-   * Default: `null`
+   * Content of the component. Can be used instead of property `data`, by adding `Breadcrumb.Item` children `<Breadcrumb.Item {...properties} />`.
    */
   children?:
     | ReactElement<BreadcrumbItemProps>
     | Array<ReactElement<BreadcrumbItemProps>>
 
   /**
-   * The variant of the component.
-   * Defaults to `single` when children and data are not defined, `responsive` if they are.
+   * Defaults to `responsive` or `single` depending on content. Options: `responsive` | `single` | `multiple` | `collapse`.
    */
   variant?: 'responsive' | 'single' | 'multiple' | 'collapse'
 
   /**
-   * Handle the click event on 'single'/'collapse'
-   * Default: `null`
+   * Will be called by user click interaction, to handle click event on "Back" for variant `single` and "Back to..." for variant `collapse`.
    */
   onClick?: MouseEventHandler<HTMLButtonElement>
 
   /**
-   * For variant 'single', use href (or onClick) to set href when clicking "Back"
-   * Default: `null`
+   * For variant `single`, set `href` for button click. Can be used instead of event/property `onClick`.
    */
   href?: string
 
   /**
-   * Every <nav> on a page needs a unique aria-label text
-   * Default: `Page hierarchy`
+   * Every `<nav>` on a page needs a unique `aria-label` text.
    */
   navText?: ReactNode
 
   /**
-   * Add custom 'Back' text for variant 'single'
-   * Default: `'Back' or defined by Context translation`
+   * Override with a custom 'Back' text for variant `single` (Not recommended).
    */
   goBackText?: ReactNode
 
   /**
-   * Add custom 'Home' text
-   * Default: `'Home' or defined by Context translation`
+   * Override with a custom 'Home' text (Not recommended).
    */
   homeText?: ReactNode
 
   /**
-   * Add custom 'Back to...' text, for variant collapse
-   * Default 'Gå til ...' or defined by Context translation
+   * Override with a custom 'Back to...' text (Not recommended).
    */
   backToText?: ReactNode
 
   /**
-   * If variant='collapse', you can override collapsed state for the collapsed content by updating this value.
-   * Default: `null`
+   * For variant `collapse`, override collapsed state for the collapsed content by updating this value using the provided property `onClick`.
    */
   collapsed?: boolean
 
   /**
-   * Include spacing properties in breadcrumb. If only `true` is given, the spacing will be `small`.
-   * Default: `false`
+   * Include spacing properties in breadcrumb. If only `true` is given, the spacing will be `small`. Defaults to `false`.
    */
   spacing?: SpaceTypeAll | SpaceTypeMedia
 
   /**
-   * Will disable the height animation
-   * Default: `false`
+   * Disables the height animation. Defaults to `false`.
    */
   noAnimation?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -103,16 +103,15 @@ export type ButtonProps = {
    */
   type?: string
   /**
-   * Required if there is no text in the button. If `text` and `children` are undefined, setting the `title` property will automatically set `aria-label` with the same value.
-   * Accepts `ReactNode`. If a JSX element is provided, it will be converted to a plain string using `convertJsxToString` — only static text content is extracted. Custom components that don't render static children will result in an empty string.
+   * Required if there is no text in the button. If `text` and `children` are `undefined`, setting the `title` property will automatically set `aria-label` with the same value. Accepts `ReactNode`. If a JSX element is provided, it will be converted to a plain string using `convertJsxToString` — only static text content is extracted. Custom components that don't render static children will result in an empty string.
    */
   title?: ReactNode
   /**
-   * Defines the kind of button. Possible values are `primary`, `secondary` and `tertiary`. Defaults to `primary` (or `secondary` if icon only).
+   * Defines the kind of button. Possible values are `primary`, `secondary` and `tertiary`. Defaults to `primary` (or `secondary` if icon only). The `tertiary` button is normally used together with an icon and officially supports only the default and large sizes.
    */
   variant?: ButtonVariant
   /**
-   * The size of the button. There is `default`, `small`, `medium` and `large`. The `tertiary` button officially supports only default and large.
+   * The size of the button. There is `default`, `small`, `medium` and `large`. The `tertiary` button officially supports only default and large. Changing the size mainly affects spacing, but the large tertiary button also has a larger font size.
    */
   size?: ButtonSize
   /**

--- a/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
+++ b/packages/dnb-eufemia/src/components/button/ButtonDocs.ts
@@ -17,7 +17,7 @@ export const ButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
   title: {
-    doc: 'Required if there is no text in the button. If `text` and `children` are `undefined`, setting the `title` property will automatically set `aria-label` with the same value.',
+    doc: "Required if there is no text in the button. If `text` and `children` are `undefined`, setting the `title` property will automatically set `aria-label` with the same value. Accepts `ReactNode`. If a JSX element is provided, it will be converted to a plain string using `convertJsxToString` — only static text content is extracted. Custom components that don't render static children will result in an empty string.",
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -79,7 +79,7 @@ export type CheckboxProps = {
    */
   checked?: boolean | undefined | null
   /**
-   * Controls the checkbox indeterminate (partial) state. The default is `false`.
+   * Controls the checkbox indeterminate (partial) state.
    */
   indeterminate?: boolean
   /**
@@ -97,15 +97,15 @@ export type CheckboxProps = {
    */
   skeleton?: SkeletonShow
   /**
-   * Will be called on state changes made by the user. Returns `{ checked, event }`.
+   * Will be called on state changes made by the user.
    */
   onChange?: (args: CheckboxOnChangeParams) => void
   /**
-   * Will be called on click made by the user. Returns the ClickEvent.
+   * Will be called on click.
    */
   onClick?: (args: CheckboxOnClickParams) => void
   /**
-   * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
+   * By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: RefObject<HTMLInputElement> | ((elem: HTMLInputElement) => void)
 } & FormStatusBaseProps &

--- a/packages/dnb-eufemia/src/components/copy-on-click/types.ts
+++ b/packages/dnb-eufemia/src/components/copy-on-click/types.ts
@@ -3,20 +3,17 @@ import type { SpacingProps } from '../../shared/types'
 
 export type CopyOnClickProps = {
   /**
-   * Whether to show the copy cursor or not.
-   * Default: `true`
+   * Define if the copy cursor should be visible. Defaults to `true`.
    */
   showCursor?: boolean
 
   /**
-   * If `true`, the copy functionality and copy cursor will be omitted.
-   * Default: `false`
+   * If `true`, the copy functionality and copy cursor will be omitted. Defaults to `false`.
    */
   disabled?: boolean
 
   /**
-   * The content to be copied.
-   * Used when the copied value should differ from the visually shown value(`children`).
+   * Contents to copy. Used when the copied value should differ from the visually shown value(`children`).
    */
   copyContent?: ReactNode
 
@@ -27,7 +24,7 @@ export type CopyOnClickProps = {
   tooltipContent?: ReactNode
 
   /**
-   * The content/children to be copied.
+   * Contents.
    */
   children: ReactNode
 }

--- a/packages/dnb-eufemia/src/components/date-format/DateFormat.tsx
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormat.tsx
@@ -40,9 +40,13 @@ type DateFormatProps = SpacingProps & {
   dateStyle?: Intl.DateTimeFormatOptions['dateStyle']
   timeStyle?: Intl.DateTimeFormatOptions['timeStyle']
   dateTimeSeparator?: string
-  /** When `true`, hides the year if the date is in the current year (any `dateStyle`). */
+  /**
+   * When `true`, the year is hidden if the date is in the current year, for any `dateStyle` (e.g. "4. feb." instead of "4. feb. 2025"). Defaults to `false`.
+   */
   hideCurrentYear?: boolean
-  /** When `true`, always hides the year from the formatted date (any `dateStyle`). */
+  /**
+   * When `true`, the year is always hidden from the formatted date, for any `dateStyle`. Defaults to `false`.
+   */
   hideYear?: boolean
   relativeTimeStyle?: Intl.DateTimeFormatOptions['dateStyle']
   relativeTime?: boolean

--- a/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
@@ -30,9 +30,13 @@ export type DateFormatOptions = {
   locale?: AnyLocale
   options?: Intl.DateTimeFormatOptions
   timeZone?: string
-  /** When true, hides the year if the date is in the current year (any dateStyle). */
+  /**
+   * When `true`, the year is hidden if the date is in the current year, for any `dateStyle` (e.g. "4. feb." instead of "4. feb. 2025"). Defaults to `false`.
+   */
   hideCurrentYear?: boolean
-  /** When true, always hides the year from the formatted date (any dateStyle). */
+  /**
+   * When `true`, the year is always hidden from the formatted date, for any `dateStyle`. Defaults to `false`.
+   */
   hideYear?: boolean
 }
 

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -96,7 +96,7 @@ export type DisplayPickerEvent = (
 
 export type DatePickerProps = {
   /**
-   * Defines the pre-filled date by either a JavaScript DateInstance or (ISO 8601) like `date="2019-05-05"`.
+   * Defines the pre-filled date by either a JavaScript `Date` instance or (ISO 8601) like `date="2019-05-05"`.
    */
   date?: DatePickerDateType
   /**
@@ -120,15 +120,15 @@ export type DatePickerProps = {
    */
   endMonth?: DatePickerDateType
   /**
-   * To limit the selectable dates in the calendar view to a minimum date. Dates before this will be disabled. Does not validate dates typed in the input field. Defaults to `null`.
+   * To limit the selectable dates in the calendar view to a minimum date. Dates before this will be disabled. Note: This does not validate dates typed in the input field. Use [Field.Date](/uilib/extensions/forms/feature-fields/Date/) for input validation. Defaults to `null`.
    */
   minDate?: DatePickerDateType
   /**
-   * To limit the selectable dates in the calendar view to a maximum date. Dates after this will be disabled. Does not validate dates typed in the input field. Defaults to `null`.
+   * To limit the selectable dates in the calendar view to a maximum date. Dates after this will be disabled. Note: This does not validate dates typed in the input field. Use [Field.Date](/uilib/extensions/forms/feature-fields/Date/) for input validation. Defaults to `null`.
    */
   maxDate?: DatePickerDateType
   /**
-   * To define the order of the masked placeholder input fields. Defaults to `dd/mm/yyyy`
+   * To define the order of the masked placeholder input fields. Defaults to `dd/mm/yyyy`.
    */
   maskOrder?: string
   /**
@@ -136,7 +136,7 @@ export type DatePickerProps = {
    */
   maskPlaceholder?: string
   /**
-   * Defines how the prop dates (`date`, `startDate` and `endDate`) should be parsed, e.g. `yyyy/MM/dd`. Defaults to `yyyy-MM-dd`.
+   * Defines how the property dates (`date`, `startDate` and `endDate`) should be parsed, e.g. `yyyy/MM/dd`. Defaults to `yyyy-MM-dd`.
    */
   dateFormat?: string
   /**
@@ -160,7 +160,7 @@ export type DatePickerProps = {
    */
   hideLastWeek?: boolean
   /**
-   * Once the date picker gets opened, there is a focus handling to ensure good accessibility. Can be disabled with this property. Defaults to `false`.
+   * Once the date picker gets opened, there is a focus handling to ensure good accessibility. This can be disabled with this property. Defaults to `false`.
    */
   disableAutofocus?: boolean
   enableKeyboardNav?: boolean
@@ -173,15 +173,15 @@ export type DatePickerProps = {
    */
   inline?: boolean
   /**
-   * If set to `true`, a submit button will be shown. You can change the default text by using `submitButtonText="Ok"`. Defaults to `false`. If the `range` prop is `true`, then the submit button is shown.
+   * If set to `true`, a submit button will be shown. You can change the default text by using `submitButtonText="Ok"`. Defaults to `false`. If the `range` property is `true`, then the submit button is shown.
    */
   showSubmitButton?: boolean
   /**
-   * If set to `true`, a cancel button will be shown. You can change the default text by using `cancelButtonText="Avbryt"`. Defaults to `false`. If the `range` prop is `true`, then the cancel button is shown.
+   * If set to `true`, a cancel button will be shown. You can change the default text by using `cancelButtonText="Avbryt"`. If the `range` property is `true`, then the cancel button is shown. Defaults to `false`.
    */
   showCancelButton?: boolean
   /**
-   * If set to `true`, a reset button will be shown. You can change the default text by using `resetButtonText="Tilbakestill"`. Defaults to `false`.
+   * If set to `true`, a reset button will be shown. You can change the default text by using `resetButtonText="Tilbakestill"`. When clicked, the date picker reverts to the value it had when it was first rendered. If no initial value was provided, the date is cleared. Defaults to `false`.
    */
   showResetButton?: boolean
   submitButtonText?: string
@@ -204,7 +204,7 @@ export type DatePickerProps = {
    */
   range?: boolean
   /**
-   * If set to `true`, only one calendar is shown in range mode instead of two side-by-side calendars. Only meant to use if the range is set to `true`. Defaults to `false`.
+   * If set to `true`, only one calendar is shown in range mode instead of two side-by-side calendars. Only meant to be used if `range` is set to `true`. Defaults to `false`.
    */
   rangeSingleCalendar?: boolean
   /**
@@ -220,7 +220,7 @@ export type DatePickerProps = {
    */
   label?: ReactNode
   /**
-   * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
+   *  Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
    */
   labelDirection?: 'vertical' | 'horizontal'
   /**
@@ -265,7 +265,7 @@ export type DatePickerProps = {
    */
   tooltip?: ReactNode
   /**
-   * Props to forward to the trigger button. Can be used to change the button `variant`, add a `text` label, or override other button properties.
+   * Props to forward to the trigger button. Can be used to change the button `variant`, add a `text` label, or override other button properties such as `icon` and `iconPosition`.
    */
   triggerProps?: Partial<
     Pick<
@@ -278,7 +278,7 @@ export type DatePickerProps = {
   noAnimation?: boolean
   direction?: 'auto' | 'top' | 'bottom'
   /**
-   * Use `right` to change the calendar alignment direction. Defaults to `left`.
+   * Use `right` to change the preferred calendar alignment direction. Defaults to `left`. If the DatePicker is close to the edge of the screen, the alignment of the calendar will change automatically to fit in the viewport.
    */
   alignPicker?: 'left' | 'center' | 'right'
   /**
@@ -302,7 +302,7 @@ export type DatePickerProps = {
     nr?: DatePickerCalendarProps['nr']
   ) => void
   /**
-   * Will be called on a date change event. Returns an `object`. See Returned Object below.
+   * Will be called on a date change event. Returns an object. See Returned Object below.
    */
   onChange?: (
     event: DatePickerEvent<ChangeEvent<HTMLInputElement>>
@@ -332,7 +332,7 @@ export type DatePickerProps = {
     event: DatePickerEvent<MouseEvent<HTMLButtonElement>>
   ) => void
   /**
-   * Will be called once a user presses the reset button. The DatePicker will revert to the value it had when it was first rendered (the initial `date`, `startDate`, or `endDate` prop values). If no initial value was provided, the date will be cleared.
+   * Will be called once a user presses the reset button. The date picker will revert to the value it had when first rendered. If no initial value was provided, the date is cleared.
    */
   onReset?: (event: DatePickerEvent<MouseEvent<HTMLButtonElement>>) => void
   /**

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -214,7 +214,7 @@ export const DatePickerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   labelDirection: {
-    doc: ' Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
+    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
     type: ['"vertical"', '"horizontal"'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/dialog/types.ts
+++ b/packages/dnb-eufemia/src/components/dialog/types.ts
@@ -78,7 +78,7 @@ export type DialogContentProps = Omit<DialogActionProps, 'children'> & {
   noAnimationOnMobile?: boolean
 
   /**
-   * Variant of Dialog. Defaults to `information`.
+   * The dialog variant. Can either be `information` or `confirmation`. Defaults to `information`.
    */
   variant?: 'information' | 'confirmation'
 

--- a/packages/dnb-eufemia/src/components/drawer/types.ts
+++ b/packages/dnb-eufemia/src/components/drawer/types.ts
@@ -4,12 +4,12 @@ import type { ModalAllProps } from '../modal/Modal'
 
 export type DrawerProps = {
   /**
-   * Defines the placement on what side the Drawer should be opened. Can be set to `left`, `right`, `top` and `bottom`. Defaults to `right`.
+   * Defines on what side the Drawer should be opened. Can be set to `left`, `right`, `top` and `bottom`. Defaults to `right`.
    */
   containerPlacement?: 'left' | 'right' | 'top' | 'bottom'
 
   /**
-   * The drawer title. Displays on the very top of the content.
+   * The drawer title. Displays at the very top of the content.
    */
   title?: ReactNode
 } & ModalAllProps
@@ -61,7 +61,7 @@ export type DrawerContentProps = {
   children?: ReactNode | ((props: DrawerContentProps) => ReactNode)
 
   /**
-   * Define the inner horizontal alignment of the content. Can be set to `left`, `center`, `right` and `centered`. If `centered`, then the content will also be centered vertically. Defaults to `left`.
+   * Define the inner horizontal alignment of the content. Can be set to `left`, `center`, `centered` and `right`. If `centered`, then the content will also be centered vertically. Defaults to `left`.
    */
   alignContent?: 'left' | 'right' | 'centered' | 'center'
 
@@ -71,7 +71,7 @@ export type DrawerContentProps = {
   fullscreen?: boolean | string
 
   /**
-   * Defines the placement on what side the Drawer should be opened. Can be set to `left`, `right`, `top` and `bottom`. Defaults to `right`.
+   * Defines on what side the Drawer should be opened. Can be set to `left`, `right`, `top` and `bottom`. Defaults to `right`.
    */
   containerPlacement?: string
 

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -112,11 +112,11 @@ export type DropdownProps = {
    */
   labelSrOnly?: boolean
   /**
-   * By providing a React.Ref you can get the internally used main element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
+   * By providing a `React.Ref` you can get the internally used main element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: Ref<HTMLElement>
   /**
-   * By providing a React.Ref you can get the internally used button element (DOM). E.g. `buttonRef={myRef}` by using `React.useRef(null)`.
+   * By providing a `React.Ref` you can get the internally used button element (DOM), e.g. `buttonRef={myRef}` by using `React.useRef(null)`.
    */
   buttonRef?: Ref<HTMLElement>
   /**
@@ -145,11 +145,11 @@ export type DropdownProps = {
    */
   suffix?: DrawerListSuffix
   /**
-   * Will be called once the Dropdown shows up.
+   * Will be called once the user presses the dropdown. Returns the data item `{ data, attributes }`.
    */
   onOpen?: (event: DropdownOpenEvent) => void
   /**
-   * Will be called once the Dropdown gets closed.
+   * Will be called once the user presses the dropdown again, or clicks somewhere else. Returns the data item `{ data, attributes }`.
    */
   onClose?: (event: DropdownCloseEvent) => void
   onOpenFocus?: (args: { element: HTMLElement }) => void

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -42,11 +42,17 @@ type Gap =
 export type FlexContainerProps = {
   direction?: 'horizontal' | 'vertical'
   wrap?: boolean
-  /** Disable automatic Space wrappers for intrinsic DOM children such as `li` or `p`. */
+  /**
+   * Define if intrinsic DOM child elements such as `li` should be wrapped in `Space` to receive spacing. Set to `false` to keep them as direct descendants.
+   * Default: `true`
+   */
   wrapChildrenInSpace?: boolean
   rowGap?: Gap
   sizeCount?: number
-  /** Distribute sub components along the main axis (CSS `justify-content`). In horizontal direction, this controls left-to-right placement. In vertical direction, this controls top-to-bottom placement. */
+  /**
+   * Distribute sub components along the main axis (CSS `justify-content`). In horizontal direction, this controls left-to-right placement. In vertical direction, this controls top-to-bottom placement.
+   * Default: `'flex-start'`
+   */
   justify?:
     | 'flex-start'
     | 'flex-end'
@@ -54,13 +60,22 @@ export type FlexContainerProps = {
     | 'space-between'
     | 'space-around'
     | 'space-evenly'
-  /** Align sub components along the cross axis (CSS `align-items`). In horizontal direction, this controls vertical alignment. In vertical direction, this controls horizontal alignment. */
+  /**
+   * Align sub components along the cross axis (CSS `align-items`). In horizontal direction, this controls vertical alignment. In vertical direction, this controls horizontal alignment.
+   * Default: `'flex-start'`
+   */
   align?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline'
   /** For when used as a flex item in an outer container in addition to being a container: */
   alignSelf?: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
-  /** When "line-framed" is used, a line will be shown between items and above the first and below the last item */
+  /**
+   * How to separate sub components.
+   * Default: `'space'`
+   */
   divider?: 'space' | 'line' | 'line-framed'
-  /** Spacing between items inside */
+  /**
+   * How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.)
+   * Default: `'small'`
+   */
   gap?: Gap
   breakpoints?: MediaQueryBreakpoints
   queries?: UseMediaQueries

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
@@ -44,7 +44,9 @@ export type FormLabelProps = {
   srOnly?: boolean
   ref?: Ref<HTMLElement>
 
-  /** Is not a part of HTMLLabelElement and not documented as of now */
+  /**
+   * If set to `true`, the label will behave as not interactive.
+   */
   disabled?: boolean
 
   /**

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -105,11 +105,11 @@ export type FormStatusProps = {
    */
   globalStatus?: GlobalStatusConfigObject
   /**
-   * The `icon` shown before the status text. Default: `error`
+   * The `icon` shown before the status text. Defaults to `error`.
    */
   icon?: IconIcon
   /**
-   * The size of the icon. Default: `medium`
+   * The size of the icon. Defaults to `medium`.
    */
   iconSize?: IconSize
   /**
@@ -129,7 +129,7 @@ export type FormStatusProps = {
   widthSelector?: string
   widthElement?: { current: HTMLElement | null } | null
   /**
-   * NB: Animation is disabled as of now. ~~use `true` to omit the animation on content visibility. Defaults to `false`.~~
+   * **NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~
    */
   noAnimation?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -28,44 +28,42 @@ export type GlobalErrorLink = {
 
 export type GlobalErrorProps = {
   /**
-   * When `404` or `500` is given, a predefined text will be shown.
-   * Defaults to `404`.
+   * Defines a status code as a string. When `404` or `500` is given, predefined `text` and `title` will be shown. Defaults to `404`.
    */
   statusCode?: '404' | '500' | string
 
   /**
-   * Will overwrite the default title.
+   * Overwrites the default title for the provided `statusCode`.
    */
   title?: ReactNode
 
   /**
-   * Will overwrite the default text.
+   * Overwrites the default text for the provided `statusCode`.
    */
   text?: ReactNode
 
   /**
-   * Will overwrite the default error message code.
+   * Overwrites the default error message code text `Feilmeldings-kode: %statusCode`.
    */
   errorMessageCode?: ReactNode
 
   /**
-   * Will overwrite the default additional help text.
+   * Overwrites the default additional help text `Her er noen lenker som kanskje kan hjelpe:`. This text is only rendered when `links` are provided.
    */
   help?: ReactNode
 
   /**
-   * Provide an array with objects `{ text: 'Text', url: 'https://...' }` to display a list of anchor links.
+   * Provide an array with objects `{ text: "Text", url: "https://..." }` to display a list of anchor links.
    */
   links?: Array<GlobalErrorLink>
 
   /**
-   * If true, it will use 80vh as the height and center its content.
+   * If `true`, it will use `80vh` as the height and center its content.
    */
   center?: boolean
 
   /**
-   * Skeleton should be applied when loading content
-   * Default: `null`
+   * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow
 }
@@ -77,12 +75,12 @@ export type GlobalErrorAllProps = GlobalErrorProps &
 
 export type GlobalErrorTranslationContent = {
   /**
-   * Defining a `title` will overwrite the default provided by the `statusCode` translation.
+   * Overwrites the default title for the provided `statusCode`.
    */
   title?: ReactNode
 
   /**
-   * Defining a `text` will overwrite the default provided by the `statusCode` translation.
+   * Overwrites the default text for the provided `statusCode`.
    */
   text?: ReactNode
 }

--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -72,12 +72,12 @@ export type HeadingProps = {
   group?: string
 
   /**
-   * A heading, can be text or ReactNode.
+   * A heading, can be text or `React.ReactNode`.
    */
   text?: ReactNode
 
   /**
-   * Define the typography font-size by a size type, e.g. `x-large`. Defaults to the predefined heading sizes.
+   * Define the typography [font-size](/uilib/typography/font-size) by a size _type_, e.g. `x-large`. Defaults to the predefined heading sizes.
    */
   size?: HeadingSize
   level?: HeadingLevel
@@ -95,7 +95,7 @@ export type HeadingProps = {
   down?: boolean
 
   /**
-   * If set to `true`, the heading will not be corrected and warnings will not be shown. Warnings do not show up in production builds else either.
+   * If set to `true`, the heading will not be corrected and warnings will not be shown. Warnings do not show up in **production builds** else either.
    */
   skipCorrection?: boolean
 

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -10,38 +10,32 @@ import type { DynamicElement, SpacingProps } from '../../shared/types'
 
 export type HeightAnimationProps = {
   /**
-   * Whether the nested children content should be kept in the DOM or not.
-   * Default: `false`
+   * Set to `true` to ensure the nested children content will be kept in the DOM. Defaults to `false`.
    */
   keepInDOM?: boolean
 
   /**
-   * Set to `true` to omit the usage of "overflow: hidden;"
-   * Default: `false`
+   * Set to `true` to omit the usage of "overflow: hidden;". Defaults to `false`.
    */
   showOverflow?: boolean
 
   /**
-   * Custom duration of the animation in milliseconds.
-   * Default: `400`
+   * Custom duration of the animation in milliseconds. Defaults to `400`.
    */
   duration?: number
 
   /**
-   * Custom delay of the animation in milliseconds.
-   * Default: `0`
+   * Custom delay of the animation in milliseconds. Defaults to `0`.
    */
   delay?: number
 
   /**
-   * Define a custom HTML Element.
-   * Default: `div`
+   * Custom HTML element for the component. Defaults to `div` HTML Element.
    */
   element?: DynamicElement
 
   /**
-   * Send along a custom React Ref.
-   * Default: `null`
+   * Send along a custom `React.Ref`.
    */
   ref?: RefObject<HTMLElement>
 } & UseHeightAnimationOptions

--- a/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/useHeightAnimation.ts
@@ -6,20 +6,17 @@ import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpe
 
 export type UseHeightAnimationOptions = {
   /**
-   * Set to `true`, when initially `false` was given, to animate from 0px to auto.
-   * Default: `true`
+   * Set to `true` on second re-render when the view should animate from 0px to auto. Defaults to `true`.
    */
   open?: boolean
 
   /**
-   * Set to `false` to omit the animation.
-   * Default: `true`
+   * Set to `false` to omit the animation. Defaults to `true`.
    */
   animate?: boolean
 
   /**
-   * To compensate for CSS gap between the rows, so animation does not jump during the animation.
-   * Provide a CSS unit or `var(--row-gap)`.
+   * To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.
    */
   compensateForGap?: string | 'auto'
 
@@ -29,22 +26,22 @@ export type UseHeightAnimationOptions = {
   children?: ReactNode | HTMLElement
 
   /**
-   * Is called once before mounting the component (useLayoutEffect)
+   * Is called once before mounting the component (useLayoutEffect). Returns the instance of the internal animation class.
    */
   onInit?: (instance: HeightAnimationInstance) => void
 
   /**
-   * Is called when fully opened or closed
+   * Is called when fully opened or closed. Returns `true` or `false` depending on the state.
    */
   onOpen?: (isOpen: boolean) => void
 
   /**
-   * Is called when animation has started.
+   * Is called when animation has started. The first parameter is a string. Depending on the state, the value can be `opening`, `closing` or `adjusting`.
    */
   onAnimationStart?: (state: HeightAnimationOnStart) => void
 
   /**
-   * Is called when animation is done and the full height is reached.
+   * Is called when animation is done and the full height is reached. The first parameter is a string. Depending on the state, the value can be `opened`, `closed` or `adjusted`.
    */
   onAnimationEnd?: (state: HeightAnimationOnEnd) => void
 }

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -89,7 +89,7 @@ export type IconProps = {
   size?: IconSize
 
   /**
-   * The color can be any valid color property, such as Hex, RGB or preferable – any CSS variable from the <a href="/uilib/usage/customisation/colors">colors table</a>, e.g. `var(--color-ocean-green)`. Default: `--color-black-80`.
+   * The color can be any valid color property, such as Hex, RGB or preferable – any CSS variable from the [colors table](/uilib/usage/customisation/colors), e.g. `var(--color-ocean-green)`. Defaults to no color, which means `--color-black-80`.
    */
   color?: IconColor
 

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -29,94 +29,80 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type InfoCardProps = {
   /**
-   * Used in combination with `src` to provide an alt attribute for the `img` element.
-   * Default: `null`
+   * Used in combination with `src` to provide an alt attribute for the image element.
    */
   alt?: ReactNode
   /**
-   * Aligns the content to center, rather than left
-   * Default: `false`
+   * Centers the content. Defaults to `false`.
    */
   centered?: boolean
   /**
-   * Determines whether to display a drop shadow around the card.
-   * Default: `true`
+   * Sets the drop shadow of the info card. Defaults to `true`.
    */
   dropShadow?: boolean
   /**
-   * Replace the default icon with custom icon.
-   * Default: `Lightbulb (icon)`
+   * Custom icon. Defaults to the `lightbulb` icon.
    */
   icon?: IconIcon
   /**
-   * Props applied to the `img` element if the component is used to display an image. Replaces the icon.
-   * Default: `null`
+   * [Image properties](/uilib/elements/image) applied to the `img` element if the component is used to display an image.
    */
   imgProps?: ImgProps
   /**
-   * If set to `true`, an overlaying skeleton with animation will be shown.
-   * Default: `false`
+   * If set to `true`, an overlaying skeleton with animation will be shown. Defaults to `false`.
    */
   skeleton?: SkeletonShow
   /**
-   * Stretch the card to fill the container
+   * Stretch the card to fill the container.
    */
   stretch?: boolean
   /**
-   * Specifies the path to the image
-   * Default: `null`
+   * Specifies the path to the image.
    */
   src?: string
   /**
-   * The text content of the InfoCard
-   * Default: `null`
+   * The text content of the InfoCard, displayed/rendered in a paragraph. To fully customize the content, see `children` property.
    */
   text?: ReactNode
   /**
    * Can be used to add custom content, which is displayed/rendered between the `text` property and buttons.
-   * Default: `null`
    */
   children?: ReactNode
   /**
-   * Component title
-   * Default: `null`
+   * The title of the InfoCard.
    */
   title?: ReactNode
   /**
-   * Is called when the close button is clicked
-   * Default: `null`
+   * Will be called when user clicks the close button.
    */
   onClose?: MouseEventHandler<HTMLButtonElement>
   /**
-   * The text of the close button.
-   * Default: `null`
+   * The close button text.
    */
   closeButtonText?: ReactNode
   /**
-   * Is called when the accept button is clicked
-   * Default: `null`
+   * Will be called when user clicks the accept button.
    */
   onAccept?: MouseEventHandler<HTMLButtonElement>
   /**
-   * The text of the accept button.
-   * Default: `null`
+   * The accept button text.
    */
   acceptButtonText?: ReactNode
   /**
    * Props forwarded to the close button.
-   * Default: `null`
    */
   closeButtonProps?: ButtonProps
   /**
+   * Deprecated. Use `closeButtonProps` instead.
    * @deprecated Use `closeButtonProps` instead.
    */
   closeButtonAttributes?: ButtonProps
   /**
    * Props forwarded to the accept button.
-   * Default: `null`
    */
   acceptButtonProps?: ButtonProps
   /**
+   * Deprecated. Use `acceptButtonProps` instead.
    * @deprecated Use `acceptButtonProps` instead.
    */
   acceptButtonAttributes?: ButtonProps

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -110,12 +110,11 @@ export type InputMaskedProps = Omit<
      */
     showMask?: boolean
     /**
-     * Allow users to keep typing after the provided mask has been filled. Extra characters will be appended unmasked.
+     * Allow users to keep typing after the defined mask has been filled. Extra characters will be appended without masking.
      */
     allowOverflow?: boolean
     /**
-     * Controls how overwriting characters is handled;
-     * `shift` (default) moves to the next slot, `replace` keeps the cursor in place.
+     * Control how overwriting characters is handled; `shift` (default) moves to the next slot while `replace` stays on the current slot.
      */
     overwriteMode?: InputMaskedOverwriteMode | null
     onSubmit?: InputMaskedEventHandler

--- a/packages/dnb-eufemia/src/components/list-format/ListFormat.tsx
+++ b/packages/dnb-eufemia/src/components/list-format/ListFormat.tsx
@@ -18,20 +18,15 @@ export type ListFormatProps = {
   locale?: InternalLocale
 
   /**
-   * Formatting options for the value when variant is `text`.
-   * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat
+   * Formatting options for the value when variant is `text`. See the [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat) documentation.
    */
   format?: Intl.ListFormatOptions
   /**
-   * Defines if the value should be displayed in list format (`ol`, `ul`) or regular text format in one line.
-   * Default: `text`
+   * Defines if the value should be displayed in list format (`ol`, `ul`) or regular text format in one line. Defaults to `text`.
    */
   variant?: 'ol' | 'ul' | 'text'
   /**
-   * Defines the type of list styling used for list variants. Used together with variant `ol` and `ul`.
-   * Variant `ol`: `a`, `A`, `i`, `I` and `1`.
-   * Variant `ul`: `circle`, `disc` and `square`.
-   * Default: `undefined`
+   * Defines the type of list styling used for list variants. Used together with variant `ol` and `ul`. Variant `ol`: `a`, `A`, `i`, `I` and `1`. Variant `ul`: `circle`, `disc` and `square`. Defaults to `undefined`.
    */
   listType?:
     | 'a'
@@ -46,14 +41,12 @@ export type ListFormatProps = {
     | undefined
 
   /**
-   * The value to format as list.
-   * Default: `null`
+   * The value to format. Can be given as `children` instead.
    */
   value?: Array<ReactNode>
 
   /**
-   * The children to format as list.
-   * Default: `null`
+   * The children to format.
    */
   children?: ReactNode
 }

--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -36,11 +36,13 @@ export type ItemAccordionProps = {
   variant?: ListVariant
   open?: boolean
   /**
-   * When true, keeps the accordion content in the DOM when closed. Defaults to `false`.
+   * When `true`, keeps the accordion content in the DOM when closed. Defaults to `false`.
+   * Default: `false`
    */
   keepInDOM?: boolean
   /**
-   * When true, the accordion is visually dimmed and interaction is prevented.
+   * If set to `true`, the accordion is visually dimmed and interaction is prevented. Sets `aria-disabled`, removes tabbing, and disables click/keyboard handlers.
+   * Default: `false`
    */
   disabled?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
@@ -8,11 +8,19 @@ import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
 
 export type ItemCenterProps = FlexItemProps & {
-  /** Font size of the center content. Defaults to `basis`. */
+  /**
+   * Font size of the center content. Defaults to `basis`. Use `small` for smaller text.
+   * Default: `"basis"`
+   */
   fontSize?: 'small' | 'basis'
-  /** Font weight of the center content. Defaults to `regular`. */
+  /**
+   * Font weight of the center content. Defaults to `regular`.
+   * Default: `"regular"`
+   */
   fontWeight?: 'regular' | 'medium'
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
@@ -12,11 +12,19 @@ import Context from '../../shared/Context'
  * Extends Flex.Item; supports spacing props.
  */
 export type ItemEndProps = {
-  /** Font weight of the end content. Defaults to `medium`. */
+  /**
+   * Font weight of the end content. Defaults to `medium`.
+   * Default: `"medium"`
+   */
   fontWeight?: 'regular' | 'medium'
-  /** Font size of the end content. Defaults to `basis`. */
+  /**
+   * Font size of the end content. Defaults to `basis`. Use `small` for smaller text.
+   * Default: `"basis"`
+   */
   fontSize?: 'small' | 'basis'
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 } & FlexItemProps
 

--- a/packages/dnb-eufemia/src/components/list/ItemFooter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemFooter.tsx
@@ -9,7 +9,9 @@ import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
 
 export type ItemFooterProps = FlexItemProps & {
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/list/ItemIcon.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemIcon.tsx
@@ -9,7 +9,9 @@ import type { SkeletonShow } from '../Skeleton'
 
 export type ItemIconProps = Omit<FlexItemProps, 'children'> & {
   children: IconIcon
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/list/ItemOverline.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemOverline.tsx
@@ -12,11 +12,19 @@ import Context from '../../shared/Context'
  * Secondary line above the main row; pairs with List.Cell.Title.Subline (below title).
  */
 export type ItemOverlineProps = FlexItemProps & {
-  /** Font size of the overline content. Defaults to `x-small`. */
+  /**
+   * Font size of the overline content. Defaults to `x-small`.
+   * Default: `"x-small"`
+   */
   fontSize?: 'basis' | 'small' | 'x-small'
-  /** Font weight of the overline content. Defaults to `medium`. */
+  /**
+   * Font weight of the overline content. Defaults to `medium`.
+   * Default: `"medium"`
+   */
   fontWeight?: 'regular' | 'medium'
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/list/ItemStart.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemStart.tsx
@@ -12,11 +12,19 @@ import Context from '../../shared/Context'
  * Extends Flex.Item; supports spacing props.
  */
 export type ItemStartProps = FlexItemProps & {
-  /** Font size of the start content. Defaults to `basis`. */
+  /**
+   * Font size of the start content. Defaults to `basis`. Use `small` for smaller text.
+   * Default: `"basis"`
+   */
   fontSize?: 'small' | 'basis'
-  /** Font weight of the start content. Defaults to `regular`. */
+  /**
+   * Font weight of the start content. Defaults to `regular`.
+   * Default: `"regular"`
+   */
   fontWeight?: 'regular' | 'medium'
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/list/ItemSubline.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemSubline.tsx
@@ -14,13 +14,23 @@ export type ItemSublineVariant = 'description'
  * Secondary line under the title; pairs with List.Cell.Title.Overline (above the row).
  */
 export type ItemSublineProps = FlexItemProps & {
-  /** Visual variant. Use `description` for smaller, muted text. */
+  /**
+   * Visual variant. Use `description` for smaller, muted text style.
+   */
   variant?: ItemSublineVariant
-  /** Font size of the subline content. Defaults to `small`. When `variant="description"`, defaults to `x-small`. */
+  /**
+   * Font size of the subline content. Defaults to `small`. When `variant="description"`, defaults to `x-small`.
+   * Default: `"small"`
+   */
   fontSize?: 'basis' | 'small' | 'x-small'
-  /** Font weight of the subline content. Defaults to `regular`. */
+  /**
+   * Font weight of the subline content. Defaults to `regular`.
+   * Default: `"regular"`
+   */
   fontWeight?: 'regular' | 'medium'
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
@@ -14,11 +14,19 @@ import Context from '../../shared/Context'
  * Extends Flex.Item; supports spacing props.
  */
 export type ItemTitleProps = FlexItemProps & {
-  /** Font size of the title content. Defaults to `basis`. */
+  /**
+   * Font size of the title content. Defaults to `basis`. Use `small` for smaller text.
+   * Default: `"basis"`
+   */
   fontSize?: 'small' | 'basis'
-  /** Font weight of the title content. Defaults to `regular`. */
+  /**
+   * Font weight of the start content. Defaults to `regular`.
+   * Default: `"regular"`
+   */
   fontWeight?: 'regular' | 'medium'
-  /** If `true`, applies skeleton loading state. Inherits from parent List context when not set. */
+  /**
+   * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
+   */
   skeleton?: SkeletonShow
 }
 

--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -56,12 +56,11 @@ export type LogoProps = {
    */
   inheritColor?: boolean
   /**
-   * Set to `true` if you want the logo to inherit the parent `height`. Defaults to `false`.
+   * Set to `true` if you want to inherit the `height` of the parent. Defaults to `false`.
    */
   inheritSize?: boolean
   /**
-   * Provide a custom SVG to render instead of the built-in logos.
-   * Can be a React component (receives standard SVG props), a React element, or a function that receives the theme and returns an SVG component.
+   * Provide a custom SVG to render instead of the built-in logos. Accepts a React SVG component, element, or a function that receives the theme and returns an SVG component. Width, height and color properties still apply. If not provided, defaults to DNB logo. Import SVGs from `@dnb/eufemia/components/Logo` (e.g., `DnbDefault`, `SbankenDefault`, `SbankenCompact`, `SbankenHorizontal`, `CarnegieDefault`, `EiendomDefault`). When using a function, it receives the theme context (useTheme return value) allowing theme-aware logo selection.
    */
   svg?: Svg
 } & SpacingProps &

--- a/packages/dnb-eufemia/src/components/menu/types.ts
+++ b/packages/dnb-eufemia/src/components/menu/types.ts
@@ -21,25 +21,25 @@ export type MenuRootProps = {
   className?: string
   children?: ReactNode
   /**
-   * Placement of the menu relative to the trigger.
-   * Default: `bottom`
+   * Preferred placement of the menu relative to the trigger.
+   * Default: `"bottom"`
    */
   placement?: PopoverPlacement
   /**
-   * Position of the popover arrow relative to the popover.
-   * Default: `left`
+   * Position of the popover arrow relative to the popover. `top` and `bottom` positions are only applicable when `placement` is `left` or `right`, and vice versa.
+   * Default: `"center"`
    */
   arrowPosition?: PopoverArrow
   /**
-   * Controlled open state.
+   * Controlled open state. Use together with `onOpenChange`.
    */
   open?: boolean
   /**
-   * Callback fired when the open state changes.
+   * Called whenever the open state changes. Receives the new open state as a boolean.
    */
   onOpenChange?: (open: boolean) => void
   /**
-   * Skip rendering in a React Portal.
+   * Render inline instead of inside a portal.
    * Default: `false`
    */
   skipPortal?: boolean
@@ -49,8 +49,8 @@ export type MenuRootProps = {
    */
   noAnimation?: boolean
   /**
-   * Control auto-flip behavior.
-   * Default: `initial`
+   * Control when the menu automatically flips its placement to fit within the viewport. `"initial"`: flip only on open. `"scroll"`: also flip during scroll. `"never"`: always use specified placement.
+   * Default: `"initial"`
    */
   autoAlignMode?: PopoverAutoAlignMode
 }
@@ -62,8 +62,7 @@ export type MenuRootProps = {
  */
 export type MenuButtonProps = Omit<ButtonProps, 'children'> & {
   /**
-   * Render function for a custom trigger element.
-   * Receives trigger props including `ref`, `active`, `open`, `close`, `toggle`.
+   * Alternative to `text`. Content rendered inside the header.
    */
   children?: ReactNode | ((context: MenuTriggerRenderProps) => ReactNode)
 }
@@ -72,7 +71,7 @@ export type MenuListProps = {
   children?: ReactNode
   className?: string
   /**
-   * Maximum number of visible items before the list scrolls.
+   * Sets the maximum visible list items before the content scrolls. The component measures the rendered height of the first visible items. An explicit `style.maxHeight` overrides this.
    */
   maxVisibleListItems?: number
 } & Omit<HTMLAttributes<HTMLUListElement>, 'children'>
@@ -90,7 +89,7 @@ export type MenuActionProps = {
    */
   text?: ReactNode
   /**
-   * Click handler for the action.
+   * Called when the action is clicked or activated via keyboard (Enter/Space). The menu closes automatically after the handler is invoked unless used as a trigger for a nested `Menu.Root`.
    */
   onClick?: MouseEventHandler<HTMLLIElement>
   /**
@@ -111,7 +110,7 @@ export type MenuActionProps = {
   target?: string
   rel?: string
   /**
-   * Whether the action is disabled.
+   * Disables the action. Sets `aria-disabled` and prevents click/keyboard activation.
    * Default: `false`
    */
   disabled?: boolean
@@ -136,12 +135,12 @@ export type MenuAccordionProps = {
    */
   text?: ReactNode
   /**
-   * Whether the accordion is disabled.
+   * Disables the accordion trigger. Sets `aria-disabled` and prevents toggling.
    * Default: `false`
    */
   disabled?: boolean
   /**
-   * Callback fired when the open state changes.
+   * Called whenever the accordion open state changes. Receives the new open state as a boolean.
    */
   onOpenChange?: (open: boolean) => void
 } & Omit<HTMLAttributes<HTMLDivElement>, 'title' | 'onClick'>
@@ -153,11 +152,11 @@ export type MenuDividerProps = {
 export type MenuHeaderProps = {
   className?: string
   /**
-   * Header text.
+   * Header text displayed in the menu.
    */
   text?: ReactNode
   /**
-   * Alternative to `text`. Rendered inside the header.
+   * Alternative to `text`. Content rendered inside the header.
    */
   children?: ReactNode
 } & Omit<HTMLAttributes<HTMLLIElement>, 'title' | 'role'>

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -35,7 +35,7 @@ export type ModalCloseHandler = (params?: ModalCloseHandlerParams) => void
 
 export type ModalProps = ModalRootProps & {
   /**
-   * The id used internal in the modal/drawer root element. Defaults to `root`, so the element id will be `dnb-modal-root`.
+   * The id used internal for the trigger button and Modal component.
    */
   id?: string
 
@@ -45,12 +45,12 @@ export type ModalProps = ModalRootProps & {
   disabled?: boolean
 
   /**
-   * Forces the modal/drawer to delay the opening. The delay is given in `ms`.
+   * Forces the modal to delay the opening. The delay is given in `ms`.
    */
   openDelay?: string | number
 
   /**
-   * If set to `true` (boolean or string), then the user can't close the modal/drawer.
+   * If set to `true` (boolean or string), then the user can't close the modal.
    */
   preventClose?: boolean
 
@@ -65,17 +65,17 @@ export type ModalProps = ModalRootProps & {
   noAnimation?: boolean
 
   /**
-   * Use this prop to control the open/close state by setting `true` / `false`.
+   * Use this property to control the open/close state by setting `true` / `false`.
    */
   open?: boolean
 
   /**
-   * The content which will appear when triggering the modal/drawer.
+   * The content which will appear when triggering open the modal. If a function is given, you get a close method `() => ({ close })` in the arguments.
    */
   children?: ReactNode | ((props: ModalProps) => ReactNode)
 
   /**
-   * Omits the default trigger button
+   * Omits the default trigger button.
    */
   omitTriggerButton?: boolean
 
@@ -98,7 +98,7 @@ export type ModalProps = ModalRootProps & {
   }) => void
 
   /**
-   * This event gets triggered once the user tries to close the modal, but `preventClose` is set to "true". Returns a callback `close` you can call to trigger the close mechanism. More details below. Returns the modal id: `{ id, event, close: Method, triggeredBy }`
+   * This event gets triggered once the user tries to close the modal, but `preventClose` is set to `true`. Returns a callback `close` you can call to trigger the close mechanism. More details below. Returns the modal id: `{ id, event, close: Method, triggeredBy }`.
    */
   onClosePrevent?: ({
     id,
@@ -113,7 +113,7 @@ export type ModalProps = ModalRootProps & {
   }) => void
 
   /**
-   * Set a function to call the callback function, once the modal/drawer should open: `openModal={(open) => open()}`
+   * Set a function to call the callback function, once the modal should open: `openModal={(open) => open()}`.
    */
   openModal?: (
     open?: (e: Event) => void,
@@ -121,7 +121,7 @@ export type ModalProps = ModalRootProps & {
   ) => () => void | void
 
   /**
-   * Set a function to call the callback function, once the modal/drawer should close: `closeModal={(close) => close()}`
+   * Set a function to call the callback function, once the modal should close: `closeModal={(close) => close()}`.
    */
   closeModal?: (
     close?: ModalCloseHandler,
@@ -129,7 +129,7 @@ export type ModalProps = ModalRootProps & {
   ) => () => void | void
 
   /**
-   * Provide a custom trigger component. Like trigger={<Anchor href="/" />}. It will set the focus on it when the modal/drawer gets closed.
+   * Provide a custom trigger component. Like `trigger={<Anchor href="/" />}`. It will set the focus on it when the modal gets closed.
    */
   trigger?: ElementType
 
@@ -139,34 +139,35 @@ export type ModalProps = ModalRootProps & {
   triggerProps?: ButtonProps
 
   /**
+   * Deprecated. Use `triggerProps` instead.
    * @deprecated Use `triggerProps` instead.
    */
   triggerAttributes?: ModalTriggerAttributes
 
   /**
-   * The content which will appear when triggering the modal/drawer.
+   * The content which will appear when triggering the modal/drawer. Alternative to `children`.
    */
   modalContent?: ReactNode | ((props: ModalProps) => ReactNode)
 
   /**
-   * If true, the drawer will not open in a new DOM but directly in the current DOM. Defaults to `false`.
+   * If true, the modal will not open in a new DOM but directly in the current DOM. Defaults to `false`. Be aware of the side effects of setting this property to `true`.
    */
   directDomReturn?: boolean
 
   /**
-   * To get the inner content Element, pass in your own React ref
+   * To get the inner content Element, pass in your own React ref.
    */
   contentRef?: RefObject<HTMLElement>
 
   /**
-   * To get the scroll Element, pass in your own React ref
+   * To get the scroll Element, pass in your own React ref.
    */
   scrollRef?: RefObject<HTMLElement>
 }
 
 export type ModalContentProps = {
   /**
-   * The content which will appear when triggering the modal/drawer.
+   * The content which will appear when triggering the modal/drawer. Alternative to `children`.
    */
   modalContent?: ReactNode | ((props: ModalContentProps) => ReactNode)
 
@@ -182,12 +183,12 @@ export type ModalContentProps = {
   hide?: boolean
 
   /**
-   * The id used internal for the trigger button and modal component.
+   * The id used internal for the trigger button and Modal component.
    */
   id?: string
 
   /**
-   * The ID of the trigger component, describing the modal/drawer content. Defaults to the internal `trigger`, so make sure you define the trigger title.
+   * The ID of the trigger component, describing the modal content. Defaults to the internal `trigger`, so make sure you define the `title` in `triggerAttributes`.
    */
   labelledBy?: string
 
@@ -197,7 +198,7 @@ export type ModalContentProps = {
   focusSelector?: string
 
   /**
-   * Defines a unique identifier to a modal. Use it in case you have to refer in some way to the modal/drawer content wrapper.
+   * Defines a unique identifier to a modal. Use it in case you have to refer in some way to the modal content.
    */
   contentId?: string
 
@@ -212,7 +213,7 @@ export type ModalContentProps = {
   dialogTitle?: string
 
   /**
-   * If boolean, the close button will not be shown.
+   * If `true`, the close button will not be shown.
    */
   hideCloseButton?: boolean
 
@@ -227,7 +228,7 @@ export type ModalContentProps = {
   closeButtonAttributes?: CloseButtonProps
 
   /**
-   * If set to `false` then the modal/drawer content will be shown without any spacing. Defaults to `true`.
+   * If set to `false` then the modal content will be shown without any spacing. Defaults to `true`.
    */
   spacing?: boolean
 
@@ -238,7 +239,7 @@ export type ModalContentProps = {
   animationDuration?: string | number
 
   /**
-   * Disable clicking the background overlay to close the modal
+   * Disable clicking the background overlay to close the modal. PS! Pressing `esc` key will still close the modal.
    */
   preventOverlayClose?: boolean
 
@@ -253,17 +254,17 @@ export type ModalContentProps = {
   noAnimationOnMobile?: boolean
 
   /**
-   * The minimum Modal content width, defined by a CSS width value like `50vw` (50% of the viewport). Be careful when using fixed `minWidth` so you don't break responsiveness. Defaults to `30rem` (average width is set to `60vw`).
+   * The minimum Modal content width, defined by a CSS width value like `50vw` (50% of the viewport). Be careful when using fixed `minWidth` so you don't break responsiveness. Defaults to `30rem`.
    */
   minWidth?: ModalContentMinWidth
 
   /**
-   * The maximum Modal content width, defined by a CSS width value like `20rem`. Defaults to `60rem` (average width is set to `60vw`).
+   * The maximum Modal content width, defined by a CSS width value like `20rem`. Defaults to `60rem`.
    */
   maxWidth?: ModalContentMaxWidth
 
   /**
-   * If set to `true` then the modal/drawer content will be shown as fullscreen, without showing the original content behind. Can be set to `false` to omit the auto fullscreen. Defaults to `auto`.
+   * If set to `true` then the modal content will be shown as fullscreen, without showing the original content behind. Can be set to `false` to omit the auto fullscreen. Defaults to `auto`.
    */
   fullscreen?: ModalFullscreen
 
@@ -273,12 +274,12 @@ export type ModalContentProps = {
   alignContent?: ModalAlignContent
 
   /**
-   * For `drawer` mode only. Defines the placement on what side the Drawer should be opened. Can be set to `left`, `right`, `top` and `bottom`. Defaults to `right`.
+   * For `drawer` mode only. Defines the placement on what side the Drawer should be opened. Defaults to `right`.
    */
   containerPlacement?: 'left' | 'right' | 'top' | 'bottom'
 
   /**
-   * Define the vertical alignment of the container. Can be set to `top` or `center`. Defaults to `center`.
+   * Define the vertical alignment of the container. Defaults to `center`.
    */
   verticalAlignment?: 'top' | 'center'
 
@@ -312,12 +313,12 @@ export type ModalContentProps = {
   className?: string
 
   /**
-   * The content which will appear when triggering the modal/drawer.
+   * The content which will appear when triggering open the modal. If a function is given, you get a close method `() => ({ close })` in the arguments.
    */
   children?: ReactNode | ((props: ModalContentProps) => ReactNode)
 
   /**
-   * The displayed text for the 'close' button. Resolved from locale translations.
+   * The title of the close button. Defaults to _Lukk_.
    */
   closeTitle?: string
 

--- a/packages/dnb-eufemia/src/components/number-format/Currency.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/Currency.tsx
@@ -9,9 +9,13 @@ export type NumberFormatCurrencyProps = Omit<
   NumberFormatAllProps,
   'compact'
 > & {
-  /** Currency code (ISO 4217) or `true` to use the default `NOK`. Defaults to `true`. */
+  /**
+   * Currency code (ISO 4217) or `true` to use the default `NOK`. Defaults to `true` when using `NumberFormat.Currency`. Uses two decimals by default.
+   */
   currency?: NumberFormatProps['currency']
-  /** Compact display: `short` (e.g., 1.2K kr), `long` (e.g., 1.2 thousand kroner) or `true` for short. */
+  /**
+   * Shortens any number or currency including an abbreviation. Available on both `NumberFormat.Number` and `NumberFormat.Currency`. It gives you zero decimal by default `decimals={0}`. Use either `short` or `long`. Defaults to `short` if `true` is given.
+   */
   compact?: NumberFormatProps['compact']
 }
 

--- a/packages/dnb-eufemia/src/components/number-format/Number.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/Number.tsx
@@ -9,7 +9,9 @@ export type NumberFormatNumberProps = Omit<
   NumberFormatAllProps,
   'currency' | 'currencyDisplay' | 'currencyPosition' | 'compact'
 > & {
-  /** Compact display: `short` (e.g., 1.2K), `long` (e.g., 1.2 thousand) or `true` for short. */
+  /**
+   * Shortens any number or currency including an abbreviation. Available on both `NumberFormat.Number` and `NumberFormat.Currency`. It gives you zero decimal by default `decimals={0}`. Use either `short` or `long`. Defaults to `short` if `true` is given.
+   */
   compact?: NumberFormatProps['compact']
 }
 

--- a/packages/dnb-eufemia/src/components/number-format/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/PhoneNumber.tsx
@@ -16,7 +16,9 @@ export type NumberFormatPhoneNumberProps = Omit<
   | 'rounding'
   | 'signDisplay'
 > & {
-  /** Wraps the formatted phone value in a clickable link: `tel` (default) or `sms`. */
+  /**
+   * Use `tel` (default) or `sms` to enable a clickable / touchable anchor link. Only available on `NumberFormat.PhoneNumber`.
+   */
   link?: NumberFormatLink | true
 }
 

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -123,7 +123,7 @@ export type PaginationProps = {
    */
   parallelLoadCount?: PaginationParallelLoadCount
   /**
-   * if set to `true`, the infinity marker will be placed before the content (on top of). This could potentially have negative side effects. But it depends really on the content if this would make more sense to use instead. Defaults to `false`.
+   * If set to `true`, the infinity marker will be placed before the content (on top of). This could potentially have negative side effects. But it depends really on the content if this would make more sense to use instead. Defaults to `false`.
    */
   placeMarkerBeforeContent?: boolean
   /**
@@ -147,28 +147,28 @@ export type PaginationProps = {
    */
   paginationBarLayout?: PaginationLayout
   /**
-   * If set to `true` it will disable the automated infinity scrolling, but shows a load more button at the end of the content instead.
+   * If set to `true`, it will disable the automated infinity scrolling, but shows a load more button at the end of the content instead.
    */
   useLoadButton?: boolean
   items?: PaginationItems
   /**
-   * If set to `true` no indicator will be shown.
+   * If set to `true`, no indicator will be shown.
    */
   hideProgressIndicator?: boolean
   /**
-   * Callback function to get the `setContent` handler from the current pagination instance. e.g. `setContentHandler={fn => (...)}`. Use this handler to insert content during infinity mode.
+   * Callback function to get the `setContent` handler from the current pagination instance, e.g. `setContentHandler={fn => (...)}`. Use this handler to insert content during infinity mode.
    */
   setContentHandler?: PaginationSetContentHandler
   /**
-   * Callback function to get the `resetContent` handler from the current pagination instance. e.g. `resetContentHandler={fn => (...)}`. Use this handler to reset all the content. You can set it to `true`, to programmatically reset the content.
+   * Callback function to get the `resetContent` handler from the current pagination instance, e.g. `resetContentHandler={fn => (...)}`. Use this handler to reset all the content. You can set it to `true`, to programmatically reset the content.
    */
   resetContentHandler?: PaginationResetContentHandler
   /**
-   * Callback function to get the `resetInfinity` handler from the current pagination instance. e.g. `resetPaginationHandler={fn => (...)}`. Use this handler to reset all the internal states. You can set it to `true`, to programmatically reset the states.
+   * Callback function to get the `resetInfinity` handler from the current pagination instance, e.g. `resetPaginationHandler={fn => (...)}`. Use this handler to reset all the internal states. You can set it to `true`, to programmatically reset the states.
    */
   resetPaginationHandler?: PaginationResetPaginationHandler
   /**
-   * Callback function to get the `endInfinity` handler from the current pagination instance. e.g. `endInfinityHandler={fn => (...)}`. Use this handler to end the infinity scrolling procedure, in case the `pageCount` is unknown.
+   * Callback function to get the `endInfinity` handler from the current pagination instance, e.g. `endInfinityHandler={fn => (...)}`. Use this handler to end the infinity scrolling procedure, in case the `pageCount` is unknown.
    */
   endInfinityHandler?: PaginationEndInfinityHandler
   /**

--- a/packages/dnb-eufemia/src/components/popover/types.ts
+++ b/packages/dnb-eufemia/src/components/popover/types.ts
@@ -68,40 +68,32 @@ type PopoverPropsBase = {
   placement?: PopoverPlacement
   arrowPosition?: PopoverArrow
   /**
-   * CSS selector used to pick the element that controls arrow alignment.
+   * CSS selector that points to the element the arrow should align with. When the popover points vertically it aligns horizontally, and vice versa for horizontal placements.
    */
   arrowPositionSelector?: string
   /**
-   * Hide the arrow element from the popover.
-   * When `true`, the arrow will not be rendered regardless of the `arrowPosition` prop.
+   * Hide the arrow element from the popover. When `true`, the arrow will not be rendered regardless of the `arrowPosition` property.
    * Default: `false`
    */
   hideArrow?: boolean
   alignOnTarget?: PopoverAlign
   /**
-   * Horizontal offset in pixels to adjust the popover placement.
-   * Positive values move the popover to the right, negative values move it to the left.
+   * Horizontal offset in pixels to adjust the popover placement. Positive values move the popover to the right, negative values move it to the left. Useful for fine-tuning alignment when the default placement needs adjustment.
    * Default: `0`
    */
   horizontalOffset?: number
   /**
-   * Offset in pixels from the edge when the arrow is positioned at the edge.
-   * When set, this value replaces the default edge spacing (8px) and arrow boundary (8px).
-   * Useful for components like Tooltip that need the arrow closer to the edge.
-   * Default: `undefined` (uses default 8px)
+   * Offset in pixels from the edge when the arrow is positioned at the edge. When set, this value replaces the default edge spacing (8px) and arrow boundary (8px). Useful for components like Tooltip that need the arrow closer to the edge.
    */
   arrowEdgeOffset?: number
   fixedPosition?: boolean
   contentRef?: RefObject<HTMLSpanElement>
   /**
-   * Skip rendering the popover in a React Portal.
-   * When `true`, the popover renders inline in the DOM tree instead of being portaled to document.body.
-   * Useful for cases where you need the popover to be part of the same DOM hierarchy for styling or event handling.
-   * Default: `false`
+   * Render inline instead of inside the shared Popover portal.
    */
   skipPortal?: boolean
   /**
-   * Forces PopoverContainer to recalculate its layout when the value changes.
+   * Forces the popover to recalculate its layout whenever this value changes. Useful when the trigger moves but the DOM tree stays mounted.
    */
   targetRefreshKey?: unknown
   noAnimation?: boolean
@@ -115,19 +107,12 @@ type PopoverPropsBase = {
   style?: CSSProperties
   omitDescribedBy?: boolean
   /**
-   * Control when the popover automatically flips its placement to fit within the viewport.
-   * - `"initial"` (default): Flip placement only on initial open when there's limited space.
-   * - `"scroll"`: Flip placement on initial open and during scroll events.
-   * - `"never"`: Never automatically flip placement, always use the specified `placement` prop.
-   * Default: `initial`
+   * Control when the popover automatically flips its placement to fit within the viewport. `initial` (default): Flip placement only on initial open when there's limited space. `scroll`: Flip placement on initial open and during scroll events. `never`: Never automatically flip placement, always use the specified `placement` property.
+   * Default: `"initial"`
    */
   autoAlignMode?: PopoverAutoAlignMode
   /**
-   * Bias vertical auto alignment toward the preferred placement until the trigger crosses
-   * a viewport threshold. Only used for `placement="top"` and `placement="bottom"`.
-   * Example: `0.75` keeps `placement="bottom"` until the trigger reaches the bottom quarter
-   * of the viewport, and keeps `placement="top"` until it leaves the top quarter.
-   * Default: `undefined`
+   * Bias vertical auto alignment toward the preferred placement until the trigger crosses a viewport threshold. Only applies to `placement="top"` and `placement="bottom"`. Example: `0.75` keeps `placement="bottom"` until the trigger reaches the bottom quarter of the viewport.
    */
   autoAlignViewportThreshold?: number
 }
@@ -137,71 +122,56 @@ export type PopoverAllProps = PopoverPropsBase &
 
 export type PopoverProps = PopoverOverlayProps & {
   /**
-   * Alternative content prop. Accepts React nodes or a render function that receives
-   * context helpers (`active`, `open`, `close`, `toggle`, `id`).
-   * If both `children` and `content` are provided, `content` takes precedence.
+   * Alternative content property. Accepts nodes or a render function that receives the same helpers as `content`.
    */
   children?: PopoverRenderable<PopoverContentRenderProps>
   /**
-   * Content rendered inside the popover. Can be React nodes or a render function
-   * that receives context helpers (`active`, `open`, `close`, `toggle`, `id`).
-   * Takes precedence over `children` when both are provided.
+   * Content rendered inside the popover. Can also be a render function that receives helpers such as `close`.
    */
   content?: PopoverRenderable<PopoverContentRenderProps>
   /**
-   * Optional heading shown above the body content.
-   * Matches the typography style used in TermDefinition component.
+   * Optional heading shown above the body content. Matches the typography used in TermDefinition.
    */
   title?: ReactNode
   /**
-   * Custom trigger element or render function. Required unless you point Popover
-   * at an existing element using `targetElement` or `targetSelector`.
-   * The render function receives trigger props including `ref`, `active`, `open`, `close`, and `toggle`.
+   * Custom trigger element or render function. Required unless you point Popover at an existing element using `targetElement` / `targetSelector`.
    */
   trigger?: PopoverRenderable<PopoverTriggerRenderProps>
   /**
-   * Props forwarded to the trigger wrapper element.
-   * Useful for adding aria-* attributes, data-* attributes, or event handlers.
-   * These are merged with the default trigger props.
+   * Props forwarded to the default trigger wrapper (e.g. aria-*).
    */
   triggerProps?: PopoverTriggerAttributes
   /**
+   * Deprecated. Use `triggerProps` instead.
    * @deprecated Use `triggerProps` instead.
    */
   triggerAttributes?: PopoverTriggerAttributes
   /**
-   * Additional class name(s) merged with the default trigger wrapper classes.
-   * The default class `dnb-popover__trigger` is always included.
+   * Class name merged with the default trigger wrapper.
    */
   triggerClassName?: string
   /**
-   * Distance in pixels between the popover and its trigger element.
-   * Default: `16`
+   * Spacing in pixels between the trigger element and the popover surface.
    */
   triggerOffset?: number
   /**
-   * Controlled open state. When provided, the popover becomes a controlled component.
-   * Use together with `onOpenChange` to manage the open state externally.
+   * Controls the open state when provided. Use together with `onOpenChange`.
    */
   open?: boolean
   /**
-   * Uncontrolled initial open state. Use this for uncontrolled popovers.
-   * Default: `false`
+   * Whether the popover should be open by default when uncontrolled.
    */
   openInitially?: boolean
   /**
-   * Callback fired when the open state changes. Receives the new open state as a parameter.
-   * Useful for syncing state with external state management or tracking user interactions.
+   * Called whenever the open state changes (both controlled and uncontrolled).
    */
   onOpenChange?: (open: boolean) => void
   /**
-   * If true, focus is moved into the popover content when it opens.
-   * Default: `true`
+   * If `true`, focus is moved into the popover content when it opens.
    */
   focusOnOpen?: boolean
   /**
    * Provide a specific element (or function returning one) to receive focus when the popover opens.
-   * Takes precedence over the default focus behavior when `focusOnOpen` is true.
    */
   focusOnOpenElement?: HTMLElement | null | (() => HTMLElement | null)
   /**
@@ -209,71 +179,56 @@ export type PopoverProps = PopoverOverlayProps & {
    */
   onFocusComplete?: () => void
   /**
-   * Moves focus back to the trigger element once the popover closes.
-   * Default: `true`
+   * Moves focus back to the trigger element once the popover closes (defaults to `true`).
    */
   restoreFocus?: boolean
   /**
-   * Prevent closing the popover when interacting outside of it or pressing Escape.
-   * Useful when you need the popover to stay open while the user interacts elsewhere in the document.
+   * Prevent closing the popover when interacting outside of it or pressing Escape. Useful when the popover needs to stay open while other parts of the page are interacted with.
    */
   preventClose?: boolean
   /**
-   * Convenience prop to remove the built-in close button.
-   * Default: `false`
+   * Removes the built-in close button.
    */
   hideCloseButton?: boolean
   /**
    * Customize the built-in close button (icon, title, variant, etc.).
-   * Only applies when the close button is rendered.
    */
   closeButtonProps?: Partial<ButtonProps>
   /**
-   * Disable inner spacing (padding) of the popover content.
-   * When set to `true`, sets `--inner-space: 0` to remove padding.
-   * Useful for components like DatePicker that manage their own spacing.
+   * Remove the default padding inside the popover by setting `--inner-space: 0` on the surface.
    */
   noInnerSpace?: boolean
   /**
-   * Disable the max-width constraint on the popover content.
-   * When set to `true`, removes the max-width limit, allowing the popover to expand to its natural width.
-   * Default: `false`
+   * If set to `true`, the popover will not have a max-width limitation.
    */
   noMaxWidth?: boolean
   /**
-   * Keep the popover portal mounted in the DOM even when closed.
-   * When `true`, the popover remains in the DOM when inactive, which is useful for:
-   * - Maintaining `aria-describedby` references for accessibility
-   * - Ensuring screen readers can always find the associated element
-   * - Preventing layout shifts when the popover appears/disappears
+   * Keep the portal mounted in the DOM even when the popover is closed. Useful when the content should preserve its state.
    * Default: `false`
    */
   keepInDOM?: boolean
   /**
-   * Control when the popover automatically flips its placement to fit within the viewport.
-   * - `"initial"` (default): Flip placement only on initial open when there's limited space.
-   * - `"scroll"`: Flip placement on initial open and during scroll events.
-   * - `"never"`: Never automatically flip placement, always use the specified `placement` prop.
-   * Default: `initial`
+   * Control when the popover automatically flips its placement to fit within the viewport. `initial` (default): Flip placement only on initial open when there's limited space. `scroll`: Flip placement on initial open and during scroll events. `never`: Never automatically flip placement, always use the specified `placement` property.
+   * Default: `"initial"`
    */
   autoAlignMode?: PopoverAutoAlignMode
   /**
-   * Additional class name(s) for the popover content element.
+   * Additional class name(s) merged into the popover content wrapper.
    * @private For internal use only.
    */
   contentClassName?: string
   /**
-   * Optional secondary base class name used to mirror Popover BEM classes.
+   * Overrides the default BEM root block. Useful when mirroring Popover styles.
    * @private For internal use only.
    */
   baseClassName?: string
   /**
-   * Disable rendering of the focus-trap button used to return focus to the trigger.
+   * Stops rendering the focus-trap button used to return focus to the trigger.
    * @private For internal use only.
    */
   disableFocusTrap?: boolean
   /**
-   * Hide outline around the popover.
+   * Removes the outline/border that normally surrounds the popover surface.
    * @private For internal use only.
    */
   hideOutline?: boolean

--- a/packages/dnb-eufemia/src/components/progress-indicator/types.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/types.ts
@@ -15,51 +15,63 @@ export function isValidSize(
 
 export type ProgressIndicatorProps = {
   /**
-   * Defines the visibility of the progress. Toggling the `show` property to `false` will force a fade-out animation. Defaults to `true`.
+   * Defines the visibility of the progress. Toggling the `show` property to `false` will force a fade-out animation.
+   * Default: `true`
    */
   show?: boolean
   /**
-   * Defines the type. Defaults to `circular`.
+   * Defines the type.
+   * Default: `"circular"`
    */
   type?: 'circular' | 'linear' | 'countdown'
   /**
-   * Disables the fade-in and fade-out animation. Defaults to `false`.
+   * Disables the fade-in and fade-out animation.
+   * Default: `false`
    */
   noAnimation?: boolean
   /**
-   * Defines the size. Defaults to `default`.
+   * Defines the size.
+   * Default: `"default"`
    */
   size?: ValidSizes | ProgressIndicatorCustomSize
   /**
-   * A number between 0-100, if not supplied a continuous loading-type animation will be used. Defaults to `undefined`
+   * A number between 0-100, if not supplied a continuous loading-type animation will be used.
+   * Default: `undefined`
    */
   progress?: string | number
   /**
-   * Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`)
+   * Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.)
+   * Default: `undefined`
    */
   label?: ReactNode
   /**
-   * Same as `label` prop (`label` prop has priority)
+   * Same as `label` prop (`label` prop has priority).
+   * Default: `undefined`
    */
   children?: ReactNode
   /**
-   * Sets the position of the label. `'inside'` only works with `type='circular'. Defaults to `vertical`.
+   * Sets the position of the label. `'inside'` only works with `type='circular'`.
+   * Default: `"vertical"`
    */
   labelDirection?: 'horizontal' | 'vertical' | 'inside'
   /**
    * If set to `true` a default label (from text locales) will be shown.
+   * Default: `false`
    */
   showDefaultLabel?: boolean
   /**
    * Use this to override the default label from text locales.
+   * Default: `undefined`
    */
   indicatorLabel?: string
   /**
-   * Used to set title and aria-label. Defaults to the value of progress property, formatted as a percent.
+   * Used to set title and `aria-label`. Defaults to the value of progress property, formatted as a percent.
+   * Default: `undefined`
    */
   title?: string
   /**
-   * Will be called once it's no longer visible (show=false).
+   * Will be called once it's no longer visible (`show=false`).
+   * Default: `undefined`
    */
   onComplete?: () => void
   /**
@@ -68,19 +80,23 @@ export type ProgressIndicatorProps = {
   customColors?: {
     /**
      * Override the moving line color.
+     * Default: `undefined`
      */
     line?: CSS.Property.BackgroundColor
     /**
      * Override the background line color.
+     * Default: `undefined`
      */
     shaft?: CSS.Property.BackgroundColor
     /**
      * Set a background color for the center of the circle.
+     * Default: `undefined`
      */
     background?: CSS.Property.BackgroundColor
   }
   /**
-   * Send in custom CSS width for circle progress line. Default: `undefined`. (`undefined` defaults to one eighth of the size).
+   * Send in custom CSS width for circle progress line. (`undefined` defaults to one eighth of the size).
+   * Default: `undefined`
    */
   customCircleWidth?: CSS.Property.StrokeWidth
 }

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -102,7 +102,7 @@ export type RadioProps = {
   children?: RadioChildren
   onChange?: (event: RadioChangeEvent) => void
   /**
-   * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
+   * By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: Ref<HTMLInputElement>
 } & Omit<

--- a/packages/dnb-eufemia/src/components/section/Section.tsx
+++ b/packages/dnb-eufemia/src/components/section/Section.tsx
@@ -41,52 +41,51 @@ export type SectionProps = {
   variant?: SectionVariants | string
 
   /**
-   * Define if the background color should break-out to a fullscreen view. Defaults to `true`.
+   * Use `true` to enable a fullscreen breakout look. Also supports media query breakpoints like `{ small: boolean }`. Defaults to `true`.
    */
   breakout?: boolean | ResponsiveProp<boolean>
 
   /**
-   * Define if the Section should break out negatively on larger screens. You cannot use `breakout` and `outset` together.
-   * Defaults to `false`
+   * Define if the Section should break out negatively on larger screens. You cannot use `breakout` and `outset` together. Defaults to `false`.
    */
   outset?: boolean | ResponsiveProp<boolean>
 
   /**
-   * Define if the section should have rounded corners. Defaults to `false`.
+   * Use `true` to enable rounded corners (border-radius). Also supports media query breakpoints like `{ small: boolean }`. Defaults to `false`.
    */
   roundedCorner?:
     | SectionRoundedCorner
     | ResponsiveProp<SectionRoundedCorner>
 
   /**
-   * Define a custom border color. Use a Eufemia color.
+   * Define a custom border color. If `true` is given, `color-black-8` is used. Use a Eufemia color. Also supports media query breakpoints like `{ small: 'black-8' }`.
    */
   outline?: SectionOutlineColor | ResponsiveProp<SectionOutlineColor>
 
   /**
-   * Define a custom border width. Defaults to `var(--card-outline-width)`.
+   * Define a custom border width. Defaults to `var(--card-outline-width)`. Also supports media query breakpoints like `{ small: '2px' }`.
    */
   outlineWidth?: number | string | ResponsiveProp<number | string>
 
   /**
-   * Define a custom text color to complement the backgroundColor. Use a Eufemia color.
+   * Define a custom text color to complement the `backgroundColor`. Use a Eufemia color. Also supports media query breakpoints like `{ small: 'black-80' }`.
    */
   textColor?: SectionTextColor | ResponsiveProp<SectionTextColor>
 
   /**
-   * Define a custom background color, instead of a variant. Use a Eufemia color.
+   * Define a custom background color, instead of a variant. Use a Eufemia color. Also supports media query breakpoints like `{ small: 'white' }`.
    */
   backgroundColor?:
     | SectionBackgroundColor
     | ResponsiveProp<SectionBackgroundColor>
 
   /**
-   * Use `true` to show the default Eufemia DropShadow. Supports media query breakpoints like `{ small: true }`.
+   * Use `true` to show the default Eufemia DropShadow. Also supports media query breakpoints like `{ small: true }`.
    */
   dropShadow?: SectionDropShadow | ResponsiveProp<SectionDropShadow>
 
   /**
-   * Define the surface color context. When set to `dark`, ondark design tokens will be used for text and outline colors. Use `initial` to reset to the component's default behavior, ignoring any parent surface context.
+   * Define the surface color context. When set to `dark`, ondark design tokens will be used for text and outline colors. Use `initial` to reset to the component's default behavior, ignoring any parent surface context. Uses `--token-color-decorative-first-bold-static` as the default background color and `--token-color-text-neutral-ondark` as the text color.
    */
   surface?: ThemeSurface
 
@@ -96,7 +95,7 @@ export type SectionProps = {
   element?: DynamicElement
 
   /**
-   * Define a React.Ref.
+   * By providing a `React.Ref` we can get the internally used element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: RefObject<HTMLElement>
 }

--- a/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
@@ -9,20 +9,17 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type SkipContentProps = {
   /**
-   * Define an existing `Section` id to focus when the inner button got pressed.
-   * Required
+   * Define an existing HTML element selector to focus when the inner button got pressed.
    */
   selector: string
 
   /**
    * Define a clear message describing the choices the user has.
-   * Optional
    */
   text?: ReactNode
 
   /**
-   * Defines the delay after the enter key has been pressed
-   * Defaults to 400
+   * Defines the delay after the enter key has been pressed.
    */
   focusDelay?: number
 }

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -23,87 +23,139 @@ export type SliderExtensions = Record<
 >
 
 export type SliderProps = {
-  /** prepends the Form Label component. If no ID is provided, a random ID is created. */
+  /**
+   * Prepends the Form Label component. If no ID is provided, a random ID is created.
+   */
   label?: ReactNode
 
-  /** use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`. */
+  /**
+   * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
+   */
   labelDirection?: 'vertical' | 'horizontal'
 
-  /** use `true` to make the label only readable by screen readers. */
+  /**
+   * Use `true` to make the label only readable by screen readers.
+   */
   labelSrOnly?: boolean
 
-  /** text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message. */
+  /**
+   * Text with a status message. The style defaults to an error message. You can use `true` to only get the status color, without a message.
+   */
   status?: string | boolean
 
-  /** defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`. */
+  /**
+   * Defines the state of the status. Currently, there are two statuses `[error, information]`. Defaults to `error`.
+   */
   statusState?: 'error' | 'information'
 
-  /** use an object to define additional FormStatus properties. */
+  /**
+   * Use an object to define additional FormStatus properties.
+   */
   statusProps?: Record<string, unknown>
   statusNoAnimation?: boolean
 
-  /** the `statusId` used for the target [GlobalStatus](/uilib/components/global-status). */
+  /**
+   * The [configuration](/uilib/components/global-status/properties/#configuration-object) used for the target [GlobalStatus](/uilib/components/global-status).
+   */
   globalStatus?: GlobalStatusConfigObject
 
-  /** text describing the content of the Slider more than the label. You can also send in a React component, so it gets wrapped inside the Slider component. */
+  /**
+   * Text describing the content of the Slider more than the label. You can also send in a React component, so it gets wrapped inside the Slider component.
+   */
   suffix?: SuffixChildren
 
-  /** give the slider thumb button a title for accessibility reasons. Defaults to `null`. */
+  /**
+   * Give the slider thumb button a title for accessibility reasons. Defaults to `null`.
+   */
   thumbTitle?: string
 
-  /** give the add button a title for accessibility reasons. Defaults to `Increase (%s)`. */
+  /**
+   * Give the add button a title for accessibility reasons. Defaults to `Increase (%s)`.
+   */
   addTitle?: string
 
-  /** give the subtract button a title for accessibility reasons. Defaults to `Decrease (%s)`. */
+  /**
+   * Give the subtract button a title for accessibility reasons. Defaults to `Decrease (%s)`.
+   */
   subtractTitle?: string
 
-  /** the minimum value. Defaults to `0`. */
+  /**
+   * The minimum value. Can be a negative number as well. Defaults to `0`.
+   */
   min?: number
 
-  /** the maximum value. Defaults to `100`. */
+  /**
+   * The maximum value. Defaults to `100`.
+   */
   max?: number
 
-  /** the `value` of the slider as a number. If an array with numbers is provided, each number will represent a thumb button (the `+` and `-` button will be hidden on multiple thumbs). */
+  /**
+   * The `value` of the slider as a number or an array. If an array with numbers is provided, each number will represent a thumb button (the `+` and `-` button will be hidden on multiple thumbs).
+   */
   value?: SliderValue
 
-  /** the steps the slider takes on changing the value. Defaults to `null`. */
+  /**
+   * The steps the slider takes on changing the value. Defaults to `null`.
+   */
   step?: number
 
-  /** makes it possible to display overlays with other functionality such as a marker on the slider marking a given value. */
+  /**
+   * Makes it possible to display overlays with other functionality such as a marker on the slider marking a given value.
+   */
   extensions?: SliderExtensions
 
-  /** show the slider vertically. Defaults to `false`. */
+  /**
+   * Show the slider vertically. Defaults to `false`.
+   */
   vertical?: boolean
 
-  /** show the slider reversed. Defaults to `false`. */
+  /**
+   * Show the slider reversed. Defaults to `false`.
+   */
   reverse?: boolean
 
-  /** if set to `true`, then the slider will be 100% in `width`. */
+  /**
+   * If set to `true`, then the slider will be 100% in `width`.
+   */
   stretch?: boolean
 
-  /** provide a function callback or use the options from the [NumberFormat](/uilib/components/number-format/properties) component. It will show a formatted number in the Tooltip (`tooltip={true}`) and enhance the screen reader UX. It will also extend the `onChange` event return object with a formatted `number` property. */
+  /**
+   * Will extend the return object with a `number` property (from `onChange` event). You can use all the options from the [NumberFormat](/uilib/components/number-format/properties) component. It also will use that formatted number in the increase/decrease buttons. If it has to represent a currency, then use e.g. `numberFormat={{ currency: true, decimals: 0 }}`.
+   */
   numberFormat?: SliderNumberFormat
 
-  /** use `true` to show a tooltip on `mouseOver`, `touchStart` and `focus`, showing the current number (if `numberFormat` is given) or the raw value. Defaults to `null`. */
+  /**
+   * Use `true` to show a tooltip on `mouseOver`, `touchStart` and `focus`, showing the current number (if `numberFormat` is given) or the raw value.
+   */
   tooltip?: boolean
 
-  /** use `true` to always show the tooltip, in addition to the `tooltip` property.  */
+  /**
+   * Use `true` to always show the tooltip, in addition to the `tooltip` property.
+   */
   alwaysShowTooltip?: boolean
 
-  /** removes the helper buttons. Defaults to `false`. */
+  /**
+   * Removes the helper buttons. Defaults to `false`.
+   */
   hideButtons?: boolean
 
-  /** use either `omit`, `push` or `swap`. This property only works for two (range) or more thumb buttons, while `omit` will stop the thumb from swapping, `push` will push its nearest thumb along. Defaults to `swap`. */
+  /**
+   * Use either `omit`, `push` or `swap`. This property only works for two (range) or more thumb buttons, while `omit` will stop the thumb from swapping, `push` will push its nearest thumb along. Defaults to `swap`.
+   */
   multiThumbBehavior?: 'swap' | 'omit' | 'push'
 
-  /** if set to `true`, an overlaying skeleton with animation will be shown. */
+  /**
+   * If set to `true`, an overlaying skeleton with animation will be shown.
+   */
   skeleton?: SkeletonShow
 
   id?: string
   disabled?: boolean
   className?: string
 
-  /** Will be called on state changes made by the user. The callback `value` and `rawValue` is a number `{ value, rawValue, event }`. But if the prop `numberFormat` is given, then it will return an additional `number` with the given format `{ value, number, rawValue, event }`. */
+  /**
+   * Will be called on state changes made by the user. The callback `value` and `rawValue` is a number `{ value, rawValue, event }`. But if the `numberFormat` property is given, then it will return an additional `number` with the given format `{ value, number, rawValue, event }`.
+   */
   onChange?: (props: SliderOnChangeParams) => void
 
   /** Will be called once the user starts dragging. Returns `{ event }`. */

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -35,8 +35,7 @@ export type {
 
 export type SpaceProps = {
   /**
-   * Defines the HTML element used.
-   * Default: `div`
+   * Defines the HTML element used. Defaults to `div`.
    */
   element?: DynamicElement
 
@@ -51,8 +50,7 @@ export type SpaceProps = {
   noCollapse?: boolean
 
   /**
-   * If set to `true`, then the space element will be 100% in width.
-   * Default: `false`
+   * If set to `true`, then the space element will be 100% in `width`.
    */
   stretch?: boolean
 

--- a/packages/dnb-eufemia/src/components/stat/Amount.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Amount.tsx
@@ -28,10 +28,8 @@ type AmountOwnProps = Omit<
   currencyDisplay?: NumberFormatProps['currencyDisplay']
   currencyPosition?: NumberFormatProps['currencyPosition']
   /**
-   * Typography size fallback.
-   *
-   * Is used for both main and auxiliary content unless `mainSize` and/or
-   * `auxiliarySize` are set.
+   * Typography size for the label. Line-height is derived from the shared heading/text scale.
+   * Default: `"basis"`
    */
   fontSize?: TypographySize
   /**
@@ -54,7 +52,8 @@ type AmountOwnProps = Omit<
    */
   auxiliaryWeight?: TypographyWeight
   /**
-   * Opt-in sign-based text color (`+` => green, `-` => red).
+   * If `true`, text color follows a signed child value when possible. You can also pass a number directly to control the tone for custom content.
+   * Default: `false`
    */
   colorizeBySign?: boolean
   /** Formats the value as a percentage. */

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -50,28 +50,23 @@ export type StepIndicatorProps = Omit<
 > &
   SpacingProps & {
     /**
-     * (required) defines how the StepIndicator should work. Use `static` for non-interactive steps. Use `strict` for a chronological step order, also, the user can navigate between visited steps. Use `loose` if the user should be able to navigate freely.
+     * Defines how the StepIndicator should work. Use `static` for non-interactive steps. Use `strict` for a chronological step order, also, the user can navigate between visited steps. Use `loose` if the user should be able to navigate freely.
      */
     mode: StepIndicatorMode
     /**
-     * (required) defines the data/steps showing up in a JavaScript Array or JSON format like `[{title,isCurrent}]`. See parameters and the example above.
+     * Defines the data/steps showing up in a JavaScript Array or JSON format like `[{title,isCurrent}]`. See below for properties of `STEP_DATA`.
      */
     data: StepIndicatorData
     /**
-     *  The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`
-     *  Defaults to `Steps Overview`
+     * The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`. Defaults to `Steps Overview`.
      */
     overviewTitle?: string
     /**
-     *  The label for `<StepIndicatorTriggerButton />` and supplemental screen reader text for `<StepIndicatorItem />`
-     *  This value need to contain `%step` and `%count` if you want to display the current step and total amount of steps
-     * `%step` is used to place the current step into the text
-     * `%count` is used to place the step total into the text
-     *  Defaults to `Step %step of %count`
+     * Label for `<StepIndicatorTriggerButton />` and screen reader text for `<StepIndicatorItem />`. Must contain `%step` and `%count` to interpolate `currentStep` and `stepCount` into the text. Defaults to `Step %step of %count`.
      */
     stepTitle?: string
     /**
-     * Defines the active number marked step starting by 0. Defaults to `0`.
+     * Defines the initial step starting from 0. Also defines the furthest step visited when `mode="strict"`. Will update to the new step if changed (but will not trigger the `onChange` event). Defaults to `0`.
      */
     currentStep?: number
     /**
@@ -79,7 +74,7 @@ export type StepIndicatorProps = Omit<
      */
     hideNumbers?: boolean
     /**
-     * Will be called once the user clicks on the current or another step. Will be emitted on every click. Returns an object `{ event, item, currentStep }`.
+     * Will be called when the user clicks on any clickable step in the list. Is called right before `onChange`. Receives parameter `{ event, item, currentStep }`.
      */
     onClick?: ({
       event,
@@ -87,7 +82,7 @@ export type StepIndicatorProps = Omit<
       currentStep,
     }: StepIndicatorMouseEvent) => void
     /**
-     * Will be called once the user visits actively a new step. Will be emitted only once. Returns an object `{ event, item, currentStep }`.
+     * Will be called when the user changes step by clicking in the steps list (changing the `currentStep` property does not trigger the event). Receives parameter `{ event, item, currentStep }`.
      */
     onChange?: ({
       event,
@@ -95,12 +90,11 @@ export type StepIndicatorProps = Omit<
       currentStep,
     }: StepIndicatorMouseEvent) => void
     /**
-     * Status text. Status is only shown if this prop has text. Defaults to `undefined`
+     * Text for status shown below the step indicator when it is not expanded. Defaults to `undefined`.
      */
     status?: FormStatusText
     /**
-     * The type of status for the `status` prop. Is either `information`, `error` or `warning`.
-     * Defaults to `warning`.
+     * The type of status shown when the `status` property is set. Defaults to `warning`.
      */
     statusState?: FormStatusState
     /**
@@ -112,7 +106,7 @@ export type StepIndicatorProps = Omit<
      */
     expandedInitially?: boolean
     /**
-     * Whether or not to break out (using negative margins) on larger screens. Defaults to `false`.
+     * Whether or not to break out (using negative margins) on larger screens. Defaults to `false`. Same as `outset` in [Card](/uilib/components/card/properties).
      */
     outset?: boolean
     skeleton?: SkeletonShow

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -93,19 +93,19 @@ export type SwitchProps = {
   className?: string
   children?: ReactNode
   /**
-   * Will be called on state changes made by the user. Returns a boolean `{ checked, event }`.
+   * Will be called on state changes made by the user.
    */
   onChange?: SwitchOnChange
   /**
    * Will be called on state changes made by the user, but with a delay. This way the user sees the animation before e.g. an error will be removed. Returns a boolean `{ checked, event }`.
    */
   /**
-   * Will be called on click made by the user. Returns the ClickEvent.
+   * Will be called on click.
    */
   onClick?: (args: SwitchOnClickParams) => void
   onChangeEnd?: SwitchOnChange
   /**
-   * By providing a React.Ref we can get the internally used input element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
+   * By providing a `React.Ref` we can get the internally used input element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.
    */
   ref?: RefObject<HTMLInputElement> | ((elem: HTMLInputElement) => void)
 } & FormStatusBaseProps &

--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -32,24 +32,26 @@ export type TableProps = {
   children: ReactNode
 
   /**
-   * Custom className on the component root
+   * Custom `className` on the component root.
+   * Default: `undefined`
    */
   className?: string
 
   /**
-   * Skeleton should be applied when loading content
+   * If set to `true`, an overlaying skeleton with animation will be shown.
+   * Default: `undefined`
    */
   skeleton?: SkeletonShow
 
   /**
-   * The size of the component.
-   * Default: `large`
+   * Spacing size inside the table header and data.
+   * Default: `"large"`
    */
   size?: TableSizes
 
   /**
-   * The style variant of the component. Currently not implemented.
-   * Default: `generic`
+   * Defines the visual style of the table header. Use `subtle` for a lighter appearance with reduced font-weight, smaller font-size, and muted text color.
+   * Default: `"emphasis"`
    */
   variant?: TableVariants
 
@@ -73,24 +75,24 @@ export type TableProps = {
 
   /**
    * Defines how the Table should look. Use `accordion` for an accordion-like table. Use `navigation` for a navigation table.
+   * Default: `null`
    */
   mode?: 'accordion' | 'navigation'
 
   /**
-   * Defines where the chevron will be placed, should only be used together with mode="accordion".
-   * Default: `'left'`
+   * Defines where the chevron will be placed, should only be used together with `mode="accordion"`.
+   * Default: `"left"`
    */
   accordionChevronPlacement?: 'left' | 'right'
 
   /**
-   * Defines if the table should behave with a fixed table layout, using: "table-layout: fixed;"
+   * If set to `true`, the table will behave with a fixed table layout, using: `table-layout: fixed;`. Use e.g. CSS `width: 40%` on a table column to define the width.
    * Default: `null`
    */
   fixed?: boolean
 
   /**
-   * ref handle to collapse all expanded accordion rows. Send in a ref and use `.current()` to collapse all rows.
-   *
+   * Ref handle to collapse all expanded accordion rows. Send in a ref and use `.current()` to collapse all rows.
    * Default: `undefined`
    */
   collapseAllHandleRef?: RefObject<() => void>

--- a/packages/dnb-eufemia/src/components/table/TableTd.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTd.tsx
@@ -23,13 +23,13 @@ export type TableTdClickInfo = {
 
 export type TableTdProps = {
   /**
-   * if set to `true`, no padding will be added
+   * If set to `true`, no padding will be added.
    * Default: `false`
    */
   noSpacing?: boolean
 
   /**
-   * Set to `horizontal` for padding on left and right side
+   * Set to `horizontal` for padding on left and right side.
    * Default: `undefined`
    */
   spacing?: 'horizontal'
@@ -41,39 +41,32 @@ export type TableTdProps = {
   verticalAlign?: 'top' | 'middle' | 'bottom'
 
   /**
-   * If set to `true`, the cell will be styled as selected.
-   * When provided (either `true` or `false`), the cell button will be
-   * announced as a toggle button by screen readers.
+   * When `true`, the cell is styled as selected (highlighted background and selected icon/border). Requires `onClick` to take effect, since the selected styling targets the cell button. When provided (either `true` or `false`), the cell button is announced as a toggle button by screen readers via `aria-pressed`. Use `setSelected` from the `onClick` callback to toggle the state.
    * Default: `undefined`
    */
   selected?: boolean
 
   /**
-   * Highlights this cell with a subtle background.
-   * Automatically set when the parent Tr has `highlight`.
+   * If set to `true`, the cell receives a highlighted background. Automatically set when the parent `<Tr>` has `highlight`, or when the corresponding `<Th>` in the same column has `highlight`.
    * Default: `false`
    */
   highlight?: boolean
 
   /**
-   * Will emit when user clicks the cell button.
-   * Renders a native button inside the cell for accessibility.
-   * The second argument contains `trElement`, `tdElement`, `thElement` (the matching Th in thead), `isSelected`, and `setSelected`.
+   * Will emit when user clicks the cell button. The second argument is an object with `trElement` (the parent `HTMLTableRowElement`), `tdElement` (the `HTMLTableCellElement`), `thElement` (the matching `<Th>` from `<thead>`, or `null` if not found), `isSelected` (current selected state), and `setSelected` (function to update the selected state — only effective when the `selected` prop is provided).
+   * Default: `undefined`
    */
   onClick?: (event: SyntheticEvent, info: TableTdClickInfo) => void
 
   /**
-   * Icon to show in the navigable cell.
-   * Set to `true` for the default chevron icon, or pass a custom icon.
-   * Set to `false` to hide the icon.
-   * Only takes effect when `onClick` is provided.
+   * Icon to show in the clickable cell. Set to `true` for the default chevron icon, or pass a custom icon. Set to `false` to hide the icon. Only takes effect when `onClick` is provided.
    * Default: `true`
    */
   icon?: boolean | IconIcon
 
   /**
    * The content of the component.
-   * Default: `null`
+   * Default: `undefined`
    */
   children?: ReactNode
 }

--- a/packages/dnb-eufemia/src/components/table/TableTh.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTh.tsx
@@ -13,46 +13,44 @@ export type TableThChildren =
 
 export type TableThProps = {
   /**
-   * Defines the table header as sortable (ascending)
+   * Defines the table header as sortable if set to `true` (ascending).
    * Default: `false`
    */
   sortable?: boolean
 
   /**
-   * Defines the sortable column as the current active (ascending)
+   * Defines the sortable column as the current active (ascending).
    * Default: `false`
    */
   active?: boolean
 
   /**
-   * Defines the sortable column as in reversed order (descending)
+   * Defines the sortable column as in reversed order (descending).
    * Default: `false`
    */
   reversed?: boolean
 
   /**
-   * If set to true, the header text will not wrap to new lines
+   * If set to `true`, the header text will not wrap to new lines.
    * Default: `false`
    */
   noWrap?: boolean
 
   /**
-   * Highlights the cell with a subtle background overlay.
-   * Use together with `useTableHighlight` to highlight the entire column.
+   * If set to `true`, the header cell and all `<Td>` cells in the same column receive a highlighted background. Also inherited from the parent `<Tr>` when it has `highlight`.
    * Default: `false`
    */
   highlight?: boolean
 
   /**
-   * Defines the visual variant of the table header.
-   * `emphasis` renders with medium font weight.
-   * `subtle` renders with regular font weight, smaller font size, and lighter color.
-   * Default: `emphasis`
+   * Defines the visual style of the table header. Use `subtle` for a lighter appearance with reduced font-weight, smaller font-size, and muted text color.
+   * Default: `"emphasis"`
    */
   variant?: 'emphasis' | 'subtle'
 
   /**
-   * The content of the table header given as Tr.
+   * The content of the component.
+   * Default: `undefined`
    */
   children?: TableThChildren | Array<TableThChildren>
 

--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -19,12 +19,13 @@ export type TableTrClickInfo = {
 
 export type TableTrProps = {
   /**
-   * The variant of the tr
+   * Override the automatic variant of the current row. The next row one will continue with the opposite.
+   * Default: `undefined`
    */
   variant?: 'even' | 'odd'
 
   /**
-   * If set to true, the inherited header text will not wrap to new lines.
+   * If set to `true`, the inherited header text will not wrap to new lines.
    * Default: `false`
    */
   noWrap?: boolean
@@ -36,55 +37,50 @@ export type TableTrProps = {
   verticalAlign?: 'top' | 'middle' | 'bottom'
 
   /**
-   * Highlights all cells in the row with a subtle background.
+   * If set to `true`, all `<Td>` and `<Th>` cells in the row receive a highlighted background.
    * Default: `false`
    */
   highlight?: boolean
 
   /**
-   * Set true to render the tr initially as expanded.
-   * Is part of the accordion feature and needs to be enabled with `mode="accordion"` prop in main Table.
+   * Use `true` to render the `<Tr>` initially as expanded.
    * Default: `false`
    */
   expanded?: boolean
 
   /**
-   * Set true to disable the tr to be accessible as an interactive element.
-   * Is part of the accordion feature and needs to be enabled with `mode="accordion"`prop in main Table.
+   * Use `true` to disable the `<Tr>` to be accessible as an interactive element.
    * Default: `false`
    */
   disabled?: boolean
 
   /**
-   * Set to true to skip animation.
-   * Is part of the accordion feature and needs to be enabled with `mode="accordion"` prop in main Table.
+   * Use `true` to disable the expand/collapse animation.
    * Default: `false`
    */
   noAnimation?: boolean
 
   /**
-   * Set to `true` to keep the accordion content in the DOM when closed.
-   * Is part of the accordion feature and needs to be enabled with `mode="accordion"` prop in main Table.
+   * When `true`, keeps the accordion content in the DOM when closed. Defaults to `false`.
    * Default: `false`
    */
   keepInDOM?: boolean
 
   /**
-   * Will emit when user clicks/expands or on keydown space/enter(in mode="accordion" and mode="navigation") in the table row.
-   * Is part of the mode feature and needs to be enabled with the `mode` prop in main Table.
-   * The second argument contains `trElement`.
+   * Will emit when user clicks/expands or on keydown space/enter (in `mode="accordion"` and `mode="navigation"`) in the table row. The second argument is an object with `trElement` (the `HTMLTableRowElement`).
+   * Default: `undefined`
    */
   onClick?: (event: SyntheticEvent, info: TableTrClickInfo) => void
 
   /**
-   * Will emit when table row is expanded.
-   * Is part of the accordion feature and needs to be enabled with `mode="accordion"` prop in main Table.
+   * Will emit when table row is expanded. Returns an object with the table row as the target: `{ target }`.
+   * Default: `undefined`
    */
   onOpen?: ({ target }: { target: HTMLTableRowElement }) => void
 
   /**
-   * Will emit when table row is closed (after it was open)
-   * Is part of the accordion feature and needs to be enabled with `mode="accordion"` prop in main Table.
+   * Will emit when table row is closed (after it was open). Returns an object with the table row as the target: `{ target }`.
+   * Default: `undefined`
    */
   onClose?: ({ target }: { target: HTMLTableRowElement }) => void
 

--- a/packages/dnb-eufemia/src/components/table/useHandleSortState.ts
+++ b/packages/dnb-eufemia/src/components/table/useHandleSortState.ts
@@ -2,8 +2,8 @@ import { useMemo, useState } from 'react'
 
 export type UseHandleSortStateOptions = {
   /**
-   * Defines if the current column should be active or not.
-   * Defaults to `false`.
+   * Defines the sortable column as the current active (ascending).
+   * Default: `false`
    */
   active?: boolean
 

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -114,12 +114,12 @@ export type TabsProps = Omit<
      */
     contentStyle?: SectionVariants | string
     /**
-     * To modify the inner space of the content wrapper. Use a supported modifier from the [Section component](/uilib/components/section/properties). Defaults to `{ top: 'large' }`.
+     * To modify the inner space of the content wrapper. Defaults to `{ top: 'large' }`.
      */
     contentInnerSpace?: InnerSpaceType | boolean
     label?: string
     /**
-     * Define what HTML element should be used. You can provide e.g. `tabElement={Link}` and then pass the `to` property inside every entry (`data={[{ to: '/url', ... }]}`). Defaults to `<button>`.
+     * Define what HTML element should be used. You can provide e.g. `tabElement={Link}` – you may then provide the `to` property inside every entry (`data={[{ to: '/url', ... }]}`). Defaults to `<button>`.
      */
     tabElement?: TabsTabElement
     /**

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -25,55 +25,47 @@ import { useSpacing } from '../space/SpacingUtils'
 
 export type TagProps = {
   /**
-   * The content of the tag element, can be a string or a React Element.
-   * Default: `null`
+   * The content of the tag can be a string or a React Element.
    */
   text?: string | ReactNode
 
   /**
-   * To be included in the tag. [Primary Icons](/icons/primary) can be set as a string (e.g. `icon="chevron_right"`), other icons should be set as React elements. Note, we recommend not to use icons with clickable tags.
+   * To be included in the tag. Primary Icons can be set as a string (e.g. `icon="chevron_right"`), other icons should be set as React elements. Note, we recommend not to use icons with clickable tags.
    */
   icon?: IconIcon
 
   /**
    * If a label is given, typically inside a table or dl (definition list), then you can disable Tag.Group as a dependent of Tag. Use `true` to omit the `Tag group required:` warning.
-   * Default: `null`
    */
   hasLabel?: boolean
 
   /**
-   * Defines the variant. Possible values are `default`, `clickable`, `addable`, or `removable`.
-   * Default: `'default'`
+   * Possible values are `default`, `clickable`, `addable`, or `removable`. Defaults to `default`.
    */
   variant?: 'default' | 'clickable' | 'addable' | 'removable'
 
   /**
-   * Custom className on the component root
-   * Default: `null`
+   * Custom `className` for the component root.
    */
   className?: string
 
   /**
-   * Skeleton should be applied when loading content
-   * Default: `null`
+   * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow
 
   /**
-   * The content of the tag element, can be a string or a React Element. Will be overwritten by text prop
-   * Default: `null`
+   * The content of the tag can be a string or a React Element.
    */
   children?: string | ReactNode // ReactNode allows multiple elements, strings, numbers, fragments, portals...
 
   /**
-   * Handle the click event on 'tag' element
-   * Default: `null`
+   * Will be called on a click event. Returns the native event.
    */
   onClick?: (args: { event: MouseEvent<HTMLButtonElement> }) => void
 
   /**
-   * Set to `true` to omit triggering an event when the user releases the `Delete` or `Backspace` keys.
-   * Default: `false`
+   * Set to `true` to omit triggering an event when the user releases the `Delete` or `Backspace` keys. Defaults to `false`.
    */
   omitOnKeyUpDeleteEvent?: boolean
 

--- a/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
+++ b/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
@@ -22,11 +22,11 @@ import { extendPropsWithContext } from '../../shared/component-helper'
 
 export type TermDefinitionProps = {
   /**
-   * The term shown as the anchor trigger.
+   * Term shown as the trigger. Typically a short word or phrase.
    */
   children: ReactNode
   /**
-   * The explanatory text/content shown inside the tooltip.
+   * Definition text that will be displayed inside.
    */
   content: ReactNode
   /**
@@ -34,7 +34,8 @@ export type TermDefinitionProps = {
    */
   className?: string
   /**
-   * Tooltip placement relative to the trigger.
+   * Defines the preferred popover placement relative to the trigger.
+   * Default: `"bottom"`
    */
   placement?: 'top' | 'right' | 'bottom' | 'left'
   /**

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -118,7 +118,7 @@ export type TextareaProps = Omit<
      */
     size?: TextareaSize
     /**
-     * To control the visual focus state as a prop, like `focus` or `blur`.
+     * To control the visual focus state as a property, like `focus` or `blur`.
      */
     textareaState?: string
     /**
@@ -134,7 +134,7 @@ export type TextareaProps = Omit<
      */
     keepPlaceholder?: boolean
     /**
-     * Defines the `text-align` of the Textarea. Defaults to `left`.
+     * Defines the `text-align` of the Textarea. Can be `left`, `center`, `right`, or `justify`. Defaults to `left`.
      */
     align?: TextareaAlign
     /**
@@ -178,7 +178,7 @@ export type TextareaProps = Omit<
      */
     locale?: InternalLocale
     /**
-     * By providing a React.Ref we can get the internally used Textarea element (DOM). E.g. `ref={myRef}` by using `React.useRef(null)`.
+     * By providing a `React.Ref` we can get the internally used Textarea element (DOM), e.g. `ref={myRef}` by using `React.useRef(null)`.
      */
     ref?: Ref<HTMLTextAreaElement> | null
   }

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -22,20 +22,17 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type TimelineProps = {
   /**
-   * Skeleton should be applied when loading content
-   * Default: `null`
+   * If set to `true`, an overlaying skeleton with animation will be shown.
    */
   skeleton?: SkeletonShow
 
   /**
-   * Pass in a list of your events as objects of TimelineItem, to render them as TimelineItems.
-   * Default: `null`
+   * List of [timeline items](/uilib/components/timeline/properties#timelineitem-properties) to render. Each object in data can include all properties from [Timeline.Item properties](/uilib/components/timeline/properties#timelineitem-properties).
    */
   data?: TimelineItemProps[]
 
   /**
-   * The content of the component. Can be used instead of prop "data".
-   * Default: `null`
+   * Content of the component. Can be used instead of property `data`, by adding [Timeline Item](/uilib/components/timeline/properties#timelineitem-properties) as children `<Timeline.Item {...properties} />`.
    */
   children?:
     | ReactElement<TimelineItemProps>[]

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -542,7 +542,7 @@ export type ToggleButtonProps = Omit<
      */
     tooltip?: ButtonTooltip
     /**
-     * Defines the `value` as a string. Use it to get the value during the `onChange` event listener callback in the **ToggleButtonGroup**.
+     * Defines the `value`. Use it to get the value during the `onChange` event listener callback in the **ToggleButtonGroup**.
      */
     value?: ToggleButtonValue
     /**

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -385,7 +385,7 @@ export type ToggleButtonGroupProps = Omit<
     labelDirection?: 'horizontal' | 'vertical'
     labelSrOnly?: boolean
     /**
-     * The `title` of the input - describing it a bit further for accessibility reasons.
+     * The `title` of group, describing it a bit further for accessibility reasons.
      */
     title?: string
     /**
@@ -405,7 +405,7 @@ export type ToggleButtonGroupProps = Omit<
      */
     suffix?: ToggleButtonGroupSuffix
     /**
-     * Defines the `value` as a string. Use it to get the value during the `onChange` event listener callback in the **ToggleButtonGroup**.
+     * Defines the pre-selected ToggleButton button. The value has to match the one provided in the ToggleButton button. Use a string value.
      */
     value?: ToggleButtonGroupValue
     /**
@@ -413,11 +413,11 @@ export type ToggleButtonGroupProps = Omit<
      */
     size?: ButtonSize
     /**
-     * Defines the layout direction of the ToggleButtonGroup. Set to `column` or `row`. Defaults to `row` if not set.
+     * Define the layout direction of the ToggleButton buttons. Can be either `column` or `row`. Defaults to `row`.
      */
     layoutDirection?: ToggleButtonGroupLayoutDirection
     /**
-     * Defines the `values` as a string. Use it to get the values during the `onChange` event listener callback in the **ToggleButtonGroup**.
+     * Defines the pre-selected ToggleButton buttons in `multiselect` mode. The values have to match the one provided in the ToggleButton buttons. Use array, either as JS or JSON string.
      */
     values?: ToggleButtonGroupValues
     readOnly?: boolean

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipDocs.ts
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipDocs.ts
@@ -27,7 +27,7 @@ export const TooltipProperties: PropertiesTableProps = {
     status: 'optional',
   },
   portalRootClass: {
-    doc: 'CSS class name applied to the portal root element. Used to style or identify the portal container.',
+    doc: 'CSS class name applied to the Tooltip portal root element. Has effect only when not using `skipPortal`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/tooltip/types.ts
+++ b/packages/dnb-eufemia/src/components/tooltip/types.ts
@@ -27,18 +27,14 @@ export type TooltipProps = {
   fixedPosition?: boolean
   contentRef?: RefObject<HTMLSpanElement>
   /**
-   * Skip rendering the tooltip in a React Portal.
-   * When `true`, the tooltip renders inline in the DOM tree instead of being portaled to document.body.
-   * Useful for cases where you need the tooltip to be part of the same DOM hierarchy for styling or event handling.
-   * Default: `false`
+   * Skip rendering the tooltip in a React Portal. When `true`, the tooltip renders inline in the DOM tree instead of being portaled to document.body. Useful for cases where you need the tooltip to be part of the same DOM hierarchy for styling or event handling. Defaults to `false`.
    */
   skipPortal?: boolean
   noAnimation?: boolean
   showDelay?: number
   hideDelay?: number
   /**
-   * CSS class name applied to the Tooltip portal root element.
-   * Has effect only when not using `skipPortal`.
+   * CSS class name applied to the Tooltip portal root element. Has effect only when not using `skipPortal`.
    */
   portalRootClass?: string
   targetSelector?: string
@@ -48,19 +44,15 @@ export type TooltipProps = {
   children?: ReactNode
   style?: CSSProperties
   /**
-   * Whether to omit the aria-describedby attribute.
+   * Set to `true` to omit the `aria-describedby` attribute on the target element. Defaults to `false`.
    */
   omitDescribedBy?: boolean
   /**
-   * Keep the tooltip portal mounted in the DOM even when closed.
-   * Useful if you want the tooltip markup to stay mounted to avoid layout shifts.
-   * Default: `false`
+   * Keep the tooltip portal mounted in the DOM even when closed. When `true`, the tooltip remains in the DOM when inactive. Defaults to `false`.
    */
   keepInDOM?: boolean
   /**
-   * Additional spacing in pixels between the tooltip and its trigger.
-   * Maps directly to the Popover `triggerOffset`.
-   * Default: `16`
+   * Adjust the pixel gap between the tooltip content and its trigger. Use positive values to place the tooltip further away (e.g., to match custom spacing). Defaults to `16`.
    */
   triggerOffset?: number
   /**

--- a/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
+++ b/packages/dnb-eufemia/src/components/upload/UploadDocs.ts
@@ -62,7 +62,7 @@ export const UploadProperties: PropertiesTableProps = {
     status: 'optional',
   },
   skeleton: {
-    doc: 'Skeleton should be applied when loading content.',
+    doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/upload/types.ts
+++ b/packages/dnb-eufemia/src/components/upload/types.ts
@@ -16,17 +16,17 @@ export type UploadAcceptedFileTypeObject = {
 
 export type UploadProps = {
   /**
-   * unique id used with the useUpload hook to manage the files
+   * Unique id used together with the `useUpload` hook to manage the files. Needed when wanting to connect with the `useUpload` hook.
    */
   id?: SharedStateId
 
   /**
-   * defines the appearance. Use one of these: `default` or `compact`. Defaults to `default`.
+   * Defines the appearance. Use one of these: `default` or `compact`. Defaults to `default`.
    */
   variant?: 'default' | 'compact'
 
   /**
-   * List of accepted file types.
+   * List of accepted file types. Either as a string or an [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype). When providing a list of [AcceptedFileType](/uilib/components/upload/properties/#acceptedfiletype), the accepted file types will be presented in a table (see [example](/uilib/components/upload/demos/#upload-with-file-max-size-based-on-file-type)).
    */
   acceptedFileTypes:
     | UploadAcceptedFiles
@@ -38,24 +38,22 @@ export type UploadProps = {
   skeleton?: SkeletonShow
 
   /**
-   * Defines the amount of files the user can select and upload
-   * Default: `100`
+   * Defines the amount of files the user can select and upload. Defaults to `100`.
    */
   filesAmountLimit?: number
 
   /**
-   * Defines the max file size of each file in MB. Use either `0` or `false` to disable.
-   * Default: `5 MB`
+   * Defines the max file size of each file in MB. Use either `0` or `false` to disable. Defaults to 5 MB.
    */
   fileMaxSize?: number | false
 
   /**
-   * will be called on `files` changes made by the user. Access the files with `{ files }`.
+   * Will be called on `files` changes made by the user. Access the files with `{ files }` (containing each a `fileItem`).
    */
   onChange?: ({ files }: { files: Array<UploadFile> }) => void
 
   /**
-   * will be called once a file gets deleted by the user. Access the deleted file with `{ fileItem }`.
+   * Will be called once a file gets deleted by the user. Access the deleted file with `{ fileItem }`.
    */
   onFileDelete?: ({
     fileItem,
@@ -73,20 +71,17 @@ export type UploadProps = {
   }) => void | Promise<void>
 
   /**
-   * Causes the browser to treat all listed files as downloadable instead of opening them in a new browser tab or window.
-   * Default: `false`
+   * Causes the browser to treat all listed files as downloadable instead of opening them in a new browser tab or window. Defaults to `false`.
    */
   download?: boolean
 
   /**
-   * Allows uploading of duplicate files.
-   * Default: `false`
+   * Allows uploading of duplicate files. Defaults to `false`.
    */
   allowDuplicates?: boolean
 
   /**
-   * Disables file drag and drop, by removing the drop zone.
-   * Default: `false`
+   * Disables file drag and drop, by removing the drop zone. Defaults to `false`.
    */
   disableDragAndDrop?: boolean
 
@@ -96,7 +91,7 @@ export type UploadProps = {
   buttonProps?: ButtonProps
 
   /**
-   * Custom text properties
+   * Custom text property. Replaces the default title. Can be disabled using `false`.
    */
   title?: ReactNode
   text?: ReactNode

--- a/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
@@ -10,14 +10,12 @@ import type { DynamicElement } from '../../shared/types'
 
 export type VisuallyHiddenProps = {
   /**
-   * Hide an element by default, but to display it when it’s focused (e.g. by a keyboard-only user)
-   * Default: `false`
+   * Set to `true` to hide an element by default, but to display it when it’s focused (e.g. by a keyboard-only user). Defaults to `false`.
    */
   focusable?: boolean
 
   /**
-   * Root element of the component
-   * Default: `span`
+   * Custom root HTML element for the component. Defaults to `<span>`.
    */
   element?: DynamicElement
 }

--- a/packages/dnb-eufemia/src/shared/MediaQueryUtils.ts
+++ b/packages/dnb-eufemia/src/shared/MediaQueryUtils.ts
@@ -74,7 +74,7 @@ export type MediaQueryListener = () => void
 
 export type MediaQueryProps = {
   /**
-   * If set to true, it will match and return the given children during SSR.
+   * If set to `true`, it will match and return the given children during SSR.
    */
   matchOnSSR?: boolean
 


### PR DESCRIPTION
Align JSDoc property descriptions in components with the doc strings in their sibling *Docs files, via the docs-types/sync-docs-jsdoc rule. Also fixed a leading-space typo in DatePickerDocs labelDirection.

