### PR TITLE
chore(VippsWalletButton): add properties page and move translations to shared locales

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button.mdx
@@ -1,50 +1,18 @@
 ---
 title: 'VippsWalletButton'
 description: 'A branded Vipps wallet call-to-action button extension.'
-showTabs: false
+showTabs: true
+tabs:
+  - title: Info
+    key: /uilib/extensions/vipps-wallet-button/info
+  - title: Demos
+    key: /uilib/extensions/vipps-wallet-button/demos
+  - title: Properties
+    key: /uilib/extensions/vipps-wallet-button/properties
 ---
 
-import {
-  VippsWalletButtonExample,
-  VippsWalletButtonPendingExample,
-} from 'Docs/uilib/extensions/vipps-wallet-button/Examples'
+import VippsWalletButtonInfo from 'Docs/uilib/extensions/vipps-wallet-button/info'
+import VippsWalletButtonDemos from 'Docs/uilib/extensions/vipps-wallet-button/demos'
 
-# VippsWalletButton
-
-## Import
-
-```tsx
-import VippsWalletButton from '@dnb/eufemia/extensions/vipps-wallet-button'
-import '@dnb/eufemia/extensions/vipps-wallet-button/style'
-```
-
-## Description
-
-A branded Vipps wallet call-to-action button extension.
-
-It uses a primary [Button](/uilib/components/button/) under the hood.
-
-## Relevant links
-
-- [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/extensions/vipps-wallet-button)
-- [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button.mdx)
-
-## Demo
-
-### Default
-
-<VippsWalletButtonExample />
-
-### With SubmitIndicator
-
-Example with property `pending` set to `true`.
-
-<VippsWalletButtonPendingExample />
-
-## Translations
-
-The label text is translated internally and follows `Provider` locale.
-
-| **nb-NO**  | **en-GB** | **sv-SE**   | **da-DK**  |
-| ---------- | --------- | ----------- | ---------- |
-| Legg til i | Add to    | Lägg till i | Tilføj til |
+<VippsWalletButtonInfo />
+<VippsWalletButtonDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button/demos.mdx
@@ -1,0 +1,20 @@
+---
+showTabs: true
+---
+
+import {
+  VippsWalletButtonExample,
+  VippsWalletButtonPendingExample,
+} from './Examples'
+
+## Demos
+
+### Default
+
+<VippsWalletButtonExample />
+
+### With SubmitIndicator
+
+Example with property `pending` set to `true`.
+
+<VippsWalletButtonPendingExample />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button/info.mdx
@@ -1,0 +1,21 @@
+---
+showTabs: true
+---
+
+## Import
+
+```tsx
+import VippsWalletButton from '@dnb/eufemia/extensions/vipps-wallet-button'
+import '@dnb/eufemia/extensions/vipps-wallet-button/style'
+```
+
+## Description
+
+A branded Vipps wallet call-to-action button extension.
+
+It uses a primary [Button](/uilib/components/button/) under the hood.
+
+## Relevant links
+
+- [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/extensions/vipps-wallet-button)
+- [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button)

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/vipps-wallet-button/properties.mdx
@@ -1,0 +1,15 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+import { VippsWalletButtonProperties } from '@dnb/eufemia/src/extensions/vipps-wallet-button/VippsWalletButtonDocs'
+
+## Properties
+
+<PropertiesTable props={VippsWalletButtonProperties} />
+
+## Translations
+
+<TranslationsTable localeKey="VippsWalletButton" />

--- a/packages/dnb-eufemia/src/extensions/vipps-wallet-button/VippsWalletButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/vipps-wallet-button/VippsWalletButton.tsx
@@ -12,37 +12,12 @@ export type VippsWalletButtonProps = Omit<ButtonProps, 'variant'> & {
   pending?: boolean
 }
 
-const messages = {
-  'nb-NO': {
-    VippsWalletButton: {
-      text: 'Legg til i',
-    },
-  },
-  'en-GB': {
-    VippsWalletButton: {
-      text: 'Add to',
-    },
-  },
-  'sv-SE': {
-    VippsWalletButton: {
-      text: 'Lägg till i',
-    },
-  },
-  'da-DK': {
-    VippsWalletButton: {
-      text: 'Tilføj til',
-    },
-  },
-}
-
 export default function VippsWalletButton({
   className,
   pending,
   ...props
 }: VippsWalletButtonProps) {
-  const {
-    VippsWalletButton: translation = messages['nb-NO'].VippsWalletButton,
-  } = useTranslation({ messages })
+  const { VippsWalletButton: translation } = useTranslation()
   const buttonText = translation?.text
 
   return (

--- a/packages/dnb-eufemia/src/extensions/vipps-wallet-button/VippsWalletButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/vipps-wallet-button/VippsWalletButtonDocs.ts
@@ -1,0 +1,19 @@
+import type { PropertiesTableProps } from '../../shared/types'
+
+export const VippsWalletButtonProperties: PropertiesTableProps = {
+  pending: {
+    doc: 'Set to `true` to show a pending state with a [SubmitIndicator](/uilib/extensions/forms/Form/SubmitIndicator/). The button is disabled while pending. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  '[Button](/uilib/components/button/properties)': {
+    doc: 'All button properties, except `variant` which is always set to `primary`.',
+    type: 'Various',
+    status: 'optional',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}

--- a/packages/dnb-eufemia/src/shared/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/shared/locales/da-DK.ts
@@ -141,6 +141,9 @@ export default {
       addTitle: 'Forøg (%s)',
       subtractTitle: 'Reducer (%s)',
     },
+    VippsWalletButton: {
+      text: 'Tilføj til',
+    },
     PaymentCard: {
       textBlocked: 'Spærret',
       textExpired: 'Udløbet',

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -140,6 +140,9 @@ export default {
       addTitle: 'Increase (%s)',
       subtractTitle: 'Decrease (%s)',
     },
+    VippsWalletButton: {
+      text: 'Add to',
+    },
     PaymentCard: {
       textBlocked: 'Blocked',
       textExpired: 'Expired',

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -139,6 +139,9 @@ export default {
       addTitle: 'Øk (%s)',
       subtractTitle: 'Reduser (%s)',
     },
+    VippsWalletButton: {
+      text: 'Legg til i',
+    },
     PaymentCard: {
       textBlocked: 'Sperret',
       textExpired: 'Utløpt',

--- a/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/shared/locales/sv-SE.ts
@@ -140,6 +140,9 @@ export default {
       addTitle: 'Öka (%s)',
       subtractTitle: 'Minska (%s)',
     },
+    VippsWalletButton: {
+      text: 'Lägg till i',
+    },
     PaymentCard: {
       textBlocked: 'Spärrat',
       textExpired: 'Utgånget',


### PR DESCRIPTION
VippsWalletButton is publicly exported (via extensions) and has props (pending, plus all Button props except variant), but its docs folder only contained Examples.tsx - there was no properties page and no *Docs.ts.

Add VippsWalletButtonDocs.ts (pending, Button and Space references) and convert the single-page docs into the standard tabbed layout (Info / Demos / Properties) so the properties are surfaced like every other component.

