### PR TITLE
fix(StepIndicator): connect step status message to step button via aria-describedby

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -7,7 +7,10 @@ import { useCallback, useContext, useMemo } from 'react'
 import type { HTMLProps, ReactNode } from 'react'
 
 import { clsx } from 'clsx'
-import { dispatchCustomElementEvent } from '../../shared/component-helper'
+import {
+  dispatchCustomElementEvent,
+  combineDescribedBy,
+} from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import type { AnchorAllProps } from '../anchor/Anchor'
 import Anchor from '../anchor/Anchor'
@@ -171,7 +174,12 @@ function StepIndicatorItem({
   const buttonParams = {
     status,
     statusState,
-    'aria-describedby': id,
+    // Describe the button by its screen-reader label and, when present,
+    // the step status message (see "textId" on the FormStatus below).
+    'aria-describedby': combineDescribedBy(
+      id,
+      status ? id + '-status' : null
+    ),
   } as StepItemButtonProps
 
   if (usedIsCurrent) {
@@ -273,6 +281,7 @@ function StepIndicatorItem({
               state={status ? statusState : undefined}
               variant="outlined"
               className="dnb-step-indicator__item-content__status"
+              textId={id + '-status'} // used for "aria-describedby"
               text={status}
             />
           </div>

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -716,6 +716,72 @@ describe('StepIndicator ARIA', () => {
     // Verify the aria-label contains step information (e.g., "Steg 1 av 4:")
     expect(buttonHTML).toMatch(/aria-label="Steg \d+ av \d+:"/)
   })
+
+  it('connects a step status message to the step button via aria-describedby', () => {
+    render(
+      <StepIndicator
+        mode="loose"
+        expandedInitially
+        data={[
+          { title: 'Step A', status: 'Step A has an error' },
+          { title: 'Step B' },
+        ]}
+      />
+    )
+
+    const firstStepItem = document.querySelectorAll(
+      'li.dnb-step-indicator__item'
+    )[0]
+
+    // The status message of the first step
+    const statusText = firstStepItem.querySelector(
+      '.dnb-step-indicator__item-content__status .dnb-form-status__text'
+    )
+    expect(statusText).toBeInTheDocument()
+    expect(statusText).toHaveTextContent('Step A has an error')
+
+    const statusTextId = statusText.getAttribute('id')
+    expect(statusTextId).toBeTruthy()
+
+    // The step button must reference both the screen-reader label and the status
+    const button = firstStepItem.querySelector(
+      '.dnb-step-indicator__button'
+    )
+    const describedBy = (
+      button.getAttribute('aria-describedby') || ''
+    ).split(/\s+/)
+
+    const srOnlyId = firstStepItem
+      .querySelector('.dnb-sr-only')
+      .getAttribute('id')
+
+    expect(describedBy).toContain(srOnlyId)
+    expect(describedBy).toContain(statusTextId)
+  })
+
+  it('does not reference a status id when the step has no status', () => {
+    render(
+      <StepIndicator
+        mode="loose"
+        expandedInitially
+        data={[{ title: 'Step A' }, { title: 'Step B' }]}
+      />
+    )
+
+    const firstStepItem = document.querySelectorAll(
+      'li.dnb-step-indicator__item'
+    )[0]
+    const button = firstStepItem.querySelector(
+      '.dnb-step-indicator__button'
+    )
+    const describedBy = button.getAttribute('aria-describedby') || ''
+
+    // No "-status" reference at all when there is no status
+    const statusRefs = describedBy
+      .split(/\s+/)
+      .filter((refId) => refId.endsWith('-status'))
+    expect(statusRefs).toHaveLength(0)
+  })
 })
 
 describe('StepIndicator scss', () => {


### PR DESCRIPTION
Each step's status was rendered as a FormStatus but never referenced by the step button, whose `aria-describedby` only pointed to the screen-reader step label. So the per-step status (e.g. an error) was visible but not announced when focusing the step. Give the per-step FormStatus a `textId` and include it in the button's `aria-describedby` via `combineDescribedBy`, so the button is described by both its label and, when present, the status. This also improves the forms Wizard, which sets a per-step error status.

