### PR TITLE
fix(Menu): add fallback for --icon-transition-expanded reference

### DIFF
--- a/packages/dnb-eufemia/src/components/menu/style/dnb-menu.scss
+++ b/packages/dnb-eufemia/src/components/menu/style/dnb-menu.scss
@@ -191,7 +191,10 @@
     }
 
     &--open > &__trigger &__indicator .dnb-icon {
-      --icon-transition: var(--icon-transition-expanded);
+      --icon-transition: var(
+        --icon-transition-expanded,
+        var(--icon-transition-default)
+      );
     }
 
     .dnb-menu__list {


### PR DESCRIPTION
## What

Adds a fallback to the accordion indicator's `--icon-transition` reference in `dnb-menu.scss`:

```scss
--icon-transition: var(
  --icon-transition-expanded,
  var(--icon-transition-default)
);
```

## Why

The accordion indicator referenced `var(--icon-transition-expanded)` **without a fallback**. That property is generated at runtime by `Icon.transition()` (attached as an inline style via the `--icon-transition-${name}` template), so it is normally present. But a bare `var()` pointing at a property that has no static definition resolves to a _guaranteed-invalid value_ whenever it is absent, which would silently break the icon path morph.

This mirrors the fallback the consumer already uses in [`dnb-icon.scss`](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/components/icon/style/dnb-icon.scss) (`d: var(--icon-transition, var(--icon-transition-default))`), so the reference now degrades gracefully and no longer relies on an undefined custom property.

## Impact

- **No visual change** — the fallback is inert while the expanded path is set (which it always is for the accordion icon: `Icon.transition({ collapsed: chevron_down, expanded: chevron_up })`).
- **No snapshot/screenshot updates needed** — Menu has no CSS dependency snapshot test, and its CSS is not embedded in other component snapshots.

This is part of the cleanup surfaced by the proposed `eufemia/no-undefined-custom-property` stylelint rule (#8679).
