### PR TITLE
feat(Provider): add missing component types to ContextComponents

### DIFF
--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -326,9 +326,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
     contextProps,
     { skeleton: context?.skeleton },
     pickFormElementProps(context.formElement),
-    (context as Record<string, unknown>)?.Radio as
-      | Record<string, unknown>
-      | undefined
+    context.Radio
   )
 
   const {

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -163,9 +163,7 @@ function RadioGroup(ownProps: RadioGroupProps) {
     resolvedProps,
     radioGroupDefaultProps,
     pickFormElementProps(context?.formElement),
-    (context as Record<string, unknown>)?.RadioGroup as
-      | Record<string, unknown>
-      | undefined
+    context.RadioGroup
   )
 
   const {

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -258,11 +258,8 @@ function ToggleButton(ownProps: ToggleButtonProps) {
     contextProps,
     (context.translation as Record<string, unknown>)
       ?.ToggleButton as Record<string, unknown>,
-    pickFormElementProps(context.formElement as Record<string, unknown>),
-    (context as Record<string, unknown>).ToggleButton as Record<
-      string,
-      unknown
-    >
+    pickFormElementProps(context.formElement),
+    context.ToggleButton
   )
 
   const {

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -155,10 +155,7 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
       >
     ).ToggleButton,
     pickFormElementProps(context?.formElement),
-    (context as Record<string, unknown>).ToggleButtonGroup as Record<
-      string,
-      unknown
-    >
+    context.ToggleButtonGroup
   )
 
   const {

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -15,6 +15,7 @@ import type { ScrollViewProps } from '../fragments/scroll-view/ScrollView'
 
 // All TypeScript based Eufemia components
 import type { AnchorProps } from '../components/Anchor'
+import type { AutocompleteProps } from '../components/autocomplete/Autocomplete'
 import type { ButtonProps } from '../components/button/Button'
 import type { AvatarProps } from '../components/avatar/Avatar'
 import type { AvatarGroupProps } from '../components/avatar/AvatarGroup'
@@ -31,6 +32,7 @@ import type { TimelineItemProps } from '../components/timeline/TimelineItem'
 import type { VisuallyHiddenProps } from '../components/visually-hidden/VisuallyHidden'
 import type { DrawerProps } from '../components/drawer/types'
 import type { DialogProps } from '../components/dialog/types'
+import type { DropdownProps } from '../components/dropdown/Dropdown'
 import type { TooltipProps } from '../components/tooltip/types'
 import type { SectionProps } from '../components/section/Section'
 import type { UploadProps } from '../components/upload/types'
@@ -46,7 +48,6 @@ import type { FormLabelProps } from '../components/FormLabel'
 import type { InputProps } from '../components/Input'
 import type { TextareaProps } from '../components/Textarea'
 import type { InputMaskedProps } from '../components/InputMasked'
-import type { DropdownProps } from '../components/Dropdown'
 import type {
   NumberFormatCurrency,
   NumberFormatAllProps,
@@ -58,6 +59,10 @@ import type { IconProps } from '../components/Icon'
 import type { ListFormatProps } from '../components/list-format/ListFormat'
 import type { IconPrimaryProps } from '../components/IconPrimary'
 import type { SwitchProps } from '../components/Switch'
+import type { RadioProps } from '../components/radio/Radio'
+import type { RadioGroupProps } from '../components/radio/RadioGroup'
+import type { ToggleButtonProps } from '../components/toggle-button/ToggleButton'
+import type { ToggleButtonGroupProps } from '../components/toggle-button/ToggleButtonGroup'
 import type { TermDefinitionProps } from '../components/term-definition/TermDefinition'
 
 import type { FormElementProps } from './helpers/filterValidProps'
@@ -69,6 +74,7 @@ import type { DatePickerAllProps } from '../components/DatePicker'
 export type ContextComponents = {
   Button?: Partial<ButtonProps>
   Anchor?: Partial<AnchorProps>
+  Autocomplete?: Partial<AutocompleteProps>
   Avatar?: Partial<AvatarProps>
   AvatarGroup?: Partial<AvatarGroupProps>
   Badge?: Partial<BadgeProps>
@@ -84,6 +90,7 @@ export type ContextComponents = {
   VisuallyHidden?: Partial<VisuallyHiddenProps>
   Drawer?: Partial<DrawerProps>
   Dialog?: Partial<DialogProps>
+  Dropdown?: Partial<DropdownProps>
   Tooltip?: Partial<TooltipProps>
   Section?: Partial<SectionProps>
   ScrollView?: Partial<ScrollViewProps>
@@ -99,7 +106,6 @@ export type ContextComponents = {
   Input?: Partial<InputProps>
   Textarea?: Partial<TextareaProps>
   InputMasked?: Partial<InputMaskedProps>
-  Dropdown?: Partial<DropdownProps>
   ProgressIndicator?: Partial<ProgressIndicatorProps>
   FormStatus?: Partial<FormStatusProps>
   Logo?: Partial<LogoProps>
@@ -109,6 +115,10 @@ export type ContextComponents = {
   ListFormat?: Partial<ListFormatProps>
 
   Switch?: Partial<SwitchProps>
+  Radio?: Partial<RadioProps>
+  RadioGroup?: Partial<RadioGroupProps>
+  ToggleButton?: Partial<ToggleButtonProps>
+  ToggleButtonGroup?: Partial<ToggleButtonGroupProps>
   NumberFormat?: Partial<NumberFormatAllProps>
   Pagination?: Partial<PaginationProps>
   TermDefinition?: Partial<TermDefinitionProps>


### PR DESCRIPTION
Add Autocomplete, Radio, RadioGroup, ToggleButton and ToggleButtonGroup to the ContextComponents type so their default props can be set through the shared Provider with full type support.

Also remove the now-redundant 'as Record<string, unknown>' casts that were used to read these defaults (and formElement) from context in Radio, RadioGroup, ToggleButton and ToggleButtonGroup.

