### PR TITLE
chore(Portal): make footer logo legible in dark mode

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -191,6 +191,10 @@
   &:global(.dnb-section) {
     display: flex;
   }
+
+  :global(.eufemia-theme__color-scheme--dark) & :global(.dnb-logo) svg {
+    fill: #fff;
+  }
 }
 
 .contentStyle {

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.module.scss
@@ -193,7 +193,7 @@
   }
 
   :global(.eufemia-theme__color-scheme--dark) & :global(.dnb-logo) svg {
-    fill: #fff;
+    fill: var(--token-color-text-neutral);
   }
 }
 


### PR DESCRIPTION
Preview: 

<img width="87" height="62" alt="Screenshot 2026-06-26 at 15 21 37" src="https://github.com/user-attachments/assets/79f49af1-c6b1-4589-a461-f38d41127bff" />
