### PR TITLE
chore(deps): pin fast-uri to 3.1.2 to resolve high severity advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "resolutions": {
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "ttf2woff2@npm:^6.0.1": "npm:8.0.1"
+    "ttf2woff2@npm:^6.0.1": "npm:8.0.1",
+    "fast-uri@npm:^3.0.1": "npm:3.1.2"
   },
   "engines": {
     "node": ">=24.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10394,10 +10394,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.6
-  resolution: "fast-uri@npm:3.0.6"
-  checksum: 10/43c87cd03926b072a241590e49eca0e2dfe1d347ddffd4b15307613b42b8eacce00a315cf3c7374736b5f343f27e27ec88726260eb03a758336d507d6fbaba0a
+"fast-uri@npm:3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10/1dff04865b2a38d3e0659deadfbf72efdf83a776bfbf9667e4aa9e5a3ec31bc341cda9622136b32b7652a857c8ba11896794186e8f876f8b2b72731fce8622f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Motivation: `yarn npm audit`

fast-uri (via ajv@8.18.0, a production dependency) resolved to 3.0.6 which is affected by two high severity advisories:
- GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments)
- GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters)

Add a root resolution to force fast-uri 3.1.2 (latest 3.x, satisfies ajv's ^3.0.1 range). Production audit is now clean.

