### PR TITLE
feat(Dialog): add a `status` message prop

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -14,14 +14,16 @@ import type {
 } from 'react'
 import { clsx } from 'clsx'
 import Button from '../../button/Button'
-import type { ButtonProps } from '../../button/Button'
+import FormStatus from '../../FormStatus'
 import Space from '../../space/Space'
-import { Context } from '../../../shared'
 import ModalContext from '../../modal/ModalContext'
 import { dispatchCustomElementEvent } from '../../../shared/component-helper'
-
-import type { SpacingProps } from '../../../shared/types'
+import { Context } from '../../../shared'
+import useId from '../../../shared/helpers/useId'
 import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
+
+import type { ButtonProps } from '../../button/Button'
+import type { SpacingProps } from '../../../shared/types'
 
 type ExtendedMouseEvent = {
   event: MouseEvent<HTMLElement>
@@ -83,9 +85,10 @@ const DialogAction = ({
   ...props
 }: DialogActionAllProps) => {
   const { translation, Button: ButtonContext } = useContext(Context)
-  const { close } = useContext(ModalContext)
+  const { close, status } = useContext(ModalContext)
   let childrenWithCloseFunc: ReactNode
 
+  const statusId = useId()
   const onConfirmHandler = useCallback(
     (event) => {
       dispatchCustomElementEvent({ onConfirm }, 'onConfirm', {
@@ -130,30 +133,44 @@ const DialogAction = ({
   }
 
   return (
-    <Space
-      element="section"
-      className={clsx('dnb-dialog__actions', className)}
-      {...props}
-    >
-      {childrenWithCloseFunc}
+    <>
+      <Space
+        element="section"
+        className={clsx('dnb-dialog__actions', className)}
+        {...props}
+      >
+        {childrenWithCloseFunc}
 
-      {!children && !hideDecline && (
-        <Button
-          text={declineText || translation?.Dialog?.declineText}
-          variant="secondary"
-          onClick={onDeclineHandler}
-          size={ButtonContext?.size || 'large'}
-        />
-      )}
-      {!children && !hideConfirm && (
-        <Button
-          text={confirmText || translation?.Dialog?.confirmText}
-          variant="primary"
-          onClick={onConfirmHandler}
-          size={ButtonContext?.size || 'large'}
-        />
-      )}
-    </Space>
+        {!children && !hideDecline && (
+          <Button
+            text={declineText || translation?.Dialog?.declineText}
+            variant="secondary"
+            onClick={onDeclineHandler}
+            size={ButtonContext?.size || 'large'}
+          />
+        )}
+        {!children && !hideConfirm && (
+          <Button
+            text={confirmText || translation?.Dialog?.confirmText}
+            variant="primary"
+            onClick={onConfirmHandler}
+            size={ButtonContext?.size || 'large'}
+            status={status ? 'error' : undefined}
+            aria-describedby={status ? statusId + '-status' : undefined}
+          />
+        )}
+      </Space>
+
+      <FormStatus
+        show={!!status}
+        id={statusId + '-form-status'}
+        textId={statusId + '-status'}
+        noAnimation={false}
+        shellSpace={{ top: 'small' }}
+      >
+        {status}
+      </FormStatus>
+    </>
   )
 }
 


### PR DESCRIPTION
## Why

A Dialog (e.g. a confirmation) currently has no built-in way to communicate a status back to the user from its action area, for example when a confirm action fails or is blocked. Consumers had to build and place their own status markup outside the actions, with no guaranteed accessibility link to the action that triggered it.

This lets a Dialog provide a `status` through its context, which renders a `FormStatus` in the action area and wires it to the confirm button via `aria-describedby`, so assistive technology announces the status as the description of the action it relates to.

## Impact

- Dialogs can surface an error/status next to their actions with correct accessibility semantics out of the box.
- No change for dialogs that do not provide a status.

> Draft: work in progress for review and further iteration.