### PR TITLE
chore: replace deprecated color variables with design tokens

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.module.scss
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/Examples.module.scss
@@ -21,19 +21,19 @@
 .showWhenLarge {
   // is green on 961 and more
   @include utilities.allAbove(medium) {
-    color: var(--color-success-green);
+    color: var(--token-color-text-positive);
   }
 }
 .showWhenMedium {
   // is green on 641 to 960
   @include utilities.allBetween(small, medium) {
-    color: var(--color-success-green);
+    color: var(--token-color-text-positive);
   }
 }
 .showWhenSmall {
   // is green on 640 and less
   @include utilities.allBelow(small) {
-    color: var(--color-success-green);
+    color: var(--token-color-text-positive);
   }
 }
 
@@ -42,20 +42,20 @@
   // is grey on 1056
   // is green on 1057
   @include utilities.allAbove(medium, 6em) {
-    color: var(--color-success-green);
+    color: var(--token-color-text-positive);
   }
 }
 .showWhenMediumOffset {
   // is grey on 736 or 865
   // is green on 737 to 864
   @include utilities.allBetween(small, medium, 6em, -6em) {
-    color: var(--color-success-green);
+    color: var(--token-color-text-positive);
   }
 }
 .showWhenSmallOffset {
   // is grey on 545
   // is green on 544
   @include utilities.allBelow(small, -6em) {
-    color: var(--color-success-green);
+    color: var(--token-color-text-positive);
   }
 }

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -112,7 +112,7 @@
     :checked + .radio-label {
       position: relative;
       z-index: 1;
-      border-color: var(--color-sea-green);
+      border-color: var(--token-color-stroke-selected);
     }
 
     .markdown-body::before {


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/28169274322/job/83429141527?pr=8652#step:5:21

## Summary

Resolves the 7 `eufemia/no-deprecated-color-variables` stylelint warnings surfaced in the portal's `lint:ci` by replacing deprecated raw color variables with semantic design tokens.

## Changes

| File | Before | After | Rationale |
| --- | --- | --- | --- |
| `src/shared/parts/Layout.module.scss` | `--color-sea-green` | `--token-color-stroke-selected` | Styles a `:checked` (selected) radio label border, matching how the DNB `Radio` component tokenizes its selected border. |
| `src/docs/uilib/helpers/Examples.module.scss` (6×) | `--color-success-green` | `--token-color-text-positive` | Positive/green demo text. In the DNB theme this token resolves to `--dnb-green-700` (`#007b5e`) — an exact value match. |

## Verification

- `stylelint './src/**/*.scss'` in the portal: 0 warnings (was 7).
- Prettier check passes on both files.
