### PR TITLE
chore(Radio): remove references to undefined CSS custom properties

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2381,8 +2381,6 @@ html[data-whatinput=keyboard] .dnb-radio__input:focus ~ .dnb-radio__dot {
   /** Disabled state **/
 }
 .dnb-radio__input[disabled] ~ .dnb-radio__button {
-  --radio-border-inset: var(--radio-border-inset--disabled);
-  --radio-border-width: var(--radio-border-width--disabled);
   --radio-color-border: var(--radio-color-border--disabled);
 }
 .dnb-radio__input[disabled] ~ .dnb-radio__button:not(.dnb-skeleton) {

--- a/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -501,8 +501,6 @@ html[data-whatinput=keyboard] .dnb-radio__input:focus ~ .dnb-radio__dot {
   /** Disabled state **/
 }
 .dnb-radio__input[disabled] ~ .dnb-radio__button {
-  --radio-border-inset: var(--radio-border-inset--disabled);
-  --radio-border-width: var(--radio-border-width--disabled);
   --radio-color-border: var(--radio-color-border--disabled);
 }
 .dnb-radio__input[disabled] ~ .dnb-radio__button:not(.dnb-skeleton) {

--- a/packages/dnb-eufemia/src/components/radio/style/dnb-radio.scss
+++ b/packages/dnb-eufemia/src/components/radio/style/dnb-radio.scss
@@ -394,8 +394,6 @@
 
   // General
   &__input[disabled] ~ &__button {
-    --radio-border-inset: var(--radio-border-inset--disabled);
-    --radio-border-width: var(--radio-border-width--disabled);
     --radio-color-border: var(--radio-color-border--disabled);
     &:not(.dnb-skeleton) {
       --radio-color-background: var(--radio-color-background--disabled);

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -1928,8 +1928,6 @@ html[data-whatinput=keyboard] .dnb-radio__input:focus ~ .dnb-radio__dot {
   /** Disabled state **/
 }
 .dnb-radio__input[disabled] ~ .dnb-radio__button {
-  --radio-border-inset: var(--radio-border-inset--disabled);
-  --radio-border-width: var(--radio-border-width--disabled);
   --radio-color-border: var(--radio-color-border--disabled);
 }
 .dnb-radio__input[disabled] ~ .dnb-radio__button:not(.dnb-skeleton) {


### PR DESCRIPTION
The disabled state set --radio-border-inset and --radio-border-width to undefined variables (--radio-border-inset--disabled and --radio-border-width--disabled). While other state variants (default, active, hover, focus) are all defined, the disabled variants were never added.

Because var() with an undefined custom property produces a guaranteed-invalid value, the border-inset and border-width of disabled radios fell back to the initial value instead of retaining the default inset border style, which could cause the disabled radio border to render inconsistently.

