### PR TITLE
chore(docs-types): resolve sync-docs-jsdoc by file and enclosing type

### DIFF
--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/cross-prefix/GroupDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/cross-prefix/GroupDocs.ts
@@ -1,0 +1,20 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const ItemStartProperties: PropertiesTableProps = {
+  fontSize: {
+    doc: 'Font size of the start content.',
+    type: 'string',
+    status: 'optional',
+  },
+}
+
+export const ItemCenterProperties: PropertiesTableProps = {
+  fontSize: {
+    doc: 'Font size of the center content.',
+    type: 'string',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-file/AlphaDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-file/AlphaDocs.ts
@@ -1,0 +1,12 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const AlphaProperties: PropertiesTableProps = {
+  fontSize: {
+    doc: 'Font size of the alpha content.',
+    type: 'string',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-file/BetaDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-file/BetaDocs.ts
@@ -1,0 +1,12 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const BetaProperties: PropertiesTableProps = {
+  fontSize: {
+    doc: 'Font size of the beta content.',
+    type: 'string',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-type/WidgetDocs.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/fixtures/sync-docs-jsdoc/multi-type/WidgetDocs.ts
@@ -1,0 +1,20 @@
+type PropertiesTableProps = Record<
+  string,
+  { doc: string; type: string | string[]; status: string }
+>
+
+export const WidgetRootProperties: PropertiesTableProps = {
+  children: {
+    doc: 'Root children content.',
+    type: 'React.ReactNode',
+    status: 'optional',
+  },
+}
+
+export const WidgetButtonProperties: PropertiesTableProps = {
+  children: {
+    doc: 'Button label content.',
+    type: 'React.ReactNode',
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/__tests__/sync-docs-jsdoc.test.ts
@@ -199,6 +199,56 @@ tester.run('sync-docs-jsdoc', rule, {
       `,
       filename: path.join(fixturesDir, 'compound/CompoundSearch.tsx'),
     },
+
+    // ── Source name without the docs prefix matches its own export group ──
+    {
+      code: `
+        export type ItemCenterProps = {
+          /** Font size of the center content. */
+          fontSize?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'cross-prefix/ItemCenter.tsx'),
+    },
+
+    // ── Multiple types in one file resolve via their enclosing type name ──
+    {
+      code: `
+        export type WidgetRootProps = {
+          /** Root children content. */
+          children?: React.ReactNode
+        }
+
+        export type WidgetButtonProps = {
+          /** Button label content. */
+          children?: React.ReactNode
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-type/types.ts'),
+    },
+
+    // ── A source file matching no docs group is left untouched ──
+    {
+      code: `
+        export type OrphanProps = {
+          /** Some hand-written description that matches no docs group. */
+          children?: React.ReactNode
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-type/Orphan.tsx'),
+    },
+
+    // ── In a directory with several docs files, a source file with no name
+    // match has no source of truth and is left untouched ──
+    {
+      code: `
+        export type GammaProps = {
+          /** Hand-written font size that matches no docs file. */
+          fontSize?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-file/Gamma.tsx'),
+    },
   ],
 
   invalid: [
@@ -665,6 +715,91 @@ tester.run('sync-docs-jsdoc', rule, {
           data: {
             docsFile: 'CompoundDocs.ts',
             expected: 'Called when a sort option is selected.',
+          },
+        },
+      ],
+    },
+
+    // ── Source name without the docs prefix is fixed from its own group ──
+    {
+      code: `
+        export type ItemCenterProps = {
+          /** Font size of the start content. */
+          fontSize?: string
+        }
+      `,
+      output: `
+        export type ItemCenterProps = {
+          /**
+           * Font size of the center content.
+           */
+          fontSize?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'cross-prefix/ItemCenter.tsx'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'GroupDocs.ts',
+            expected: 'Font size of the center content.',
+          },
+        },
+      ],
+    },
+
+    // ── Wrong group via shared property name is fixed by enclosing type ──
+    {
+      code: `
+        export type WidgetButtonProps = {
+          /** Root children content. */
+          children?: React.ReactNode
+        }
+      `,
+      output: `
+        export type WidgetButtonProps = {
+          /**
+           * Button label content.
+           */
+          children?: React.ReactNode
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-type/types.ts'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'WidgetDocs.ts',
+            expected: 'Button label content.',
+          },
+        },
+      ],
+    },
+
+    // ── A name-matched source file syncs from its own docs file even when
+    // the directory has several docs files ──
+    {
+      code: `
+        export type AlphaProps = {
+          /** Outdated alpha font size. */
+          fontSize?: string
+        }
+      `,
+      output: `
+        export type AlphaProps = {
+          /**
+           * Font size of the alpha content.
+           */
+          fontSize?: string
+        }
+      `,
+      filename: path.join(fixturesDir, 'multi-file/Alpha.tsx'),
+      errors: [
+        {
+          messageId: 'mismatchedJsdoc',
+          data: {
+            docsFile: 'AlphaDocs.ts',
+            expected: 'Font size of the alpha content.',
           },
         },
       ],

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
@@ -231,11 +231,40 @@ function getDocsMap(dir, sourceBasename) {
   const docs = new Map()
   const fileMap = new Map()
 
+  // Docs grouped by their component base name (e.g. "MenuButton"), so a
+  // property can be resolved against the export group that matches its
+  // enclosing type, e.g. type "MenuButtonProps" → "MenuButtonProperties".
+  // Groups sharing a base (e.g. "MenuRootProperties" and "MenuRootEvents")
+  // are merged together.
+  const groupMap = new Map()
+
+  // Whether the source file name maps to a docs file in this directory,
+  // either by sharing its prefix (e.g. "FilterSortButton" ↔ "FilterDocs")
+  // or by matching an export group name (e.g. "ItemCenter" ↔
+  // "ItemCenterProperties"). When it does not, the merged docs map is an
+  // arbitrary mix of unrelated groups and must not be used as a fallback.
+  let fileMatched = false
+
   for (const file of files) {
     const filePath = path.join(dir, file)
 
     try {
       const groups = extractGroupedDocsFromFile(filePath)
+
+      for (const [varName, props] of groups) {
+        const base = varName.replace(/(Properties|Props|Events)$/, '')
+
+        let group = groupMap.get(base)
+
+        if (!group) {
+          group = { props: new Map(), file }
+          groupMap.set(base, group)
+        }
+
+        for (const [key, value] of props) {
+          group.props.set(key, value)
+        }
+      }
 
       // Derive the component prefix from the docs filename,
       // e.g. "FilterDocs.ts" → "Filter"
@@ -248,6 +277,33 @@ function getDocsMap(dir, sourceBasename) {
 
       if (sourceBasename && sourceBasename.startsWith(docsPrefix)) {
         subComponent = sourceBasename.slice(docsPrefix.length)
+        fileMatched = true
+      }
+
+      // When the source file name does not share the docs-file prefix
+      // (e.g. "ItemCenter.tsx" alongside "ListDocs.ts"), match the source
+      // file name directly against an export group name instead, e.g.
+      // "ItemCenter" → "ItemCenterProperties". Without this, the ambiguous
+      // match would merge every group and the last one would win, producing
+      // the wrong docs for sibling sub-components.
+      let explicitGroups = null
+
+      if (!subComponent && groups.size > 1 && sourceBasename) {
+        explicitGroups = new Set()
+
+        for (const [varName] of groups) {
+          const base = varName.replace(/(Properties|Props|Events)$/, '')
+
+          if (base === sourceBasename) {
+            explicitGroups.add(varName)
+          }
+        }
+
+        if (explicitGroups.size === 0) {
+          explicitGroups = null
+        } else {
+          fileMatched = true
+        }
       }
 
       for (const [varName, props] of groups) {
@@ -257,6 +313,12 @@ function getDocsMap(dir, sourceBasename) {
           if (!varName.startsWith(subComponent)) {
             continue
           }
+        }
+
+        // When matching the source file name directly to export groups,
+        // only include the matched group(s).
+        if (explicitGroups && !explicitGroups.has(varName)) {
+          continue
         }
 
         for (const [key, value] of props) {
@@ -273,7 +335,19 @@ function getDocsMap(dir, sourceBasename) {
     return null
   }
 
-  return { docs, fileMap }
+  // A source file maps to the directory's docs when its name matches a docs
+  // file or export group (see above), or when the directory has a single
+  // docs file (the common "types.ts" + "XDocs.ts" convention). When there
+  // are several docs files (e.g. the typography directory's Ingress/Lead/P/
+  // Typography docs), a source file with no name match (e.g. "H.tsx") has no
+  // source of truth and must be left untouched.
+  return {
+    docs,
+    fileMap,
+    groupMap,
+    fileCount: files.length,
+    fileMatched: fileMatched || !sourceBasename,
+  }
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -361,16 +435,86 @@ module.exports = {
       return lines.join('\n')
     }
 
+    // Walks up to the nearest named type/interface declaration and returns
+    // its identifier, e.g. a property inside `type MenuButtonProps = {…}`
+    // resolves to "MenuButtonProps".
+    function getEnclosingTypeName(node) {
+      let current = node.parent
+
+      while (current) {
+        if (
+          current.type === 'TSInterfaceDeclaration' ||
+          current.type === 'TSTypeAliasDeclaration'
+        ) {
+          return current.id && current.id.name ? current.id.name : null
+        }
+
+        current = current.parent
+      }
+
+      return null
+    }
+
+    // Resolves the doc entry for a property, preferring the export group that
+    // matches the property's enclosing type (e.g. "MenuButtonProps" →
+    // "MenuButtonProperties"), and falling back to the file-level docs map.
+    function resolveDoc(propName, node) {
+      const typeName = getEnclosingTypeName(node)
+
+      if (typeName && docsData.groupMap) {
+        const base = typeName.replace(/(AllProps|Props|Properties)$/, '')
+        const group = docsData.groupMap.get(base)
+
+        if (group && group.props.has(propName)) {
+          return { entry: group.props.get(propName), docsFile: group.file }
+        }
+      }
+
+      // A directory is unambiguous only when it has a single docs file with a
+      // single group. In that case the merged map is the one source of truth
+      // and applies to any source file in the directory (e.g. the common
+      // "types.ts" + "XDocs.ts" convention). When there are several docs files
+      // or several groups, only fall back to the merged map for files that map
+      // to this directory's docs, and only for the component's own props type
+      // (e.g. "DrawerListProps"), never for nested data types declared in the
+      // same file (e.g. "DrawerListDataArrayObject") which would otherwise
+      // inherit unrelated component-level text.
+      const unambiguous =
+        (!docsData.groupMap || docsData.groupMap.size <= 1) &&
+        docsData.fileCount <= 1
+
+      const isComponentPropsType =
+        !typeName || /(Props|Properties)$/.test(typeName)
+
+      if (
+        (unambiguous || (docsData.fileMatched && isComponentPropsType)) &&
+        docsData.docs.has(propName)
+      ) {
+        return {
+          entry: docsData.docs.get(propName),
+          docsFile: docsData.fileMap.get(propName),
+        }
+      }
+
+      return null
+    }
+
     function checkProperty(node) {
       const propName = getEslintPropertyName(node)
 
-      if (!propName || !docsData.docs.has(propName)) {
+      if (!propName) {
+        return // stop here
+      }
+
+      const resolved = resolveDoc(propName, node)
+
+      if (!resolved) {
         return // stop here
       }
 
       const { doc: expectedDoc, defaultValue: expectedDefault } =
-        docsData.docs.get(propName)
-      const docsFile = docsData.fileMap.get(propName)
+        resolved.entry
+      const docsFile = resolved.docsFile
 
       const comments = sourceCode.getCommentsBefore(node)
 

--- a/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
+++ b/packages/dnb-eufemia/scripts/eslint/plugins/docs-types/rules/sync-docs-jsdoc.js
@@ -215,6 +215,22 @@ function extractJsdocTags(commentValue) {
   return tags
 }
 
+// Strips the conventional suffix from a *docs export* variable name to get its
+// component base, e.g. "MenuButtonProperties" → "MenuButton". Docs exports use
+// the "Properties" / "Props" / "Events" suffixes.
+function stripDocsSuffix(varName) {
+  return varName.replace(/(Properties|Props|Events)$/, '')
+}
+
+// Strips the conventional suffix from a *source type/interface* name to get its
+// component base, e.g. "MenuButtonProps" → "MenuButton". The suffix set
+// deliberately differs from stripDocsSuffix: source types can be "...AllProps"
+// but never "...Events", whereas docs exports can be "...Events" but never
+// "...AllProps". Keep both in sync with their respective naming conventions.
+function stripTypeSuffix(typeName) {
+  return typeName.replace(/(AllProps|Props|Properties)$/, '')
+}
+
 function getDocsMap(dir, sourceBasename) {
   let files
 
@@ -252,11 +268,16 @@ function getDocsMap(dir, sourceBasename) {
       const groups = extractGroupedDocsFromFile(filePath)
 
       for (const [varName, props] of groups) {
-        const base = varName.replace(/(Properties|Props|Events)$/, '')
+        const base = stripDocsSuffix(varName)
 
         let group = groupMap.get(base)
 
         if (!group) {
+          // `file` records where the group was first seen. When one base
+          // spans several docs files, the reported docsFile may therefore
+          // point at the first contributing file rather than the exact one
+          // a later merged property came from — acceptable for an error
+          // message, which only needs to name a relevant docs file.
           group = { props: new Map(), file }
           groupMap.set(base, group)
         }
@@ -292,7 +313,7 @@ function getDocsMap(dir, sourceBasename) {
         explicitGroups = new Set()
 
         for (const [varName] of groups) {
-          const base = varName.replace(/(Properties|Props|Events)$/, '')
+          const base = stripDocsSuffix(varName)
 
           if (base === sourceBasename) {
             explicitGroups.add(varName)
@@ -346,6 +367,8 @@ function getDocsMap(dir, sourceBasename) {
     fileMap,
     groupMap,
     fileCount: files.length,
+    // A missing source basename is treated as "matched": there is nothing to
+    // disambiguate by, so fall back to the merged map rather than skipping.
     fileMatched: fileMatched || !sourceBasename,
   }
 }
@@ -461,8 +484,8 @@ module.exports = {
     function resolveDoc(propName, node) {
       const typeName = getEnclosingTypeName(node)
 
-      if (typeName && docsData.groupMap) {
-        const base = typeName.replace(/(AllProps|Props|Properties)$/, '')
+      if (typeName) {
+        const base = stripTypeSuffix(typeName)
         const group = docsData.groupMap.get(base)
 
         if (group && group.props.has(propName)) {
@@ -480,8 +503,7 @@ module.exports = {
       // same file (e.g. "DrawerListDataArrayObject") which would otherwise
       // inherit unrelated component-level text.
       const unambiguous =
-        (!docsData.groupMap || docsData.groupMap.size <= 1) &&
-        docsData.fileCount <= 1
+        docsData.groupMap.size <= 1 && docsData.fileCount <= 1
 
       const isComponentPropsType =
         !typeName || /(Props|Properties)$/.test(typeName)


### PR DESCRIPTION
## What

Makes the `sync-docs-jsdoc` ESLint rule resolve each documented property against the **export group that matches its enclosing type**, instead of a single flat per-directory map.

## Why

When sibling `*Docs` files — or several types within one source file — share a property name (e.g. `children`, `fontSize`), the old flat lookup merged every group into one map and the **last-written entry won**. A property could therefore be auto-fixed to the *wrong* description, depending on file read order.

## How

- Group docs by component base name (`WidgetButtonProperties` → `WidgetButton`) and resolve a property via the group matching its enclosing type (`WidgetButtonProps` → `WidgetButton`).
- Fall back to the merged map **only** when the directory is unambiguous (single docs file/group) or the source file clearly maps to this directory's docs and the type is the component's own props type — never for nested data types that happen to share a property name.
- Files that match no docs group are left untouched (no risky auto-fix without a clear source of truth).

## Tests

Adds fixtures and valid/invalid cases for cross-prefix, multi-file and multi-type scenarios, including the "leave untouched" guards. Full `sync-docs-jsdoc` suite (61 tests) passes.
