### PR TITLE
docs(Forms): clarify how non-finite numbers (Infinity, NaN) are validated

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
@@ -12,6 +12,7 @@ showTabs: true
 - [About schemas](#about-schemas)
 - [Using schema with DataContext](#using-schema-with-datacontext)
 - [Fields which are disabled or read-only](#fields-which-are-disabled-or-read-only)
+- [Non-finite numbers (Infinity and NaN)](#non-finite-numbers-infinity-and-nan)
 - [JSONSchema and TypeScript](#jsonschema-and-typescript)
 - [Complex schemas](#complex-schemas)
   - [Custom Ajv instance and keywords](#custom-ajv-instance-and-keywords)
@@ -135,6 +136,21 @@ Also, note you can describe the schema without using the `type` property, as the
 ## Fields which are disabled or read-only
 
 Fields which have the `disabled` property or the `readOnly` property, will skip validation.
+
+## Non-finite numbers (Infinity and NaN)
+
+Zod's `z.number()` does not accept non-finite numbers (`Infinity`, `-Infinity` and `NaN`) and rejects them with a type error. A user-supplied schema will therefore block submit if the data contains such a value – for example a calculated percentage where the previous value was `0`, where the division by zero produces `Infinity`.
+
+Eufemia does not override your schema, so the recommended approach is to store an empty value (such as `undefined`) for impossible results instead of a non-finite number:
+
+```ts
+const change =
+  previous === 0 ? undefined : ((current - previous) / previous) * 100
+```
+
+If you do need to accept non-finite numbers, widen your schema accordingly, for example with a `z.preprocess` that maps non-finite values to `undefined`.
+
+Note that [Field.Number](/uilib/extensions/forms/base-fields/Number/#non-finite-values-infinity-and-nan)'s built-in default schema already treats non-finite values as empty.
 
 ## Zod schemas and TypeScript
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
@@ -139,9 +139,9 @@ Fields which have the `disabled` property or the `readOnly` property, will skip 
 
 ## Non-finite numbers (Infinity and NaN)
 
-Zod's `z.number()` does not accept non-finite numbers (`Infinity`, `-Infinity` and `NaN`) and rejects them with a type error. A user-supplied schema will therefore block submit if the data contains such a value – for example a calculated percentage where the previous value was `0`, where the division by zero produces `Infinity`.
+Zod's `z.number()` does not accept non-finite numbers (`Infinity`, `-Infinity` and `NaN`) and rejects them with a type error. A schema you supply will therefore block submit if the data contains such a value – for example a calculated percentage where the previous value was `0`, where the division by zero produces `Infinity`. Eufemia shows a clear, localized message for this instead of a cryptic type error, but does not change the verdict: the value is still invalid.
 
-Eufemia does not override your schema, so the recommended approach is to store an empty value (such as `undefined`) for impossible results instead of a non-finite number:
+The recommended approach is to store an empty value (such as `undefined`) for impossible results instead of a non-finite number:
 
 ```ts
 const change =
@@ -150,7 +150,7 @@ const change =
 
 If you do need to accept non-finite numbers, widen your schema accordingly, for example with a `z.preprocess` that maps non-finite values to `undefined`.
 
-Note that [Field.Number](/uilib/extensions/forms/base-fields/Number/#non-finite-values-infinity-and-nan)'s built-in default schema already treats non-finite values as empty.
+See [Field.Number](/uilib/extensions/forms/base-fields/Number/#non-finite-values-infinity-and-nan) for how the field displays and validates these values.
 
 ## Zod schemas and TypeScript
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/info.mdx
@@ -37,6 +37,14 @@ However, for a customer number, you should rather use [Field.String](/uilib/exte
 
 Internally, it is used by e.g. [Field.Currency](/uilib/extensions/forms/feature-fields/Currency/).
 
+## Non-finite values (Infinity and NaN)
+
+A derived value can sometimes resolve to a non-finite number. A common example is a calculated percentage where the previous value is `0`, which results in a division by zero and produces `Infinity`.
+
+`Field.Number`'s built-in validation treats non-finite values (`Infinity`, `-Infinity` and `NaN`) as empty. Nothing is shown in the input and no validation error is raised, so the user is not blocked by an impossible calculation. The value stored in the data context is left untouched.
+
+This applies to the built-in default schema only. If you provide your own `schema` – on the field or on [Form.Handler](/uilib/extensions/forms/Form/Handler/) – non-finite numbers are validated by your schema. See [Schema validation](/uilib/extensions/forms/Form/schema-validation/#non-finite-numbers-infinity-and-nan) for details.
+
 ## Browser autofill
 
 Check out the [Field.String](/uilib/extensions/forms/base-fields/String/#browser-autofill) docs about autocomplete.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/info.mdx
@@ -41,9 +41,9 @@ Internally, it is used by e.g. [Field.Currency](/uilib/extensions/forms/feature-
 
 A derived value can sometimes resolve to a non-finite number. A common example is a calculated percentage where the previous value is `0`, which results in a division by zero and produces `Infinity`.
 
-`Field.Number`'s built-in validation treats non-finite values (`Infinity`, `-Infinity` and `NaN`) as empty. Nothing is shown in the input and no validation error is raised, so the user is not blocked by an impossible calculation. The value stored in the data context is left untouched.
+`Field.Number` renders non-finite values (`Infinity`, `-Infinity` and `NaN`) as an empty input rather than a partial value like `-`. They are still invalid: validation fails with a clear, localized message (`NumberField.errorInvalidNumber`, for example "Must be a valid number.") instead of a cryptic type error, so the user is blocked until an empty or finite value is provided. The value stored in the data context is left untouched.
 
-This applies to the built-in default schema only. If you provide your own `schema` – on the field or on [Form.Handler](/uilib/extensions/forms/Form/Handler/) – non-finite numbers are validated by your schema. See [Schema validation](/uilib/extensions/forms/Form/schema-validation/#non-finite-numbers-infinity-and-nan) for details.
+For an impossible calculation, store an empty value (such as `undefined`) instead of a non-finite number so the field is valid. The same applies when you provide your own `schema` – see [Schema validation](/uilib/extensions/forms/Form/schema-validation/#non-finite-numbers-infinity-and-nan) for details.
 
 ## Browser autofill
 


### PR DESCRIPTION
Documents how Eufemia Forms treats non-finite numbers (`Infinity`, `-Infinity`, `NaN`), so developers find it from the symptom (a number field blocking on an impossible result).

- `Field.Number`: renders non-finite as an empty input, but validation fails with a clear, localized message and blocks.
- Schema validation: a schema you supply also rejects non-finite values (Zod's `z.number()`); store an empty value (e.g. `undefined`) for impossible results.

Docs only. Complements #8699.
