### PR TITLE
refactor(Space): rename ResponsiveContext `breakpoint` prop to `breakOn`

### DIFF
--- a/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
@@ -63,7 +63,7 @@ export const SpaceResponsiveContextProperties: PropertiesTableProps = {
     status: 'optional',
   },
   breakOn: {
-    doc: 'Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.',
+    doc: 'Sets the breakpoint at which density switches from `compact` to `basis`. Default: `small`.',
     type: ['"small"', '"medium"'],
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceDocs.ts
@@ -58,11 +58,11 @@ export const SpaceProperties: PropertiesTableProps = {
 
 export const SpaceResponsiveContextProperties: PropertiesTableProps = {
   density: {
-    doc: 'Forces a specific spacing density for descendants. Overrides `breakpoint` when set. Use `false` to disable.',
+    doc: 'Forces a specific spacing density for descendants. Overrides `breakOn` when set. Use `false` to disable.',
     type: ['"compact"', '"basis"', 'false'],
     status: 'optional',
   },
-  breakpoint: {
+  breakOn: {
     doc: 'Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.',
     type: ['"small"', '"medium"'],
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsive.tsx
@@ -11,7 +11,7 @@ type SpaceResponsiveProps = SpaceResponsiveContextValue & {
 
 function SpaceResponsive({
   density,
-  breakpoint,
+  breakOn,
   off,
   children,
 }: SpaceResponsiveProps) {
@@ -22,7 +22,7 @@ function SpaceResponsive({
     : {
         ...(parent || undefined),
         ...(density !== undefined && { density }),
-        ...(breakpoint !== undefined && { breakpoint }),
+        ...(breakOn !== undefined && { breakOn }),
         ...(off !== undefined && { off }),
       }
 

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
@@ -3,14 +3,14 @@ import type { MediaQuerySizes } from '../../shared/MediaQueryUtils'
 
 export type SpaceResponsiveContextValue = {
   /**
-   * Forces a specific spacing density for descendants. Overrides `breakpoint` when set. Use `false` to disable.
+   * Forces a specific spacing density for descendants. Overrides `breakOn` when set. Use `false` to disable.
    */
   density?: 'compact' | 'basis' | false
 
   /**
    * Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.
    */
-  breakpoint?: Extract<MediaQuerySizes, 'small' | 'medium'>
+  breakOn?: Extract<MediaQuerySizes, 'small' | 'medium'>
 
   /**
    * When `true`, disables responsive spacing for descendants, overriding a parent `Space.ResponsiveContext`. Defaults to `false`.

--- a/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
+++ b/packages/dnb-eufemia/src/components/space/SpaceResponsiveContext.ts
@@ -8,7 +8,7 @@ export type SpaceResponsiveContextValue = {
   density?: 'compact' | 'basis' | false
 
   /**
-   * Sets at which breakpoint we switch from `compact` to `basis` density. Default: `small`.
+   * Sets the breakpoint at which density switches from `compact` to `basis`. Default: `small`.
    */
   breakOn?: Extract<MediaQuerySizes, 'small' | 'medium'>
 

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -550,7 +550,7 @@ export const useSpacing = <T extends ApplySpacingTarget>(
       'dnb-space-responsive',
       responsive.breakOn &&
         responsive.breakOn !== 'small' &&
-        `dnb-space-responsive--breakpoint-${responsive.breakOn}`,
+        `dnb-space-responsive--break-on-${responsive.breakOn}`,
       responsive.density &&
         `dnb-space-responsive--force-${responsive.density}`
     )

--- a/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
+++ b/packages/dnb-eufemia/src/components/space/SpacingUtils.ts
@@ -548,9 +548,9 @@ export const useSpacing = <T extends ApplySpacingTarget>(
     result.className = clsx(
       result.className,
       'dnb-space-responsive',
-      responsive.breakpoint &&
-        responsive.breakpoint !== 'small' &&
-        `dnb-space-responsive--breakpoint-${responsive.breakpoint}`,
+      responsive.breakOn &&
+        responsive.breakOn !== 'small' &&
+        `dnb-space-responsive--breakpoint-${responsive.breakOn}`,
       responsive.density &&
         `dnb-space-responsive--force-${responsive.density}`
     )

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -482,7 +482,7 @@ describe('Space.ResponsiveContext', () => {
     const element = document.querySelector('.test-component')
     expect(element.className).toContain('dnb-space-responsive--off')
     expect(element.className).not.toContain(
-      'dnb-space-responsive dnb-space-responsive--breakpoint'
+      'dnb-space-responsive dnb-space-responsive--break-on'
     )
   })
 
@@ -528,7 +528,7 @@ describe('Space.ResponsiveContext', () => {
     const element = document.querySelector('.test-component')
     expect(element.className).toContain('dnb-space-responsive')
     expect(element.className).not.toContain(
-      'dnb-space-responsive--breakpoint'
+      'dnb-space-responsive--break-on'
     )
   })
 
@@ -553,7 +553,7 @@ describe('Space.ResponsiveContext', () => {
     )
   })
 
-  it('should use breakpoint when density is not set', () => {
+  it('should use breakOn when density is not set', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -570,14 +570,14 @@ describe('Space.ResponsiveContext', () => {
 
     const element = document.querySelector('.test-component')
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-medium'
+      'dnb-space-responsive--break-on-medium'
     )
     expect(element.className).not.toContain(
       'dnb-space-responsive--force-compact'
     )
   })
 
-  it('should apply both breakpoint and density classes', () => {
+  it('should apply both breakOn and density classes', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -594,7 +594,7 @@ describe('Space.ResponsiveContext', () => {
 
     const element = document.querySelector('.test-component')
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-medium'
+      'dnb-space-responsive--break-on-medium'
     )
     expect(element.className).toContain(
       'dnb-space-responsive--force-compact'
@@ -613,7 +613,7 @@ describe('Space.ResponsiveContext', () => {
     expect(element.className).toContain('dnb-space__top--large')
   })
 
-  it('should add breakpoint class to Space component', () => {
+  it('should add break-on class to Space component', () => {
     render(
       <Space.ResponsiveContext breakOn="medium">
         <Space top="large">Content</Space>
@@ -622,7 +622,7 @@ describe('Space.ResponsiveContext', () => {
 
     const element = document.querySelector('.dnb-space')
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-medium'
+      'dnb-space-responsive--break-on-medium'
     )
   })
 
@@ -651,7 +651,7 @@ describe('Space.ResponsiveContext', () => {
     const element = document.querySelector('.dnb-space')
     expect(element.className).toContain('dnb-space-responsive--off')
     expect(element.className).not.toContain(
-      'dnb-space-responsive dnb-space-responsive--breakpoint'
+      'dnb-space-responsive dnb-space-responsive--break-on'
     )
   })
 
@@ -709,7 +709,7 @@ describe('Space.ResponsiveContext', () => {
     expect(SpaceResponsive['_supportsSpacingProps']).toBe('passthrough')
   })
 
-  it('should inherit parent density when inner only sets breakpoint', () => {
+  it('should inherit parent density when inner only sets breakOn', () => {
     const TestComponent = () => {
       const params = useSpacing(
         { top: 'large' },
@@ -731,7 +731,7 @@ describe('Space.ResponsiveContext', () => {
       'dnb-space-responsive--force-compact'
     )
     expect(element.className).toContain(
-      'dnb-space-responsive--breakpoint-medium'
+      'dnb-space-responsive--break-on-medium'
     )
   })
 

--- a/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
+++ b/packages/dnb-eufemia/src/components/space/__tests__/Space.test.tsx
@@ -563,7 +563,7 @@ describe('Space.ResponsiveContext', () => {
     }
 
     render(
-      <Space.ResponsiveContext breakpoint="medium">
+      <Space.ResponsiveContext breakOn="medium">
         <TestComponent />
       </Space.ResponsiveContext>
     )
@@ -587,7 +587,7 @@ describe('Space.ResponsiveContext', () => {
     }
 
     render(
-      <Space.ResponsiveContext density="compact" breakpoint="medium">
+      <Space.ResponsiveContext density="compact" breakOn="medium">
         <TestComponent />
       </Space.ResponsiveContext>
     )
@@ -615,7 +615,7 @@ describe('Space.ResponsiveContext', () => {
 
   it('should add breakpoint class to Space component', () => {
     render(
-      <Space.ResponsiveContext breakpoint="medium">
+      <Space.ResponsiveContext breakOn="medium">
         <Space top="large">Content</Space>
       </Space.ResponsiveContext>
     )
@@ -720,7 +720,7 @@ describe('Space.ResponsiveContext', () => {
 
     render(
       <Space.ResponsiveContext density="compact">
-        <Space.ResponsiveContext breakpoint="medium">
+        <Space.ResponsiveContext breakOn="medium">
           <TestComponent />
         </Space.ResponsiveContext>
       </Space.ResponsiveContext>

--- a/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/space/__tests__/SpacingUtils.test.ts
@@ -883,7 +883,7 @@ describe('useSpacing', () => {
 
     expect(result.current.className).toContain('dnb-space-responsive')
     expect(result.current.className).not.toContain(
-      'dnb-space-responsive--breakpoint'
+      'dnb-space-responsive--break-on'
     )
     expect(result.current.className).toContain('dnb-space__top--large')
   })
@@ -924,7 +924,7 @@ describe('useSpacing', () => {
 
     expect(result.current.className).toContain('dnb-space-responsive--off')
     expect(result.current.className).not.toContain(
-      'dnb-space-responsive dnb-space-responsive--breakpoint'
+      'dnb-space-responsive dnb-space-responsive--break-on'
     )
   })
 

--- a/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/space/__tests__/__snapshots__/Space.test.tsx.snap
@@ -826,17 +826,17 @@ exports[`Space scss > should match style dependencies css 1`] = `
   }
 }
 @media screen and (max-width: 40em) {
-  .dnb-space-responsive--breakpoint-medium {
+  .dnb-space-responsive--break-on-medium {
     --responsive-spacing-tier: -1;
   }
 }
 @media screen and (max-width: 60em) and (min-width: 40.00625em) {
-  .dnb-space-responsive--breakpoint-medium {
+  .dnb-space-responsive--break-on-medium {
     --responsive-spacing-tier: -1;
   }
 }
 @media screen and (min-width: 60.00625em) {
-  .dnb-space-responsive--breakpoint-medium {
+  .dnb-space-responsive--break-on-medium {
     --responsive-spacing-tier: 0;
   }
 }

--- a/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
+++ b/packages/dnb-eufemia/src/components/space/style/dnb-space.scss
@@ -299,7 +299,7 @@
   }
 
   // Breakpoint overrides – shift at which breakpoint the sizes change
-  &-responsive--breakpoint-medium {
+  &-responsive--break-on-medium {
     @include utilities.allBelow(small) {
       --responsive-spacing-tier: -1;
     }


### PR DESCRIPTION
The `breakpoint` prop on `Space.ResponsiveContext` was easy to confuse with the media-query `breakpoint` keys used elsewhere in the spacing API. Renaming it to `breakOn` makes its purpose – the point at which density switches from `compact` to `basis` – clearer and avoids that ambiguity.

This is a straightforward prop rename of a recently added API; no behavioral change.