### PR TITLE
chore(Grid): remove unused dnb-grid-item--full-width class

### DIFF
--- a/packages/dnb-eufemia/src/components/grid/style/grid-item.scss
+++ b/packages/dnb-eufemia/src/components/grid/style/grid-item.scss
@@ -15,9 +15,4 @@
     --start-c: var(--large-c-s, 1);
     --end-c: var(--large-c-e, calc(var(--grid-columns) + 1));
   }
-
-  &--full-width {
-    --start-c: 0;
-    --end-c: var(--grid-columns);
-  }
 }


### PR DESCRIPTION
Grid.Item's span="full" sets the grid CSS variables directly (Item.tsx), so the dnb-grid-item--full-width modifier class is never applied and is obsolete.

