### PR TITLE
docs(Field.Number): make step controls discoverable in search

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
@@ -27,6 +27,10 @@ You may consider using [InputMasked](/uilib/components/input-masked/) for format
 
 <Examples.CurrencyField />
 
+### Step controls (increment and decrement)
+
+For a number input with stepper buttons to increment and decrement the value (plus/minus, number spinner), use [Field.Number](/uilib/extensions/forms/base-fields/Number/#step-controls) (or [Field.Currency](/uilib/extensions/forms/feature-fields/Currency/)) with the `showStepControls` property.
+
 ### Browser autofill styling
 
 When users insert values using autofill in their browser, the browser applies its own background and text colors that override Eufemia's styling.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Field.Number'
 description: '`Field.Number` is the base component for receiving user input where the target data is of type `number`.'
+search: 'Step controls: stepper buttons to increment and decrement the value (plus / minus) using showStepControls'
 componentType: 'base-input'
 showTabs: true
 theme: ['sbanken', 'carnegie']


### PR DESCRIPTION
## Why

The `Field.Number` step controls (`showStepControls`) were only documented as a heading inside the Number base field. As a result the feature was hard to find via the portal search, and easy to miss for anyone browsing the classic Input component who could benefit from it. Finding it required knowing it already existed and digging through the base-field docs.

## What this improves

- Adds a `search` keyword entry to the `Field.Number` page frontmatter so queries like "step controls", "stepper", "increment/decrement", "plus/minus", and "number spinner" surface the page in the portal search.
- Adds a short cross-link from the classic Input component docs to the step controls feature on `Field.Number` (and `Field.Currency`), so it is discoverable from where users would naturally look for a number input with stepper buttons.

## Note

The new search keywords take effect once the Algolia index is rebuilt; the in-page cross-link works immediately.

Preview: https://chore-docs-step-controls-sea.eufemia-e25.pages.dev/uilib/components/input/#step-controls-increment-and-decrement