### PR TITLE
chore(PaymentCard): remove unused business-no-visa and business-with-visa card design classes

### DIFF
--- a/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/packages/dnb-eufemia/src/extensions/payment-card/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -193,14 +193,6 @@ exports[`PaymentCard scss > has to match style dependencies css 1`] = `
   background-color: var(--color-black);
   color: var(--color-white);
 }
-.dnb-payment-card__card--design-business-no-visa {
-  background-color: var(--dnb-payment-bg-business-no-visa);
-  color: var(--color-white);
-}
-.dnb-payment-card__card--design-business-with-visa {
-  background-color: var(--dnb-payment-bg-business-with-visa);
-  color: var(--color-white);
-}
 .dnb-payment-card__card--design-sbanken-mastercard {
   background-color: var(--sb-color-purple);
   color: var(--color-white);

--- a/packages/dnb-eufemia/src/extensions/payment-card/components/StatusOverlay.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/components/StatusOverlay.tsx
@@ -39,8 +39,6 @@ const StatusOverlay = ({
 
   const cardStatusOverlayThemeMap: Record<string, string> = {
     'card--design-default': 'light',
-    'card--design-business-no-visa': 'light',
-    'card--design-business-with-visa': 'light',
     'card--design-ung': 'light',
     'card--design-youth': 'light',
     'card--design-my-first': 'light',

--- a/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
+++ b/packages/dnb-eufemia/src/extensions/payment-card/style/dnb-payment-card.scss
@@ -124,18 +124,6 @@
         color: var(--color-white);
       }
 
-      // Design for a business card without Visa support
-      &-business-no-visa {
-        background-color: var(--dnb-payment-bg-business-no-visa);
-        color: var(--color-white);
-      }
-
-      // Design for a business card with Visa support
-      &-business-with-visa {
-        background-color: var(--dnb-payment-bg-business-with-visa);
-        color: var(--color-white);
-      }
-
       // Sbanken-themed Mastercard with purple background
       &-sbanken-mastercard {
         background-color: var(--sb-color-purple);


### PR DESCRIPTION
These CSS design classes referenced undefined custom properties (--dnb-payment-bg-business-no-visa and --dnb-payment-bg-business-with-visa) but were never used by any cardStyle. The businessNoVisa and businessWithVisa designs map to card--design-default, so the dead classes and their StatusOverlay theme entries can be safely removed.

