### PR TITLE
chore(Table): remove unused dnb-table__td-wrapper class

### DIFF
--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -1244,9 +1244,5 @@ html:not([data-whatinput=keyboard]) .dnb-table__tr--clickable.dnb-table__tr.dnb-
 
 .dnb-table__tr--clickable:has(.dnb-table + .dnb-table__tr__accordion-content--animating) {
   user-select: none;
-}
-
-.dnb-table__td-wrapper {
-  display: flex;
 }"
 `;

--- a/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
+++ b/packages/dnb-eufemia/src/components/table/style/table-accordion.scss
@@ -327,8 +327,4 @@
   &__tr--clickable:has(& + &__tr__accordion-content--animating) {
     user-select: none;
   }
-
-  &__td-wrapper {
-    display: flex;
-  }
 }


### PR DESCRIPTION
The dnb-table__td-wrapper class (display: flex) was never applied to any element. Removed it and updated the Table snapshot which embeds the compiled CSS.

