### PR TITLE
fix(Field.Number): allow non-finite values without blocking the user

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -176,7 +176,7 @@ function NumberComponent(props: FieldNumberProps) {
           return formatNumber(value, formatOptions)
         }
 
-        return z
+        const numberSchema = z
           .number()
           .nullish()
           .superRefine((val, ctx) => {
@@ -314,6 +314,15 @@ function NumberComponent(props: FieldNumberProps) {
               })
             }
           })
+
+        // Non-finite numbers (Infinity, -Infinity, NaN) can result from
+        // impossible calculations (e.g. division by zero). Treat them as
+        // empty so they don't block the user with a validation error.
+        return z.preprocess(
+          (val) =>
+            typeof val === 'number' && !Number.isFinite(val) ? null : val,
+          numberSchema
+        )
       })
     )
 
@@ -335,8 +344,10 @@ function NumberComponent(props: FieldNumberProps) {
     if (external === undefined || external === null) {
       return null
     }
-    // Handle invalid types (e.g., strings) by converting to empty string for display
-    if (typeof external !== 'number' || isNaN(external)) {
+    // Handle invalid types (e.g., strings) and non-finite numbers
+    // (NaN, Infinity, -Infinity) by converting to empty string for display.
+    // These can result from impossible calculations (e.g. division by zero).
+    if (typeof external !== 'number' || !Number.isFinite(external)) {
       return ''
     }
     return external

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/__tests__/Number.test.tsx
@@ -1069,6 +1069,89 @@ describe('Field.Number', () => {
     })
   })
 
+  describe('non-finite values', () => {
+    it('displays nothing when value is Infinity', () => {
+      render(<Field.Number value={Infinity} />)
+      expect(document.querySelector('input')).toHaveValue('')
+    })
+
+    it('displays nothing when value is -Infinity', () => {
+      render(<Field.Number value={-Infinity} />)
+      expect(document.querySelector('input')).toHaveValue('')
+    })
+
+    it('displays nothing when value is NaN', () => {
+      render(<Field.Number value={NaN} />)
+      expect(document.querySelector('input')).toHaveValue('')
+    })
+
+    it('does not show a validation error for Infinity with validateInitially', async () => {
+      render(<Field.Number value={Infinity} validateInitially />)
+
+      await act(async () => undefined)
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show a validation error for -Infinity with validateInitially', async () => {
+      render(<Field.Number value={-Infinity} validateInitially />)
+
+      await act(async () => undefined)
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not block form submit when value is Infinity', () => {
+      const onSubmit = vi.fn()
+
+      render(
+        <Form.Handler
+          defaultData={{ percentage: Infinity }}
+          onSubmit={onSubmit}
+        >
+          <Field.Number path="/percentage" />
+        </Form.Handler>
+      )
+
+      fireEvent.submit(document.querySelector('form'))
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenCalledWith(
+        { percentage: Infinity },
+        expect.anything()
+      )
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+    })
+
+    it('still validates finite out-of-range values through the preprocess wrapper', async () => {
+      render(
+        <Field.Number value={1500} maximum={1000} validateInitially />
+      )
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('still validates finite below-minimum values through the preprocess wrapper', async () => {
+      render(<Field.Number value={500} minimum={1000} validateInitially />)
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
   describe('localized number formatting in error messages', () => {
     it('formats {maximum} using nb-NO locale', async () => {
       render(<Field.Number maximum={1000} />)


### PR DESCRIPTION
## Why

Zod 4's `z.number()` rejects `Infinity`/`-Infinity`/`NaN`. A `Field.Number` whose value comes from a derived calculation (e.g. a percentage with a `0` denominator → `Infinity`) was therefore hard-blocked by a validation error.

## Change

`Field.Number`'s built-in default schema now treats non-finite values as empty: nothing is shown, no validation error, stored data untouched. Finite values validate as before.

## Scope

Only the built-in default schema. Schemas you supply (on the field or `Form.Handler`) still reject non-finite values – Eufemia does not override your validation.

Preview: https://chore-field-number-non-finit.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/Number