### PR TITLE
chore(Skeleton): remove unused dnb-skeleton--font-only class

### DIFF
--- a/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.tsx.snap
@@ -77,13 +77,13 @@ exports[`Skeleton scss > has to match style dependencies css 1`] = `
   font-style: unset !important;
   box-shadow: none !important;
 }
-.dnb-skeleton--font-only, .dnb-skeleton--font, .dnb-skeleton--font .dnb-skeleton--show-font, .dnb-skeleton--font .dnb-p {
+.dnb-skeleton--font, .dnb-skeleton--font .dnb-skeleton--show-font, .dnb-skeleton--font .dnb-p {
   pointer-events: none;
   --font-family-default: 'DNBSkeleton' !important;
   font-family: var(--font-family-default) !important;
   font-style: unset !important;
 }
-.dnb-skeleton--font-only::marker, .dnb-skeleton--font::marker, .dnb-skeleton--font .dnb-skeleton--show-font::marker, .dnb-skeleton--font .dnb-p::marker {
+.dnb-skeleton--font::marker, .dnb-skeleton--font .dnb-skeleton--show-font::marker, .dnb-skeleton--font .dnb-p::marker {
   color: var(--skeleton-color);
 }
 .dnb-skeleton--font, .dnb-skeleton--font .dnb-skeleton--show-font, .dnb-skeleton--font .dnb-p {

--- a/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skeleton/__tests__/__snapshots__/Skeleton.test.tsx.snap
@@ -82,11 +82,6 @@ exports[`Skeleton scss > has to match style dependencies css 1`] = `
   --font-family-default: 'DNBSkeleton' !important;
   font-family: var(--font-family-default) !important;
   font-style: unset !important;
-}
-.dnb-skeleton--font::marker, .dnb-skeleton--font .dnb-skeleton--show-font::marker, .dnb-skeleton--font .dnb-p::marker {
-  color: var(--skeleton-color);
-}
-.dnb-skeleton--font, .dnb-skeleton--font .dnb-skeleton--show-font, .dnb-skeleton--font .dnb-p {
   background-position-y: 50% !important;
   background-repeat: no-repeat !important;
   background-size: 30rem 100% !important;
@@ -97,6 +92,9 @@ exports[`Skeleton scss > has to match style dependencies css 1`] = `
   background-color: var(--skeleton-color) !important;
   background-position-x: 30rem;
   animation: skeletonFontAnimation 5s linear infinite var(--skeleton-delay);
+}
+.dnb-skeleton--font::marker, .dnb-skeleton--font .dnb-skeleton--show-font::marker, .dnb-skeleton--font .dnb-p::marker {
+  color: var(--skeleton-color);
 }
 .dnb-skeleton__figure {
   position: relative;

--- a/packages/dnb-eufemia/src/components/skeleton/style/dnb-skeleton.scss
+++ b/packages/dnb-eufemia/src/components/skeleton/style/dnb-skeleton.scss
@@ -102,14 +102,6 @@
     font-family: var(--font-family-default) !important;
     font-style: unset !important;
 
-    &::marker {
-      color: var(--skeleton-color);
-    }
-  }
-
-  &--font,
-  &--font &--show-font,
-  &--font .dnb-p {
     background-position-y: 50% !important;
     background-repeat: no-repeat !important;
     background-size: 30rem 100% !important;
@@ -129,6 +121,10 @@
     background-position-x: 30rem;
     animation: skeletonFontAnimation 5s linear infinite
       var(--skeleton-delay);
+
+    &::marker {
+      color: var(--skeleton-color);
+    }
   }
 
   &__figure {

--- a/packages/dnb-eufemia/src/components/skeleton/style/dnb-skeleton.scss
+++ b/packages/dnb-eufemia/src/components/skeleton/style/dnb-skeleton.scss
@@ -92,7 +92,6 @@
     }
   }
 
-  &--font-only,
   &--font,
   &--font &--show-font,
   &--font .dnb-p {


### PR DESCRIPTION
The dnb-skeleton--font-only selector was never applied to any element; the Skeleton component only outputs dnb-skeleton--font (and dnb-skeleton--show-font is used by Button). Removed the dead selector and updated the snapshot.

