### PR TITLE
chore: add trailing periods to component doc strings

### DIFF
--- a/packages/dnb-eufemia/eslint.config.mjs
+++ b/packages/dnb-eufemia/eslint.config.mjs
@@ -444,7 +444,7 @@ export default [
     rules: {
       'docs-types/warn-supported-types': 'warn',
       'docs-types/validate-supported-types': 'error',
-      'docs-types/doc-trailing-period': 'warn',
+      'docs-types/doc-trailing-period': 'error',
       'docs-types/defaultvalue-inner-quotes': 'warn',
       'docs-types/doc-no-double-spaces': 'warn',
       '@typescript-eslint/naming-convention': [

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -80,7 +80,7 @@ export type AvatarProps = Omit<HTMLProps<HTMLElement>, 'size'> & {
   imgProps?: ImgProps
 
   /**
-   * An icon name or component. (Will override the `src` property.).
+   * An icon name or component (will override the `src` property).
    */
 
   icon?: IconIcon

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -80,7 +80,7 @@ export type AvatarProps = Omit<HTMLProps<HTMLElement>, 'size'> & {
   imgProps?: ImgProps
 
   /**
-   * An icon name or component. (Will override the `src` property.)
+   * An icon name or component. (Will override the `src` property.).
    */
 
   icon?: IconIcon

--- a/packages/dnb-eufemia/src/components/avatar/AvatarDocs.ts
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarDocs.ts
@@ -27,7 +27,7 @@ export const AvatarProperties: PropertiesTableProps = {
     status: 'optional',
   },
   icon: {
-    doc: 'An icon name or component. (Will override the `src` property.)',
+    doc: 'An icon name or component. (Will override the `src` property.).',
     type: ['string', '[Icon](/uilib/components/icon)'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/avatar/AvatarDocs.ts
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarDocs.ts
@@ -27,7 +27,7 @@ export const AvatarProperties: PropertiesTableProps = {
     status: 'optional',
   },
   icon: {
-    doc: 'An icon name or component. (Will override the `src` property.).',
+    doc: 'An icon name or component (will override the `src` property).',
     type: ['string', '[Icon](/uilib/components/icon)'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -74,7 +74,7 @@ export type FlexContainerProps = {
    */
   divider?: 'space' | 'line' | 'line-framed'
   /**
-   * How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.)
+   * How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.).
    * Default: `'small'`
    */
   gap?: Gap

--- a/packages/dnb-eufemia/src/components/flex/Container.tsx
+++ b/packages/dnb-eufemia/src/components/flex/Container.tsx
@@ -74,7 +74,7 @@ export type FlexContainerProps = {
    */
   divider?: 'space' | 'line' | 'line-framed'
   /**
-   * How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.).
+   * How much space between child items. Use `false` for no spacing. If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.
    * Default: `'small'`
    */
   gap?: Gap

--- a/packages/dnb-eufemia/src/components/flex/ContainerDocs.ts
+++ b/packages/dnb-eufemia/src/components/flex/ContainerDocs.ts
@@ -51,7 +51,7 @@ export const FlexContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   gap: {
-    doc: 'How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.)',
+    doc: 'How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.).',
     type: [
       `'xx-small'`,
       `'x-small'`,
@@ -66,7 +66,7 @@ export const FlexContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   rowGap: {
-    doc: 'How much space between rows. Use `false` for no row gap. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.)',
+    doc: 'How much space between rows. Use `false` for no row gap. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.).',
     type: [
       `'xx-small'`,
       `'x-small'`,

--- a/packages/dnb-eufemia/src/components/flex/ContainerDocs.ts
+++ b/packages/dnb-eufemia/src/components/flex/ContainerDocs.ts
@@ -51,7 +51,7 @@ export const FlexContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   gap: {
-    doc: 'How much space between child items. Use `false` for no spacing. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.).',
+    doc: 'How much space between child items. Use `false` for no spacing. If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.',
     type: [
       `'xx-small'`,
       `'x-small'`,
@@ -66,7 +66,7 @@ export const FlexContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   rowGap: {
-    doc: 'How much space between rows. Use `false` for no row gap. (If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.).',
+    doc: 'How much space between rows. Use `false` for no row gap. If in vertical layout: if both `rowGap` and `gap` is set, `rowGap` will be used.',
     type: [
       `'xx-small'`,
       `'x-small'`,

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -129,7 +129,7 @@ export type FormStatusProps = {
   widthSelector?: string
   widthElement?: { current: HTMLElement | null } | null
   /**
-   * **NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~.
+   * ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~ **NB:** Animation is disabled as of now.
    */
   noAnimation?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -129,7 +129,7 @@ export type FormStatusProps = {
   widthSelector?: string
   widthElement?: { current: HTMLElement | null } | null
   /**
-   * **NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~
+   * **NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~.
    */
   noAnimation?: boolean
   /**

--- a/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
@@ -63,7 +63,7 @@ export const FormStatusProperties: PropertiesTableProps = {
     status: 'optional',
   },
   noAnimation: {
-    doc: '**NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~',
+    doc: '**NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatusDocs.ts
@@ -63,7 +63,7 @@ export const FormStatusProperties: PropertiesTableProps = {
     status: 'optional',
   },
   noAnimation: {
-    doc: '**NB:** Animation is disabled as of now. ~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~.',
+    doc: '~~Use `true` to omit the animation on content visibility. Defaults to `false`.~~ **NB:** Animation is disabled as of now.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorDocs.ts
@@ -39,7 +39,7 @@ export const ProgressIndicatorProperties: PropertiesTableProps = {
     status: 'optional',
   },
   label: {
-    doc: 'Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.).',
+    doc: 'Content of a custom label (overrides `indicatorLabel` and `showDefaultLabel`).',
     type: 'React.ReactNode',
     defaultValue: 'undefined',
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorDocs.ts
@@ -39,7 +39,7 @@ export const ProgressIndicatorProperties: PropertiesTableProps = {
     status: 'optional',
   },
   label: {
-    doc: 'Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.)',
+    doc: 'Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.).',
     type: 'React.ReactNode',
     defaultValue: 'undefined',
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/progress-indicator/types.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/types.ts
@@ -40,7 +40,7 @@ export type ProgressIndicatorProps = {
    */
   progress?: string | number
   /**
-   * Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.)
+   * Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.).
    * Default: `undefined`
    */
   label?: ReactNode

--- a/packages/dnb-eufemia/src/components/progress-indicator/types.ts
+++ b/packages/dnb-eufemia/src/components/progress-indicator/types.ts
@@ -40,7 +40,7 @@ export type ProgressIndicatorProps = {
    */
   progress?: string | number
   /**
-   * Content of a custom label. (Overrides `indicatorLabel` and `showDefaultLabel`.).
+   * Content of a custom label (overrides `indicatorLabel` and `showDefaultLabel`).
    * Default: `undefined`
    */
   label?: ReactNode

--- a/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/blocks/ChildrenWithAge/ChildrenWithAgeDocs.ts
@@ -7,7 +7,7 @@ export const ChildrenWithAgeProperties: PropertiesTableProps = {
     status: 'optional',
   },
   enableAdditionalQuestions: {
-    doc: '[`joint-responsibility`, `daycare`]',
+    doc: '[`joint-responsibility`, `daycare`].',
     type: 'array',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCardDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCardDocs.ts
@@ -141,72 +141,72 @@ export const PaymentCardDesign: PropertiesTableProps = {
 }
 export const PaymentCardDesigns: PropertiesTableProps = {
   defaultDesign: {
-    doc: 'Default',
+    doc: 'Default.',
     type: 'object',
     status: 'optional',
   },
   pluss: {
-    doc: 'Pluss',
+    doc: 'Pluss.',
     type: 'object',
     status: 'optional',
   },
   young: {
-    doc: 'Ung',
+    doc: 'Ung.',
     type: 'object',
     status: 'optional',
   },
   myFirst: {
-    doc: 'My first',
+    doc: 'My first.',
     type: 'object',
     status: 'optional',
   },
   youth: {
-    doc: 'Youth',
+    doc: 'Youth.',
     type: 'object',
     status: 'optional',
   },
   gold: {
-    doc: 'Gold',
+    doc: 'Gold.',
     type: 'object',
     status: 'optional',
   },
   saga: {
-    doc: 'Saga',
+    doc: 'Saga.',
     type: 'object',
     status: 'optional',
   },
   sagaPlatinum: {
-    doc: 'Saga Platinum',
+    doc: 'Saga Platinum.',
     type: 'object',
     status: 'optional',
   },
   privateBanking: {
-    doc: 'Private Banking',
+    doc: 'Private Banking.',
     type: 'object',
     status: 'optional',
   },
   mcBlack: {
-    doc: 'Mastercard Black',
+    doc: 'Mastercard Black.',
     type: 'object',
     status: 'optional',
   },
   businessNoVisa: {
-    doc: 'Bedriftskort BankAxept',
+    doc: 'Bedriftskort BankAxept.',
     type: 'object',
     status: 'optional',
   },
   businessWithVisa: {
-    doc: 'Bedriftskort Visa',
+    doc: 'Bedriftskort Visa.',
     type: 'object',
     status: 'optional',
   },
   sbankenVisa: {
-    doc: 'Sbanken Visa',
+    doc: 'Sbanken Visa.',
     type: 'object',
     status: 'optional',
   },
   sbankenMastercard: {
-    doc: 'Sbanken Mastercard',
+    doc: 'Sbanken Mastercard.',
     type: 'object',
     status: 'optional',
   },


### PR DESCRIPTION
Resolves the docs-types/doc-trailing-period lint warnings (20 doc strings) and syncs the corresponding JSDoc via docs-types/sync-docs-jsdoc.

