### PR TITLE
docs: clarify when to use classic inputs vs Eufemia Forms

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
@@ -8,6 +8,7 @@ import {
   AutocompleteContentAsFragmentExample,
   AutocompleteContentDecoupledExample,
 } from 'Docs/uilib/components/autocomplete/Examples'
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
 
 ## Import
 
@@ -18,6 +19,12 @@ import { Autocomplete } from '@dnb/eufemia'
 ## Description
 
 The Autocomplete component is a combination of an [Input](/uilib/components/input) and a [Dropdown](/uilib/components/dropdown), also called **ComboBox**. During typing, matching data items get suggested in an option menu (listbox).
+
+## When to use Autocomplete vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Autocomplete` is [Field.Selection](/uilib/extensions/forms/base-fields/Selection/) with the autocomplete variant (`variant="autocomplete"`), or [Field.ArraySelection](/uilib/extensions/forms/base-fields/ArraySelection/) for selecting multiple values.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -11,6 +13,12 @@ import { Checkbox } from '@dnb/eufemia'
 ## Description
 
 The Checkbox component is displayed as a square box that is ticked (checked) when activated. Checkboxes let users select one or more options from a limited number of choices.
+
+## When to use Checkbox vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of a single `Checkbox` is [Field.Boolean](/uilib/extensions/forms/base-fields/Boolean/), while [Field.ArraySelection](/uilib/extensions/forms/base-fields/ArraySelection/) handles selecting multiple values with checkboxes.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
@@ -6,6 +6,7 @@ import {
   DatePickerDateFnsRangeIsWeekend,
   DatePickerOsloDate,
 } from 'Docs/uilib/components/date-picker/Examples'
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
 
 ## Import
 
@@ -16,6 +17,12 @@ import { DatePicker } from '@dnb/eufemia'
 ## Description
 
 The DatePicker component should be used whenever the user is to enter a single date or a date range/period with a start and end date.
+
+## When to use DatePicker vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `DatePicker` is [Field.Date](/uilib/extensions/forms/feature-fields/Date/).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -11,6 +13,12 @@ import { Dropdown } from '@dnb/eufemia'
 ## Description
 
 The Dropdown component is a fully custom-made component. This allows us to change its form based on context (small screens, touch devices, etc.).
+
+## When to use Dropdown vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Dropdown` is [Field.Selection](/uilib/extensions/forms/base-fields/Selection/) (the default dropdown variant).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/info.mdx
@@ -10,6 +10,7 @@ import {
   InputMaskedInfoDecimalsNumberProvider,
   InputMaskedInfoRemoveDecimalLimit,
 } from 'Docs/uilib/components/input-masked/Examples'
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
 
 ## Import
 
@@ -20,6 +21,12 @@ import { InputMasked } from '@dnb/eufemia'
 ## Description
 
 The InputMasked component uses the basic [Input](/uilib/components/input) component, but with input masking powered by [Maskito](https://maskito.dev/).
+
+## When to use InputMasked vs Eufemia Forms
+
+<WhenToUseForms />
+
+For masked numbers and amounts, the Eufemia Forms equivalents are [Field.Number](/uilib/extensions/forms/base-fields/Number/) and [Field.Currency](/uilib/extensions/forms/feature-fields/Currency/). For common formatted values, use the dedicated fields such as [Field.PhoneNumber](/uilib/extensions/forms/feature-fields/PhoneNumber/), [Field.NationalIdentityNumber](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/), [Field.BankAccountNumber](/uilib/extensions/forms/feature-fields/BankAccountNumber/), [Field.OrganizationNumber](/uilib/extensions/forms/feature-fields/OrganizationNumber/), and [Field.Expiry](/uilib/extensions/forms/feature-fields/Expiry/).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
@@ -15,6 +15,18 @@ import { Input } from '@dnb/eufemia'
 
 The Input component is an umbrella component for all inputs that share the same style as the classic `text` input field.
 
+## When to use Input vs Eufemia Forms
+
+The classic `Input` component is a presentational form control. It handles the styling, sizing, icons, and basic events, while you manage its value, validation, and error handling yourself.
+
+For most data input and forms situations, use [Eufemia Forms](/uilib/extensions/forms/) fields instead. They build on the same input, but add data handling, validation, and error messages through the surrounding [Form.Handler](/uilib/extensions/forms/Form/Handler/):
+
+- [Field.String](/uilib/extensions/forms/base-fields/String/) is the Eufemia Forms equivalent of `Input` for text values.
+- [Field.Number](/uilib/extensions/forms/base-fields/Number/) and [Field.Currency](/uilib/extensions/forms/feature-fields/Currency/) handle numbers and amounts.
+- Browse all [field components](/uilib/extensions/forms/all-fields/) for more specific needs such as email, phone number or date.
+
+Reach for the classic `Input` when you need a standalone input outside of a form context, or when you handle the value and validation yourself.
+
 ## Relevant links
 
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=4243-1495)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
@@ -4,6 +4,7 @@ showTabs: true
 
 import * as Examples from './Examples'
 import { MultipleOneRow } from '../../extensions/forms/base-fields/String/Examples'
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
 
 ## Import
 
@@ -17,15 +18,9 @@ The Input component is an umbrella component for all inputs that share the same 
 
 ## When to use Input vs Eufemia Forms
 
-The classic `Input` component is a presentational form control. It handles the styling, sizing, icons, and basic events, while you manage its value, validation, and error handling yourself.
+<WhenToUseForms />
 
-For most data input and forms situations, use [Eufemia Forms](/uilib/extensions/forms/) fields instead. They build on the same input, but add data handling, validation, and error messages through the surrounding [Form.Handler](/uilib/extensions/forms/Form/Handler/):
-
-- [Field.String](/uilib/extensions/forms/base-fields/String/) is the Eufemia Forms equivalent of `Input` for text values.
-- [Field.Number](/uilib/extensions/forms/base-fields/Number/) and [Field.Currency](/uilib/extensions/forms/feature-fields/Currency/) handle numbers and amounts.
-- Browse all [field components](/uilib/extensions/forms/all-fields/) for more specific needs such as email, phone number or date.
-
-Reach for the classic `Input` when you need a standalone input outside of a form context, or when you handle the value and validation yourself.
+The Eufemia Forms equivalent of `Input` is [Field.String](/uilib/extensions/forms/base-fields/String/) for text values, while [Field.Number](/uilib/extensions/forms/base-fields/Number/) and [Field.Currency](/uilib/extensions/forms/feature-fields/Currency/) handle numbers and amounts.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -13,6 +15,12 @@ import { Radio } from '@dnb/eufemia'
 The Radio component is displayed as a circle that is filled (checked) when activated. Radio buttons let users select one option from a limited number of choices within a group.
 
 It is recommended to use radio buttons in a group. You can use either the React component `<Radio.Group>` or the property `group="NAME"` to define the group.
+
+## When to use Radio vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Radio` is [Field.Selection](/uilib/extensions/forms/base-fields/Selection/) with the radio variant (`variant="radio"`).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -11,6 +13,12 @@ import { Slider } from '@dnb/eufemia'
 ## Description
 
 The Slider component provides a visual indication of an adjustable value. A value can be adjusted (increased or decreased) by moving the drag handle along a track (usually horizontal or vertical). Remember to inform users that they can also adjust the value directly in the value input field (if it exists).
+
+## When to use Slider vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Slider` is [Field.Slider](/uilib/extensions/forms/base-fields/Slider/).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -15,6 +17,12 @@ _Also known as a toggle switch or toggle._
 The Switch component (toggle) is a digital on/off switch. Toggle switches are best used for changing system functionalities and preferences. "Toggles may replace two radio buttons or a single checkbox to allow users to choose between two opposing states." – [Source][1]
 
 You may also check out the [Checkbox](/uilib/components/checkbox) component.
+
+## When to use Switch vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Switch` is [Field.Boolean](/uilib/extensions/forms/base-fields/Boolean/) with the switch variant (`variant="switch"`), or [Field.Toggle](/uilib/extensions/forms/base-fields/Toggle/) for toggling between two values.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/info.mdx
@@ -3,6 +3,7 @@ showTabs: true
 ---
 
 import * as Examples from './Examples'
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
 
 ## Import
 
@@ -13,6 +14,12 @@ import { Textarea } from '@dnb/eufemia'
 ## Description
 
 The Textarea component is a multi-line text input control with an unlimited number of characters.
+
+## When to use Textarea vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Textarea` is [Field.String](/uilib/extensions/forms/base-fields/String/) with the `multiline` property.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -11,6 +13,12 @@ import { ToggleButton } from '@dnb/eufemia'
 ## Description
 
 The ToggleButton component is used to toggle on or off a limited number of choices.
+
+## When to use ToggleButton vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `ToggleButton` is [Field.Selection](/uilib/extensions/forms/base-fields/Selection/) with the buttons variant (`variant="buttons"`), or [Field.Boolean](/uilib/extensions/forms/base-fields/Boolean/) with the button variant for on/off choices.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/info.mdx
@@ -2,6 +2,8 @@
 showTabs: true
 ---
 
+import WhenToUseForms from 'Docs/uilib/extensions/forms/when-to-use-forms.mdx'
+
 ## Import
 
 ```tsx
@@ -11,6 +13,12 @@ import { Upload } from '@dnb/eufemia'
 ## Description
 
 The Upload component should be used in scenarios where the user has to upload any kind of files.
+
+## When to use Upload vs Eufemia Forms
+
+<WhenToUseForms />
+
+The Eufemia Forms equivalent of `Upload` is [Field.Upload](/uilib/extensions/forms/base-fields/Upload/).
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/when-to-use-forms.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/when-to-use-forms.mdx
@@ -1,0 +1,10 @@
+---
+title: 'When to use Eufemia Forms'
+draft: true
+---
+
+Classic form components like this one are presentational controls. They handle the styling, sizing, icons, and basic events, while you manage their value, validation, and error handling yourself.
+
+For most data input and forms situations, use [Eufemia Forms](/uilib/extensions/forms/) fields instead. They build on these same components, but add data handling, validation, and error messages through the surrounding [Form.Handler](/uilib/extensions/forms/Form/Handler/). Browse the [field components](/uilib/extensions/forms/all-fields/) to find the one that matches your data.
+
+Reach for a classic component when you need it standalone outside of a form context, or when you handle the value and validation yourself.


### PR DESCRIPTION
## Why

The classic form components (`Input`, `InputMasked`, `Dropdown`, `Checkbox`, etc.) look similar to Eufemia Forms fields and are easy to confuse, but the docs did not point developers to the Forms equivalents (which add data handling, validation, and error messages).

Motivation: https://dnb-it.slack.com/archives/C081G91GCT0/p1782374921480539

## What

Adds a reusable "When to use Eufemia Forms" MDX fragment and a short "When to use … vs Eufemia Forms" section to the classic form components (Input, InputMasked, Textarea, Autocomplete, Dropdown, Checkbox, Radio, Switch, Slider, DatePicker, ToggleButton, Upload), each linking to its matching Forms field.

Preview: https://chore-docs-input-vs-forms.eufemia-e25.pages.dev/uilib/components/input