### PR TITLE
fix(Forms): read `not_multiple_of` value from Zod v4 `divisor` property

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/zod.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/zod.test.ts
@@ -18,14 +18,15 @@ describe('zod not_multiple_of', () => {
   })
 
   it('reads the `divisor` property instead of relying on the message text', () => {
-    // Zod v4 emits the value on `divisor`. Use a non-English message that does
-    // not contain "multiple of", so only the `divisor` lookup can resolve it.
+    // Zod v4 exposes the value on `divisor`. The issue carries a message that
+    // does not contain a parseable number, so a passing assertion proves the
+    // value is taken from `divisor` and not scraped from the message text.
     const issue = {
       code: 'not_multiple_of',
       origin: 'number',
       divisor: 0.5,
       path: [],
-      message: 'Må kunne deles på 0,5',
+      message: 'Må kunne deles på et halvtall',
     } as unknown as zType.core.$ZodIssue
 
     const errors = zodErrorsToFormErrors([issue])

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/zod.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/zod.test.ts
@@ -1,0 +1,35 @@
+import { z, zodErrorsToFormErrors } from '../zod'
+import type * as zType from 'zod'
+
+describe('zod not_multiple_of', () => {
+  it('extracts multipleOf value from a real Zod schema error', () => {
+    const schema = z.number().multipleOf(0.5)
+    const result = schema.safeParse(0.3)
+
+    expect(result.success).toBe(false)
+    if (result.success) {
+      return // stop here
+    }
+
+    const errors = zodErrorsToFormErrors(result.error.issues)
+
+    expect(errors['/'].message).toBe('NumberField.errorMultipleOf')
+    expect(errors['/'].messageValues).toEqual({ multipleOf: '0.5' })
+  })
+
+  it('reads the `divisor` property instead of relying on the message text', () => {
+    // Zod v4 emits the value on `divisor`. Use a non-English message that does
+    // not contain "multiple of", so only the `divisor` lookup can resolve it.
+    const issue = {
+      code: 'not_multiple_of',
+      origin: 'number',
+      divisor: 0.5,
+      path: [],
+      message: 'Må kunne deles på 0,5',
+    } as unknown as zType.core.$ZodIssue
+
+    const errors = zodErrorsToFormErrors([issue])
+
+    expect(errors['/'].messageValues).toEqual({ multipleOf: '0.5' })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/utils/zod.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/zod.ts
@@ -187,13 +187,17 @@ function getMessageValuesFromZodIssue(
       }
     }
     if (code === 'not_multiple_of') {
-      // Type guard: Zod's not_multiple_of issue may have multipleOf or multiple property
+      // Type guard: Zod v4 emits the value on `divisor`. Older/alternative
+      // shapes may use `multipleOf` or `multiple`, so we check those too.
       const issueWithMultiple = issue as z.core.$ZodIssue & {
+        divisor?: number
         multipleOf?: number
         multiple?: number
       }
       const multipleOf =
-        issueWithMultiple.multipleOf ?? issueWithMultiple.multiple
+        issueWithMultiple.divisor ??
+        issueWithMultiple.multipleOf ??
+        issueWithMultiple.multiple
       if (typeof multipleOf === 'number') {
         return { multipleOf: String(multipleOf) }
       }

--- a/packages/dnb-eufemia/src/extensions/forms/utils/zod.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/zod.ts
@@ -187,24 +187,13 @@ function getMessageValuesFromZodIssue(
       }
     }
     if (code === 'not_multiple_of') {
-      // Type guard: Zod v4 emits the value on `divisor`. Older/alternative
-      // shapes may use `multipleOf` or `multiple`, so we check those too.
-      const issueWithMultiple = issue as z.core.$ZodIssue & {
-        divisor?: number
-        multipleOf?: number
-        multiple?: number
-      }
-      const multipleOf =
-        issueWithMultiple.divisor ??
-        issueWithMultiple.multipleOf ??
-        issueWithMultiple.multiple
-      if (typeof multipleOf === 'number') {
-        return { multipleOf: String(multipleOf) }
-      }
-      const fallbackMsg = String(issue?.message ?? '')
-      const m = fallbackMsg.match(/multiple\s*of\s*([0-9]+(?:\.[0-9]+)?)/i)
-      if (m && m[1]) {
-        return { multipleOf: m[1] }
+      // Zod v4 exposes the value on the canonical, always-present `divisor`
+      // field (typed as `number`, even for bigint inputs). Read it directly,
+      // like the other issue fields above, instead of parsing the message
+      // text, which would break for custom or non-English Zod error maps.
+      const { divisor } = issue as z.core.$ZodIssueNotMultipleOf
+      if (typeof divisor === 'number') {
+        return { multipleOf: String(divisor) }
       }
     }
   }


### PR DESCRIPTION
With Zod 4.1, any number field using a .multipleOf() rule shows a broken error message containing the raw {multipleOf} placeholder instead of the actual number — in every non-English locale, which for DNB is the normal case. The fix reads the value from Zod's real divisor field, so it works regardless of the message language.