### PR TITLE
style(Space): update responsive spacing values BETA

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
@@ -49,7 +49,7 @@ Both `space` and `innerSpace` properties support `inline` and `block` shorthand 
 
 **NB**: This feature is in beta and may be subject to change.
 
-Use `Space.ResponsiveContext` to make spacing used in child components rsponsive. Does not affect `innerSpace` sizes.
+Use `Space.ResponsiveContext` to make spacing used in child components responsive. Does not affect `innerSpace` sizes.
 
 See the [responsive spacing](/uilib/layout/space#responsive-spacing) table for the specific values.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/demos.mdx
@@ -49,7 +49,7 @@ Both `space` and `innerSpace` properties support `inline` and `block` shorthand 
 
 **NB**: This feature is in beta and may be subject to change.
 
-Use `Space.ResponsiveContext` to preview responsive spacing in practice. The default `basis` density follows viewport breakpoints.
+Use `Space.ResponsiveContext` to make spacing used in child components rsponsive. Does not affect `innerSpace` sizes.
 
 See the [responsive spacing](/uilib/layout/space#responsive-spacing) table for the specific values.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/space/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/space/info.mdx
@@ -104,20 +104,20 @@ element.setAttribute('style', merged)
 
 **NB**: This feature is in beta and may be subject to change.
 
-Wrap a section of your UI in `Space.ResponsiveContext` to enable spacing that adapts automatically across breakpoints. Components inside the wrapper that use `useSpacing` will receive a `dnb-space-responsive--<density>` CSS class, which remaps static `--spacing-*` values to the responsive `--responsive-spacing-*` custom properties below.
+Wrap a section of your UI in `Space.ResponsiveContext` to enable spacing that adapts automatically across breakpoints. Components inside the wrapper that use `useSpacing` will receive a `dnb-space-responsive` CSS class, which remaps static `--spacing-*` values to the responsive `--responsive-spacing-*` custom properties below.
 
 This is useful when you want consistent, viewport-aware gaps between elements without managing breakpoint-specific spacing props on every component.
 
 See the [Responsive layout gap demo](/uilib/layout/space/demos/#responsive-layout-gap) for a live example.
 
-| CSS Variable                    | Compact `← small` | Basis `small → medium` | Spacious `medium →` |
-| ------------------------------- | ----------------- | ---------------------- | ------------------- |
-| `--responsive-spacing-xx-small` | 0.25rem (4px)     | 0.5rem (8px)           | 1rem (16px)         |
-| `--responsive-spacing-x-small`  | 0.5rem (8px)      | 1rem (16px)            | 1.5rem (24px)       |
-| `--responsive-spacing-small`    | 1rem (16px)       | 1.5rem (24px)          | 2rem (32px)         |
-| `--responsive-spacing-medium`   | 1.5rem (24px)     | 2rem (32px)            | 2.5rem (40px)       |
-| `--responsive-spacing-large`    | 2rem (32px)       | 2.5rem (40px)          | 3rem (48px)         |
-| `--responsive-spacing-x-large`  | 2.5rem (40px)     | 3rem (48px)            | 3.5rem (56px)       |
-| `--responsive-spacing-xx-large` | 3rem (48px)       | 3.5rem (56px)          | 4rem (64px)         |
+| CSS Variable                    | `← small`      | `small → medium` | `medium →`    |
+| ------------------------------- | -------------- | ---------------- | ------------- |
+| `--responsive-spacing-xx-small` | 0.125rem (2px) | 0.25rem (4px)    | 0.25rem (4px) |
+| `--responsive-spacing-x-small`  | 0.25rem (4px)  | 0.5rem (8px)     | 0.5rem (8px)  |
+| `--responsive-spacing-small`    | 0.5rem (8px)   | 1rem (16px)      | 1rem (16px)   |
+| `--responsive-spacing-medium`   | 1rem (16px)    | 1.5rem (24px)    | 1.5rem (24px) |
+| `--responsive-spacing-large`    | 1.5rem (24px)  | 2rem (32px)      | 2rem (32px)   |
+| `--responsive-spacing-x-large`  | 2rem (32px)    | 2.5rem (40px)    | 2.5rem (40px) |
+| `--responsive-spacing-xx-large` | 2.5rem (40px)  | 3rem (48px)      | 3rem (48px)   |
 
 All `--responsive-spacing-*` CSS variables are scoped to the `.dnb-space` class as of now.

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing-table.mdx
@@ -2,13 +2,14 @@
 draft: true
 ---
 
-| Pixel | Type       | Rem     | CSS Variable         |
-| ----- | ---------- | ------- | -------------------- |
-| 8     | `x-small`  | **0.5** | `--spacing-x-small`  |
-| 16    | `small`    | **1**   | `--spacing-small`    |
-| 24    | `medium`   | **1.5** | `--spacing-medium`   |
-| 32    | `large`    | **2**   | `--spacing-large`    |
-| 48    | `x-large`  | **3**   | `--spacing-x-large`  |
-| 56    | `xx-large` | **3.5** | `--spacing-xx-large` |
+| Pixel | Type       | Rem      | CSS Variable         |
+| ----- | ---------- | -------- | -------------------- |
+| 4     | `xx-small` | **0.25** | `--spacing-xx-small` |
+| 8     | `x-small`  | **0.5**  | `--spacing-x-small`  |
+| 16    | `small`    | **1**    | `--spacing-small`    |
+| 24    | `medium`   | **1.5**  | `--spacing-medium`   |
+| 32    | `large`    | **2**    | `--spacing-large`    |
+| 48    | `x-large`  | **3**    | `--spacing-x-large`  |
+| 56    | `xx-large` | **3.5**  | `--spacing-xx-large` |
 
-**NB:** In some circumstances you may be in need of using **0.25rem** (4px) - therefore `xx-small` also exists, but as a single type. So, combining `xx-small` and `small` would not result in 0.25rem, but still remain 1rem.
+**NB:** When combining sizes we only allow increments of `0.5rem`, so `xx-small` will not increment by `0.25rem` when combined with other sizes.

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -27,11 +27,6 @@ import type { SkeletonShow } from '../Skeleton'
 import type { InnerSpaceType } from './types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import SpaceResponsive from './SpaceResponsive'
-export type { SpaceResponsiveProps } from './SpaceResponsive'
-export type {
-  SpaceDensity,
-  SpaceBreakpoint,
-} from './SpaceResponsiveContext'
 
 export type SpaceProps = {
   /**

--- a/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
@@ -58,7 +58,7 @@ export const SpaceProperties: PropertiesTableProps = {
 
 export const SpaceResponsiveContextProperties: PropertiesTableProps = {
   density: {
-    doc: 'Forces a specific spacing density for descendants. Overrides `breakpoint` when set. Defaults to `false`.',
+    doc: 'Forces a specific spacing density for descendants. Overrides `breakpoint` when set. Use `false` to disable.',
     type: ['"compact"', '"basis"', 'false'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
@@ -58,11 +58,11 @@ export const SpaceProperties: PropertiesTableProps = {
 
 export const SpaceResponsiveContextProperties: PropertiesTableProps = {
   density: {
-    doc: 'Forces a specific spacing density for descendants. Overrides `defaultBreakpoint` when set. Defaults to `false`.',
+    doc: 'Forces a specific spacing density for descendants. Overrides `breakpoint` when set. Defaults to `false`.',
     type: ['"compact"', '"basis"', 'false'],
     status: 'optional',
   },
-  defaultBreakpoint: {
+  breakpoint: {
     doc: 'Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.',
     type: ['"small"', '"medium"'],
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
@@ -58,13 +58,13 @@ export const SpaceProperties: PropertiesTableProps = {
 
 export const SpaceResponsiveContextProperties: PropertiesTableProps = {
   density: {
-    doc: 'Forces a specific spacing density for descendants. Overrides `defaultBreakpoint` when set.',
-    type: ['"compact"', '"basis"', '"spacious"'],
+    doc: 'Forces a specific spacing density for descendants. Overrides `defaultBreakpoint` when set. Defaults to `false`.',
+    type: ['"compact"', '"basis"', 'false'],
     status: 'optional',
   },
   defaultBreakpoint: {
-    doc: "Sets which breakpoint's spacing scale to use as the default. Default: `medium`.",
-    type: ['"small"', '"medium"', '"large"'],
+    doc: 'Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.',
+    type: ['"small"', '"medium"'],
     status: 'optional',
   },
   off: {

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
@@ -1,27 +1,11 @@
 import { useContext } from 'react'
 import type { ReactNode } from 'react'
-import SpaceResponsiveContext from './SpaceResponsiveContext'
-import type {
-  SpaceDensity,
-  SpaceBreakpoint,
+import SpaceResponsiveContext, {
+  type SpaceResponsiveContextValue,
 } from './SpaceResponsiveContext'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
-export type SpaceResponsiveProps = {
-  /**
-   * Forces a specific spacing density for descendants. Overrides `breakpoint` when set.
-   */
-  density?: SpaceDensity
-
-  /**
-   * Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.
-   */
-  breakpoint?: SpaceBreakpoint
-
-  /**
-   * When `true`, disables responsive spacing for descendants, overriding a parent `Space.ResponsiveContext`. Defaults to `false`.
-   */
-  off?: boolean
+type SpaceResponsiveProps = SpaceResponsiveContextValue & {
   children?: ReactNode
 }
 

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
@@ -39,6 +39,7 @@ function SpaceResponsive({
         ...(parent || undefined),
         ...(density !== undefined && { density }),
         ...(defaultBreakpoint !== undefined && { defaultBreakpoint }),
+        ...(off !== undefined && { off }),
       }
 
   return (

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
@@ -9,14 +9,14 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type SpaceResponsiveProps = {
   /**
-   * Forces a specific spacing density for descendants. Overrides `defaultBreakpoint` when set.
+   * Forces a specific spacing density for descendants. Overrides `breakpoint` when set.
    */
   density?: SpaceDensity
 
   /**
    * Sets which breakpoint's spacing scale to use as the default. Default: `medium`.
    */
-  defaultBreakpoint?: SpaceBreakpoint
+  breakpoint?: SpaceBreakpoint
 
   /**
    * When `true`, disables responsive spacing for descendants, overriding a parent `Space.ResponsiveContext`. Defaults to `false`.
@@ -27,7 +27,7 @@ export type SpaceResponsiveProps = {
 
 function SpaceResponsive({
   density,
-  defaultBreakpoint,
+  breakpoint,
   off,
   children,
 }: SpaceResponsiveProps) {
@@ -38,7 +38,7 @@ function SpaceResponsive({
     : {
         ...(parent || undefined),
         ...(density !== undefined && { density }),
-        ...(defaultBreakpoint !== undefined && { defaultBreakpoint }),
+        ...(breakpoint !== undefined && { breakpoint }),
         ...(off !== undefined && { off }),
       }
 

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
@@ -14,7 +14,7 @@ export type SpaceResponsiveProps = {
   density?: SpaceDensity
 
   /**
-   * Sets which breakpoint's spacing scale to use as the default. Default: `medium`.
+   * Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.
    */
   breakpoint?: SpaceBreakpoint
 

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
@@ -1,15 +1,12 @@
 import { createContext } from 'react'
 import type { MediaQuerySizes } from '../../shared/MediaQueryUtils'
 
-export type SpaceDensity = 'compact' | 'basis' | 'spacious'
-export type SpaceBreakpoint = Extract<
-  MediaQuerySizes,
-  'small' | 'medium' | 'large'
->
+export type SpaceDensity = 'compact' | 'basis'
+export type SpaceBreakpoint = Extract<MediaQuerySizes, 'small' | 'medium'>
 
 export type SpaceResponsiveContextValue = {
   defaultBreakpoint?: SpaceBreakpoint
-  density?: SpaceDensity
+  density?: SpaceDensity | false
   off?: boolean
 }
 

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
@@ -1,12 +1,20 @@
 import { createContext } from 'react'
 import type { MediaQuerySizes } from '../../shared/MediaQueryUtils'
 
-export type SpaceDensity = 'compact' | 'basis'
-export type SpaceBreakpoint = Extract<MediaQuerySizes, 'small' | 'medium'>
-
 export type SpaceResponsiveContextValue = {
-  breakpoint?: SpaceBreakpoint
-  density?: SpaceDensity | false
+  /**
+   * Forces a specific spacing density for descendants. Overrides `breakpoint` when set. Use `false` to disable.
+   */
+  density?: 'compact' | 'basis' | false
+
+  /**
+   * Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.
+   */
+  breakpoint?: Extract<MediaQuerySizes, 'small' | 'medium'>
+
+  /**
+   * When `true`, disables responsive spacing for descendants, overriding a parent `Space.ResponsiveContext`. Defaults to `false`.
+   */
   off?: boolean
 }
 

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
@@ -5,7 +5,7 @@ export type SpaceDensity = 'compact' | 'basis'
 export type SpaceBreakpoint = Extract<MediaQuerySizes, 'small' | 'medium'>
 
 export type SpaceResponsiveContextValue = {
-  defaultBreakpoint?: SpaceBreakpoint
+  breakpoint?: SpaceBreakpoint
   density?: SpaceDensity | false
   off?: boolean
 }

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -510,7 +510,7 @@ export const applySpacing = <T extends ApplySpacingTarget>(
  *
  * Additionally reads `SpaceResponsiveContext` (provided by
  * `Space.ResponsiveContext`) and, when the component is rendered inside that
- * wrapper, appends a `dnb-space-responsive--<density>` CSS class.
+ * wrapper, appends a `dnb-space-responsive` CSS class.
  * This lets descendant components opt into responsive spacing driven
  * by `--responsive-spacing-*` custom properties.
  *
@@ -528,7 +528,7 @@ export const applySpacing = <T extends ApplySpacingTarget>(
  *   <Space.ResponsiveContext>
  *     <Button top="large">Click</Button>
  *   </Space.ResponsiveContext>
- *   // Button's root element will include 'dnb-space-responsive--basis'
+ *   // Button's root element will include 'dnb-space-responsive'
  *
  * @param props - component props containing spacing properties
  *                (top, right, bottom, left, space, innerSpace, noCollapse)

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -549,6 +549,7 @@ export const useSpacing = <T extends ApplySpacingTarget>(
       result.className,
       'dnb-space-responsive',
       responsive.defaultBreakpoint &&
+        responsive.defaultBreakpoint !== 'small' &&
         `dnb-space-responsive--breakpoint-${responsive.defaultBreakpoint}`,
       responsive.density &&
         `dnb-space-responsive--force-${responsive.density}`

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -548,9 +548,9 @@ export const useSpacing = <T extends ApplySpacingTarget>(
     result.className = clsx(
       result.className,
       'dnb-space-responsive',
-      responsive.defaultBreakpoint &&
-        responsive.defaultBreakpoint !== 'small' &&
-        `dnb-space-responsive--breakpoint-${responsive.defaultBreakpoint}`,
+      responsive.breakpoint &&
+        responsive.breakpoint !== 'small' &&
+        `dnb-space-responsive--breakpoint-${responsive.breakpoint}`,
       responsive.density &&
         `dnb-space-responsive--force-${responsive.density}`
     )

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -760,4 +760,31 @@ describe('Space.ResponsiveContext', () => {
       'dnb-space-responsive--force-compact'
     )
   })
+
+  it('should disable density when inner context sets density to false', () => {
+    const TestComponent = () => {
+      const params = useSpacing(
+        { top: 'large' },
+        { className: 'test-component' }
+      )
+      return <div {...params} />
+    }
+
+    render(
+      <Space.ResponsiveContext density="compact">
+        <Space.ResponsiveContext density={false}>
+          <TestComponent />
+        </Space.ResponsiveContext>
+      </Space.ResponsiveContext>
+    )
+
+    const element = document.querySelector('.test-component')
+    expect(element.className).toContain('dnb-space-responsive')
+    expect(element.className).not.toContain(
+      'dnb-space-responsive--force-compact'
+    )
+    expect(element.className).not.toContain(
+      'dnb-space-responsive--force-basis'
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -486,6 +486,30 @@ describe('Space.ResponsiveContext', () => {
     )
   })
 
+  it('should reenable responsive context when off is false', () => {
+    const TestComponent = () => {
+      const params = useSpacing(
+        { top: 'large' },
+        { className: 'test-component' }
+      )
+      return <div {...params} />
+    }
+
+    render(
+      <Space.ResponsiveContext>
+        <Space.ResponsiveContext off>
+          <Space.ResponsiveContext off={false}>
+            <TestComponent />
+          </Space.ResponsiveContext>
+        </Space.ResponsiveContext>
+      </Space.ResponsiveContext>
+    )
+
+    const element = document.querySelector('.test-component')
+    expect(element.className).not.toContain('dnb-space-responsive--off')
+    expect(element.className).toContain('dnb-space-responsive')
+  })
+
   it('should enable responsive context with medium default by default', () => {
     const TestComponent = () => {
       const params = useSpacing(

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -553,7 +553,7 @@ describe('Space.ResponsiveContext', () => {
     )
   })
 
-  it('should use defaultBreakpoint when density is not set', () => {
+  it('should use breakpoint when density is not set', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -563,7 +563,7 @@ describe('Space.ResponsiveContext', () => {
     }
 
     render(
-      <Space.ResponsiveContext defaultBreakpoint="medium">
+      <Space.ResponsiveContext breakpoint="medium">
         <TestComponent />
       </Space.ResponsiveContext>
     )
@@ -577,7 +577,7 @@ describe('Space.ResponsiveContext', () => {
     )
   })
 
-  it('should apply both defaultBreakpoint and density classes', () => {
+  it('should apply both breakpoint and density classes', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -587,10 +587,7 @@ describe('Space.ResponsiveContext', () => {
     }
 
     render(
-      <Space.ResponsiveContext
-        density="compact"
-        defaultBreakpoint="medium"
-      >
+      <Space.ResponsiveContext density="compact" breakpoint="medium">
         <TestComponent />
       </Space.ResponsiveContext>
     )
@@ -618,7 +615,7 @@ describe('Space.ResponsiveContext', () => {
 
   it('should add breakpoint class to Space component', () => {
     render(
-      <Space.ResponsiveContext defaultBreakpoint="medium">
+      <Space.ResponsiveContext breakpoint="medium">
         <Space top="large">Content</Space>
       </Space.ResponsiveContext>
     )
@@ -712,7 +709,7 @@ describe('Space.ResponsiveContext', () => {
     expect(SpaceResponsive['_supportsSpacingProps']).toBe('passthrough')
   })
 
-  it('should inherit parent density when inner only sets defaultBreakpoint', () => {
+  it('should inherit parent density when inner only sets breakpoint', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -723,7 +720,7 @@ describe('Space.ResponsiveContext', () => {
 
     render(
       <Space.ResponsiveContext density="compact">
-        <Space.ResponsiveContext defaultBreakpoint="medium">
+        <Space.ResponsiveContext breakpoint="medium">
           <TestComponent />
         </Space.ResponsiveContext>
       </Space.ResponsiveContext>

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -553,27 +553,6 @@ describe('Space.ResponsiveContext', () => {
     )
   })
 
-  it('should apply spacious density class', () => {
-    const TestComponent = () => {
-      const params = useSpacing(
-        { top: 'large' },
-        { className: 'test-component' }
-      )
-      return <div {...params} />
-    }
-
-    render(
-      <Space.ResponsiveContext density="spacious">
-        <TestComponent />
-      </Space.ResponsiveContext>
-    )
-
-    const element = document.querySelector('.test-component')
-    expect(element.className).toContain(
-      'dnb-space-responsive--force-spacious'
-    )
-  })
-
   it('should use defaultBreakpoint when density is not set', () => {
     const TestComponent = () => {
       const params = useSpacing(
@@ -584,21 +563,21 @@ describe('Space.ResponsiveContext', () => {
     }
 
     render(
-      <Space.ResponsiveContext defaultBreakpoint="small">
+      <Space.ResponsiveContext defaultBreakpoint="medium">
         <TestComponent />
       </Space.ResponsiveContext>
     )
 
     const element = document.querySelector('.test-component')
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-small'
+      'dnb-space-responsive--breakpoint-medium'
     )
     expect(element.className).not.toContain(
       'dnb-space-responsive--force-compact'
     )
   })
 
-  it('should apply both default and density classes', () => {
+  it('should apply both defaultBreakpoint and density classes', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -609,8 +588,8 @@ describe('Space.ResponsiveContext', () => {
 
     render(
       <Space.ResponsiveContext
-        density="spacious"
-        defaultBreakpoint="small"
+        density="compact"
+        defaultBreakpoint="medium"
       >
         <TestComponent />
       </Space.ResponsiveContext>
@@ -618,10 +597,10 @@ describe('Space.ResponsiveContext', () => {
 
     const element = document.querySelector('.test-component')
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-small'
+      'dnb-space-responsive--breakpoint-medium'
     )
     expect(element.className).toContain(
-      'dnb-space-responsive--force-spacious'
+      'dnb-space-responsive--force-compact'
     )
   })
 
@@ -639,14 +618,14 @@ describe('Space.ResponsiveContext', () => {
 
   it('should add breakpoint class to Space component', () => {
     render(
-      <Space.ResponsiveContext defaultBreakpoint="small">
+      <Space.ResponsiveContext defaultBreakpoint="medium">
         <Space top="large">Content</Space>
       </Space.ResponsiveContext>
     )
 
     const element = document.querySelector('.dnb-space')
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-small'
+      'dnb-space-responsive--breakpoint-medium'
     )
   })
 
@@ -744,7 +723,7 @@ describe('Space.ResponsiveContext', () => {
 
     render(
       <Space.ResponsiveContext density="compact">
-        <Space.ResponsiveContext defaultBreakpoint="small">
+        <Space.ResponsiveContext defaultBreakpoint="medium">
           <TestComponent />
         </Space.ResponsiveContext>
       </Space.ResponsiveContext>
@@ -755,7 +734,7 @@ describe('Space.ResponsiveContext', () => {
       'dnb-space-responsive--force-compact'
     )
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-small'
+      'dnb-space-responsive--breakpoint-medium'
     )
   })
 
@@ -770,7 +749,7 @@ describe('Space.ResponsiveContext', () => {
 
     render(
       <Space.ResponsiveContext density="compact">
-        <Space.ResponsiveContext density="spacious">
+        <Space.ResponsiveContext density="basis">
           <TestComponent />
         </Space.ResponsiveContext>
       </Space.ResponsiveContext>
@@ -778,7 +757,7 @@ describe('Space.ResponsiveContext', () => {
 
     const element = document.querySelector('.test-component')
     expect(element.className).toContain(
-      'dnb-space-responsive--force-spacious'
+      'dnb-space-responsive--force-basis'
     )
     expect(element.className).not.toContain(
       'dnb-space-responsive--force-compact'

--- a/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
@@ -22,6 +22,17 @@ exports[`Space scss > should match style dependencies css 1`] = `
  */
 @media screen and (max-width: 40em) {
   .dnb-space {
+    --responsive-spacing-xx-small: 0.125rem;
+    --responsive-spacing-x-small: 0.25rem;
+    --responsive-spacing-small: 0.5rem;
+    --responsive-spacing-medium: 1rem;
+    --responsive-spacing-large: 1.5rem;
+    --responsive-spacing-x-large: 2rem;
+    --responsive-spacing-xx-large: 2.5rem;
+  }
+}
+@media screen and (max-width: 60em) and (min-width: 40.00625em) {
+  .dnb-space {
     --responsive-spacing-xx-small: 0.25rem;
     --responsive-spacing-x-small: 0.5rem;
     --responsive-spacing-small: 1rem;
@@ -31,26 +42,15 @@ exports[`Space scss > should match style dependencies css 1`] = `
     --responsive-spacing-xx-large: 3rem;
   }
 }
-@media screen and (max-width: 60em) and (min-width: 40.00625em) {
-  .dnb-space {
-    --responsive-spacing-xx-small: 0.5rem;
-    --responsive-spacing-x-small: 1rem;
-    --responsive-spacing-small: 1.5rem;
-    --responsive-spacing-medium: 2rem;
-    --responsive-spacing-large: 2.5rem;
-    --responsive-spacing-x-large: 3rem;
-    --responsive-spacing-xx-large: 3.5rem;
-  }
-}
 @media screen and (min-width: 60.00625em) {
   .dnb-space {
-    --responsive-spacing-xx-small: 1rem;
-    --responsive-spacing-x-small: 1.5rem;
-    --responsive-spacing-small: 2rem;
-    --responsive-spacing-medium: 2.5rem;
-    --responsive-spacing-large: 3rem;
-    --responsive-spacing-x-large: 3.5rem;
-    --responsive-spacing-xx-large: 4rem;
+    --responsive-spacing-xx-small: 0.25rem;
+    --responsive-spacing-x-small: 0.5rem;
+    --responsive-spacing-small: 1rem;
+    --responsive-spacing-medium: 1.5rem;
+    --responsive-spacing-large: 2rem;
+    --responsive-spacing-x-large: 2.5rem;
+    --responsive-spacing-xx-large: 3rem;
   }
 }
 
@@ -779,81 +779,72 @@ exports[`Space scss > should match style dependencies css 1`] = `
 .dnb-space-responsive {
   --responsive-spacing-tier: 0;
   --responsive-spacing-xx-small: max(
-    0.25rem,
-    calc(0.5rem + var(--responsive-spacing-tier) * 0.5rem)
+    0.125rem,
+    calc(0.25rem + var(--responsive-spacing-tier) * 0.5rem)
   );
   --responsive-spacing-x-small: max(
     0.25rem,
+    calc(0.5rem + var(--responsive-spacing-tier) * 0.5rem)
+  );
+  --responsive-spacing-small: max(
+    0.5rem,
     calc(1rem + var(--responsive-spacing-tier) * 0.5rem)
   );
-  --responsive-spacing-small: calc(
+  --responsive-spacing-medium: calc(
     1.5rem + var(--responsive-spacing-tier) * 0.5rem
   );
-  --responsive-spacing-medium: calc(
+  --responsive-spacing-large: calc(
     2rem + var(--responsive-spacing-tier) * 0.5rem
   );
-  --responsive-spacing-large: calc(
+  --responsive-spacing-x-large: calc(
     2.5rem + var(--responsive-spacing-tier) * 0.5rem
   );
-  --responsive-spacing-x-large: calc(
+  --responsive-spacing-xx-large: calc(
     3rem + var(--responsive-spacing-tier) * 0.5rem
   );
-  --responsive-spacing-xx-large: calc(
-    3.5rem + var(--responsive-spacing-tier) * 0.5rem
-  );
   --spacing-xx-small: var(--responsive-spacing-xx-small);
-  --spacing-x-small: var(--responsive-spacing-xx-small);
-  --spacing-small: var(--responsive-spacing-x-small);
-  --spacing-medium: var(--responsive-spacing-small);
-  --spacing-large: var(--responsive-spacing-medium);
-  --spacing-x-large: var(--responsive-spacing-large);
-  --spacing-xx-large: var(--responsive-spacing-x-large);
+  --spacing-x-small: var(--responsive-spacing-x-small);
+  --spacing-small: var(--responsive-spacing-small);
+  --spacing-medium: var(--responsive-spacing-medium);
+  --spacing-large: var(--responsive-spacing-large);
+  --spacing-x-large: var(--responsive-spacing-x-large);
+  --spacing-xx-large: var(--responsive-spacing-xx-large);
 }
 @media screen and (max-width: 40em) {
   .dnb-space-responsive {
     --responsive-spacing-tier: -1;
   }
 }
-@media screen and (min-width: 60.00625em) {
+@media screen and (max-width: 60em) and (min-width: 40.00625em) {
   .dnb-space-responsive {
-    --responsive-spacing-tier: 1;
-  }
-}
-@media screen and (max-width: 40em) {
-  .dnb-space-responsive--breakpoint-small {
     --responsive-spacing-tier: 0;
   }
 }
-@media screen and (max-width: 60em) and (min-width: 40.00625em) {
-  .dnb-space-responsive--breakpoint-small {
-    --responsive-spacing-tier: 1;
-  }
-}
 @media screen and (min-width: 60.00625em) {
-  .dnb-space-responsive--breakpoint-small {
-    --responsive-spacing-tier: 2;
+  .dnb-space-responsive {
+    --responsive-spacing-tier: 0;
   }
 }
 @media screen and (max-width: 40em) {
-  .dnb-space-responsive--breakpoint-large {
-    --responsive-spacing-tier: -2;
+  .dnb-space-responsive--breakpoint-medium {
+    --responsive-spacing-tier: -1;
   }
 }
 @media screen and (max-width: 60em) and (min-width: 40.00625em) {
-  .dnb-space-responsive--breakpoint-large {
+  .dnb-space-responsive--breakpoint-medium {
     --responsive-spacing-tier: -1;
   }
 }
 @media screen and (min-width: 60.00625em) {
-  .dnb-space-responsive--breakpoint-large {
+  .dnb-space-responsive--breakpoint-medium {
     --responsive-spacing-tier: 0;
   }
 }
 .dnb-space-responsive--force-compact {
   --responsive-spacing-tier: -1;
 }
-.dnb-space-responsive--force-spacious {
-  --responsive-spacing-tier: 1;
+.dnb-space-responsive--force-basis {
+  --responsive-spacing-tier: 0;
 }
 .dnb-space-responsive--off {
   --spacing-xx-small: 0.25rem;

--- a/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
+++ b/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
@@ -243,8 +243,9 @@
 
   // Responsive modifiers
   // A single --responsive-spacing-tier variable controls the active tier.
-  // Each --responsive-spacing-* is computed from its basis value + tier × 0.5rem.
-  // Default mapping: small viewport = -1, medium = 0, large = +1.
+  // Each --responsive-spacing-* is computed from its basis value + tier × 0.5rem,
+  // with a minimum value to avoid negative spacing.
+  // Default mapping: below small = -1, above small = 0.
   // Shifting the breakpoint shifts the tier integers accordingly.
 
   &-responsive {

--- a/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
+++ b/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
@@ -252,63 +252,55 @@
 
     // Compute responsive spacing values
     --responsive-spacing-xx-small: max(
-      0.25rem,
-      calc(0.5rem + var(--responsive-spacing-tier) * 0.5rem)
+      0.125rem,
+      calc(0.25rem + var(--responsive-spacing-tier) * 0.5rem)
     );
     --responsive-spacing-x-small: max(
       0.25rem,
+      calc(0.5rem + var(--responsive-spacing-tier) * 0.5rem)
+    );
+    --responsive-spacing-small: max(
+      0.5rem,
       calc(1rem + var(--responsive-spacing-tier) * 0.5rem)
     );
-    --responsive-spacing-small: calc(
+    --responsive-spacing-medium: calc(
       1.5rem + var(--responsive-spacing-tier) * 0.5rem
     );
-    --responsive-spacing-medium: calc(
+    --responsive-spacing-large: calc(
       2rem + var(--responsive-spacing-tier) * 0.5rem
     );
-    --responsive-spacing-large: calc(
+    --responsive-spacing-x-large: calc(
       2.5rem + var(--responsive-spacing-tier) * 0.5rem
     );
-    --responsive-spacing-x-large: calc(
-      3rem + var(--responsive-spacing-tier) * 0.5rem
-    );
     --responsive-spacing-xx-large: calc(
-      3.5rem + var(--responsive-spacing-tier) * 0.5rem
+      3rem + var(--responsive-spacing-tier) * 0.5rem
     );
 
     // Map spacing tokens to responsive spacing values
     --spacing-xx-small: var(--responsive-spacing-xx-small);
-    --spacing-x-small: var(--responsive-spacing-xx-small);
-    --spacing-small: var(--responsive-spacing-x-small);
-    --spacing-medium: var(--responsive-spacing-small);
-    --spacing-large: var(--responsive-spacing-medium);
-    --spacing-x-large: var(--responsive-spacing-large);
-    --spacing-xx-large: var(--responsive-spacing-x-large);
+    --spacing-x-small: var(--responsive-spacing-x-small);
+    --spacing-small: var(--responsive-spacing-small);
+    --spacing-medium: var(--responsive-spacing-medium);
+    --spacing-large: var(--responsive-spacing-large);
+    --spacing-x-large: var(--responsive-spacing-x-large);
+    --spacing-xx-large: var(--responsive-spacing-xx-large);
 
-    // Default viewport mapping (medium = basis)
+    // Default breakpoint changes size at "small" viewport
     @include utilities.allBelow(small) {
       --responsive-spacing-tier: -1;
     }
-    @include utilities.allAbove(medium) {
-      --responsive-spacing-tier: 1;
-    }
-  }
-
-  // Breakpoint overrides – shift which viewport gets the "basis" tier
-  &-responsive--breakpoint-small {
-    @include utilities.allBelow(small) {
+    @include utilities.allBetween(small, medium) {
       --responsive-spacing-tier: 0;
     }
-    @include utilities.allBetween(small, medium) {
-      --responsive-spacing-tier: 1;
-    }
     @include utilities.allAbove(medium) {
-      --responsive-spacing-tier: 2;
+      --responsive-spacing-tier: 0;
     }
   }
 
-  &-responsive--breakpoint-large {
+  // Breakpoint overrides – shift at which breakpoint the sizes change
+  &-responsive--breakpoint-medium {
     @include utilities.allBelow(small) {
-      --responsive-spacing-tier: -2;
+      --responsive-spacing-tier: -1;
     }
     @include utilities.allBetween(small, medium) {
       --responsive-spacing-tier: -1;
@@ -323,8 +315,8 @@
     --responsive-spacing-tier: -1;
   }
 
-  &-responsive--force-spacious {
-    --responsive-spacing-tier: 1;
+  &-responsive--force-basis {
+    --responsive-spacing-tier: 0;
   }
 
   // Reset responsive overrides when Space.ResponsiveContext off is set,

--- a/packages/dnb-eufemia/src/components/space/style/responsive-spacing.scss
+++ b/packages/dnb-eufemia/src/components/space/style/responsive-spacing.scss
@@ -7,6 +7,15 @@
 // The theme is not compatible with :root today.
 .dnb-space {
   @include utilities.allBelow(small) {
+    --responsive-spacing-xx-small: 0.125rem; // 2px
+    --responsive-spacing-x-small: 0.25rem; // 4px
+    --responsive-spacing-small: 0.5rem; // 8px
+    --responsive-spacing-medium: 1rem; // 16px
+    --responsive-spacing-large: 1.5rem; // 24px
+    --responsive-spacing-x-large: 2rem; // 32px
+    --responsive-spacing-xx-large: 2.5rem; // 40px
+  }
+  @include utilities.allBetween(small, medium) {
     --responsive-spacing-xx-small: 0.25rem; // 4px
     --responsive-spacing-x-small: 0.5rem; // 8px
     --responsive-spacing-small: 1rem; // 16px
@@ -15,22 +24,13 @@
     --responsive-spacing-x-large: 2.5rem; // 40px
     --responsive-spacing-xx-large: 3rem; // 48px
   }
-  @include utilities.allBetween(small, medium) {
-    --responsive-spacing-xx-small: 0.5rem; // 8px
-    --responsive-spacing-x-small: 1rem; // 16px
-    --responsive-spacing-small: 1.5rem; // 24px
-    --responsive-spacing-medium: 2rem; // 32px
-    --responsive-spacing-large: 2.5rem; // 40px
-    --responsive-spacing-x-large: 3rem; // 48px
-    --responsive-spacing-xx-large: 3.5rem; // 56px
-  }
   @include utilities.allAbove(medium) {
-    --responsive-spacing-xx-small: 1rem; // 16px
-    --responsive-spacing-x-small: 1.5rem; // 24px
-    --responsive-spacing-small: 2rem; // 32px
-    --responsive-spacing-medium: 2.5rem; // 40px
-    --responsive-spacing-large: 3rem; // 48px
-    --responsive-spacing-x-large: 3.5rem; // 56px
-    --responsive-spacing-xx-large: 4rem; // 64px
+    --responsive-spacing-xx-small: 0.25rem; // 4px
+    --responsive-spacing-x-small: 0.5rem; // 8px
+    --responsive-spacing-small: 1rem; // 16px
+    --responsive-spacing-medium: 1.5rem; // 24px
+    --responsive-spacing-large: 2rem; // 32px
+    --responsive-spacing-x-large: 2.5rem; // 40px
+    --responsive-spacing-xx-large: 3rem; // 48px
   }
 }


### PR DESCRIPTION
Responsive spacing now only have two densities, `"compact"` and `"basis"`, and has values that match design.

- update responsive values to match design
- change `defaultBreakpoint` to `breakpoint`. Can only select `"small"` or `"medium"`, any other breakpoint would be the same as setting a density or turning responsive spacing off.
- make it possible to turn off `density` in child context