### PR TITLE
fix(Switch): connect status message to input via aria-describedby

### DIFF
--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -320,6 +320,7 @@ function Switch(props: SwitchProps) {
             id={id + '-form-status'}
             globalStatus={globalStatus}
             label={label}
+            textId={id + '-status'} // used for "aria-describedby"
             widthSelector={id + ', ' + id + '-label'}
             text={status}
             state={statusState}

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -170,6 +170,33 @@ describe('Switch component', () => {
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 
+  it('connects the status message to the input via aria-describedby', () => {
+    render(<Switch {...props} status="switch error" />)
+
+    const input = document.querySelector('input')
+    const describedBy = input.getAttribute('aria-describedby')
+
+    expect(describedBy).toBeTruthy()
+
+    // The referenced element must exist and contain the status text
+    const statusText = document.getElementById(describedBy)
+    expect(statusText).toBeInTheDocument()
+    expect(statusText).toHaveTextContent('switch error')
+    expect(statusText).toHaveClass('dnb-form-status__text')
+  })
+
+  it('does not set aria-describedby when no status is given', () => {
+    render(<Switch {...props} />)
+
+    const input = document.querySelector('input')
+    expect(input).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('should validate with ARIA rules when a status is set', async () => {
+    const Comp = render(<Switch {...props} status="switch error" />)
+    expect(await axeComponent(Comp)).toHaveNoViolations()
+  })
+
   it('gets valid ref element', () => {
     let ref: RefObject<HTMLInputElement>
 


### PR DESCRIPTION
Switch set `aria-describedby` to `id-status` on the input, but its FormStatus was rendered without a `textId`, so the text element never received that id. The reference was therefore dangling, pointing to a non-existent element, and screen readers could not announce the message. Add `textId={id + '-status'}` to the FormStatus, matching Checkbox, Input and the other form controls.

