### PR TITLE
chore(types): replace any with concrete types in element helpers

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'react'
 import { clsx } from 'clsx'
 import Button from '../../button/Button'
+import type { ButtonProps } from '../../button/Button'
 import Space from '../../space/Space'
 import { Context } from '../../../shared'
 import ModalContext from '../../modal/ModalContext'
@@ -106,11 +107,11 @@ const DialogAction = ({
 
   if (children) {
     childrenWithCloseFunc = Children.map(children, (child) => {
-      if (isValidElement<any>(child) && child.type === Button) {
-        const childElement = child as ReactElement<any>
+      if (isValidElement<ButtonProps>(child) && child.type === Button) {
+        const childElement = child as ReactElement<ButtonProps>
 
         return createElement(
-          childElement.type as ComponentType<any>,
+          childElement.type as ComponentType<ButtonProps>,
           {
             ...(childElement.props || {}),
             onClick: (event) => {

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -28,6 +28,7 @@ import type { SpaceType } from '../../shared/types'
 import type { UseMediaQueries } from '../../shared/useMedia'
 import type { FlexEnd, FlexStart } from './types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
+import type { ComponentMarkers } from '../../shared/helpers/withComponentMarkers'
 
 type Gap =
   | false
@@ -278,14 +279,15 @@ function FlexContainer(props: FlexContainerAllProps) {
 function wrapChildren(props: FlexContainerAllProps, children: ReactNode) {
   return Children.toArray(children).map((child) => {
     if (
-      isValidElement<any>(child) &&
-      child.type['_supportsSpacingProps'] === 'children'
+      isValidElement<{ children?: ReactNode }>(child) &&
+      (child.type as ComponentMarkers)?._supportsSpacingProps ===
+        'children'
     ) {
-      const childElement = child as ReactElement<any>
+      const childElement = child as ReactElement<{ children?: ReactNode }>
       const childKey = childElement.key
       const childProps = childElement.props || {}
       return createElement(
-        childElement.type as ComponentType<any>,
+        childElement.type as ComponentType<{ children?: ReactNode }>,
         { ...childProps, key: childKey },
         <FlexContainer {...props}>
           {childElement.props.children}

--- a/packages/dnb-eufemia/src/components/flex/utils.tsx
+++ b/packages/dnb-eufemia/src/components/flex/utils.tsx
@@ -18,6 +18,12 @@ import type { ComponentMarkers } from '../../shared/helpers/withComponentMarkers
 
 export const omitSpacingProps = removeSpaceProps
 
+type SpacingElementProps = Partial<
+  Record<FlexStart | FlexEnd, SpaceType>
+> & {
+  space?: Partial<Record<FlexStart | FlexEnd, SpaceType>>
+}
+
 /**
  * Picks the spacing props from the given props object.
  * @template Props - The type of the props object.
@@ -46,11 +52,11 @@ export function getSpaceValue(
   type: FlexStart | FlexEnd,
   element: ReactNode
 ): SpaceType | undefined {
-  if (!isValidElement<Record<string, any>>(element)) {
+  if (!isValidElement<SpacingElementProps>(element)) {
     return undefined
   }
 
-  const elementProps = (element as ReactElement<any>).props || {}
+  const elementProps = element.props || {}
 
   return (
     elementProps?.[type] ??
@@ -78,7 +84,7 @@ export function isHeadingElement(element: ReactNode): boolean {
  * @returns The spacing variant (true, false or "children") of the element, or undefined if it does not support spacing props.
  */
 export function getSpaceVariant(element: ReactNode) {
-  if (isValidElement<Record<string, any>>(element)) {
+  if (isValidElement<SpacingElementProps>(element)) {
     if (element?.type === Fragment) {
       return 'children'
     }
@@ -90,7 +96,7 @@ export function getSpaceVariant(element: ReactNode) {
     }
 
     const keys = ['space', 'top', 'right', 'bottom', 'left']
-    const props = (element as ReactElement<any>)?.props ?? {}
+    const props = element?.props ?? {}
     if (keys.some((key) => key in (props as object))) {
       return true
     }
@@ -125,7 +131,7 @@ export function renderWithSpacing(
   }
 
   if (variant === 'passthrough') {
-    const childElement = element as ReactElement<any>
+    const childElement = element as ReactElement<{ children?: ReactNode }>
     const children = childElement?.props?.children
     const childKey = childElement?.key
     const childProps = childElement?.props || {}
@@ -225,11 +231,13 @@ function cloneIntrinsicElementWithSpacing(
     wrapInSpace?: boolean
   }
 ) {
-  if (!isValidElement<Record<string, any>>(element)) {
+  if (
+    !isValidElement<{ className?: string; style?: CSSProperties }>(element)
+  ) {
     return element
   }
 
-  const elementProps = (element as ReactElement<any>).props || {}
+  const elementProps = element.props || {}
 
   const spacing = createSpacing(spaceProps)
 

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -1,5 +1,5 @@
 import { Children, Fragment, isValidElement } from 'react'
-import type { HTMLProps, ReactElement, ReactNode } from 'react'
+import type { HTMLProps, ReactNode } from 'react'
 import { clsx } from 'clsx'
 import Space from '../space/Space'
 import type { SpacingProps } from '../../shared/types'
@@ -74,7 +74,7 @@ function hasOnlySupportedChildren(children: ReactNode): boolean {
 }
 
 function isSupportedChild(child: ReactNode): boolean {
-  if (!isValidElement<Record<string, any>>(child)) {
+  if (!isValidElement<{ children?: ReactNode }>(child)) {
     // allow null/boolean and whitespace-only text nodes
     if (typeof child === 'string') {
       return child.trim().length === 0
@@ -83,9 +83,7 @@ function isSupportedChild(child: ReactNode): boolean {
   }
 
   if (child.type === Fragment) {
-    return hasOnlySupportedChildren(
-      (child as ReactElement<any>).props.children
-    )
+    return hasOnlySupportedChildren(child.props.children)
   }
 
   const role = (child.type as { _statRole?: string })?._statRole
@@ -97,12 +95,12 @@ function hasRequiredLabel(children: ReactNode): boolean {
 }
 
 function hasLabelChild(child: ReactNode): boolean {
-  if (!isValidElement<Record<string, any>>(child)) {
+  if (!isValidElement<{ children?: ReactNode }>(child)) {
     return false
   }
 
   if (child.type === Fragment) {
-    return hasRequiredLabel((child as ReactElement<any>).props.children)
+    return hasRequiredLabel(child.props.children)
   }
 
   const role = (child.type as { _statRole?: string })?._statRole
@@ -113,14 +111,12 @@ function flattenRoles(children: ReactNode): Array<'label' | 'content'> {
   const roles: Array<'label' | 'content'> = []
 
   for (const child of Children.toArray(children)) {
-    if (!isValidElement<Record<string, any>>(child)) {
+    if (!isValidElement<{ children?: ReactNode }>(child)) {
       continue
     }
 
     if (child.type === Fragment) {
-      roles.push(
-        ...flattenRoles((child as ReactElement<any>).props.children)
-      )
+      roles.push(...flattenRoles(child.props.children))
       continue
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -714,19 +714,22 @@ function useEnableFieldset({
     if (label && !result && !nestedFieldBlockContext) {
       let count = 0
 
-      findElementInChildren(children, (child: ReactElement<any>) => {
-        if (
-          child?.props?.label ||
-          (child?.type as ComponentMarkers)?._formElement === true
-        ) {
-          count++
-        }
-        if (count > 1) {
-          return (result = true)
-        }
+      findElementInChildren(
+        children,
+        (child: ReactElement<{ label?: ReactNode }>) => {
+          if (
+            child?.props?.label ||
+            (child?.type as ComponentMarkers)?._formElement === true
+          ) {
+            count++
+          }
+          if (count > 1) {
+            return (result = true)
+          }
 
-        return undefined
-      })
+          return undefined
+        }
+      )
     }
 
     return Boolean(result)

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/IterateOverSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/IterateOverSteps.tsx
@@ -56,7 +56,7 @@ export function IterateOverSteps({
   totalStepsRef.current = 0
 
   const childrenArray = Children.map(children, (child) => {
-    if (isValidElement<any>(child)) {
+    if (isValidElement<StepProps>(child)) {
       const stepElement = getWizardStepElement(child)
 
       if (stepElement) {


### PR DESCRIPTION
Replace explicit any usages with concrete element/prop types across several components and form helpers, without introducing unknown:

- stat/Root: type isValidElement children checks with { children?: ReactNode }
- dialog/DialogAction: type button children as ReactElement<ButtonProps>
- flex/Container: type spacing-aware children via ComponentMarkers
- flex/utils: add SpacingElementProps and concrete element prop types
- forms/FieldBlock: type findElementInChildren callback element props
- forms/Wizard/IterateOverSteps: use StepProps in isValidElement

