### PR TITLE
chore(Forms): guard json-pointer remove against prototype tampering

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
@@ -275,6 +275,32 @@ describe('json-pointer', () => {
       remove(rfcExample, p)
       expect(() => get(pointer, rfcExample)).toThrow(Error)
     })
+
+    it('should not delete from Object.prototype via a nested "__proto__" token', () => {
+      const obj = { keep: 'me' }
+      remove(obj, '/__proto__/hasOwnProperty')
+      expect(typeof ({} as object).hasOwnProperty).toBe('function')
+      expect(obj.keep).toBe('me')
+    })
+
+    it('should not delete from Object.prototype via a "constructor/prototype" chain', () => {
+      const obj = {}
+      remove(obj, '/constructor/prototype/toString')
+      expect(typeof ({} as object).toString).toBe('function')
+    })
+
+    it('should ignore a "__proto__" final token', () => {
+      const obj = {}
+      remove(obj, '/__proto__')
+      expect(Object.getPrototypeOf(obj)).toBe(Object.prototype)
+    })
+
+    it('should still remove a legitimate key named like a sibling', () => {
+      const obj = { a: { b: 'gone', c: 'stay' } }
+      remove(obj, '/a/b')
+      expect(obj.a).not.toHaveProperty('b')
+      expect(obj.a.c).toBe('stay')
+    })
   })
 
   describe('dict', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/json-pointer.ts
@@ -92,6 +92,19 @@ export function remove<T = JsonObject>(obj: T, pointer: PointerPath) {
     throw new Error('Invalid JSON pointer for remove: "' + pointer + '"')
   }
 
+  // Prevent prototype tampering: a token like "__proto__" would make the
+  // traversal below resolve to Object.prototype and delete from it globally.
+  if (
+    refTokens.some(
+      (tok) =>
+        String(tok) === '__proto__' ||
+        String(tok) === 'constructor' ||
+        String(tok) === 'prototype'
+    )
+  ) {
+    return
+  }
+
   const parent = get(obj, refTokens.slice(0, -1))
   if (Array.isArray(parent)) {
     const index = +finalToken


### PR DESCRIPTION
## Why

Follow-up to #8657, which guarded `set()` against prototype pollution. The sibling `remove()` has an analogous — and arguably worse — hole that #8657 left open: it can **delete properties from `Object.prototype` globally**.

`remove()` resolves the parent via `get()`, and `get()` happily follows a `__proto__` token (`'__proto__' in obj` is `true`). So an attacker-influenced pointer reaches the real prototype and then `delete parent[finalToken]` runs against it:

```ts
remove({}, '/__proto__/hasOwnProperty') // deletes Object.prototype.hasOwnProperty for the whole realm
remove({}, '/constructor/prototype/toString') // same via the constructor chain
```

Real-world exposure is low in Forms (pointers come from developer-defined field paths, not end-user input), so this is hardening / defense-in-depth — consistent with #8657 being labelled `chore`.

## What

Mirror the `set()` guard inside `remove()`: if **any** path segment is a reserved key (`__proto__`, `constructor`, `prototype`), the operation is a no-op. This blocks both the dangerous traversal and a dangerous final token, and leaves legitimate removals untouched.

`get()` itself is left unchanged — it is a read primitive (returning the prototype object isn't tampering), and `remove()` no longer feeds it a dangerous path.

## Tests

Added regression tests under `describe('remove')`:
- nested `__proto__` token does not delete `Object.prototype.hasOwnProperty`
- `constructor/prototype` chain does not delete `Object.prototype.toString`
- a `__proto__` final token is ignored
- a legitimate nested key is still removed

Verified the new tests fail without the guard (without it, deleting `hasOwnProperty` globally even crashes the vitest runner) and the full `json-pointer` suite passes with it (104 tests).