### PR TITLE
chore(MultiSelection): remove references to undefined CSS custom property

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
@@ -27,7 +27,6 @@
     &:focus-visible {
       outline: var(--focus-ring-width) solid
         var(--token-color-stroke-action-focus);
-      outline-offset: var(--focus-ring-offset);
     }
   }
 
@@ -192,7 +191,6 @@
     &:focus-visible {
       outline: var(--focus-ring-width) solid
         var(--token-color-stroke-action-focus);
-      outline-offset: var(--focus-ring-offset);
     }
   }
 


### PR DESCRIPTION
The focus-visible outline-offset was set to var(--focus-ring-offset), but this custom property is never defined anywhere in the codebase (neither in SCSS nor in JavaScript). The related --focus-ring-width IS defined in the theme, but --focus-ring-offset was never added.

Because var() with an undefined custom property produces a guaranteed-invalid value, the outline-offset declaration was silently invalid, causing it to fall back to the initial value (0). While the result happened to be correct by accident, the dead reference adds confusion and could mask issues if the outline behavior is changed in the future.

