### PR TITLE
fix(Field.Number): show clear error for non-finite numbers

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -335,8 +335,11 @@ function NumberComponent(props: FieldNumberProps) {
     if (external === undefined || external === null) {
       return null
     }
-    // Handle invalid types (e.g., strings) by converting to empty string for display
-    if (typeof external !== 'number' || isNaN(external)) {
+    // Handle invalid types (e.g., strings) and non-finite numbers
+    // (NaN, Infinity, -Infinity) by converting to empty string for display.
+    // Such values still fail validation, but should not render as partial
+    // output (e.g. "-" for -Infinity).
+    if (typeof external !== 'number' || !Number.isFinite(external)) {
       return ''
     }
     return external

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -1910,6 +1910,72 @@ describe('Field.Number', () => {
       })
     })
 
+    describe('non-finite values (NaN, Infinity, -Infinity)', () => {
+      it.each([Infinity, -Infinity, NaN])(
+        'should show a clear, translated error message for %p',
+        async (value) => {
+          render(<Field.Number value={value} validateInitially />)
+
+          await waitFor(() => {
+            const status = document.querySelector('.dnb-form-status')
+            expect(status).toBeInTheDocument()
+            expect(status).toHaveTextContent(
+              nb.NumberField.errorInvalidNumber
+            )
+          })
+        }
+      )
+
+      it('should show the message in the active locale', async () => {
+        render(
+          <SharedProvider locale="en-GB">
+            <Field.Number value={Infinity} validateInitially />
+          </SharedProvider>
+        )
+
+        await waitFor(() => {
+          expect(
+            document.querySelector('.dnb-form-status')
+          ).toHaveTextContent(en.NumberField.errorInvalidNumber)
+        })
+      })
+
+      it('should display non-finite values as an empty input', () => {
+        const { rerender } = render(<Field.Number value={NaN} />)
+        expect(document.querySelector('input')).toHaveValue('')
+
+        rerender(<Field.Number value={Infinity} />)
+        expect(document.querySelector('input')).toHaveValue('')
+
+        rerender(<Field.Number value={-Infinity} />)
+        expect(document.querySelector('input')).toHaveValue('')
+      })
+
+      it('should not use the clear message for genuinely invalid types', async () => {
+        const log = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => undefined)
+
+        const schema = z.object({ myField: z.number() }) as never
+
+        render(
+          <Form.Handler schema={schema} data={{ myField: 'foo' }}>
+            <Field.Number path="/myField" validateInitially />
+          </Form.Handler>
+        )
+
+        await waitFor(() => {
+          const status = document.querySelector('.dnb-form-status')
+          expect(status).toBeInTheDocument()
+          expect(status).not.toHaveTextContent(
+            nb.NumberField.errorInvalidNumber
+          )
+        })
+
+        log.mockRestore()
+      })
+    })
+
     describe('validation based on required-prop', () => {
       it('should show error for empty value', async () => {
         render(<Field.Number value={1} required />)

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
@@ -99,6 +99,7 @@ export default {
       errorExclusiveMaximum: 'Skal være mindre end {exclusiveMaximum}.',
       errorMultipleOf: 'Skal kunne deles med {multipleOf}.',
       errorInteger: 'Skal være et helt tal (uden decimaler).',
+      errorInvalidNumber: 'Skal være et gyldigt tal.',
     },
     BooleanField: {
       yes: 'Ja',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -97,6 +97,7 @@ export default {
       errorExclusiveMaximum: 'Must be less than {exclusiveMaximum}.',
       errorMultipleOf: 'Must be divisible by {multipleOf}.',
       errorInteger: 'Must be a whole number (no decimals).',
+      errorInvalidNumber: 'Must be a valid number.',
     },
     BooleanField: {
       yes: 'Yes',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -98,6 +98,7 @@ export default {
       errorExclusiveMaximum: 'Må være mindre enn {exclusiveMaximum}.',
       errorMultipleOf: 'Må kunne deles på {multipleOf}.',
       errorInteger: 'Må være et helt tall (uten desimaler).',
+      errorInvalidNumber: 'Må være et gyldig tall.',
     },
     BooleanField: {
       yes: 'Ja',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -99,6 +99,7 @@ export default {
       errorExclusiveMaximum: 'Måste vara mindre än {exclusiveMaximum}.',
       errorMultipleOf: 'Måste vara delbart med {multipleOf}.',
       errorInteger: 'Måste vara ett heltal (utan decimaler).',
+      errorInvalidNumber: 'Måste vara ett giltigt tal.',
     },
     BooleanField: {
       yes: 'Ja',

--- a/packages/dnb-eufemia/src/extensions/forms/utils/zod.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/zod.ts
@@ -41,6 +41,22 @@ function normalizeZodIssueMessage(
     return 'NumberField.errorInteger'
   }
 
+  // Non-finite numbers (NaN, Infinity, -Infinity) fail Zod's `z.number()`
+  // type check with a confusing default message ("expected number, received
+  // number"). Map these to a clear, translated message. Genuine wrong types
+  // (string, boolean, etc.) don't set `received` to a number-like value, so
+  // they keep Zod's regular type-error message.
+  if (issue?.code === 'invalid_type' && issue.expected === 'number') {
+    const received = (issue as { received?: unknown }).received
+    if (
+      received === 'NaN' ||
+      received === 'Infinity' ||
+      received === '-Infinity'
+    ) {
+      return 'NumberField.errorInvalidNumber'
+    }
+  }
+
   if (
     issue?.code === 'too_small' &&
     issue.origin === 'number' &&


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1782305540488539
Reported issue reprod: https://stackblitz.com/edit/ehsg7umv?file=src%2FApp.tsx
Reprod based on this PR: https://stackblitz.com/edit/ehsg7umv-vwejhrly?file=package.json

To reprod: change 0kr to i.e 10kr, click "Send"-button, and watch error message appear.

From:

<img width="323" height="129" alt="image" src="https://github.com/user-attachments/assets/a75d4d55-2502-4257-830d-825e858ae572" />


To:


<img width="240" height="119" alt="Screenshot 2026-06-24 at 15 33 23" src="https://github.com/user-attachments/assets/eb73c5a4-4df1-4e82-8a38-23754cabdf8c" />



Replace Zod v4's cryptic "Invalid input: expected number, received number" with a clear, localized message (NumberField.errorInvalidNumber) when a non-finite value (NaN, Infinity, -Infinity) reaches the field. Genuine type errors keep their normal message. Also render non-finite values as an empty input instead of a stray "-".

