### PR TITLE
chore(Table, Input): replace phantom custom properties with their real variables

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -1302,7 +1302,7 @@ legend.dnb-form-label {
 }
 .dnb-input__shell, .dnb-input__input {
   height: var(--input-height);
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
 }
 .dnb-input__placeholder, .dnb-input__input {
   width: 100%;
@@ -1331,7 +1331,7 @@ legend.dnb-form-label {
 }
 .dnb-input__border {
   display: flex;
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
   --border-color: var(--b-color, var(--input-border-color));
   --border-width: var(--b-width, var(--input-border-width, var(--input-border-width--default)));
   box-shadow: var(--b-inset, var(--input-border-inset, inset)) 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1302,7 +1302,7 @@ legend.dnb-form-label {
 }
 .dnb-input__shell, .dnb-input__input {
   height: var(--input-height);
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
 }
 .dnb-input__placeholder, .dnb-input__input {
   width: 100%;
@@ -1331,7 +1331,7 @@ legend.dnb-form-label {
 }
 .dnb-input__border {
   display: flex;
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
   --border-color: var(--b-color, var(--input-border-color));
   --border-width: var(--b-width, var(--input-border-width, var(--input-border-width--default)));
   box-shadow: var(--b-inset, var(--input-border-inset, inset)) 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/__snapshots__/InputMasked.test.tsx.snap
@@ -1302,7 +1302,7 @@ legend.dnb-form-label {
 }
 .dnb-input__shell, .dnb-input__input {
   height: var(--input-height);
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
 }
 .dnb-input__placeholder, .dnb-input__input {
   width: 100%;
@@ -1331,7 +1331,7 @@ legend.dnb-form-label {
 }
 .dnb-input__border {
   display: flex;
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
   --border-color: var(--b-color, var(--input-border-color));
   --border-width: var(--b-width, var(--input-border-width, var(--input-border-width--default)));
   box-shadow: var(--b-inset, var(--input-border-inset, inset)) 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -1298,7 +1298,7 @@ legend.dnb-form-label {
 }
 .dnb-input__shell, .dnb-input__input {
   height: var(--input-height);
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
 }
 .dnb-input__placeholder, .dnb-input__input {
   width: 100%;
@@ -1327,7 +1327,7 @@ legend.dnb-form-label {
 }
 .dnb-input__border {
   display: flex;
-  border-radius: var(--b-radius, var(--input-border-radius--default));
+  border-radius: var(--input-border-radius);
   --border-color: var(--b-color, var(--input-border-color));
   --border-width: var(--b-width, var(--input-border-width, var(--input-border-width--default)));
   box-shadow: var(--b-inset, var(--input-border-inset, inset)) 0 0 0 var(--border-width) var(--border-color);

--- a/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
+++ b/packages/dnb-eufemia/src/components/input/style/dnb-input.scss
@@ -146,7 +146,7 @@
   &__shell,
   &__input {
     height: var(--input-height);
-    border-radius: var(--b-radius, var(--input-border-radius--default));
+    border-radius: var(--input-border-radius);
   }
 
   &__placeholder,
@@ -195,7 +195,7 @@
   &__border {
     display: flex;
 
-    border-radius: var(--b-radius, var(--input-border-radius--default));
+    border-radius: var(--input-border-radius);
 
     @include utilities.fakeBorder(
       var(--b-color, var(--input-border-color)),

--- a/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -286,7 +286,7 @@ html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active
   /* stylelint-disable-next-line no-descending-specificity */
 }
 .dnb-table, .dnb-table__th--emphasis {
-  --table-th-text-color: var(--theme-color-black-80, currentColor);
+  --table-th-text-color: currentcolor;
   --table-th-font-weight: var(--font-weight-medium);
   --table-th-font-size: var(--font-size-basis);
 }
@@ -329,7 +329,7 @@ html:not([data-whatintent=touch]) .dnb-table > thead > tr > th.dnb-table--active
 }
 .dnb-table__td, .dnb-table tbody .dnb-table__th, .dnb-table tbody td, .dnb-table tbody th {
   padding: 1rem;
-  color: var(--theme-color-black-80, currentColor);
+  color: currentcolor;
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
   vertical-align: baseline;

--- a/packages/dnb-eufemia/src/components/table/style/dnb-table.scss
+++ b/packages/dnb-eufemia/src/components/table/style/dnb-table.scss
@@ -159,7 +159,7 @@
   /* stylelint-disable-next-line no-descending-specificity */
   &,
   &__th--emphasis {
-    --table-th-text-color: var(--theme-color-black-80, currentColor);
+    --table-th-text-color: currentcolor;
     --table-th-font-weight: var(--font-weight-medium);
     --table-th-font-size: var(--font-size-basis);
   }
@@ -222,7 +222,7 @@
     padding: 1rem;
 
     // typography
-    color: var(--theme-color-black-80, currentColor);
+    color: currentcolor;
     font-size: var(--font-size-basis);
     line-height: var(--line-height-basis);
     vertical-align: baseline;


### PR DESCRIPTION
Two references pointed at custom properties that are never defined anywhere, so they silently resolved to their fallback:

- Table: --theme-color-black-80 is dead legacy naming (its only historical definition was anchor-scoped; removed globally long ago), so the header/body text fell back to currentColor. Use currentcolor directly to remove the phantom variable while preserving the exact inherited behavior (no visual change).

- Input: --b-radius belongs to the internal --b-* border alias family but, unlike --b-color/--b-width/--b-inset, is never reassigned, and its fallback bypassed the base --input-border-radius hook. Use --input-border-radius directly (already defaults to --input-border-radius--default), preserving behavior and honoring the override hook.