### PR TITLE
chore(Modal): remove unused dnb-modal__content__content class

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -1218,9 +1218,6 @@ html[data-dnb-modal-active] .eufemia-portal-root {
   align-items: flex-start;
   justify-content: flex-start;
 }
-.dnb-modal__content--fullscreen .dnb-modal__content__content {
-  height: auto;
-}
 .dnb-modal__content--left, .dnb-modal__content--top {
   align-items: flex-start;
   justify-content: flex-start;

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1219,9 +1219,6 @@ html[data-dnb-modal-active] .eufemia-portal-root {
   align-items: flex-start;
   justify-content: flex-start;
 }
-.dnb-modal__content--fullscreen .dnb-modal__content__content {
-  height: auto;
-}
 .dnb-modal__content--left, .dnb-modal__content--top {
   align-items: flex-start;
   justify-content: flex-start;

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -1214,9 +1214,6 @@ html[data-dnb-modal-active] .eufemia-portal-root {
   align-items: flex-start;
   justify-content: flex-start;
 }
-.dnb-modal__content--fullscreen .dnb-modal__content__content {
-  height: auto;
-}
 .dnb-modal__content--left, .dnb-modal__content--top {
   align-items: flex-start;
   justify-content: flex-start;

--- a/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
+++ b/packages/dnb-eufemia/src/components/modal/style/dnb-modal.scss
@@ -42,11 +42,6 @@ html[data-dnb-modal-active] {
       justify-content: flex-start;
     }
 
-    // Is this used?
-    &--fullscreen &__content {
-      height: auto;
-    }
-
     &--left,
     &--top {
       align-items: flex-start;


### PR DESCRIPTION
The selector resolved to .dnb-modal__content--fullscreen .dnb-modal__content__content, an inner class that is never rendered (it was already flagged with a // Is this used? comment). Removed it and updated the Modal, Dialog and Drawer snapshots which embed the compiled CSS.

