### PR TITLE
fix(Logo): keep Carnegie logo legible since it only supports light mode

### DIFF
--- a/packages/dnb-eufemia/src/components/logo/LogoSvg.tsx
+++ b/packages/dnb-eufemia/src/components/logo/LogoSvg.tsx
@@ -35,7 +35,7 @@ export const logoColors = {
   dnb: { light: '#007272', dark: '#a5e1d2' },
   eiendom: { light: '#007272', dark: '#fff' },
   sbanken: { light: '#18172a', dark: '#fff' },
-  carnegie: { light: '#5c0022', dark: '#fff' },
+  carnegie: { light: '#5c0022' },
 }
 
 const DnbPaths = () => {
@@ -93,10 +93,8 @@ export const CarnegieDefault: LogoSvgComponent = function ({
   fill,
   ...props
 }) {
-  const theme = useTheme()
-  const isDark = theme?.colorScheme === 'dark'
-  const resolvedFill =
-    fill ?? (isDark ? logoColors.carnegie.dark : logoColors.carnegie.light)
+  // Carnegie only supports light mode, so it always uses the light fill color.
+  const resolvedFill = fill ?? logoColors.carnegie.light
 
   return (
     <svg fill={resolvedFill} {...props} viewBox="0 0 641.35 333.56">

--- a/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
+++ b/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
@@ -405,7 +405,7 @@ describe('Logo component', () => {
       expect(svg).toHaveAttribute('fill', logoColors.carnegie.light)
     })
 
-    it('should use correct fill in dark mode for CarnegieDefault', () => {
+    it('should use light fill in dark mode for CarnegieDefault since it only supports light mode', () => {
       render(
         <Theme colorScheme="dark">
           <Logo svg={CarnegieDefault} />
@@ -413,7 +413,7 @@ describe('Logo component', () => {
       )
 
       const svg = document.querySelector('svg')
-      expect(svg).toHaveAttribute('fill', logoColors.carnegie.dark)
+      expect(svg).toHaveAttribute('fill', logoColors.carnegie.light)
     })
 
     it('should allow overriding fill via the fill prop', () => {


### PR DESCRIPTION
The Carnegie brand only supports light mode (it ships no dark-mode tokens). The `Logo` component, however, still resolved the Carnegie SVG to a white fill whenever `colorScheme="dark"` was active. Since Carnegie's surface stays light, the white logo became invisible.

The Carnegie logo now always uses its light fill color, regardless of color scheme, so it stays legible.
