### PR TITLE
chore(types): replace remaining safe any usages with concrete types

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
@@ -13,7 +13,7 @@ async function mockFetch(countryCode: string, data) {
       json: () => {
         return Promise.resolve(data)
       },
-    }) as any
+    }) as Promise<Response>
   }
 
   await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
@@ -14,7 +14,12 @@ import path from 'node:path'
 import { defineBrowserCommand } from '@vitest/browser-playwright'
 import blazediff from '@blazediff/core'
 import { PNG } from 'pngjs'
-import type { Browser, BrowserContext, Page } from 'playwright'
+import type {
+  Browser,
+  BrowserContext,
+  BrowserType,
+  Page,
+} from 'playwright'
 
 import {
   getPageResetStrategyFromMutation,
@@ -144,8 +149,7 @@ type BrowserSlot = {
 
 const browserSlots: BrowserSlot[] = []
 const sessionToSlot = new Map<string, BrowserSlot>()
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let playwrightModule: any = null
+let playwrightModule: { firefox: BrowserType } | null = null
 let poolCleanedUp = false
 
 const getPlaywright = async () => {

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -1140,7 +1140,7 @@ async function evaluateTsModule(file: string, seen = new Set<string>()) {
     await import('@babel/plugin-transform-modules-commonjs')
   const vm = await import('node:vm')
   const moduleApi = await import('node:module')
-  const localRequire = (moduleApi as any).createRequire(file)
+  const localRequire = moduleApi.Module.createRequire(file)
 
   let code = await fs.readFile(file, 'utf-8')
   const bindings = await buildModuleInjectionBindings(


### PR DESCRIPTION
- screenshotEngine: type lazy-loaded playwright module via { firefox: BrowserType }
- llm-metadata: use moduleApi.Module.createRequire instead of (moduleApi as any)
- portal Bring example: cast mock fetch to Promise<Response> instead of any

