### PR TITLE
chore: replace explicit `any` with concrete types

### DIFF
--- a/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
+++ b/packages/dnb-eufemia/src/components/date-format/DateFormatUtils.ts
@@ -26,6 +26,16 @@ type DurationFormatConstructor = {
   new (locale?: string, options?: DurationFormatOptions): DurationFormat
 }
 
+// Augment the global Intl namespace with the newer DurationFormat API,
+// which is not yet part of the bundled TypeScript lib definitions.
+// Runtime availability is guarded with a try/catch where it is used.
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Intl {
+    const DurationFormat: DurationFormatConstructor
+  }
+}
+
 export type DateFormatOptions = {
   locale?: AnyLocale
   options?: Intl.DateTimeFormatOptions
@@ -533,8 +543,7 @@ function createDurationFormatter(
   dateStyle?: Intl.DateTimeFormatOptions['dateStyle']
 ): DurationFormat | null {
   try {
-    const DurationFormat = (Intl as any)
-      .DurationFormat as DurationFormatConstructor
+    const DurationFormat = Intl.DurationFormat
     return new DurationFormat(locale, {
       style:
         dateStyle === 'short'

--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
@@ -9,6 +9,7 @@ import {
   getDecimalSeparator,
   getThousandsSeparator,
 } from '../number-format/NumberUtils'
+import type { NumberFormatValue } from '../number-format/NumberUtils'
 import { warn } from '../../shared/component-helper'
 import { IS_IOS } from '../../shared/helpers'
 import { safeSetSelection } from './text-mask/safeSetSelection'
@@ -330,7 +331,7 @@ export const handlePercentMask = ({
   locale: string
   maskParams: InputMaskParams
 }) => {
-  const value = formatPercent(props.value as any, { locale })
+  const value = formatPercent(props.value as NumberFormatValue, { locale })
   const m = String(value).match(/((\s|)%)$/g)
   maskParams.suffix = m?.[0] || ' %'
 

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/summaryOnlyReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/summaryOnlyReporter.ts
@@ -1,4 +1,4 @@
-import type { TestModule } from 'vitest/node'
+import type { RunnerTestFile, TestModule } from 'vitest/node'
 import { DefaultReporter } from 'vitest/node'
 
 export default class SummaryOnlyReporter extends DefaultReporter {
@@ -10,7 +10,7 @@ export default class SummaryOnlyReporter extends DefaultReporter {
     // Intentionally empty – the LiveReporter already handles per-test output.
   }
 
-  override reportSummary(files: any[], errors: any[]) {
+  override reportSummary(files: RunnerTestFile[], errors: any[]) {
     // Skip printErrorsSummary – the LiveReporter already shows failures.
     // Only print the final "Test Files / Tests / Duration" block.
     this.reportTestSummary(files, errors, 0)

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -16,6 +16,14 @@ import { type DocsSource, normalizeDocsPath } from './docs-source'
 
 type ToolResult = CallToolResult
 
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
 type ResolvedComponent = {
   name: string
   doc: string
@@ -207,7 +215,7 @@ function conventionalDocPath(name: string): string[] {
 }
 
 function extractJsonBlocks(markdown: string) {
-  const blocks: Array<any> = []
+  const blocks: Array<JsonValue> = []
   const regex = /```json\s*([\s\S]*?)```/gi
   let match: RegExpExecArray | null
   while ((match = regex.exec(markdown))) {
@@ -216,7 +224,7 @@ function extractJsonBlocks(markdown: string) {
       continue
     }
     try {
-      blocks.push(JSON.parse(raw))
+      blocks.push(JSON.parse(raw) as JsonValue)
     } catch {
       // ignore invalid JSON blocks
     }


### PR DESCRIPTION
- date-format: augment global `Intl` namespace with `DurationFormat` and drop the `(Intl as any)` cast.
- input-masked: type `props.value` as `NumberFormatValue` when formatting percent values.
- vitest-screenshots: type `reportSummary` `files` param as `RunnerTestFile[]`.
- mcp-docs-server: introduce a `JsonValue` type for parsed JSON blocks instead of `Array<any>`.

