### PR TITLE
chore(Portal): fix broken spacing image on the Spacing page

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/spacing.mdx
@@ -9,6 +9,8 @@ breadcrumb:
 ---
 
 import SpacingTable from 'Docs/uilib/layout/spacing-table.mdx'
+import InlineImg from 'dnb-design-system-portal/src/shared/tags/Img'
+import UxLayoutSpacing from 'Docs/uilib/usage/assets/ux-layout-spacing.png'
 
 # Spacing
 
@@ -16,7 +18,12 @@ import SpacingTable from 'Docs/uilib/layout/spacing-table.mdx'
 
 Eufemia has a [Spatial System](/quickguide-designer/spatial-system) with a grid of **8px** (0.5rem). This is simply a guide grid which helps with making design decisions about the sizes of components, elements, margins, paddings etc.
 
-![UX layout spacing](../usage/assets/ux-layout-spacing.png)
+<InlineImg
+  src={UxLayoutSpacing}
+  caption="UX layout spacing"
+  width="auto"
+  className="blank x-10"
+/>
 
 Also have a look at the designers example guide on [using Eufemia's spatial system for layout](/quickguide-designer/inspiration#using-eufemias-spatial-system-for-layout).
 


### PR DESCRIPTION
Import the UX layout spacing image and render it via the Img component instead of markdown relative image syntax, which the portal build does not bundle (resulting in a broken asset URL).


Deploy preview: https://fix-docs-relative-image-rend.eufemia-e25.pages.dev/uilib/layout/spacing
