### PR TITLE
chore(stylelint): add eufemia/no-undefined-custom-property rule

### DIFF
--- a/packages/dnb-eufemia/.stylelintrc
+++ b/packages/dnb-eufemia/.stylelintrc
@@ -42,6 +42,23 @@
     "eufemia/no-deprecated-color-variables": [
       true,
       { "severity": "warning" }
+    ],
+    "eufemia/no-undefined-custom-property": [
+      true,
+      {
+        "reportFallbacks": true,
+        "ignoreProperties": [
+          "/^--(small|medium|large)-columns$/",
+          "/^--(small|medium|large)-c-[se]$/",
+          "/^--icon-transition-/",
+          "/^--anchor-background-gutter-/",
+          "--block-content-width",
+          "--blockquote-icon-color",
+          "--hr-thickness",
+          "--hr-thickness-modifier",
+          "--table-td-background--selected"
+        ]
+      }
     ]
   },
   "overrides": [
@@ -54,6 +71,38 @@
       ],
       "rules": {
         "eufemia/no-deprecated-color-variables": null
+      }
+    },
+    {
+      "files": ["src/components/section/**/*.scss"],
+      "rules": {
+        "eufemia/no-undefined-custom-property": [
+          true,
+          {
+            "reportFallbacks": true,
+            "ignoreProperties": [
+              "/^--breakout--/",
+              "/^--outset--/",
+              "/^--rounded-corner--/",
+              "/^--text-color--/",
+              "/^--background-color--/",
+              "/^--outline-color--/",
+              "/^--outline-width--/"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/components/space/**/*.scss"],
+      "rules": {
+        "eufemia/no-undefined-custom-property": [
+          true,
+          {
+            "reportFallbacks": true,
+            "ignoreProperties": ["/^--padding-[trbl]-[sml]$/"]
+          }
+        ]
       }
     }
   ]

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -113,6 +113,7 @@ describe('babel build', () => {
       '/plugin-scope-hash.cjs',
       '/token-name-policy.cjs',
       '/no-unused-use.cjs',
+      '/no-undefined-custom-property.cjs',
       '/dnb-ui-lib.min.mjs',
       '/dnb-ui-basis.min.mjs',
       '/dnb-ui-components.min.mjs',

--- a/packages/dnb-eufemia/src/elements/hr/style/dnb-hr.scss
+++ b/packages/dnb-eufemia/src/elements/hr/style/dnb-hr.scss
@@ -32,7 +32,9 @@
     border-radius: 0;
   }
 
-  --thickness: calc(var(--hr-thickness, 0.0625rem) + var(--modifier, 0px));
+  --thickness: calc(
+    var(--hr-thickness, 0.0625rem) + var(--hr-thickness-modifier, 0px)
+  );
 
   .dnb-spacing & {
     @include ui-spacing.defaultSpacing();

--- a/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-undefined-custom-property.test.ts
+++ b/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-undefined-custom-property.test.ts
@@ -1,0 +1,280 @@
+import stylelint from 'stylelint'
+const noUndefinedCustomPropertyPlugin = require('../rules/no-undefined-custom-property.cjs')
+
+const lintWithRule = async (
+  code: string,
+  options: boolean | [boolean, Record<string, unknown>] = true
+) => {
+  const result = await stylelint.lint({
+    code,
+    codeFilename: 'test.scss',
+    customSyntax: 'postcss-scss',
+    config: {
+      plugins: [noUndefinedCustomPropertyPlugin],
+      rules: {
+        [noUndefinedCustomPropertyPlugin.ruleName]: options,
+      },
+    },
+  })
+
+  return result.results?.[0]?.warnings || []
+}
+
+describe('no-undefined-custom-property', () => {
+  // The first lint triggers a one-time filesystem scan to build the set of
+  // known custom properties. Warm it up here with a generous timeout so the
+  // individual test cases run against the cached result.
+  beforeAll(async () => {
+    await lintWithRule(
+      `.dnb-warmup { color: var(--token-color-text-action); }`
+    )
+  }, 120000)
+
+  it('should report a var() reference to a property that is never defined', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz);
+      }
+    `)
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain(
+      '--this-property-does-not-exist-anywhere-xyz'
+    )
+    expect(warnings[0].rule).toBe(noUndefinedCustomPropertyPlugin.ruleName)
+  })
+
+  it('should not report when the property is defined in the same file', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        --this-property-does-not-exist-anywhere-xyz: 1rem;
+        color: var(--this-property-does-not-exist-anywhere-xyz);
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report when the var() has a fallback value', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz, red);
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report SCSS-interpolated property references', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        margin: var(--margin-#{$short}-does-not-exist-xyz);
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report a property that is defined elsewhere in the codebase', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        color: var(--token-color-text-action);
+      }
+    `)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report properties listed in ignoreProperties', async () => {
+    const warnings = await lintWithRule(
+      `
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz);
+      }
+    `,
+      [
+        true,
+        {
+          ignoreProperties: [
+            '--this-property-does-not-exist-anywhere-xyz',
+          ],
+        },
+      ]
+    )
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should not report properties matching a regex in ignoreProperties', async () => {
+    const warnings = await lintWithRule(
+      `
+      .dnb-foo {
+        color: var(--made-up-family--small-xyz);
+        background: var(--made-up-family--large-xyz);
+      }
+    `,
+      [true, { ignoreProperties: ['/^--made-up-family--/'] }]
+    )
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should report each undefined reference within a single declaration', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        margin: var(--undefined-one-xyz) var(--undefined-two-xyz);
+      }
+    `)
+
+    expect(warnings).toHaveLength(2)
+  })
+
+  it('should report a nested fallback reference that is undefined', async () => {
+    const warnings = await lintWithRule(`
+      .dnb-foo {
+        color: var(--token-color-text-action, var(--undefined-nested-xyz));
+      }
+    `)
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain('--undefined-nested-xyz')
+  })
+
+  it('should not throw on a malformed ignoreProperties regex', async () => {
+    const warnings = await lintWithRule(
+      `
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz);
+      }
+    `,
+      [true, { ignoreProperties: ['/[/'] }]
+    )
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].text).toContain(
+      '--this-property-does-not-exist-anywhere-xyz'
+    )
+  })
+
+  it('should not run when the rule is disabled', async () => {
+    const warnings = await lintWithRule(
+      `
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz);
+      }
+    `,
+      false
+    )
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  describe('reportFallbacks option', () => {
+    it('should report an undefined primary in a var() with a fallback when enabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz, red);
+      }
+    `,
+        [true, { reportFallbacks: true }]
+      )
+
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0].text).toContain(
+        '--this-property-does-not-exist-anywhere-xyz'
+      )
+      expect(warnings[0].text).toContain('phantom')
+    })
+
+    it('should not report undefined-with-fallback when reportFallbacks is explicitly disabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        color: var(--this-property-does-not-exist-anywhere-xyz, red);
+      }
+    `,
+        [true, { reportFallbacks: false }]
+      )
+
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('should not report a defined primary used with a fallback even when enabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        color: var(--token-color-text-action, red);
+      }
+    `,
+        [true, { reportFallbacks: true }]
+      )
+
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('should not report a primary defined in the same file used with a fallback when enabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        --this-property-does-not-exist-anywhere-xyz: 1rem;
+        margin: var(--this-property-does-not-exist-anywhere-xyz, 0);
+      }
+    `,
+        [true, { reportFallbacks: true }]
+      )
+
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('should respect ignoreProperties for phantom references when enabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        color: var(--made-up-hook--small-xyz, red);
+        background: var(--made-up-hook--large-xyz, blue);
+      }
+    `,
+        [
+          true,
+          {
+            reportFallbacks: true,
+            ignoreProperties: ['/^--made-up-hook--/'],
+          },
+        ]
+      )
+
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('should not report SCSS-interpolated names in a fallback var() when enabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        margin: var(--margin-#{$short}-does-not-exist-xyz, 0);
+      }
+    `,
+        [true, { reportFallbacks: true }]
+      )
+
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('should report both no-fallback and phantom references when enabled', async () => {
+      const warnings = await lintWithRule(
+        `
+      .dnb-foo {
+        margin: var(--undefined-no-fallback-xyz);
+        padding: var(--undefined-with-fallback-xyz, 0);
+      }
+    `,
+        [true, { reportFallbacks: true }]
+      )
+
+      expect(warnings).toHaveLength(2)
+      const texts = warnings.map((warning) => warning.text).join('\n')
+      expect(texts).toContain('--undefined-no-fallback-xyz')
+      expect(texts).toContain('--undefined-with-fallback-xyz')
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/plugins/stylelint/index.js
+++ b/packages/dnb-eufemia/src/plugins/stylelint/index.js
@@ -1,11 +1,13 @@
 const noDeprecatedColorVariables = require('./rules/no-deprecated-color-variables.js')
 const tokenNamePolicy = require('./rules/token-name-policy.cjs')
 const noUnusedUse = require('./rules/no-unused-use.cjs')
+const noUndefinedCustomProperty = require('./rules/no-undefined-custom-property.cjs')
 
 const pluginPack = [
   noDeprecatedColorVariables,
   tokenNamePolicy,
   noUnusedUse,
+  noUndefinedCustomProperty,
 ]
 
 pluginPack.recommended = {
@@ -13,6 +15,7 @@ pluginPack.recommended = {
   rules: {
     [noDeprecatedColorVariables.ruleName]: true,
     [tokenNamePolicy.ruleName]: true,
+    [noUndefinedCustomProperty.ruleName]: true,
   },
 }
 

--- a/packages/dnb-eufemia/src/plugins/stylelint/rules/no-undefined-custom-property.cjs
+++ b/packages/dnb-eufemia/src/plugins/stylelint/rules/no-undefined-custom-property.cjs
@@ -1,0 +1,278 @@
+const stylelint = require('stylelint')
+const fs = require('fs')
+const path = require('path')
+
+const RULE_NAME = 'eufemia/no-undefined-custom-property'
+
+// Resolve the dnb-eufemia "src" root relative to this rule file
+// (src/plugins/stylelint/rules/ -> src).
+const SRC_ROOT = path.resolve(__dirname, '../../..')
+
+const messages = stylelint.utils.ruleMessages(RULE_NAME, {
+  undefined: (prop) =>
+    `Unexpected reference to undefined custom property "${prop}". ` +
+    `It is referenced via "var(${prop})" without a fallback but is never ` +
+    `defined in any SCSS file nor set via JavaScript/TypeScript. A var() ` +
+    `pointing at an undefined custom property resolves to a ` +
+    `guaranteed-invalid value, which silently breaks the declaration. ` +
+    `Define the property, add a fallback ("var(${prop}, <fallback>)"), or ` +
+    `remove the reference.`,
+  undefinedWithFallback: (prop) =>
+    `Unexpected reference to undefined custom property "${prop}". ` +
+    `It is referenced via "var(${prop}, <fallback>)" but is never defined ` +
+    `in any SCSS file nor set via JavaScript/TypeScript, so it always ` +
+    `resolves to the fallback \u2013 a "phantom" reference. Reference the ` +
+    `real variable or value directly, define the property, or add it to ` +
+    `"ignoreProperties" if it is an intentional override hook or is set at ` +
+    `runtime with a dynamically built name.`,
+})
+
+const meta = {
+  url: 'https://github.com/dnbexperience/eufemia',
+}
+
+// Matches a custom property *definition*, e.g. "--foo:" but not the "--foo"
+// inside "var(--foo)". The leading boundary avoids matching inside words.
+const SCSS_DEFINITION = /(?:^|[^\w-])(--[\w-]+)\s*:/g
+
+// Matches any custom-property-looking token. Used to harvest properties that
+// are defined dynamically from JavaScript/TypeScript (e.g. element.style
+// .setProperty('--foo', …) or inline style strings like "--foo: 1rem").
+const ANY_CUSTOM_PROPERTY = /--[\w-]+/g
+
+// Matches a var() reference *without* a fallback, e.g. "var(--foo)".
+// References that include a fallback ("var(--foo, 0)") or SCSS interpolation
+// ("var(--foo-#{$x})") intentionally do not match and are therefore skipped.
+const VAR_WITHOUT_FALLBACK = /var\(\s*(--[\w-]+)\s*\)/g
+
+// Matches a var() reference *with* a fallback and captures the primary
+// property, e.g. "var(--foo, red)" or "var(--foo, var(--bar))" -> "--foo".
+// Used only when the "reportFallbacks" option is enabled, to catch "phantom"
+// references whose primary property is never defined and therefore always
+// resolve to the fallback. Interpolated names ("var(--foo-#{$x}, …)") do not
+// match and are therefore skipped.
+const VAR_WITH_FALLBACK = /var\(\s*(--[\w-]+)\s*,/g
+
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  '__tests__',
+  '__snapshots__',
+  'build',
+])
+
+// Cache the expensive filesystem scan per source root so it runs only once
+// per stylelint process, no matter how many files are linted.
+const knownPropertiesCache = new Map()
+
+const walkFiles = (dir, extensions, onFile) => {
+  let entries
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      if (
+        IGNORED_DIRECTORIES.has(entry.name) ||
+        entry.name.startsWith('.')
+      ) {
+        continue
+      }
+      walkFiles(fullPath, extensions, onFile)
+    } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+      onFile(fullPath)
+    }
+  }
+}
+
+const collectMatches = (content, regex, group, target) => {
+  let match
+  while ((match = regex.exec(content)) !== null) {
+    target.add(group === 0 ? match[0] : match[group])
+  }
+}
+
+// Read and scan files asynchronously, yielding to the event loop between
+// files. The scan touches the entire "src" tree (thousands of files), so doing
+// it synchronously would block long enough to trip worker heartbeats in some
+// test runners; an async pass keeps the process responsive.
+const scanFiles = async (files, regex, group, target) => {
+  for (const file of files) {
+    let content
+    try {
+      content = await fs.promises.readFile(file, 'utf8')
+    } catch {
+      continue
+    }
+    collectMatches(content, regex, group, target)
+  }
+}
+
+const buildKnownProperties = (srcRoot) => {
+  if (knownPropertiesCache.has(srcRoot)) {
+    return knownPropertiesCache.get(srcRoot)
+  }
+
+  const scan = (async () => {
+    const properties = new Set()
+
+    // Definitions declared anywhere in SCSS/CSS (cross-file, including theme
+    // and shared property files).
+    const styleFiles = []
+    walkFiles(srcRoot, ['.scss', '.css'], (file) => styleFiles.push(file))
+    await scanFiles(styleFiles, SCSS_DEFINITION, 1, properties)
+
+    // Properties referenced from JavaScript/TypeScript. These are treated as
+    // "known" because they may be assigned dynamically at runtime (setProperty,
+    // inline style strings, etc.), which a static SCSS scan cannot see.
+    // Properties whose *names* are themselves built dynamically (e.g. via
+    // template literals like `--${name}--${size}`) cannot be discovered this
+    // way and should be declared through the "ignoreProperties" option instead.
+    const scriptFiles = []
+    walkFiles(
+      srcRoot,
+      ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'],
+      (file) => scriptFiles.push(file)
+    )
+    await scanFiles(scriptFiles, ANY_CUSTOM_PROPERTY, 0, properties)
+
+    return properties
+  })()
+
+  // Cache the in-flight promise so concurrent lints share a single scan.
+  knownPropertiesCache.set(srcRoot, scan)
+  return scan
+}
+
+const collectLocalDefinitions = (root) => {
+  const local = new Set()
+
+  root.walkDecls((decl) => {
+    if (decl.prop && decl.prop.startsWith('--')) {
+      local.add(decl.prop)
+    }
+  })
+
+  return local
+}
+
+const ruleFunction = (primary, secondaryOptions) => {
+  return async (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(
+      result,
+      RULE_NAME,
+      {
+        actual: primary,
+        possible: [true, false],
+      },
+      {
+        actual: secondaryOptions,
+        possible: {
+          ignoreProperties: [(value) => typeof value === 'string'],
+          reportFallbacks: [true, false],
+        },
+        optional: true,
+      }
+    )
+
+    if (!validOptions || !primary) {
+      return
+    }
+
+    // ignoreProperties entries may be exact names ("--foo") or regular
+    // expressions written in "/pattern/" form (e.g. "/^--breakout--/") to
+    // ignore whole families of dynamically generated properties.
+    const ignoreExact = new Set()
+    const ignorePatterns = []
+    for (const entry of (secondaryOptions &&
+      secondaryOptions.ignoreProperties) ||
+      []) {
+      const regexMatch = /^\/(.*)\/([a-z]*)$/.exec(entry)
+      if (regexMatch) {
+        try {
+          ignorePatterns.push(new RegExp(regexMatch[1], regexMatch[2]))
+        } catch (error) {
+          result.warn(
+            `Invalid "ignoreProperties" regex "${entry}" for ${RULE_NAME}: ${error.message}`,
+            { stylelintType: 'invalidOption' }
+          )
+        }
+      } else {
+        ignoreExact.add(entry)
+      }
+    }
+
+    // When enabled, also flag "phantom" references – var() with a fallback
+    // whose primary property is never defined, so the fallback always wins.
+    const reportFallbacks = Boolean(
+      secondaryOptions && secondaryOptions.reportFallbacks
+    )
+
+    const knownProperties = await buildKnownProperties(SRC_ROOT)
+    const localDefinitions = collectLocalDefinitions(root)
+
+    const isKnown = (property) =>
+      knownProperties.has(property) ||
+      localDefinitions.has(property) ||
+      ignoreExact.has(property) ||
+      ignorePatterns.some((pattern) => pattern.test(property))
+
+    root.walkDecls((decl) => {
+      if (!decl.value || !decl.value.includes('var(')) {
+        return
+      }
+
+      let match
+      while ((match = VAR_WITHOUT_FALLBACK.exec(decl.value)) !== null) {
+        const property = match[1]
+
+        if (isKnown(property)) {
+          continue
+        }
+
+        stylelint.utils.report({
+          message: messages.undefined(property),
+          node: decl,
+          word: property,
+          result,
+          ruleName: RULE_NAME,
+        })
+      }
+
+      if (!reportFallbacks) {
+        return
+      }
+
+      let fallbackMatch
+      while (
+        (fallbackMatch = VAR_WITH_FALLBACK.exec(decl.value)) !== null
+      ) {
+        const property = fallbackMatch[1]
+
+        if (isKnown(property)) {
+          continue
+        }
+
+        stylelint.utils.report({
+          message: messages.undefinedWithFallback(property),
+          node: decl,
+          word: property,
+          result,
+          ruleName: RULE_NAME,
+        })
+      }
+    })
+  }
+}
+
+ruleFunction.ruleName = RULE_NAME
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+module.exports = stylelint.createPlugin(RULE_NAME, ruleFunction)
+module.exports.ruleName = RULE_NAME
+module.exports.messages = messages

--- a/packages/dnb-eufemia/src/style/__tests__/__snapshots__/Elements.test.ts.snap
+++ b/packages/dnb-eufemia/src/style/__tests__/__snapshots__/Elements.test.ts.snap
@@ -266,7 +266,9 @@ del .dnb-code {
   border-radius: 0;
 }
 .dnb-hr {
-  --thickness: calc(var(--hr-thickness, 0.0625rem) + var(--modifier, 0px));
+  --thickness: calc(
+    var(--hr-thickness, 0.0625rem) + var(--hr-thickness-modifier, 0px)
+  );
 }
 .dnb-spacing .dnb-hr:not([class*=dnb-space__top]) {
   margin-top: 0;


### PR DESCRIPTION
Add a custom Stylelint rule that flags var() references to custom properties that are never defined anywhere in the codebase (neither in SCSS/CSS nor set at runtime via JavaScript/TypeScript).

It detects two failure modes:

- var(--foo) without a fallback, which resolves to a guaranteed-invalid value and silently breaks the declaration.

- var(--foo, <fallback>) whose primary is never defined (a 'phantom' reference that always resolves to the fallback), behind an opt-in 'reportFallbacks' option.