### PR TITLE
chore: replace ComponentType<any> casts with concrete element proptypes

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -1380,7 +1380,7 @@ function AutocompleteInstance(ownProps: AutocompleteAllProps) {
               }
 
               return createElement(
-                node.type as ComponentType<any>,
+                node.type as ComponentType<{ children?: ReactNode }>,
                 {
                   ...node.props,
                   key: node.key ?? 'clone' + cacheHash + keyPart,

--- a/packages/dnb-eufemia/src/components/popover/internal/PopoverCloseButton.tsx
+++ b/packages/dnb-eufemia/src/components/popover/internal/PopoverCloseButton.tsx
@@ -49,7 +49,7 @@ export default function PopoverCloseButton({
   const hasContent = Boolean(content)
   const isIconOnly = Boolean(hasIcon && !hasContent)
   const iconElement = isValidElement<{ className?: string }>(icon)
-    ? createElement(icon.type as ComponentType<any>, {
+    ? createElement(icon.type as ComponentType<{ className?: string }>, {
         ...icon.props,
         className: clsx(icon.props.className, 'dnb-button__icon'),
       })

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -518,7 +518,7 @@ export function mapOptions(
             createOption,
           })
           return createElement(
-            child.type as ComponentType<any>,
+            child.type as ComponentType<OptionProps>,
             child.props,
             nestedChildren
           )

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/ItemNo.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/ItemNo.tsx
@@ -38,7 +38,11 @@ export function replaceItemNo(node: ReactNode, index: number): ReactNode {
     // Only clone if children changed (optional optimization)
     return nextChildren === childProps
       ? node
-      : createElement(node.type as ComponentType<any>, rest, nextChildren)
+      : createElement(
+          node.type as ComponentType<{ children?: ReactNode }>,
+          rest,
+          nextChildren
+        )
   }
 
   // Fallback: try to convert to string if possible


### PR DESCRIPTION
Replace 'any' with the actual element prop type derived from the surrounding isValidElement/ReactElement generic in createElement calls:

- Autocomplete: ComponentType<{ children?: ReactNode }>
- Popover (PopoverCloseButton): ComponentType<{ className?: string }>
- Field.Selection (mapOptions): ComponentType<OptionProps>
- Iterate.ItemNo (replaceItemNo): ComponentType<{ children?: ReactNode }>

No runtime change; type-check (tsc --noEmit) and lint pass.

