### PR TITLE
chore(Button): use --default for never-defined custom properties in active/focus states

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -548,8 +548,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -563,7 +563,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -540,8 +540,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -555,7 +555,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/button/style/dnb-button.scss
+++ b/packages/dnb-eufemia/src/components/button/style/dnb-button.scss
@@ -117,8 +117,8 @@
       --button-color-border: var(--button-color-border--active);
       --button-color-icon: var(--button-color-icon--active);
       --button-color-text: var(--button-color-text--active);
-      --button-color-underline: var(--button-color-underline--active);
-      --button-border-inset: var(--button-border-inset--active);
+      --button-color-underline: var(--button-color-underline--default);
+      --button-border-inset: var(--button-border-inset--default);
       --button-border-width: var(--button-border-width--active);
       --button-input-separator-color: var(
         --button-input-separator-color--active
@@ -130,7 +130,7 @@
       --button-color-border: var(--button-color-border--focus);
       --button-color-icon: var(--button-color-icon--focus);
       --button-color-text: var(--button-color-text--focus);
-      --button-color-underline: var(--button-color-underline--focus);
+      --button-color-underline: var(--button-color-underline--default);
       --button-border-inset: var(--button-border-inset--focus);
       --button-border-width: var(--button-border-width--focus);
       --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -548,8 +548,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -563,7 +563,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -552,8 +552,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -567,7 +567,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -553,8 +553,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -568,7 +568,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -548,8 +548,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -563,7 +563,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/__snapshots__/GlobalError.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/global-status/__tests__/__snapshots__/GlobalStatus.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/__snapshots__/HelpButton.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -548,8 +548,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -563,7 +563,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -548,8 +548,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -563,7 +563,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/__snapshots__/SkipContent.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/__snapshots__/StepIndicator.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tag/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -544,8 +544,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -559,7 +559,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -605,8 +605,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -620,7 +620,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(

--- a/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/__snapshots__/Upload.test.tsx.snap
@@ -548,8 +548,8 @@ html:not([data-whatintent=touch]) .dnb-button--primary:hover:not([disabled]), ht
   --button-color-border: var(--button-color-border--active);
   --button-color-icon: var(--button-color-icon--active);
   --button-color-text: var(--button-color-text--active);
-  --button-color-underline: var(--button-color-underline--active);
-  --button-border-inset: var(--button-border-inset--active);
+  --button-color-underline: var(--button-color-underline--default);
+  --button-border-inset: var(--button-border-inset--default);
   --button-border-width: var(--button-border-width--active);
   --button-input-separator-color: var(
     --button-input-separator-color--active
@@ -563,7 +563,7 @@ html:not([data-whatinput=touch]) .dnb-button--primary:focus-visible:not([disable
   --button-color-border: var(--button-color-border--focus);
   --button-color-icon: var(--button-color-icon--focus);
   --button-color-text: var(--button-color-text--focus);
-  --button-color-underline: var(--button-color-underline--focus);
+  --button-color-underline: var(--button-color-underline--default);
   --button-border-inset: var(--button-border-inset--focus);
   --button-border-width: var(--button-border-width--focus);
   --button-input-separator-color: var(


### PR DESCRIPTION
The active and focus state blocks referenced --button-color-underline--active, --button-border-inset--active and --button-color-underline--focus, which are never defined in any theme. A var() pointing at an undefined custom property without a fallback resolves to a guaranteed-invalid value, silently breaking the declaration.

Add the --default fallback (matching the existing consumption pattern) to preserve current behavior. Snapshots updated accordingly.

