### PR TITLE
fix(Button): connect status message to button via aria-describedby

### DIFF
--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -24,6 +24,7 @@ import {
   validateDOMAttributes,
   processChildren,
   getStatusState,
+  combineDescribedBy,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
@@ -285,6 +286,7 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     skeleton,
     element,
     selected,
+    id: _id, // excluded so the default `null` does not override the resolvedId
     ...attributes
   } = props
 
@@ -430,6 +432,15 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
   }
   if (isIconOnly) {
     params['aria-label'] = params['aria-label'] || titleString
+  }
+
+  // Link the FormStatus message to the button for screen readers.
+  // The FormStatus text element uses the same id (see "textId" below).
+  if (showStatus) {
+    params['aria-describedby'] = combineDescribedBy(
+      params,
+      resolvedId + '-status'
+    )
   }
 
   skeletonDOMAttributes(params, skeleton, context)

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -656,6 +656,90 @@ describe('Button transitionState', () => {
   })
 })
 
+describe('Button status', () => {
+  it('connects the status message to the button via aria-describedby', () => {
+    render(
+      <Button text="Primary button with text only" status="my error" />
+    )
+
+    const button = document.querySelector('button')
+    const describedBy = button.getAttribute('aria-describedby')
+
+    expect(describedBy).toBeTruthy()
+
+    // The referenced element must exist and contain the status text
+    const statusText = document.getElementById(describedBy)
+    expect(statusText).toBeInTheDocument()
+    expect(statusText).toHaveTextContent('my error')
+    expect(statusText).toHaveClass('dnb-form-status__text')
+  })
+
+  it('derives the button id and the form-status ids from the same id', () => {
+    render(<Button text="With status" status="my error" />)
+
+    const button = document.querySelector('button')
+    const buttonId = button.getAttribute('id')
+
+    expect(buttonId).toBeTruthy()
+    expect(
+      document.querySelector('.dnb-form-status').getAttribute('id')
+    ).toBe(`${buttonId}-form-status`)
+    expect(button.getAttribute('aria-describedby')).toBe(
+      `${buttonId}-status`
+    )
+  })
+
+  it('does not set aria-describedby when no status is given', () => {
+    render(<Button text="No status" />)
+
+    const button = document.querySelector('button')
+    expect(button).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('combines a user provided aria-describedby with the status id', () => {
+    render(
+      <Button
+        text="With custom describedby"
+        status="my error"
+        aria-describedby="custom-id"
+      />
+    )
+
+    const button = document.querySelector('button')
+    const describedBy = button.getAttribute('aria-describedby')
+    const statusId = document
+      .querySelector('.dnb-form-status__text')
+      .getAttribute('id')
+
+    expect(describedBy).toContain('custom-id')
+    expect(describedBy).toContain(statusId)
+  })
+
+  it('keeps the status describedby when a tooltip is also set', () => {
+    render(
+      <Button
+        text="With status and tooltip"
+        status="my error"
+        tooltip="Helpful hint"
+      />
+    )
+
+    const button = document.querySelector('button')
+    const statusId = document
+      .querySelector('.dnb-form-status__text')
+      .getAttribute('id')
+
+    // The tooltip id is only added on hover/focus, but the status link
+    // must already be present and share the same base id.
+    expect(button.getAttribute('aria-describedby')).toBe(statusId)
+  })
+
+  it('should validate with ARIA rules when a status is set', async () => {
+    const Comp = render(<Button text="With status" status="my error" />)
+    expect(await axeComponent(Comp)).toHaveNoViolations()
+  })
+})
+
 describe('Button scss', () => {
   it('has to match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))


### PR DESCRIPTION
The FormStatus rendered for the `status` prop generated ids but was never referenced by the button, so screen readers did not announce the message. Add `aria-describedby` on the button pointing to the FormStatus text element, combining with any user-provided value and the Tooltip, matching the pattern used by Input, Textarea, Checkbox, Radio and Slider.

Also stop the default `id: null` from overriding the resolved id, so the button renders its generated id when a status or tooltip is present.

