### PR TITLE
fix(Dialog): link action status to a visible button in all cases

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -275,6 +275,81 @@ describe('Dialog', () => {
     expect(formStatus.textContent).toBe('Something went wrong')
   })
 
+  it('connects the status message to the confirm button via aria-describedby', () => {
+    render(
+      <Dialog
+        {...props}
+        open
+        variant="confirmation"
+        title="Title"
+        status="Something went wrong"
+      >
+        content
+      </Dialog>
+    )
+
+    const statusTextId = document
+      .querySelector('.dnb-form-status__text')
+      .getAttribute('id')
+    expect(statusTextId).toBeTruthy()
+
+    const confirmButton = document.querySelector(
+      '.dnb-dialog__actions .dnb-button--primary'
+    )
+    expect(
+      (confirmButton.getAttribute('aria-describedby') || '').split(/\s+/)
+    ).toContain(statusTextId)
+  })
+
+  it('connects the status message to the decline button when hideConfirm is given', () => {
+    render(
+      <Dialog
+        {...props}
+        open
+        variant="confirmation"
+        title="Title"
+        status="Something went wrong"
+        hideConfirm
+      >
+        content
+      </Dialog>
+    )
+
+    const statusTextId = document
+      .querySelector('.dnb-form-status__text')
+      .getAttribute('id')
+    expect(statusTextId).toBeTruthy()
+
+    const declineButton = document.querySelector(
+      '.dnb-dialog__actions .dnb-button--secondary'
+    )
+    expect(
+      (declineButton.getAttribute('aria-describedby') || '').split(/\s+/)
+    ).toContain(statusTextId)
+  })
+
+  it('connects the status message to custom action buttons via aria-describedby', () => {
+    render(
+      <Dialog {...props} open variant="confirmation" title="Title">
+        <Dialog.Action status="Something went wrong">
+          <Button text="Custom" />
+        </Dialog.Action>
+      </Dialog>
+    )
+
+    const statusTextId = document
+      .querySelector('.dnb-form-status__text')
+      .getAttribute('id')
+    expect(statusTextId).toBeTruthy()
+
+    const customButton = document.querySelector(
+      '.dnb-dialog__actions .dnb-button'
+    )
+    expect(
+      (customButton.getAttribute('aria-describedby') || '').split(/\s+/)
+    ).toContain(statusTextId)
+  })
+
   it('omits action buttons when hideDecline or hideConfirm is given', () => {
     const props: DialogProps & DialogContentProps = {
       noAnimation: true,

--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -350,6 +350,25 @@ describe('Dialog', () => {
     ).toContain(statusTextId)
   })
 
+  it('does not reference the status from the decline button by default', () => {
+    render(
+      <Dialog
+        {...props}
+        open
+        variant="confirmation"
+        title="Title"
+        status="Something went wrong"
+      >
+        content
+      </Dialog>
+    )
+
+    const declineButton = document.querySelector(
+      '.dnb-dialog__actions .dnb-button--secondary'
+    )
+    expect(declineButton).not.toHaveAttribute('aria-describedby')
+  })
+
   it('omits action buttons when hideDecline or hideConfirm is given', () => {
     const props: DialogProps & DialogContentProps = {
       noAnimation: true,

--- a/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/parts/DialogAction.tsx
@@ -17,7 +17,10 @@ import Button from '../../button/Button'
 import FormStatus from '../../FormStatus'
 import Space from '../../space/Space'
 import ModalContext from '../../modal/ModalContext'
-import { dispatchCustomElementEvent } from '../../../shared/component-helper'
+import {
+  dispatchCustomElementEvent,
+  combineDescribedBy,
+} from '../../../shared/component-helper'
 import { Context } from '../../../shared'
 import useId from '../../../shared/helpers/useId'
 import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
@@ -95,6 +98,8 @@ const DialogAction = ({
   let childrenWithCloseFunc: ReactNode
 
   const statusId = useId()
+  // Id of the FormStatus message, used to link it to the action button(s).
+  const statusDescribedBy = status ? statusId + '-status' : undefined
 
   const onConfirmHandler = useCallback(
     (event) => {
@@ -130,6 +135,13 @@ const DialogAction = ({
                 close,
               })
             },
+            // Link the status message to custom action buttons too.
+            ...(statusDescribedBy && {
+              'aria-describedby': combineDescribedBy(
+                childElement.props,
+                statusDescribedBy
+              ),
+            }),
           },
           childElement.props.children
         )
@@ -154,6 +166,9 @@ const DialogAction = ({
             variant="secondary"
             onClick={onDeclineHandler}
             size={ButtonContext?.size || 'large'}
+            // When the confirm button is hidden, the status must still be
+            // linked to a visible action button.
+            aria-describedby={hideConfirm ? statusDescribedBy : undefined}
           />
         )}
         {!children && !hideConfirm && (
@@ -163,7 +178,7 @@ const DialogAction = ({
             onClick={onConfirmHandler}
             size={ButtonContext?.size || 'large'}
             status={status ? 'error' : undefined}
-            aria-describedby={status ? statusId + '-status' : undefined}
+            aria-describedby={statusDescribedBy}
           />
         )}
       </Space>


### PR DESCRIPTION
The DialogAction status message (FormStatus with a textId) was only referenced by the auto-generated confirm button. When the confirm button was hidden (hideConfirm) or replaced by custom children, the status text id was left unreferenced, so the message was not associated with any action button. Apply the status aria-describedby to the decline button when the confirm button is hidden, and inject it into custom Button children, so the status is always linked to a visible action button.

