### PR TITLE
chore: replace any types with concrete types in Context and components

### DIFF
--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -407,10 +407,9 @@ const DropdownInstance = memo(function DropdownInstance({
     propsWithDefaults,
     dropdownDefaultProps,
     { skeleton: context?.skeleton },
-    (context as Record<string, any>).getTranslation(propsWithDefaults)
-      .Dropdown,
+    context?.getTranslation?.(propsWithDefaults)?.Dropdown,
     pickFormElementProps(context?.formElement),
-    (context as Record<string, any>).Dropdown
+    context?.Dropdown
   )
 
   const {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionActions.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionActions.tsx
@@ -7,7 +7,10 @@ export type MultiSelectionActionsProps = {
   show: boolean
   disabled?: boolean
   tempValueLength: number
-  formatMessage: (key: string, values?: Record<string, any>) => string
+  formatMessage: (
+    key: string,
+    values?: Record<string, string | number>
+  ) => string
   translation: {
     confirmButton: string
     cancelButton: string

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -46,6 +46,7 @@ import type { FormLabelProps } from '../components/FormLabel'
 import type { InputProps } from '../components/Input'
 import type { TextareaProps } from '../components/Textarea'
 import type { InputMaskedProps } from '../components/InputMasked'
+import type { DropdownProps } from '../components/Dropdown'
 import type {
   NumberFormatCurrency,
   NumberFormatAllProps,
@@ -98,6 +99,7 @@ export type ContextComponents = {
   Input?: Partial<InputProps>
   Textarea?: Partial<TextareaProps>
   InputMasked?: Partial<InputMaskedProps>
+  Dropdown?: Partial<DropdownProps>
   ProgressIndicator?: Partial<ProgressIndicatorProps>
   FormStatus?: Partial<FormStatusProps>
   Logo?: Partial<LogoProps>


### PR DESCRIPTION
- Add Dropdown to ContextComponents so provider config is typed
- Remove (context as Record<string, any>) casts in Dropdown using typed context access (getTranslation and Dropdown context props)
- Narrow MultiSelectionActions formatMessage values to string | number

