### PR TITLE
chore(Portal): make live code example toggles accessible and animated

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.module.scss
@@ -143,6 +143,12 @@
     border-start-end-radius: var(--border-radius);
   }
 
+  :global(.hide-preview) & {
+    &::after {
+      border-top: none;
+    }
+  }
+
   :global(.omit-wrapper:not(.hide-code)) & {
     box-shadow: inset 0 0 0 0.0625rem
       var(--token-color-stroke-neutral-subtle);
@@ -174,6 +180,13 @@
   :global {
     .example-caption {
       margin-bottom: 1.5rem;
+    }
+
+    // HeightAnimation renders .dnb-accordion__content as a flex container, so its
+    // direct children (the preview's Theme wrapper and the code editor) must fill
+    // the full width instead of shrinking to their content.
+    .dnb-accordion__content > * {
+      width: 100%;
     }
 
     .dnb-live-editor {

--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -16,11 +17,11 @@ import clsx from 'clsx'
 import { Highlight, Prism } from 'prism-react-renderer'
 import Tag from './Tag'
 import {
+  Accordion,
   Button,
   Checkbox,
   Flex,
   Space,
-  ToggleButton,
 } from '@dnb/eufemia/src/components'
 import {
   copy as copyIcon,
@@ -237,6 +238,9 @@ function prepareCode(code: string) {
 function LiveCode(props: LiveCodeProps) {
   const context = useContext(Context)
   const focusModeId = props.stableName
+  const baseId = useId()
+  const codeAccordionId = `${baseId}-code`
+  const previewAccordionId = `${baseId}-preview`
 
   const [hideCode, setHideCode] = useState(props.hideCode)
   const [hidePreview, setHidePreview] = useState(props.hidePreview)
@@ -422,6 +426,68 @@ function LiveCode(props: LiveCodeProps) {
     />
   )
 
+  const codeEditor = (
+    <Space
+      title="Make changes to see them live!"
+      element="section"
+      className={clsx(
+        'dnb-live-editor',
+        createSkeletonClass('code', context.skeleton)
+      )}
+    >
+      <LiveCodeEditor onCodeChange={setEditedCode} />
+    </Space>
+  )
+
+  const previewContent = (
+    <Theme colorScheme={colorScheme} surface={surface}>
+      {omitWrapper ? (
+        <LivePreview
+          className={clsx('dnb-live-preview')}
+          data-visual-test={visualTest}
+        />
+      ) : (
+        <div
+          className={clsx(
+            'example-box',
+            exampleBoxStyle,
+            showFocusModePadding && showFocusModePaddingStyle
+          )}
+        >
+          <LivePreview
+            className={clsx('dnb-live-preview')}
+            data-visual-test={visualTest}
+          />
+        </div>
+      )}
+    </Theme>
+  )
+
+  // The code editor is collapsible via an Accordion whenever a toggle is
+  // rendered in the toolbar (always for omitWrapper, or when hideCode is set).
+  // Without a toolbar there is no toggle, so the editor renders directly.
+  const showCodeToggle = !hideToolbar && (omitWrapper || hideCodeProp)
+
+  const codeToggleAccordion = (
+    <Accordion
+      variant="tertiary"
+      id={codeAccordionId}
+      expanded={!hideCode}
+      onChange={({ expanded }) => setHideCode(!expanded)}
+      title="Code"
+    />
+  )
+
+  const previewToggleAccordion = (
+    <Accordion
+      variant="tertiary"
+      id={previewAccordionId}
+      expanded={!hidePreview}
+      onChange={({ expanded }) => setHidePreview(!expanded)}
+      title="Preview"
+    />
+  )
+
   return (
     <div
       ref={wrapperRef}
@@ -445,28 +511,12 @@ function LiveCode(props: LiveCodeProps) {
           noInline={noInline}
           {...restProps}
         >
-          {!hidePreview && (
-            <Theme colorScheme={colorScheme} surface={surface}>
-              {omitWrapper ? (
-                <LivePreview
-                  className={clsx('dnb-live-preview')}
-                  data-visual-test={visualTest}
-                />
-              ) : (
-                <div
-                  className={clsx(
-                    'example-box',
-                    exampleBoxStyle,
-                    showFocusModePadding && showFocusModePaddingStyle
-                  )}
-                >
-                  <LivePreview
-                    className={clsx('dnb-live-preview')}
-                    data-visual-test={visualTest}
-                  />
-                </div>
-              )}
-            </Theme>
+          {!omitWrapper && hidePreviewProp ? (
+            <Accordion.Content connectedTo={previewAccordionId}>
+              {previewContent}
+            </Accordion.Content>
+          ) : (
+            !hidePreview && previewContent
           )}
 
           {!global.IS_TEST && !hideToolbar && (
@@ -476,36 +526,10 @@ function LiveCode(props: LiveCodeProps) {
               className={clsx('dnb-live-toolbar', toolbarStyle)}
             >
               {omitWrapper ? (
-                <Button
-                  variant="tertiary"
-                  icon={hideCode ? 'chevron_down' : 'chevron_up'}
-                  onClick={() => setHideCode((checked) => !checked)}
-                  size="medium"
-                  left
-                >
-                  {hideCode ? 'Show Code' : 'Hide Code'}
-                </Button>
+                codeToggleAccordion
               ) : (
                 <>
-                  {hideCodeProp && (
-                    <ToggleButton
-                      checked={!hideCode}
-                      onChange={({ checked }) => setHideCode(!checked)}
-                      size="medium"
-                    >
-                      {hideCode ? 'Show Code' : 'Hide Code'}
-                    </ToggleButton>
-                  )}
-
-                  {hidePreviewProp && (
-                    <ToggleButton
-                      checked={!hidePreview}
-                      onChange={({ checked }) => setHidePreview(!checked)}
-                      size="medium"
-                    >
-                      Preview
-                    </ToggleButton>
-                  )}
+                  {hideCodeProp && codeToggleAccordion}
 
                   {isInFocusMode && (
                     <ChangeStyleTheme
@@ -517,22 +541,27 @@ function LiveCode(props: LiveCodeProps) {
                   )}
 
                   <Flex.Horizontal align="center">
-                    <Checkbox
-                      checked={
-                        colorScheme === (inheritedDark ? 'light' : 'dark')
-                      }
-                      onChange={({ checked }) => {
-                        setColorScheme(
-                          checked
-                            ? inheritedDark
-                              ? 'light'
-                              : 'dark'
-                            : undefined
-                        )
-                      }}
-                      size="medium"
-                      label={inheritedDark ? 'Light mode' : 'Dark mode'}
-                    />
+                    {!hidePreview && (
+                      <Checkbox
+                        checked={
+                          colorScheme ===
+                          (inheritedDark ? 'light' : 'dark')
+                        }
+                        onChange={({ checked }) => {
+                          setColorScheme(
+                            checked
+                              ? inheritedDark
+                                ? 'light'
+                                : 'dark'
+                              : undefined
+                          )
+                        }}
+                        size="medium"
+                        label={inheritedDark ? 'Light mode' : 'Dark mode'}
+                      />
+                    )}
+
+                    {hidePreviewProp && previewToggleAccordion}
 
                     {surfaceProp === 'dark' && (
                       <Checkbox
@@ -560,18 +589,14 @@ function LiveCode(props: LiveCodeProps) {
             </Space>
           )}
 
-          {!global.IS_TEST && !hideCode && (
-            <Space
-              title="Make changes to see them live!"
-              element="section"
-              className={clsx(
-                'dnb-live-editor',
-                createSkeletonClass('code', context.skeleton)
-              )}
-            >
-              <LiveCodeEditor onCodeChange={setEditedCode} />
-            </Space>
-          )}
+          {!global.IS_TEST &&
+            (showCodeToggle ? (
+              <Accordion.Content connectedTo={codeAccordionId}>
+                {codeEditor}
+              </Accordion.Content>
+            ) : (
+              !hideCode && codeEditor
+            ))}
 
           <LiveError className="dnb-form-status dnb-form-status__text dnb-form-status--error" />
         </LiveProvider>

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -86,12 +86,93 @@ vi.mock('@dnb/eufemia/src/shared/helpers', async (importOriginal) => {
 
 // Mock Eufemia components
 vi.mock('@dnb/eufemia/src/components', async () => {
-  const { createElement } = (await vi.importActual('react')) as {
-    createElement: typeof CreateElement
+  const { createElement, useEffect, useState } = (await vi.importActual(
+    'react'
+  )) as typeof import('react')
+
+  // Faithfully model the tertiary Accordion + connected content pair backed by
+  // an order-independent shared store (mirroring Eufemia's useSharedState). The
+  // connected content subscribes to its trigger's expanded state, so it stays
+  // in sync even when it renders before the trigger in the tree — as the preview
+  // content does, since it sits above the toolbar that holds its toggle.
+  const expandedById = new Map<string, boolean>()
+  const listenersById = new Map<string, Set<() => void>>()
+  const getExpanded = (id: string) => expandedById.get(id) ?? false
+  const setExpanded = (id: string, value: boolean) => {
+    expandedById.set(id, value)
+    listenersById.get(id)?.forEach((notify) => notify())
   }
+  const subscribe = (id: string, notify: () => void) => {
+    let listeners = listenersById.get(id)
+    if (!listeners) {
+      listeners = new Set()
+      listenersById.set(id, listeners)
+    }
+    listeners.add(notify)
+    return () => {
+      listeners?.delete(notify)
+    }
+  }
+
+  const Accordion = ({
+    title,
+    expanded,
+    onChange,
+    id,
+    variant: _variant,
+    ...rest
+  }: any) => {
+    if (!expandedById.has(id)) {
+      expandedById.set(id, expanded)
+    }
+    useEffect(() => {
+      setExpanded(id, expanded)
+    }, [id, expanded])
+
+    return createElement(
+      'button',
+      {
+        type: 'button',
+        id,
+        'aria-expanded': expanded,
+        'aria-controls': `${id}-content`,
+        onClick: (event: any) =>
+          onChange?.({ expanded: !expanded, event }),
+        ...rest,
+      },
+      title
+    )
+  }
+  const AccordionContent = ({ children, connectedTo, ...rest }: any) => {
+    const [, forceRender] = useState(0)
+    useEffect(
+      () =>
+        subscribe(connectedTo, () => forceRender((count) => count + 1)),
+      [connectedTo]
+    )
+    const expanded = getExpanded(connectedTo)
+
+    return createElement(
+      'section',
+      {
+        id: `${connectedTo}-content`,
+        'aria-hidden': !expanded,
+        ...rest,
+      },
+      createElement(
+        'div',
+        { 'data-height-animation-open': expanded },
+        expanded ? children : null
+      )
+    )
+  }
+  Accordion.Content = AccordionContent
+
   return {
+    Accordion,
     Button: ({ text, onClick, icon: _icon, ...rest }: any) =>
       createElement('button', { onClick, ...rest }, text),
+
     Checkbox: ({ label, checked, onChange, ...rest }: any) =>
       createElement(
         'label',
@@ -111,17 +192,6 @@ vi.mock('@dnb/eufemia/src/components', async () => {
       Horizontal: ({ children, ...rest }: any) =>
         createElement('div', rest, children),
     },
-    ToggleButton: ({ children, checked, onChange, ...rest }: any) =>
-      createElement(
-        'button',
-        {
-          type: 'button',
-          'aria-pressed': checked,
-          onClick: () => onChange?.({ checked: !checked }),
-          ...rest,
-        },
-        children
-      ),
   }
 })
 
@@ -853,6 +923,207 @@ describe('CodeBlock', () => {
       expect(appCode).toContain('<Example />')
 
       vi.restoreAllMocks()
+    })
+  })
+
+  describe('Show/Hide Code toggle (omitWrapper)', () => {
+    it('should wire aria-controls and aria-expanded to the code content section', () => {
+      const { container } = render(
+        <CodeBlock
+          reactLive
+          omitWrapper
+          hideCode
+          scope={{}}
+          language="jsx"
+        >
+          {'<div>Hello</div>'}
+        </CodeBlock>
+      )
+
+      const toggle = container.querySelector(
+        'button[aria-controls]'
+      ) as HTMLButtonElement
+      expect(toggle).toBeTruthy()
+
+      const contentId = toggle.getAttribute('aria-controls')
+      const content = container.querySelector(`#${contentId}`)
+      expect(content).toBeTruthy()
+
+      // Collapsed by default when hideCode is set
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(content.getAttribute('aria-hidden')).toBe('true')
+
+      const heightAnimation = content.querySelector(
+        '[data-height-animation-open]'
+      )
+      expect(
+        heightAnimation.getAttribute('data-height-animation-open')
+      ).toBe('false')
+    })
+
+    it('should toggle the aria state and HeightAnimation open prop on click', () => {
+      const { container } = render(
+        <CodeBlock
+          reactLive
+          omitWrapper
+          hideCode
+          scope={{}}
+          language="jsx"
+        >
+          {'<div>Hello</div>'}
+        </CodeBlock>
+      )
+
+      const toggle = container.querySelector(
+        'button[aria-controls]'
+      ) as HTMLButtonElement
+      const contentId = toggle.getAttribute('aria-controls')
+      const content = container.querySelector(`#${contentId}`)
+
+      act(() => {
+        toggle.click()
+      })
+
+      // Expanded: aria state flips and the editor is animated open
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(content.getAttribute('aria-hidden')).toBe('false')
+      expect(
+        content
+          .querySelector('[data-height-animation-open]')
+          .getAttribute('data-height-animation-open')
+      ).toBe('true')
+
+      act(() => {
+        toggle.click()
+      })
+
+      // Collapsed again
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(content.getAttribute('aria-hidden')).toBe('true')
+    })
+  })
+
+  describe('Show/Hide Code toggle (standard wrapper)', () => {
+    it('should render the code toggle as an accordion alongside the preview', () => {
+      const { container } = render(
+        <CodeBlock reactLive hideCode scope={{}} language="jsx">
+          {'<div>Hello</div>'}
+        </CodeBlock>
+      )
+
+      // The preview stays visible while the code is collapsed behind a toggle
+      expect(
+        container.querySelector('[data-testid="live-preview"]')
+      ).toBeTruthy()
+
+      const toggle = container.querySelector(
+        'button[aria-controls]'
+      ) as HTMLButtonElement
+      expect(toggle).toBeTruthy()
+      expect(toggle.textContent).toContain('Code')
+
+      const contentId = toggle.getAttribute('aria-controls')
+      const content = container.querySelector(`#${contentId}`)
+      expect(content).toBeTruthy()
+
+      // Collapsed by default when hideCode is set
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(content.getAttribute('aria-hidden')).toBe('true')
+      expect(
+        content.querySelector('[data-testid="live-editor"]')
+      ).toBeNull()
+
+      // Expanding reveals the editor
+      act(() => {
+        toggle.click()
+      })
+
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(content.getAttribute('aria-hidden')).toBe('false')
+      expect(
+        content.querySelector('[data-testid="live-editor"]')
+      ).toBeTruthy()
+    })
+
+    it('should render the editor directly without a toggle when the toolbar is hidden', () => {
+      const { container } = render(
+        <CodeBlock reactLive hideToolbar scope={{}} language="jsx">
+          {'<div>Hello</div>'}
+        </CodeBlock>
+      )
+
+      // No toolbar, so no accordion toggle is rendered
+      expect(container.querySelector('.dnb-live-toolbar')).toBeNull()
+      expect(container.querySelector('button[aria-controls]')).toBeNull()
+
+      // The editor renders directly (not wrapped in an Accordion.Content region)
+      expect(
+        container.querySelector('[data-testid="live-editor"]')
+      ).toBeTruthy()
+    })
+  })
+
+  describe('Preview toggle', () => {
+    it('should wire aria-controls to the preview content section', () => {
+      const { container } = render(
+        <CodeBlock reactLive hidePreview scope={{}} language="jsx">
+          {'<div>Hello</div>'}
+        </CodeBlock>
+      )
+
+      const toggle = container.querySelector(
+        'button[aria-controls]'
+      ) as HTMLButtonElement
+      expect(toggle).toBeTruthy()
+      expect(toggle.textContent).toContain('Preview')
+
+      const contentId = toggle.getAttribute('aria-controls')
+      const content = container.querySelector(`#${contentId}`)
+      expect(content).toBeTruthy()
+
+      // Hidden by default when hidePreview is set
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(content.getAttribute('aria-hidden')).toBe('true')
+      expect(
+        content
+          .querySelector('[data-height-animation-open]')
+          .getAttribute('data-height-animation-open')
+      ).toBe('false')
+    })
+
+    it('should toggle the preview aria state and HeightAnimation open prop on click', () => {
+      const { container } = render(
+        <CodeBlock reactLive hidePreview scope={{}} language="jsx">
+          {'<div>Hello</div>'}
+        </CodeBlock>
+      )
+
+      const toggle = container.querySelector(
+        'button[aria-controls]'
+      ) as HTMLButtonElement
+      const contentId = toggle.getAttribute('aria-controls')
+      const content = container.querySelector(`#${contentId}`)
+
+      act(() => {
+        toggle.click()
+      })
+
+      // Visible: aria state flips and the preview is animated open
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(content.getAttribute('aria-hidden')).toBe('false')
+      expect(
+        content
+          .querySelector('[data-height-animation-open]')
+          .getAttribute('data-height-animation-open')
+      ).toBe('true')
+
+      act(() => {
+        toggle.click()
+      })
+
+      // Hidden again
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(content.getAttribute('aria-hidden')).toBe('true')
     })
   })
 })


### PR DESCRIPTION


https://github.com/user-attachments/assets/036825cf-39b8-4416-9a58-a5543ca9c817


### Why

The portal's live code examples render a small toolbar with "Show/Hide Code" and "Preview" toggles. Previously these toggles swapped their content in and out instantly, and the controls were not linked to the regions they manage — there was no `aria-controls`/`aria-expanded`, so assistive technology could not tell which area a toggle expands or whether it is currently open. The chevron on the compact (`omitWrapper`) code toggle also swapped between two static icons rather than animating.

### What this improves

- Each toggle now exposes `aria-controls` (and `aria-expanded` where applicable) pointing at a persistent region, so screen readers can announce the relationship and the open/closed state.
- Showing/hiding the code and the preview now animates the height, consistent with Eufemia's own `Accordion`/`HeightAnimation` interaction patterns instead of snapping.
- The compact code toggle uses an animated chevron transition.
- The dark/light-mode control only appears when a preview is visible, and a stray toolbar top border is removed when there is no preview.

