### PR TITLE
docs: link related components on component info pages

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/info.mdx
@@ -37,3 +37,5 @@ Both `Accordion.Provider` and `Accordion.Group` are available. They're technical
 #### Unexpected behavior
 
 **Note:** Please avoid using a group when possible, as it creates unexpected behavior from an accessibility perspective. When a user interacts with one accordion, it triggers an action elsewhere, outside the current context—something users may not expect. It's an automated, out-of-context UI execution.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/info.mdx
@@ -58,3 +58,5 @@ render(
 ## Security
 
 For security reasons, the Anchor removes `href` and `to` values that use a script-executing protocol (`javascript:` or `vbscript:`), including obfuscated variants such as `java\tscript:`. This prevents cross-site scripting (XSS) when untrusted input is passed to these properties; the element then renders without a link target. Other protocols, such as `data:` and `blob:`, are left untouched.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/aria-live/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/aria-live/info.mdx
@@ -61,3 +61,5 @@ function MyCustomAriaLive(props) {
   return <section {...ariaAttributes} />
 }
 ```
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/info.mdx
@@ -124,3 +124,5 @@ You can also set the width directly, but then it has to be defined like so (incl
 ## Root Element (React Portal)
 
 The Autocomplete component uses [PortalRoot](/uilib/components/portal-root) internally to render its option list. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/info.mdx
@@ -17,3 +17,5 @@ Avatars are identifiers that make people and companies more scannable for paymen
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=17869-0)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/avatar)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/avatar)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge/info.mdx
@@ -29,3 +29,5 @@ The notification badge has a very limited use. The area of use is currently limi
 Can be used to describe or inform about new activity or features in our applications. The label can be placed on top of element backgrounds or inline with text within cells.
 
 The logic of how long it should be visible would differ from case to case, so that's up to the designer.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/info.mdx
@@ -17,3 +17,5 @@ The Breadcrumb is a component for navigation and for showing the current website
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=17025-0)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/breadcrumb)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx
@@ -60,3 +60,5 @@ It is **not** recommended to use the tertiary button without an icon. Looking fo
 Icon buttons come in all sizes.
 
 <IconButtonSizes />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/card/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/card/info.mdx
@@ -46,3 +46,5 @@ It uses a `section` element. Which allows you to add an `aria-label` or `aria-la
 ## Card.List and Card.ListItem
 
 Use `Card.List` and `Card.ListItem` to render a semantic `<ul>` / `<li>` list of cards. `Card.List` provides a responsive flex layout with wrapping. `Card.ListItem` supports a `center` prop to center content vertically — set it to `true` to always center, or `"when-small"` to center only on small screens.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/checkbox/info.mdx
@@ -21,3 +21,5 @@ The Checkbox component is displayed as a square box that is ticked (checked) whe
 ## Accessibility
 
 Checkbox components use semantic `<input type="checkbox">` elements, ensuring full keyboard accessibility (Space to toggle) and proper state announcement by screen readers. Labels are properly associated using `htmlFor` attributes.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/copy-on-click/info.mdx
@@ -31,3 +31,5 @@ render(
   </P>
 )
 ```
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag/info.mdx
@@ -28,3 +28,5 @@ For UX designers, there is the [Figma Flags Library](https://www.figma.com/desig
 
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/country-flag)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/country-flag)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-format/info.mdx
@@ -83,3 +83,5 @@ This is helpful when you are comparing "today" against backend data or applying 
 | --------- | ---------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `locale`  | `AnyLocale`                  | `'nb-NO'`                | The locale to use for formatting.                                                                                                                                 |
 | `options` | `Intl.DateTimeFormatOptions` | `{ dateStyle: 'short' }` | The format options following the [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) API. |
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
@@ -134,3 +134,5 @@ Additional event return object properties:
 ## Root Element (React Portal)
 
 The DatePicker component uses [PortalRoot](/uilib/components/portal-root) internally to render its calendar. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dialog/info.mdx
@@ -58,3 +58,5 @@ For more details regarding the component functionality, check out the [Modal doc
 ## Root Element (React Portal)
 
 The Dialog component uses [PortalRoot](/uilib/components/portal-root) internally through Modal to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/drawer/info.mdx
@@ -33,3 +33,5 @@ For more details regarding the component functionality, check out the [Modal doc
 ## Root Element (React Portal)
 
 The Drawer component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/info.mdx
@@ -68,3 +68,5 @@ You can also set the width directly, but then it has to be defined like so (incl
 ## Root Element (React Portal)
 
 The Dropdown component uses [PortalRoot](/uilib/components/portal-root) internally to render its option list. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
@@ -284,3 +284,5 @@ When the filter panel is closed — via the "Hide filter" button, the "Apply" bu
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=15807-0)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/filter)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/filter)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-label/info.mdx
@@ -21,3 +21,5 @@ The FormLabel component represents a caption for all sorts of HTML elements in a
 ### Colon character
 
 DNB UX has chosen to not use colon on the end of form element labels. For consistency throughout our websites, please avoid using them.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/form-status/info.mdx
@@ -44,3 +44,5 @@ Also, all the [fields](/uilib/extensions/forms/all-fields/) based on the [FieldB
 In order to enhance accessibility (readability), the FormStatus will align its width to a linked component. This means that if the FormStatus is built into the Input component, it will inherit the width of the input.
 
 The `min-width` is set to be **12rem**. Use CSS `min-width` or `max-width` to set a custom (manual) width.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/scroll-view/info.mdx
@@ -30,3 +30,5 @@ This uses the CSS `scrollbar-gutter: stable` property. On systems with overlay s
 [Dialog](/uilib/components/dialog) and [Drawer](/uilib/components/drawer) enable this automatically by default.
 
 <ScrollViewInfo />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/text-counter/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/text-counter/info.mdx
@@ -20,3 +20,5 @@ It is used in the [Textarea](/uilib/components/textarea/) component.
 
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/fragments/text-counter)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/fragments/text-counter)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-error/info.mdx
@@ -33,3 +33,5 @@ You may also take a look at how it behaves once [404](/404) or [500](/500) is us
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=22259-19235)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/global-error)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/global-error)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/global-status/info.mdx
@@ -78,3 +78,5 @@ You can access and manipulate an existing GlobalStatus from outside of the React
 If you need an additional `GlobalStatus`, define a custom ID (custom-status):
 
 <GlobalStatusInfoExampleManipulate3 />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading/info.mdx
@@ -124,3 +124,5 @@ You could additionally define "what is a page change" and what not, by using the
 You may still consider of using the basic elements. But keep in mind, you have to define headings responsibly.
 
 <HeadingInfoBasic />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -38,3 +38,5 @@ It is important to never animate from 0 to e.g. 64px – because:
 - The content may differ based on the viewport width (screen size)
 - The content itself may change
 - The user may have a larger `font-size`
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/help-button/info.mdx
@@ -19,3 +19,5 @@ This button is used as the default [Modal trigger button](/uilib/components/moda
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=43836-5699)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/help-button)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/help-button)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary/info.mdx
@@ -18,3 +18,5 @@ There is also the basic [Icon](/uilib/components/icon/) component, you can use f
 
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/icon-primary)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/icon-primary)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/info.mdx
@@ -114,3 +114,5 @@ render(<Icon size="medium">{CustomIcon}</Icon>)
 ### Primary Icon
 
 There is also the [IconPrimary](/uilib/components/icon-primary) component, which comes with all the [Primary Icons](/icons/primary) included in `@dnb/eufemia`. You do not have to import the primary icons separately.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/info-card/info.mdx
@@ -19,3 +19,5 @@ The text content is set to a max width of 70 characters to ensure an optimal [UU
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=20315-8016)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/info-card)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/info-card)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input-masked/info.mdx
@@ -94,3 +94,5 @@ This example also shows how to affect every InputMasked component in your applic
 To remove a decimal limit, you can provide `null` and allow decimals with `allowDecimal`:
 
 <InputMaskedInfoRemoveDecimalLimit />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/input/info.mdx
@@ -40,3 +40,5 @@ Please avoid using the `maxlength` attribute when possible, as it may reduce acc
 You may also consider using a multiline input with a `characterCounter`:
 
 <MultipleOneRow />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list-format/info.mdx
@@ -46,3 +46,5 @@ return listFormat(myList, {
 See the following [demo](/uilib/components/list-format/demos/#using-listformat-function) for a more detailed example.
 
 The `listFormat` function supports an object with `{ format, locale }` as the second parameter. `format` and `locale` will accept the same values as documented in [format property](/uilib/components/list-format/properties/) of the `ListFormat` component.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -98,3 +98,5 @@ render(
 - **List.Item.Action** uses `role="button"` so assistive technologies announce it as a button. It is focusable (`tabIndex={0}`) and activates on Enter and Space. When `pending` is true, it is not focusable and has `aria-disabled="true"`. You can override the role via the `role` prop (e.g. `role="link"`).
 - **List.Item.Accordion** exposes full ARIA for expand/collapse: the header has `id`, `aria-controls`, and `aria-expanded`; the content region has `id`, `aria-labelledby`, `aria-hidden`, and `aria-expanded`. Pass an `id` prop for stable references, or leave it unset for an auto-generated id. When `pending` is true, the header is not focusable and has `aria-disabled="true"`.
 - Use `aria-label` or other ARIA attributes on the container or items when needed for screen readers.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/info.mdx
@@ -16,3 +16,5 @@ A ready-to-use Logo component with the needed SVGs.
 
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/logo)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/logo)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
@@ -45,3 +45,5 @@ For inline expandable groups, use `Menu.Accordion` instead of a nested `Menu.Roo
 ## Root Element (React Portal)
 
 The Menu component uses [PortalRoot](/uilib/components/portal-root) internally through Popover to render its top-level menu. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/modal/info.mdx
@@ -97,3 +97,5 @@ html[data-dnb-modal-active='MODAL-ID'] {
 ## Root Element (React Portal)
 
 The Modal component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
@@ -320,3 +320,5 @@ You can [disable this behavior](https://developer.mozilla.org/en-US/docs/Web/HTM
   ...
 </html>
 ```
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/info.mdx
@@ -117,3 +117,5 @@ const { InfinityMarker, endInfinity, resetInfinity } =
 
 render(<InfinityMarker>ReactComponent</InfinityMarker>)
 ```
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/info.mdx
@@ -102,3 +102,5 @@ render(<Pagination pageCount={2} />)
 ```
 
 ---
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/popover/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/popover/info.mdx
@@ -34,3 +34,5 @@ It is used in the [Tooltip](/uilib/components/tooltip) and [DatePicker](/uilib/c
 ## Root Element (React Portal)
 
 The Popover component uses [PortalRoot](/uilib/components/portal-root) internally to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/portal-root/info.mdx
@@ -165,3 +165,5 @@ render(
 ```
 
 When `off` is set, every form component inside the scope will have `translate="no"` on both its trigger element and its portal content. Without `off`, the component renders children as-is.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator/info.mdx
@@ -54,3 +54,5 @@ Use the `show` prop to control when the indicator appears and disappears. When `
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=21616-18893)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/progress-indicator)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/progress-indicator)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/radio/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/radio/info.mdx
@@ -23,3 +23,5 @@ It is recommended to use radio buttons in a group. You can use either the React 
 ## Accessibility
 
 Radio buttons use semantic `<input type="radio">` elements grouped by the `name` attribute. Arrow keys navigate between options within a group, and Space selects an option. Screen readers announce the group label, current selection, and number of options.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/section/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/section/info.mdx
@@ -41,3 +41,5 @@ Each of these properties do support either a single value or an object containin
 - `backgroundColor={string}` or e.g. `backgroundColor={{ small: 'white' }}`
 - `textColor={string}` or e.g. `textColor={{ small: 'black-80' }}`
 - `innerSpace={string}` or e.g. `innerSpace={{ small: { top: 'small' } }}`
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skeleton/info.mdx
@@ -101,3 +101,5 @@ You can take advantage of an async component by using the React Suspense with a 
 In order to create the same skeletons as the build-ins, you can make use of a couple of helper tools.
 
 <SkeletonInfoCustom />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/skip-content/info.mdx
@@ -73,3 +73,5 @@ Optionally, you should consider including the `SkipContent.Return` utility as we
 The `SkipContent` helper component is mainly dedicated to keyboard navigation.
 
 In order to let screen readers skip large parts of content, you need to ensure your HTML has [logical landmarks and regions](/uilib/usage/accessibility/checklist/#landmark--and-semantics-example).
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/slider/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/slider/info.mdx
@@ -25,3 +25,5 @@ The Slider uses a semantic `<input type="range">` element for the thumb control,
 ### Define a `min` and `max` value
 
 Keep in mind, you should most probably define your `min` and `max` value, because they are tied closely to your given value property.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/stat/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/stat/info.mdx
@@ -50,3 +50,5 @@ import { Stat } from '@dnb/eufemia'
 
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/stat)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/stat)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.mdx
@@ -58,3 +58,5 @@ const steps = [
 ```
 
 More details about modifying steps in the [properties panel](/uilib/components/step-indicator/properties#step-item-properties).
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/switch/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/switch/info.mdx
@@ -41,3 +41,5 @@ Do not use a toggle switch if the user is required to click Save or Update to ap
 The label should describe what the toggle will do when the switch is on.
 
 [1]: https://www.nngroup.com/articles/toggle-switch-guidelines/
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.mdx
@@ -199,3 +199,5 @@ The hook accepts an optional options object:
 | Option    | Type      | Default | Description                           |
 | --------- | --------- | ------- | ------------------------------------- |
 | `enabled` | `boolean` | `true`  | Whether keyboard navigation is active |
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/info.mdx
@@ -21,3 +21,5 @@ Tabs are a set of buttons that allow navigation between content that is related 
 ## Accessibility
 
 The Tabs component follows the [WAI-ARIA Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). It uses `role="tablist"`, `role="tab"`, and `role="tabpanel"` with proper ARIA attributes. Keyboard navigation includes arrow keys to move between tabs and Tab key to navigate into the active panel content.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tag/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tag/info.mdx
@@ -19,3 +19,5 @@ Tags with the `onDelete` property can be used to define an action. A clickable t
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=18412-7293)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/tag)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/tag)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/term-definition/info.mdx
@@ -36,3 +36,5 @@ To ensure that the TermDefinition component is accessible, it uses semantic HTML
 ## Root Element (React Portal)
 
 The TermDefinition component uses [PortalRoot](/uilib/components/portal-root) internally to render its explanation content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/textarea/info.mdx
@@ -33,3 +33,5 @@ This way, the user gets visual feedback on the number of characters entered and 
 You can still set the requirement for your desired maximum number of characters by setting the `maxLength` property in [Eufemia Forms](/uilib/extensions/forms/base-fields/String/).
 
 <Examples.MaxLength />
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/timeline/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/timeline/info.mdx
@@ -17,3 +17,5 @@ A timeline shows events in chronological order and gives a great overview of the
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=19517-7350)
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/timeline)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/timeline)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/info.mdx
@@ -35,3 +35,5 @@ You can use the ToggleButton in different modes. Either as a stand-alone compone
 If `multiselect` is enabled on the group, several items can be enabled or disabled by the user.
 
 You need to decide if you want to track the state yourself by using the `checked` property, or if you want to listen to the internal state with `onChange(({ values }) => console.log(values))`. In this case, you also need to give every item a `value` property.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tooltip/info.mdx
@@ -48,3 +48,5 @@ To use the built-in hover/focus/touch behavior, omit the `open` property and let
 ## Root Element (React Portal)
 
 The Tooltip component uses [PortalRoot](/uilib/components/portal-root) internally through Popover to render its content. See the [PortalRoot documentation](/uilib/components/portal-root) for information on how to control where the portal content appears in the DOM, and for the [BrowserTranslate helper](/uilib/components/portal-root/#browsertranslate-helper-google-translate) when browser translation tools such as Google Translate should not modify content rendered through PortalRoot.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/upload/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/upload/info.mdx
@@ -96,3 +96,5 @@ In some situations, it's more suitable to have each link download the file inste
 ## Prevents uploading duplicate files
 
 By default, the Upload component prevents uploading duplicate files. It determines if a file is a duplicate if the file's `name`, `size` (if existing), and `lastModified` (if existing) values are equal. You can use the property `allowDuplicates={true}` to allow duplicate files.
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden/info.mdx
@@ -18,3 +18,5 @@ import { VisuallyHidden } from '@dnb/eufemia'
 
 - [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/visually-hidden)
 - [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/components/visually-hidden)
+
+<RelatedComponents />

--- a/packages/dnb-design-system-portal/src/shared/parts/ListComponentsOverview.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/ListComponentsOverview.tsx
@@ -6,48 +6,14 @@ import AutoLinkHeader from '../tags/AutoLinkHeader'
 import { basicComponents } from '../../shared/tags'
 import { makeSlug } from '../../uilib/utils/slug'
 import { cardItemStyle } from '../menu/MainMenu.module.scss'
-
-const categoryOrder = [
-  {
-    id: 'actions',
-    title: 'Actions',
-    description:
-      'For things people click to do something, open choices, follow a link, or get help.',
-  },
-  {
-    id: 'input',
-    title: 'Input',
-    description:
-      'For entering information, choosing options, uploading files, or changing values.',
-  },
-  {
-    id: 'navigation',
-    title: 'Navigation',
-    description:
-      'For helping people move between pages, jump to content, or continue through steps.',
-  },
-  {
-    id: 'feedback',
-    title: 'Feedback',
-    description:
-      'For messages and panels that tell people what happened, what is happening, or what needs attention.',
-  },
-  {
-    id: 'content',
-    title: 'Content',
-    description:
-      'For showing information, such as text, numbers, tables, icons, lists, and cards.',
-  },
-  {
-    id: 'other',
-    title: 'Other',
-    description:
-      'For special page behavior that does not fit the groups above.',
-  },
-] as const
-
-type CategoryId = (typeof categoryOrder)[number]['id']
-type CategoryValue = string | false | null | undefined
+import {
+  categoryOrder,
+  excludedSlugs,
+  getCategoryId,
+  type CategoryDefinition,
+  type CategoryId,
+  type CategoryValue,
+} from './componentCategories'
 
 type Entry = {
   slug: string
@@ -75,37 +41,8 @@ type QueryData = {
   }
 }
 
-type CategoryDefinition = {
-  id: CategoryId
-  title: string
-  description: string
-}
-
 type Category = CategoryDefinition & {
   entries: Entry[]
-}
-
-const categoryIds = new Set<string>(categoryOrder.map(({ id }) => id))
-
-const excludedSlugs = new Set([
-  'uilib/components/fragments',
-  'uilib/components/overview',
-])
-
-function isCategoryId(category: CategoryValue): category is CategoryId {
-  return typeof category === 'string' && categoryIds.has(category)
-}
-
-function getCategoryId(category: CategoryValue): CategoryId | undefined {
-  if (category === false) {
-    return undefined
-  }
-
-  if (isCategoryId(category)) {
-    return category
-  }
-
-  return 'other'
 }
 
 export default function ListComponentsOverview() {

--- a/packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
@@ -47,6 +47,11 @@ function cleanTitle(title: string): string {
   return title.replace(/\s*\(.*\)\s*$/, '')
 }
 
+// Cap how many siblings are listed inline; the rest are reachable via the
+// "See all" link to the overview category, to avoid long lists on big
+// categories like Content and Input.
+const MAX_VISIBLE_RELATED = 6
+
 function toReason(description?: string): string | undefined {
   if (!description) {
     return undefined
@@ -139,6 +144,8 @@ export default function RelatedComponents() {
   }
 
   const categoryTitle = getCategoryTitle(current.category)
+  const visibleRelated = related.slice(0, MAX_VISIBLE_RELATED)
+  const hasMore = related.length > visibleRelated.length
 
   return (
     <>
@@ -155,7 +162,7 @@ export default function RelatedComponents() {
       </P>
 
       <Ul>
-        {related.map(({ slug, title, description }) => {
+        {visibleRelated.map(({ slug, title, description }) => {
           const reason = toReason(description)
 
           return (
@@ -166,6 +173,14 @@ export default function RelatedComponents() {
           )
         })}
       </Ul>
+
+      {hasMore && (
+        <P top="x-small">
+          <Anchor href={`/uilib/components/overview/#${current.category}`}>
+            See all in {categoryTitle} →
+          </Anchor>
+        </P>
+      )}
     </>
   )
 }

--- a/packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
@@ -1,0 +1,171 @@
+import { useStaticQuery, graphql } from 'portal-query'
+import { Li, P, Ul } from '@dnb/eufemia/src'
+import { useLocation } from 'react-router-dom'
+import Anchor from '../tags/Anchor'
+import AutoLinkHeader from '../tags/AutoLinkHeader'
+import {
+  excludedSlugs,
+  getCategoryId,
+  getCategoryTitle,
+  type CategoryId,
+  type CategoryValue,
+} from './componentCategories'
+
+type QueryEdge = {
+  node: {
+    fields: {
+      slug: string
+    }
+    frontmatter: {
+      title: string
+      description?: string | undefined
+      category: CategoryValue
+    }
+  }
+}
+
+type QueryData = {
+  components: {
+    edges: QueryEdge[]
+  }
+}
+
+type Entry = {
+  slug: string
+  title: string
+  description?: string | undefined
+  category: CategoryId
+}
+
+function normalizeSlug(pathname: string): string {
+  return pathname
+    .replace(/^\/|\/$/g, '')
+    .replace(/\/(info|demos|properties|events)$/, '')
+}
+
+function cleanTitle(title: string): string {
+  return title.replace(/\s*\(.*\)\s*$/, '')
+}
+
+function toReason(description?: string): string | undefined {
+  if (!description) {
+    return undefined
+  }
+
+  // Turn "Use <Component> to/when …" into a short reason clause.
+  // Only strip the leading "Use <Name> " when the next word is a
+  // connector, so descriptions with other phrasing stay intact.
+  return description.replace(
+    /^Use\s+[A-Z]\S*\s+(?=to\b|when\b|for\b|as\b|if\b)/,
+    ''
+  )
+}
+
+export default function RelatedComponents() {
+  const location = useLocation()
+
+  const data = useStaticQuery(graphql`
+    {
+      components: allMdx(
+        filter: {
+          frontmatter: {
+            title: { ne: null }
+            draft: { ne: true }
+            hideInMenu: { ne: true }
+          }
+          internal: {
+            contentFilePath: { regex: "/(uilib/components/.*)/" }
+          }
+        }
+        sort: [
+          { frontmatter: { order: ASC } }
+          { frontmatter: { title: ASC } }
+        ]
+      ) {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              description
+              category
+            }
+          }
+        }
+      }
+    }
+  `) as QueryData
+
+  const currentSlug = normalizeSlug(location?.pathname || '')
+
+  const entries = data.components.edges.reduce<Entry[]>(
+    (entries, { node }) => {
+      const slug = node.fields.slug
+      const category = getCategoryId(node.frontmatter.category)
+
+      if (excludedSlugs.has(slug) || !category) {
+        return entries
+      }
+
+      entries.push({
+        slug,
+        title: node.frontmatter.title,
+        description: node.frontmatter.description,
+        category,
+      })
+
+      return entries
+    },
+    []
+  )
+
+  const current = entries.find((entry) => entry.slug === currentSlug)
+
+  if (!current) {
+    return null
+  }
+
+  const related = entries
+    .filter(
+      (entry) =>
+        entry.category === current.category && entry.slug !== current.slug
+    )
+    .sort((a, b) => a.title.localeCompare(b.title))
+
+  if (related.length === 0) {
+    return null
+  }
+
+  const categoryTitle = getCategoryTitle(current.category)
+
+  return (
+    <>
+      <AutoLinkHeader level={2} useSlug="related-components">
+        Related components
+      </AutoLinkHeader>
+
+      <P bottom="small">
+        {cleanTitle(current.title)} is part of the{' '}
+        <Anchor href={`/uilib/components/overview/#${current.category}`}>
+          {categoryTitle}
+        </Anchor>{' '}
+        category. Other components for similar needs:
+      </P>
+
+      <Ul>
+        {related.map(({ slug, title, description }) => {
+          const reason = toReason(description)
+
+          return (
+            <Li key={slug}>
+              <Anchor href={`/${slug}`}>{cleanTitle(title)}</Anchor>
+              {reason ? ` — ${reason}` : null}
+            </Li>
+          )
+        })}
+      </Ul>
+    </>
+  )
+}

--- a/packages/dnb-design-system-portal/src/shared/parts/__tests__/RelatedComponents.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/__tests__/RelatedComponents.test.tsx
@@ -40,6 +40,61 @@ const mockData = vi.hoisted(() => ({
       },
       {
         node: {
+          fields: { slug: 'uilib/components/checkbox' },
+          frontmatter: {
+            title: 'Checkbox',
+            description:
+              'Use Checkbox when people can turn one or more options on or off.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/input' },
+          frontmatter: {
+            title: 'Input',
+            description:
+              'Use Input when people need to enter a short line of text.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/slider' },
+          frontmatter: {
+            title: 'Slider',
+            description:
+              'Use Slider when people need to choose a value from a range.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/switch' },
+          frontmatter: {
+            title: 'Switch',
+            description:
+              'Use Switch when people can turn one setting on or off.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/textarea' },
+          frontmatter: {
+            title: 'Textarea',
+            description:
+              'Use Textarea when people need to write longer text over several lines.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
           fields: { slug: 'uilib/components/anchor' },
           frontmatter: {
             title: 'Anchor (Text Link)',
@@ -125,11 +180,48 @@ describe('RelatedComponents', () => {
       (a as HTMLAnchorElement).getAttribute('href')
     )
 
+    expect(links).toContain('/uilib/components/autocomplete')
+    expect(links).toContain('/uilib/components/radio')
+    expect(links).not.toContain('/uilib/components/dropdown')
+  })
+
+  it('caps the inline list at six and links to the rest of the category', () => {
+    const { container } = renderAt('/uilib/components/dropdown')
+
+    const links = Array.from(container.querySelectorAll('li a')).map((a) =>
+      (a as HTMLAnchorElement).getAttribute('href')
+    )
+
+    // Input has 7 siblings here; only the first six (alphabetical) show.
     expect(links).toEqual([
       '/uilib/components/autocomplete',
+      '/uilib/components/checkbox',
+      '/uilib/components/input',
       '/uilib/components/radio',
+      '/uilib/components/slider',
+      '/uilib/components/switch',
     ])
-    expect(links).not.toContain('/uilib/components/dropdown')
+    expect(links).not.toContain('/uilib/components/textarea')
+
+    const seeAll = Array.from(container.querySelectorAll('a')).find((a) =>
+      a.textContent?.includes('See all')
+    )
+
+    expect(seeAll).toBeTruthy()
+    expect(seeAll?.getAttribute('href')).toBe(
+      '/uilib/components/overview/#input'
+    )
+    expect(seeAll?.textContent).toContain('Input')
+  })
+
+  it('omits the See all link when the whole category fits inline', () => {
+    const { container } = renderAt('/uilib/components/button')
+
+    const hasSeeAll = Array.from(container.querySelectorAll('a')).some(
+      (a) => a.textContent?.includes('See all')
+    )
+
+    expect(hasSeeAll).toBe(false)
   })
 
   it('links to the matching overview category anchor', () => {

--- a/packages/dnb-design-system-portal/src/shared/parts/__tests__/RelatedComponents.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/__tests__/RelatedComponents.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockData = vi.hoisted(() => ({
+  components: {
+    edges: [
+      {
+        node: {
+          fields: { slug: 'uilib/components/dropdown' },
+          frontmatter: {
+            title: 'Dropdown',
+            description:
+              'Use Dropdown when people need to choose one option from a list.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/autocomplete' },
+          frontmatter: {
+            title: 'Autocomplete',
+            description:
+              'Use Autocomplete to help people find and choose from matching suggestions as they type.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/radio' },
+          frontmatter: {
+            title: 'Radio',
+            description:
+              'Use Radio when people must choose one option from a set.',
+            category: 'input',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/anchor' },
+          frontmatter: {
+            title: 'Anchor (Text Link)',
+            description:
+              'Use Anchor to take people to another page, section, or website.',
+            category: 'actions',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/button' },
+          frontmatter: {
+            title: 'Button',
+            description:
+              'Use Button when people need to start, confirm, or submit an action.',
+            category: 'actions',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/breadcrumb' },
+          frontmatter: {
+            title: 'Breadcrumb',
+            description: 'Use Breadcrumb to show where someone is.',
+            category: 'navigation',
+          },
+        },
+      },
+      {
+        node: {
+          fields: { slug: 'uilib/components/fragments/drawer-list' },
+          frontmatter: {
+            title: 'DrawerList',
+            description: 'Use DrawerList as an internal list pattern.',
+            category: false,
+          },
+        },
+      },
+    ],
+  },
+}))
+
+vi.mock('portal-query', () => ({
+  graphql: (strings: TemplateStringsArray) => String(strings),
+  useStaticQuery: () => mockData,
+}))
+
+vi.mock('../../tags/Anchor', () => ({
+  default: ({ href, children }: { href: string; children: unknown }) => (
+    <a href={href}>{children as never}</a>
+  ),
+}))
+
+vi.mock('../../tags/AutoLinkHeader', () => ({
+  default: ({ children }: { children: unknown }) => (
+    <h2>{children as never}</h2>
+  ),
+}))
+
+import RelatedComponents from '../RelatedComponents'
+
+afterEach(cleanup)
+
+function renderAt(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <RelatedComponents />
+    </MemoryRouter>
+  )
+}
+
+describe('RelatedComponents', () => {
+  it('lists the other components in the same category, excluding itself', () => {
+    const { container } = renderAt('/uilib/components/dropdown')
+
+    expect(container.querySelector('h2')?.textContent).toBe(
+      'Related components'
+    )
+
+    const links = Array.from(container.querySelectorAll('li a')).map((a) =>
+      (a as HTMLAnchorElement).getAttribute('href')
+    )
+
+    expect(links).toEqual([
+      '/uilib/components/autocomplete',
+      '/uilib/components/radio',
+    ])
+    expect(links).not.toContain('/uilib/components/dropdown')
+  })
+
+  it('links to the matching overview category anchor', () => {
+    const { container } = renderAt('/uilib/components/dropdown')
+
+    const categoryLink = container.querySelector(
+      'a[href="/uilib/components/overview/#input"]'
+    )
+
+    expect(categoryLink).not.toBeNull()
+    expect(categoryLink?.textContent).toBe('Input')
+  })
+
+  it('shows a short reason derived from each description', () => {
+    const { container } = renderAt('/uilib/components/dropdown')
+
+    const items = Array.from(container.querySelectorAll('li')).map(
+      (li) => li.textContent
+    )
+
+    expect(items).toContain(
+      'Autocomplete — to help people find and choose from matching suggestions as they type.'
+    )
+    expect(items).toContain(
+      'Radio — when people must choose one option from a set.'
+    )
+  })
+
+  it('strips the parenthetical part of a related component title', () => {
+    const { container } = renderAt('/uilib/components/button')
+
+    const anchorLink = container.querySelector(
+      'li a[href="/uilib/components/anchor"]'
+    )
+
+    expect(anchorLink?.textContent).toBe('Anchor')
+  })
+
+  it('resolves the current component when on a tab sub-route', () => {
+    const { container } = renderAt('/uilib/components/dropdown/info')
+
+    expect(container.querySelector('h2')?.textContent).toBe(
+      'Related components'
+    )
+  })
+
+  it('renders nothing when the category has no other members', () => {
+    const { container } = renderAt('/uilib/components/breadcrumb')
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing for a page with category false', () => {
+    const { container } = renderAt(
+      '/uilib/components/fragments/drawer-list'
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing for an unknown page', () => {
+    const { container } = renderAt('/uilib/components/does-not-exist')
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/packages/dnb-design-system-portal/src/shared/parts/__tests__/componentCategories.test.ts
+++ b/packages/dnb-design-system-portal/src/shared/parts/__tests__/componentCategories.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  categoryOrder,
+  categoryIds,
+  excludedSlugs,
+  getCategoryId,
+  getCategoryTitle,
+  isCategoryId,
+} from '../componentCategories'
+
+describe('componentCategories', () => {
+  describe('categoryOrder', () => {
+    it('defines the six known categories in order', () => {
+      expect(categoryOrder.map(({ id }) => id)).toEqual([
+        'actions',
+        'input',
+        'navigation',
+        'feedback',
+        'content',
+        'other',
+      ])
+    })
+
+    it('exposes the ids as a set', () => {
+      expect(categoryIds.has('input')).toBe(true)
+      expect(categoryIds.has('unknown')).toBe(false)
+    })
+  })
+
+  describe('excludedSlugs', () => {
+    it('excludes the fragments index and the overview page', () => {
+      expect(excludedSlugs.has('uilib/components/fragments')).toBe(true)
+      expect(excludedSlugs.has('uilib/components/overview')).toBe(true)
+      expect(excludedSlugs.has('uilib/components/dropdown')).toBe(false)
+    })
+  })
+
+  describe('isCategoryId', () => {
+    it('accepts known category ids', () => {
+      expect(isCategoryId('input')).toBe(true)
+      expect(isCategoryId('content')).toBe(true)
+    })
+
+    it('rejects unknown values', () => {
+      expect(isCategoryId('unknown')).toBe(false)
+      expect(isCategoryId(false)).toBe(false)
+      expect(isCategoryId(null)).toBe(false)
+      expect(isCategoryId(undefined)).toBe(false)
+    })
+  })
+
+  describe('getCategoryId', () => {
+    it('returns the id for a known category', () => {
+      expect(getCategoryId('feedback')).toBe('feedback')
+    })
+
+    it('returns undefined when the category is explicitly false', () => {
+      expect(getCategoryId(false)).toBeUndefined()
+    })
+
+    it('falls back to "other" for unknown or missing categories', () => {
+      expect(getCategoryId('does-not-exist')).toBe('other')
+      expect(getCategoryId(null)).toBe('other')
+      expect(getCategoryId(undefined)).toBe('other')
+    })
+  })
+
+  describe('getCategoryTitle', () => {
+    it('returns the human readable title for a category id', () => {
+      expect(getCategoryTitle('input')).toBe('Input')
+      expect(getCategoryTitle('other')).toBe('Other')
+    })
+  })
+})

--- a/packages/dnb-design-system-portal/src/shared/parts/__tests__/relatedComponentsCoverage.test.ts
+++ b/packages/dnb-design-system-portal/src/shared/parts/__tests__/relatedComponentsCoverage.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { excludedSlugs, getCategoryId } from '../componentCategories'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const componentsDir = path.resolve(
+  currentDir,
+  '../../../docs/uilib/components'
+)
+
+const tabPagePattern = /\/(info|demos|properties|events)\.mdx$/
+
+function findMdxFiles(dir: string): string[] {
+  const files: string[] = []
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...findMdxFiles(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+function readFrontmatterValue(
+  content: string,
+  key: string
+): string | undefined {
+  const match = content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))
+
+  if (!match) {
+    return undefined
+  }
+
+  return match[1].trim().replace(/^['"]|['"]$/g, '')
+}
+
+function toSlug(file: string): string {
+  const relative = path.relative(componentsDir, file).replace(/\.mdx$/, '')
+
+  return `uilib/components/${relative}`
+}
+
+describe('Related components coverage', () => {
+  // Mirrors the ListComponentsOverview GraphQL selection so this fails if a
+  // component shown on the overview is missing its <RelatedComponents />.
+  it('adds <RelatedComponents /> to every component shown on the overview', () => {
+    const parentPages = findMdxFiles(componentsDir).filter(
+      (file) => !tabPagePattern.test(file)
+    )
+
+    const overviewComponents = parentPages.filter((file) => {
+      const content = readFileSync(file, 'utf-8')
+
+      const hasTitle = readFrontmatterValue(content, 'title') !== undefined
+      const isDraft = readFrontmatterValue(content, 'draft') === 'true'
+      const isHidden =
+        readFrontmatterValue(content, 'hideInMenu') === 'true'
+
+      if (!hasTitle || isDraft || isHidden) {
+        return false
+      }
+
+      const rawCategory = readFrontmatterValue(content, 'category')
+      const category = getCategoryId(
+        rawCategory === 'false' ? false : rawCategory
+      )
+
+      return Boolean(category) && !excludedSlugs.has(toSlug(file))
+    })
+
+    // Guard against the rule itself silently matching nothing.
+    expect(overviewComponents.length).toBeGreaterThan(40)
+
+    const missing = overviewComponents
+      .map((file) => path.join(file.replace(/\.mdx$/, ''), 'info.mdx'))
+      .filter(
+        (infoFile) =>
+          !existsSync(infoFile) ||
+          !readFileSync(infoFile, 'utf-8').includes(
+            '<RelatedComponents />'
+          )
+      )
+      .map((infoFile) => path.relative(componentsDir, infoFile))
+
+    expect(
+      missing,
+      `These overview components are missing <RelatedComponents />: ${missing.join(', ')}`
+    ).toEqual([])
+  })
+})

--- a/packages/dnb-design-system-portal/src/shared/parts/componentCategories.ts
+++ b/packages/dnb-design-system-portal/src/shared/parts/componentCategories.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared category definitions for the component overview and related
+ * components linking. Both `ListComponentsOverview` and `RelatedComponents`
+ * use these so the grouping stays in sync.
+ *
+ * The source of truth for a component's category is the `category`
+ * frontmatter on its parent `.mdx` page.
+ */
+
+export const categoryOrder = [
+  {
+    id: 'actions',
+    title: 'Actions',
+    description:
+      'For things people click to do something, open choices, follow a link, or get help.',
+  },
+  {
+    id: 'input',
+    title: 'Input',
+    description:
+      'For entering information, choosing options, uploading files, or changing values.',
+  },
+  {
+    id: 'navigation',
+    title: 'Navigation',
+    description:
+      'For helping people move between pages, jump to content, or continue through steps.',
+  },
+  {
+    id: 'feedback',
+    title: 'Feedback',
+    description:
+      'For messages and panels that tell people what happened, what is happening, or what needs attention.',
+  },
+  {
+    id: 'content',
+    title: 'Content',
+    description:
+      'For showing information, such as text, numbers, tables, icons, lists, and cards.',
+  },
+  {
+    id: 'other',
+    title: 'Other',
+    description:
+      'For special page behavior that does not fit the groups above.',
+  },
+] as const
+
+export type CategoryId = (typeof categoryOrder)[number]['id']
+export type CategoryValue = string | false | null | undefined
+
+export type CategoryDefinition = {
+  id: CategoryId
+  title: string
+  description: string
+}
+
+export const categoryIds = new Set<string>(
+  categoryOrder.map(({ id }) => id)
+)
+
+export const excludedSlugs = new Set([
+  'uilib/components/fragments',
+  'uilib/components/overview',
+])
+
+export function isCategoryId(
+  category: CategoryValue
+): category is CategoryId {
+  return typeof category === 'string' && categoryIds.has(category)
+}
+
+export function getCategoryId(
+  category: CategoryValue
+): CategoryId | undefined {
+  if (category === false) {
+    return undefined
+  }
+
+  if (isCategoryId(category)) {
+    return category
+  }
+
+  return 'other'
+}
+
+export function getCategoryTitle(id: CategoryId): string {
+  return categoryOrder.find((category) => category.id === id)?.title ?? id
+}

--- a/packages/dnb-design-system-portal/src/shared/tags/index.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/index.tsx
@@ -22,6 +22,7 @@ import VisibilityByTheme from '@dnb/eufemia/src/shared/VisibilityByTheme'
 import { TypographyBox } from '../parts/TypographyBox'
 import Details from './Details'
 import Summary from './Summary'
+import RelatedComponents from '../parts/RelatedComponents'
 
 export const basicComponents = {
   // img: Img, // -> <figure> cannot appear as a descendant of <p>
@@ -77,6 +78,7 @@ export default {
   VisibilityByTheme,
   Details,
   Summary,
+  RelatedComponents,
   VisibleWhenVisualTest: ({ children }) => {
     if (typeof globalThis !== 'undefined' && globalThis.IS_TEST) {
       return children

--- a/packages/dnb-design-system-portal/vite/vitest.config.ts
+++ b/packages/dnb-design-system-portal/vite/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      'portal-query': path.resolve(
+        __dirname,
+        'client/shims/portal-query.tsx'
+      ),
       'virtual:portal-pages': path.resolve(
         __dirname,
         '__tests__/mocks/virtual-portal-pages.ts'


### PR DESCRIPTION
[Deploy preview](https://feat-related-components-link.eufemia-e25.pages.dev/uilib/components/accordion/#related-components)

Add a "Related components" section to every component info page, listing the other components in the same overview category with a short reason, so similar components are easier to discover.

- Add RelatedComponents shared part, registered as a global MDX shortcode
- Extract shared componentCategories used by both the overview page and the related-components links so the grouping stays in sync
- Append <RelatedComponents /> to all categorized component info.mdx pages
- Add tests for the category helpers, the component, and overview coverage

Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1782377479330419?thread_ts=1782369181.000929&cid=CMXABCHEY