### PR TITLE
chore(mcp): cap search query length to prevent DoS

### DIFF
--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -4,6 +4,7 @@ import os from 'os'
 import path from 'path'
 import {
   createDocsTools,
+  DocsSearchInput,
   MAX_SEARCH_QUERY_LENGTH,
 } from '../mcp-docs-server'
 
@@ -398,9 +399,21 @@ describe('docs_search', () => {
     expect(hits.length).toBe(0)
   })
 
-  it('caps oversized queries at the maximum length without throwing', async () => {
+  it('truncates an oversized query before scoring so words past the cap are ignored', async () => {
     const tools = createDocsTools({ docsRoot })
-    const oversizedQuery = 'input'.repeat(MAX_SEARCH_QUERY_LENGTH)
+
+    // "form" and "input" both appear in the fixture docs. Pad the real query
+    // out to exactly the cap with spaces, then append a word that exists in no
+    // document *beyond* the cap. Multi-word search uses AND matching, so if the
+    // query were NOT truncated, the bogus trailing word would be required and
+    // every file would be rejected, yielding zero hits. Because searchInMarkdown
+    // caps the query first, the trailing word is sliced off and the real words
+    // still match. This test therefore fails if the length cap is removed.
+    const realWords = 'form input'.padEnd(MAX_SEARCH_QUERY_LENGTH, ' ')
+    const wordPastTheCap = 'zzqwxneverpresent'
+    const oversizedQuery = realWords + wordPastTheCap
+    expect(oversizedQuery.length).toBeGreaterThan(MAX_SEARCH_QUERY_LENGTH)
+
     const result = await tools.docsSearch({
       query: oversizedQuery,
       limit: 5,
@@ -408,10 +421,8 @@ describe('docs_search', () => {
     const hits = JSON.parse(getText(result)) as Array<{
       path: string
     }>
-    // The query is truncated to MAX_SEARCH_QUERY_LENGTH before scoring, so an
-    // enormous query is handled safely and returns a bounded result array
-    // instead of doing unbounded work.
-    expect(Array.isArray(hits)).toBe(true)
+
+    expect(hits.length).toBeGreaterThan(0)
     expect(hits.length).toBeLessThanOrEqual(5)
   })
 
@@ -460,6 +471,30 @@ describe('docs_search', () => {
       (h) => h.path === '/uilib/components/input.md'
     )
     expect(inputHit?.occurrences).toBeGreaterThan(0)
+  })
+})
+
+describe('DocsSearchInput schema', () => {
+  it('truncates a query longer than the maximum length', () => {
+    const parsed = DocsSearchInput.parse({
+      query: 'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 25),
+    })
+    // Without the length cap an oversized query would pass through unchanged
+    // and could be split into an unbounded word list (denial of service).
+    expect(parsed.query).toHaveLength(MAX_SEARCH_QUERY_LENGTH)
+  })
+
+  it('leaves a query within the limit unchanged', () => {
+    const query = 'a'.repeat(MAX_SEARCH_QUERY_LENGTH)
+    expect(DocsSearchInput.parse({ query }).query).toBe(query)
+  })
+
+  it('coerces a non-string query to a string', () => {
+    expect(DocsSearchInput.parse({ query: 12345 }).query).toBe('12345')
+  })
+
+  it('coerces a missing query to an empty string', () => {
+    expect(DocsSearchInput.parse({ query: undefined }).query).toBe('')
   })
 })
 

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -2,7 +2,10 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { createDocsTools } from '../mcp-docs-server'
+import {
+  createDocsTools,
+  MAX_SEARCH_QUERY_LENGTH,
+} from '../mcp-docs-server'
 
 type DocsFixture = {
   docsRoot: string
@@ -393,6 +396,23 @@ describe('docs_search', () => {
       path: string
     }>
     expect(hits.length).toBe(0)
+  })
+
+  it('caps oversized queries at the maximum length without throwing', async () => {
+    const tools = createDocsTools({ docsRoot })
+    const oversizedQuery = 'input'.repeat(MAX_SEARCH_QUERY_LENGTH)
+    const result = await tools.docsSearch({
+      query: oversizedQuery,
+      limit: 5,
+    })
+    const hits = JSON.parse(getText(result)) as Array<{
+      path: string
+    }>
+    // The query is truncated to MAX_SEARCH_QUERY_LENGTH before scoring, so an
+    // enormous query is handled safely and returns a bounded result array
+    // instead of doing unbounded work.
+    expect(Array.isArray(hits)).toBe(true)
+    expect(hits.length).toBeLessThanOrEqual(5)
   })
 
   it('ranks results by score (higher scores first)', async () => {

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -553,7 +553,11 @@ const DocsReadInput = z.object({
 const DocsSearchInput = z.object({
   query: z
     .preprocess(
-      (value) => (value == null ? '' : String(value)),
+      // Coerce to string and truncate up front, mirroring the runtime cap in
+      // searchInMarkdown. Truncating (rather than rejecting) means an
+      // oversized query still returns useful results instead of failing the
+      // whole tool call, while never doing unbounded work.
+      (value) => String(value ?? '').slice(0, MAX_SEARCH_QUERY_LENGTH),
       z.string().max(MAX_SEARCH_QUERY_LENGTH)
     )
     .describe('Search query (string recommended).'),

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -550,7 +550,7 @@ const DocsReadInput = z.object({
     ),
 })
 
-const DocsSearchInput = z.object({
+export const DocsSearchInput = z.object({
   query: z
     .preprocess(
       // Coerce to string and truncate up front, mirroring the runtime cap in

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -43,6 +43,13 @@ function withLeadingSlash(p: string): string {
 }
 
 /**
+ * Upper bound for the length of a search query. Prevents a single oversized
+ * query string from being split into a huge word list and scored against
+ * every documentation file (denial of service).
+ */
+export const MAX_SEARCH_QUERY_LENGTH = 10_000
+
+/**
  * Computes the default Node.js docs root (used when neither `{ docsRoot }`
  * nor `{ source }` is passed to {@link createDocsTools}). Imports `node:*`
  * lazily so this module can still be bundled for non-Node runtimes.
@@ -340,7 +347,11 @@ function createDocsContext(source: DocsSource) {
     prefix?: string,
     opts: { concurrency?: number; timeoutMs?: number } = {}
   ): Promise<SearchHit[]> {
-    const q = String(query ?? '').trim()
+    // Cap the query length before any further processing to avoid scoring an
+    // unbounded word list against every file (denial of service).
+    const q = String(query ?? '')
+      .slice(0, MAX_SEARCH_QUERY_LENGTH)
+      .trim()
     if (q.length < 2) {
       return []
     }
@@ -540,7 +551,12 @@ const DocsReadInput = z.object({
 })
 
 const DocsSearchInput = z.object({
-  query: z.any().describe('Search query (string recommended).'),
+  query: z
+    .preprocess(
+      (value) => (value == null ? '' : String(value)),
+      z.string().max(MAX_SEARCH_QUERY_LENGTH)
+    )
+    .describe('Search query (string recommended).'),
   limit: z.number().int().min(1).max(50).default(10),
   prefix: z
     .string()


### PR DESCRIPTION
Bound the docs_search query to MAX_SEARCH_QUERY_LENGTH (10000 chars) both in the zod input schema and inside searchInMarkdown, so an oversized query cannot be split into an unbounded word list and scored against every file.

