### PR TITLE
chore(Form.Snapshot): surface component properties on useSnapshot page

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot.mdx
@@ -7,6 +7,8 @@ tabs:
     key: '/info'
   - title: Demos
     key: '/demos'
+  - title: Properties
+    key: '/properties'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot/properties.mdx
@@ -1,0 +1,12 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { SnapshotProperties } from '@dnb/eufemia/src/extensions/forms/Form/Snapshot/SnapshotDocs'
+
+## Form.Snapshot
+
+Properties for the `Form.Snapshot` component, used to create partial data snapshots.
+
+<PropertiesTable props={SnapshotProperties} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot/properties.mdx
@@ -7,6 +7,4 @@ import { SnapshotProperties } from '@dnb/eufemia/src/extensions/forms/Form/Snaps
 
 ## Form.Snapshot
 
-Properties for the `Form.Snapshot` component, used to create partial data snapshots.
-
 <PropertiesTable props={SnapshotProperties} />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Snapshot/SnapshotDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Snapshot/SnapshotDocs.ts
@@ -4,7 +4,7 @@ export const SnapshotProperties: PropertiesTableProps = {
   name: {
     doc: 'A unique name for the sliced snapshot area.',
     type: 'string',
-    status: 'optional',
+    status: 'required',
   },
 }
 


### PR DESCRIPTION
The Form.Snapshot component (exported as Form.Snapshot) has a SnapshotDocs.ts with SnapshotProperties, and is already documented in the Form.useSnapshot Info tab, but its properties were never rendered in any properties.mdx.

Add a Properties tab to the Form.useSnapshot page that renders SnapshotProperties via PropertiesTable.

