### PR TITLE
chore(llm-metadata): resolve re-export barrels in docs property tables

### DIFF
--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -193,15 +193,14 @@ async function prerender() {
   // Step: Generate LLM metadata (llms.txt + markdown copies)
   // Skip for visual-test builds — they only need rendered pages for screenshots.
   if (process.env.IS_VISUAL_TEST !== '1') {
-    try {
-      console.log('\nGenerating LLM metadata...')
-      execSync('node vite/prod/generate-llm-metadata.mts', {
-        cwd: portalRoot,
-        stdio: 'inherit',
-      })
-    } catch {
-      console.warn('Warning: LLM metadata generation failed (non-fatal)')
-    }
+    console.log('\nGenerating LLM metadata...')
+    // Fail the build if generation fails. Otherwise a broken llms.txt or
+    // missing .md files ship silently and only surface later as portal e2e
+    // failures (see src/e2e/llm-metadata.spec.ts).
+    execSync('node vite/prod/generate-llm-metadata.mts', {
+      cwd: portalRoot,
+      stdio: 'inherit',
+    })
   }
 
   // Step: Copy fonts to dist/fonts/ (serves as CDN for all Eufemia consumers)

--- a/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
@@ -155,6 +155,101 @@ describe('convertMdxToMd', () => {
     expect(output).not.toContain('PropertiesTable')
   })
 
+  it('resolves PropertiesTable props imported through a named re-export barrel', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-barrel-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    fs.mkdirSync(docsRoot, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(docsRoot, 'CurrencyDocs.ts'),
+      [
+        'export const CurrencyProperties = {',
+        "  currency: { doc: 'Currency code', type: 'string' },",
+        '};',
+      ].join('\n')
+    )
+
+    // Barrel that re-exports from the underlying module.
+    fs.writeFileSync(
+      path.join(docsRoot, 'StatDocs.ts'),
+      "export { CurrencyProperties } from './CurrencyDocs'\n"
+    )
+
+    const mdxPath = path.join(docsRoot, 'stat.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      [
+        "import { CurrencyProperties } from './StatDocs'",
+        '',
+        '## Properties',
+        '',
+        '<PropertiesTable props={CurrencyProperties} />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).toContain('```json')
+    expect(output).toContain('"currency"')
+    expect(output).toContain('"Currency code"')
+    expect(output).not.toContain('PropertiesTable')
+  })
+
+  it('resolves PropertiesTable props imported through a wildcard re-export barrel', async () => {
+    const tmpRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'mdx-barrel-star-')
+    )
+    const docsRoot = path.join(tmpRoot, 'docs')
+    fs.mkdirSync(docsRoot, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(docsRoot, 'TrendDocs.ts'),
+      [
+        'export const TrendProperties = {',
+        "  trend: { doc: 'Trend direction', type: 'string' },",
+        '};',
+      ].join('\n')
+    )
+
+    fs.writeFileSync(
+      path.join(docsRoot, 'StatDocs.ts'),
+      "export * from './TrendDocs'\n"
+    )
+
+    const mdxPath = path.join(docsRoot, 'stat.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      [
+        "import { TrendProperties } from './StatDocs'",
+        '',
+        '## Properties',
+        '',
+        '<PropertiesTable props={TrendProperties} />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).toContain('```json')
+    expect(output).toContain('"trend"')
+    expect(output).toContain('"Trend direction"')
+    expect(output).not.toContain('PropertiesTable')
+  })
+
   it('includes extra attributes when converting PropertiesTable', async () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-attrs-'))
     const docsRoot = path.join(tmpRoot, 'docs')

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -1150,6 +1150,14 @@ async function evaluateTsModule(file: string, seen = new Set<string>()) {
     nextSeen
   )
 
+  // Resolve `export ... from '...'` barrels ahead of time and remove those
+  // statements from the code. The sandboxed require cannot load sibling TS
+  // modules, so leaving them in would emit require() calls that fail and
+  // produce getters that throw when accessed.
+  const { values: reExports, code: codeWithoutReExports } =
+    await resolveReExports(file, code, localRequire, nextSeen)
+  code = codeWithoutReExports
+
   code = code.replace(
     /(^\s*import[\s\S]*?from\s+['"][^'"]+['"][^\n]*$)/gm,
     ''
@@ -1183,7 +1191,14 @@ async function evaluateTsModule(file: string, seen = new Set<string>()) {
 
   const exp = sandbox.exports
   const mod = sandbox.module && sandbox.module.exports
-  return (exp && Object.keys(exp).length ? exp : mod) || {}
+  const evaluated = (exp && Object.keys(exp).length ? exp : mod) || {}
+
+  if (Object.keys(reExports).length) {
+    // Locally defined exports take precedence over re-exported ones.
+    return { ...reExports, ...evaluated }
+  }
+
+  return evaluated
 }
 
 async function buildModuleInjectionBindings(
@@ -1261,6 +1276,134 @@ async function buildModuleInjectionBindings(
   }
 
   return bindings
+}
+
+/**
+ * Resolve values re-exported from sibling modules, e.g. barrel files that do
+ * `export { Foo } from './FooDocs'` or `export * from './FooDocs'`.
+ *
+ * Returns the resolved values plus the source code with the re-export
+ * statements removed. The sandboxed require used by evaluateTsModule cannot
+ * load sibling TypeScript modules, so the statements are resolved here and
+ * stripped before the code is evaluated.
+ */
+async function resolveReExports(
+  file: string,
+  source: string,
+  localRequire: NodeJS.Require,
+  seen: Set<string>
+): Promise<{ values: Record<string, unknown>; code: string }> {
+  const parser = await import('@babel/parser')
+  const dir = path.dirname(file)
+  let ast
+
+  try {
+    ast = parser.parse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    })
+  } catch {
+    return { values: {}, code: source }
+  }
+
+  const values: Record<string, unknown> = {}
+  const ranges: Array<[number, number]> = []
+
+  const recordRange = (node: {
+    start?: number | null
+    end?: number | null
+  }) => {
+    if (typeof node.start === 'number' && typeof node.end === 'number') {
+      ranges.push([node.start, node.end])
+    }
+  }
+
+  for (const node of ast.program.body) {
+    // export * from './source'
+    if (node.type === 'ExportAllDeclaration') {
+      recordRange(node)
+
+      if (node.exportKind === 'type') {
+        continue
+      }
+
+      const mod = await loadImportedModuleForEvaluation({
+        baseDir: dir,
+        source: node.source.value,
+        localRequire,
+        seen,
+      })
+
+      if (!mod) {
+        continue
+      }
+
+      for (const key of Object.keys(mod)) {
+        if (key === 'default' || key === '__esModule') {
+          continue
+        }
+        values[key] = (mod as Record<string, unknown>)[key]
+      }
+      continue
+    }
+
+    // export { a, b as c } from './source' / export * as ns from './source'
+    if (node.type === 'ExportNamedDeclaration' && node.source) {
+      recordRange(node)
+
+      if (node.exportKind === 'type') {
+        continue
+      }
+
+      const mod = await loadImportedModuleForEvaluation({
+        baseDir: dir,
+        source: node.source.value,
+        localRequire,
+        seen,
+      })
+
+      if (!mod) {
+        continue
+      }
+
+      for (const specifier of node.specifiers) {
+        if (specifier.type === 'ExportNamespaceSpecifier') {
+          values[specifier.exported.name] = mod
+          continue
+        }
+
+        if (specifier.type !== 'ExportSpecifier') {
+          continue
+        }
+
+        if (specifier.exportKind === 'type') {
+          continue
+        }
+
+        const localName = specifier.local.name
+        const exportedName =
+          specifier.exported.type === 'Identifier'
+            ? specifier.exported.name
+            : specifier.exported.value
+
+        if (Object.prototype.hasOwnProperty.call(mod, localName)) {
+          values[exportedName] = (mod as Record<string, unknown>)[
+            localName
+          ]
+        }
+      }
+      continue
+    }
+  }
+
+  // Remove the re-export statements, highest offset first so earlier ranges
+  // stay valid.
+  let code = source
+  for (const [start, end] of ranges.sort((a, b) => b[0] - a[0])) {
+    code = code.slice(0, start) + code.slice(end)
+  }
+
+  return { values, code }
 }
 
 async function loadImportedModuleForEvaluation({


### PR DESCRIPTION
evaluateTsModule only handled 'import ... from' declarations, so docs pages importing from a re-export barrel (export { X } from './Y') crashed during markdown generation. The error was swallowed as non-fatal in prerender.mjs, so llms.txt and the .md copies were silently skipped and only surfaced as portal e2e failures.

- Resolve named, aliased and wildcard (export *) re-export barrels in evaluateTsModule, and strip those statements before VM evaluation.
- Fail the portal build when LLM metadata generation fails, so regressions surface at build time instead of as e2e failures.
- Add tests for named and wildcard re-export barrels.

