### PR TITLE
chore: drop unused empty events exports from *Docs.ts files

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/AnchorDocs.ts
+++ b/packages/dnb-eufemia/src/components/anchor/AnchorDocs.ts
@@ -87,5 +87,3 @@ export const AnchorProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const AnchorEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Slider/SliderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Slider/SliderDocs.ts
@@ -25,5 +25,3 @@ export const SliderFieldProperties: PropertiesTableProps = {
   '[Space](/uilib/layout/space/properties)':
     SliderProperties['[Space](/uilib/layout/space/properties)'],
 }
-
-export const SliderFieldEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Snapshot/SnapshotDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Snapshot/SnapshotDocs.ts
@@ -7,5 +7,3 @@ export const SnapshotProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const SnapshotEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/AnimatedContainer/AnimatedContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/AnimatedContainer/AnimatedContainerDocs.ts
@@ -4,5 +4,3 @@ import { EditContainerProperties } from '../EditContainer/EditContainerDocs'
 export const AnimatedContainerProperties: PropertiesTableProps = {
   ...EditContainerProperties,
 }
-
-export const AnimatedContainerEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Count/CountDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Count/CountDocs.ts
@@ -17,5 +17,3 @@ export const CountProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const CountEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/EditContainerDocs.ts
@@ -37,5 +37,3 @@ export const EditContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const EditContainerEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushButton/PushButtonDocs.ts
@@ -22,5 +22,3 @@ export const PushButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const PushButtonEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/RemoveButton/RemoveButtonDocs.ts
@@ -12,5 +12,3 @@ export const RemoveButtonProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const RemoveButtonEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/ToolbarDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/ToolbarDocs.ts
@@ -1,5 +1,3 @@
 import type { PropertiesTableProps } from '../../../../shared/types'
 
 export const ToolbarProperties: PropertiesTableProps = {}
-
-export const ToolbarEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ViewContainer/ViewContainerDocs.ts
@@ -27,5 +27,3 @@ export const ViewContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const ViewContainerEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Provider/ValueProviderDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Provider/ValueProviderDocs.ts
@@ -9,5 +9,3 @@ export const ValueProviderProperties: PropertiesTableProps = {
     status: 'required',
   },
 }
-
-export const StepEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Value/SummaryList/SummaryListDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/SummaryList/SummaryListDocs.ts
@@ -31,5 +31,3 @@ export const SummaryListProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const StepEvents: PropertiesTableProps = {}

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/StepDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/StepDocs.ts
@@ -47,5 +47,3 @@ export const StepProperties: PropertiesTableProps = {
     status: 'optional',
   },
 }
-
-export const StepEvents: PropertiesTableProps = {}


### PR DESCRIPTION
Several *Docs.ts files exported an empty `*Events: PropertiesTableProps = {}` object that nothing consumes - no properties.mdx or events.mdx renders them, and they are not re-exported or spread anywhere. Remove these 13 dead exports.

The similarly-named ToolbarEvents / ViewContainerEvents / EditContainerEvents under Form/Section (which DO have content and are rendered in events.mdx) are left untouched; only the empty duplicates under Iterate and the other empty ones (Snapshot, Count, AnimatedContainer, PushButton, RemoveButton, Step, SummaryList, ValueProvider, Slider, Anchor) are removed.

