### PR TITLE
chore(Wizard): document NextButton and PreviousButton properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/NextButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/NextButton/properties.mdx
@@ -3,6 +3,12 @@ showTabs: true
 ---
 
 import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { WizardNextButtonProperties } from '@dnb/eufemia/src/extensions/forms/Wizard/NextButton/NextButtonDocs'
+
+## Properties
+
+<PropertiesTable props={WizardNextButtonProperties} />
 
 ## Translations
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/PreviousButton/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/PreviousButton/properties.mdx
@@ -3,6 +3,12 @@ showTabs: true
 ---
 
 import TranslationsTable from 'dnb-design-system-portal/src/shared/parts/TranslationsTable'
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { WizardPreviousButtonProperties } from '@dnb/eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButtonDocs'
+
+## Properties
+
+<PropertiesTable props={WizardPreviousButtonProperties} />
 
 ## Translations
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/NextButton/NextButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/NextButton/NextButtonDocs.ts
@@ -22,5 +22,3 @@ export const WizardNextButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const WizardNextButtonEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/NextButton/NextButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/NextButton/NextButtonDocs.ts
@@ -1,0 +1,26 @@
+import type { PropertiesTableProps } from '../../../../shared/types'
+
+export const WizardNextButtonProperties: PropertiesTableProps = {
+  icon: {
+    doc: 'The icon shown in the button. Defaults to `chevron_right`.',
+    type: ['string', 'React.ReactNode'],
+    status: 'optional',
+  },
+  iconPosition: {
+    doc: 'Position of the icon inside the button. Defaults to `right`.',
+    type: ['"left"', '"right"', '"top"'],
+    status: 'optional',
+  },
+  '[Button](/uilib/components/button/properties)': {
+    doc: 'All button properties, except `variant`.',
+    type: 'Various',
+    status: 'optional',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}
+
+export const WizardNextButtonEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButtonDocs.ts
@@ -1,0 +1,31 @@
+import type { PropertiesTableProps } from '../../../../shared/types'
+
+export const WizardPreviousButtonProperties: PropertiesTableProps = {
+  variant: {
+    doc: 'Defines the kind of button. Defaults to `tertiary`.',
+    type: ['"primary"', '"secondary"', '"tertiary"', '"unstyled"'],
+    status: 'optional',
+  },
+  icon: {
+    doc: 'The icon shown in the button. Defaults to `chevron_left`.',
+    type: ['string', 'React.ReactNode'],
+    status: 'optional',
+  },
+  iconPosition: {
+    doc: 'Position of the icon inside the button. Defaults to `left`.',
+    type: ['"left"', '"right"', '"top"'],
+    status: 'optional',
+  },
+  '[Button](/uilib/components/button/properties)': {
+    doc: 'All button properties.',
+    type: 'Various',
+    status: 'optional',
+  },
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}
+
+export const WizardPreviousButtonEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/PreviousButton/PreviousButtonDocs.ts
@@ -27,5 +27,3 @@ export const WizardPreviousButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const WizardPreviousButtonEvents: PropertiesTableProps = {}


### PR DESCRIPTION
Wizard.NextButton and Wizard.PreviousButton extend ButtonProps (with Wizard specific defaults), but their properties.mdx pages only rendered a TranslationsTable - the Properties tab listed no properties.

Add NextButtonDocs.ts and PreviousButtonDocs.ts (overridden icon / iconPosition / variant defaults, plus Button and Space references) and render them with PropertiesTable on the respective pages.

