### PR TITLE
fix(PaymentCard): add missing CSS custom property definitions

### DIFF
--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -117,6 +117,8 @@ exports[`PaymentCard scss > has to match style dependencies css 1`] = `
   --dnb-payment-bg-gold: #d8c583;
   --dnb-payment-bg-black-gold: #1f1b10;
   --dnb-payment-bg-black-grey: #1c1c1e;
+  --dnb-payment-bg-business-no-visa: var(--color-sea-green);
+  --dnb-payment-bg-business-with-visa: var(--color-sea-green);
   --dnb-payment-overlay-bg-dark: rgba(0 0 0 / 60%);
   --dnb-payment-overlay-bg-light: rgba(255 255 255 / 70%);
   --dnb-payment-border-radius: 12px;

--- a/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
+++ b/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
@@ -17,6 +17,8 @@
   --dnb-payment-bg-gold: #d8c583;
   --dnb-payment-bg-black-gold: #1f1b10;
   --dnb-payment-bg-black-grey: #1c1c1e;
+  --dnb-payment-bg-business-no-visa: var(--color-sea-green);
+  --dnb-payment-bg-business-with-visa: var(--color-sea-green);
   --dnb-payment-overlay-bg-dark: rgba(0 0 0 / 60%);
   --dnb-payment-overlay-bg-light: rgba(255 255 255 / 70%);
   --dnb-payment-border-radius: 12px;


### PR DESCRIPTION
The card design variants business-no-visa and business-with-visa referenced --dnb-payment-bg-business-no-visa and
--dnb-payment-bg-business-with-visa, but these custom properties were never defined. All other card background variables (default, pluss, white, gold, etc.) are defined at the top of the file.

Because var() with an undefined custom property produces a guaranteed-invalid value, the background-color declaration was silently invalid for these card types, causing them to render with a transparent background instead of the intended card color.

