### PR TITLE
chore: render portal MDX components and resolve Field.Date tables in LLM docs

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -33,6 +33,7 @@ import useInvalidDates from './hooks/useInvalidDates'
 import type { DateFormatOptions } from '../../../../components/date-format/DateFormatUtils'
 import { formatDate } from '../../../../components/date-format/DateFormatUtils'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
+import { datePickerPropKeys } from './datePickerPropKeys'
 
 // `range`, `showInput`, `showCancelButton` and `showResetButton` are not picked from the `DatePickerProps`
 // Since they require `Field.Date` specific comments, due to them having different default values
@@ -666,50 +667,11 @@ function isEmptyOrPlaceholder(date: string): boolean {
   return !/\d/.test(date)
 }
 
-// Used to filter out DatePickerProps from the FieldProps.
-// Includes DatePickerProps that are not destructured in useFieldProps.
-// Single source of truth for both the type and the runtime key list.
-// Also used by DateDocs.ts to keep documentation in sync.
-export const datePickerPropKeys = [
-  'month',
-  'startMonth',
-  'endMonth',
-  'minDate',
-  'maxDate',
-  'maskOrder',
-  'maskPlaceholder',
-  'dateFormat',
-  'returnFormat',
-  'hideNavigation',
-  'hideDays',
-  'onlyMonth',
-  'hideLastWeek',
-  'disableAutofocus',
-  'showSubmitButton',
-  'submitButtonText',
-  'cancelButtonText',
-  'resetButtonText',
-  'firstDay',
-  'link',
-  'size',
-  'sync',
-  'addonElement',
-  'shortcuts',
-  'open',
-  'direction',
-  'alignPicker',
-  'onDaysRender',
-  'onType',
-  'onOpen',
-  'onClose',
-  'onSubmit',
-  'onCancel',
-  'onReset',
-  'skipPortal',
-  'yearNavigation',
-  'tooltip',
-  'triggerProps',
-] as const satisfies ReadonlyArray<keyof DatePickerProps>
+// `datePickerPropKeys` (used to filter DatePickerProps out of FieldProps)
+// lives in its own lightweight module so documentation tooling can import
+// it without evaluating this component. Re-exported here to preserve the
+// existing `./Date` import path.
+export { datePickerPropKeys }
 
 type PickedDatePickerProps = Pick<
   DatePickerProps,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/DateDocs.ts
@@ -3,7 +3,7 @@ import {
   DatePickerEvents,
 } from '../../../../components/date-picker/DatePickerDocs'
 import type { PropertiesTableProps } from '../../../../shared/types'
-import { datePickerPropKeys } from './Date'
+import { datePickerPropKeys } from './datePickerPropKeys'
 
 // Build the subset of DatePickerProperties that Field.Date forwards,
 // using datePickerPropKeys as the source of truth.

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/datePickerPropKeys.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/datePickerPropKeys.ts
@@ -1,0 +1,47 @@
+import type { DatePickerProps } from '../../../../components/DatePicker'
+
+// Includes DatePickerProps that are not destructured in useFieldProps.
+// Single source of truth for both the type and the runtime key list.
+// Lives in its own lightweight module (no component imports) so that
+// documentation tooling (DateDocs.ts) can import it without evaluating
+// the full Field.Date component.
+export const datePickerPropKeys = [
+  'month',
+  'startMonth',
+  'endMonth',
+  'minDate',
+  'maxDate',
+  'maskOrder',
+  'maskPlaceholder',
+  'dateFormat',
+  'returnFormat',
+  'hideNavigation',
+  'hideDays',
+  'onlyMonth',
+  'hideLastWeek',
+  'disableAutofocus',
+  'showSubmitButton',
+  'submitButtonText',
+  'cancelButtonText',
+  'resetButtonText',
+  'firstDay',
+  'link',
+  'size',
+  'sync',
+  'addonElement',
+  'shortcuts',
+  'open',
+  'direction',
+  'alignPicker',
+  'onDaysRender',
+  'onType',
+  'onOpen',
+  'onClose',
+  'onSubmit',
+  'onCancel',
+  'onReset',
+  'skipPortal',
+  'yearNavigation',
+  'tooltip',
+  'triggerProps',
+] as const satisfies ReadonlyArray<keyof DatePickerProps>

--- a/tools/eufemia-llm-metadata/scripts/__tests__/componentCatalog.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/componentCatalog.test.ts
@@ -1,0 +1,178 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+  cleanComponentTitle,
+  componentCategoryOrder,
+  getComponentCategoryTitle,
+  loadComponentCatalog,
+  normalizeComponentSlug,
+  toRelatedReason,
+} from '../../src/extensions/mdx/componentCatalog.ts'
+
+function writeComponent(
+  componentsDir: string,
+  fileName: string,
+  frontmatter: string[]
+) {
+  const filePath = path.join(componentsDir, fileName)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(
+    filePath,
+    ['---', ...frontmatter, '---', '', '# Page'].join('\n')
+  )
+}
+
+describe('componentCatalog', () => {
+  it('normalizeComponentSlug strips edge slashes and tab suffixes', () => {
+    expect(normalizeComponentSlug('/uilib/components/accordion/')).toBe(
+      'uilib/components/accordion'
+    )
+    expect(normalizeComponentSlug('uilib/components/accordion/info')).toBe(
+      'uilib/components/accordion'
+    )
+    expect(
+      normalizeComponentSlug('uilib/components/accordion/demos')
+    ).toBe('uilib/components/accordion')
+    expect(
+      normalizeComponentSlug('uilib/components/accordion/properties')
+    ).toBe('uilib/components/accordion')
+    // Nested component pages are not treated as tab suffixes.
+    expect(
+      normalizeComponentSlug(
+        'uilib/components/pagination/infinity-scroller'
+      )
+    ).toBe('uilib/components/pagination/infinity-scroller')
+  })
+
+  it('cleanComponentTitle removes trailing parenthetical', () => {
+    expect(cleanComponentTitle('Anchor (Text Link)')).toBe('Anchor')
+    expect(cleanComponentTitle('Button')).toBe('Button')
+  })
+
+  it('toRelatedReason strips the "Use <Component>" prefix', () => {
+    expect(
+      toRelatedReason('Use Anchor to take people to another page.')
+    ).toBe('to take people to another page.')
+    expect(toRelatedReason('A standalone sentence.')).toBe(
+      'A standalone sentence.'
+    )
+    expect(toRelatedReason(null)).toBeUndefined()
+  })
+
+  it('builds a catalog and applies frontmatter filters', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'catalog-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    const componentsDir = path.join(docsRoot, 'uilib', 'components')
+
+    writeComponent(componentsDir, 'button.mdx', [
+      'title: Button',
+      "category: 'actions'",
+      "description: 'Use Button to confirm.'",
+    ])
+    writeComponent(componentsDir, 'anchor.mdx', [
+      'title: Anchor',
+      "category: 'actions'",
+    ])
+    // No category -> falls back to "other".
+    writeComponent(componentsDir, 'mystery.mdx', ['title: Mystery'])
+    // category: false -> excluded entirely.
+    writeComponent(componentsDir, 'nocat.mdx', [
+      'title: NoCat',
+      'category: false',
+    ])
+    // draft / hideInMenu -> excluded.
+    writeComponent(componentsDir, 'draft.mdx', [
+      'title: Draft',
+      "category: 'content'",
+      'draft: true',
+    ])
+    writeComponent(componentsDir, 'hidden.mdx', [
+      'title: Hidden',
+      "category: 'content'",
+      'hideInMenu: true',
+    ])
+    // Missing title -> excluded (e.g. an info/demos tab file).
+    writeComponent(componentsDir, 'notitle.mdx', ['showTabs: true'])
+    // excludedSlugs -> excluded.
+    writeComponent(componentsDir, 'overview.mdx', ['title: Overview'])
+    writeComponent(componentsDir, 'fragments.mdx', ['title: Fragments'])
+    // Fragment sub-pages are still included.
+    writeComponent(componentsDir, 'fragments/scroll-view.mdx', [
+      'title: ScrollView',
+      "category: 'other'",
+    ])
+
+    const catalog = await loadComponentCatalog(docsRoot)
+
+    const actions = catalog.byCategory.get('actions') || []
+    expect(actions.map((entry) => entry.title)).toEqual([
+      'Anchor',
+      'Button',
+    ])
+
+    const other = (catalog.byCategory.get('other') || []).map(
+      (entry) => entry.title
+    )
+    expect(other).toContain('Mystery')
+    expect(other).toContain('ScrollView')
+
+    expect(catalog.byNormalizedSlug.has('uilib/components/button')).toBe(
+      true
+    )
+    expect(
+      catalog.byNormalizedSlug.has(
+        'uilib/components/fragments/scroll-view'
+      )
+    ).toBe(true)
+
+    const allTitles = Array.from(catalog.byNormalizedSlug.values()).map(
+      (entry) => entry.title
+    )
+    expect(allTitles).not.toContain('NoCat')
+    expect(allTitles).not.toContain('Draft')
+    expect(allTitles).not.toContain('Hidden')
+    expect(allTitles).not.toContain('Overview')
+    expect(allTitles).not.toContain('Fragments')
+  })
+
+  it('getComponentCategoryTitle returns the mapped title', () => {
+    expect(getComponentCategoryTitle('actions')).toBe('Actions')
+    expect(getComponentCategoryTitle('input')).toBe('Input')
+  })
+
+  it('stays in sync with the portal componentCategories source', () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const portalSource = fs.readFileSync(
+      path.join(
+        repoRoot,
+        'packages',
+        'dnb-design-system-portal',
+        'src',
+        'shared',
+        'parts',
+        'componentCategories.ts'
+      ),
+      'utf-8'
+    )
+
+    const blockMatch = portalSource.match(
+      /categoryOrder\s*=\s*\[([\s\S]*?)\]\s*as const/
+    )
+    expect(blockMatch).not.toBeNull()
+
+    const portalCategories: Array<{ id: string; title: string }> = []
+    const entryRegex = /\{\s*id:\s*'([^']+)',\s*title:\s*'([^']+)'/g
+    let match: RegExpExecArray | null
+
+    while ((match = entryRegex.exec(blockMatch?.[1] || ''))) {
+      portalCategories.push({ id: match[1], title: match[2] })
+    }
+
+    expect(portalCategories.length).toBeGreaterThan(0)
+    expect(
+      componentCategoryOrder.map(({ id, title }) => ({ id, title }))
+    ).toEqual(portalCategories)
+  })
+})

--- a/tools/eufemia-llm-metadata/scripts/__tests__/componentCatalog.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/componentCatalog.test.ts
@@ -5,11 +5,25 @@ import path from 'path'
 import {
   cleanComponentTitle,
   componentCategoryOrder,
+  excludedSlugs,
   getComponentCategoryTitle,
   loadComponentCatalog,
   normalizeComponentSlug,
   toRelatedReason,
 } from '../../src/extensions/mdx/componentCatalog.ts'
+import { MAX_VISIBLE_RELATED } from '../../src/extensions/mdx/relatedComponents.ts'
+
+function readPortalSource(repoRoot: string, ...segments: string[]) {
+  return fs.readFileSync(
+    path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      ...segments
+    ),
+    'utf-8'
+  )
+}
 
 function writeComponent(
   componentsDir: string,
@@ -144,17 +158,12 @@ describe('componentCatalog', () => {
 
   it('stays in sync with the portal componentCategories source', () => {
     const repoRoot = path.resolve(process.cwd(), '..', '..')
-    const portalSource = fs.readFileSync(
-      path.join(
-        repoRoot,
-        'packages',
-        'dnb-design-system-portal',
-        'src',
-        'shared',
-        'parts',
-        'componentCategories.ts'
-      ),
-      'utf-8'
+    const portalSource = readPortalSource(
+      repoRoot,
+      'src',
+      'shared',
+      'parts',
+      'componentCategories.ts'
     )
 
     const blockMatch = portalSource.match(
@@ -162,17 +171,72 @@ describe('componentCatalog', () => {
     )
     expect(blockMatch).not.toBeNull()
 
-    const portalCategories: Array<{ id: string; title: string }> = []
-    const entryRegex = /\{\s*id:\s*'([^']+)',\s*title:\s*'([^']+)'/g
+    const portalCategories: Array<{
+      id: string
+      title: string
+      description: string
+    }> = []
+    // Captures id, title and description (the description value sits on the
+    // line after `description:`, so `\s*` spans the newline). None of the
+    // descriptions contain a single quote, so `'([^']+)'` is sufficient.
+    const entryRegex =
+      /\{\s*id:\s*'([^']+)',\s*title:\s*'([^']+)',\s*description:\s*'([^']+)'/g
     let match: RegExpExecArray | null
 
     while ((match = entryRegex.exec(blockMatch?.[1] || ''))) {
-      portalCategories.push({ id: match[1], title: match[2] })
+      portalCategories.push({
+        id: match[1],
+        title: match[2],
+        description: match[3],
+      })
     }
 
     expect(portalCategories.length).toBeGreaterThan(0)
     expect(
-      componentCategoryOrder.map(({ id, title }) => ({ id, title }))
+      componentCategoryOrder.map(({ id, title, description }) => ({
+        id,
+        title,
+        description,
+      }))
     ).toEqual(portalCategories)
+  })
+
+  it('excludedSlugs stays in sync with the portal source', () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const portalSource = readPortalSource(
+      repoRoot,
+      'src',
+      'shared',
+      'parts',
+      'componentCategories.ts'
+    )
+
+    const blockMatch = portalSource.match(
+      /excludedSlugs\s*=\s*new Set\(\[([\s\S]*?)\]\)/
+    )
+    expect(blockMatch).not.toBeNull()
+
+    const portalExcluded = Array.from(
+      (blockMatch?.[1] || '').matchAll(/'([^']+)'/g),
+      (entry) => entry[1]
+    )
+
+    expect(portalExcluded.length).toBeGreaterThan(0)
+    expect([...excludedSlugs].sort()).toEqual([...portalExcluded].sort())
+  })
+
+  it('MAX_VISIBLE_RELATED stays in sync with the portal source', () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const portalSource = readPortalSource(
+      repoRoot,
+      'src',
+      'shared',
+      'parts',
+      'RelatedComponents.tsx'
+    )
+
+    const match = portalSource.match(/MAX_VISIBLE_RELATED\s*=\s*(\d+)/)
+    expect(match).not.toBeNull()
+    expect(MAX_VISIBLE_RELATED).toBe(Number(match?.[1]))
   })
 })

--- a/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/convertHelpers.test.ts
@@ -976,4 +976,288 @@ describe('convertMdxToMd', () => {
       '| 043 | Sølv MasterCard | Pluss Mastercard | Pluss |'
     )
   })
+
+  it('renders MenuCard cards and strips the Card.List wrapper', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-menucard-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    fs.mkdirSync(docsRoot, { recursive: true })
+
+    const mdxPath = path.join(docsRoot, 'contribute.mdx')
+    fs.writeFileSync(
+      mdxPath,
+      [
+        '## Dive in',
+        '',
+        '<Card.List bottom="small">',
+        '  <MenuCard',
+        '    url="/contribute/rules"',
+        '    about="Code of conduct and Development principles"',
+        '    title="Ground rules"',
+        '    icon={Principles}',
+        '  />',
+        '  <MenuCard',
+        '    url="/contribute/getting-started"',
+        '    about="Set up environment"',
+        '    title="Getting started"',
+        '    icon={GettingStarted}',
+        '  />',
+        '</Card.List>',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: mdxPath,
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).toContain(
+      '- [Ground rules](/contribute/rules) – Code of conduct and Development principles'
+    )
+    expect(output).toContain(
+      '- [Getting started](/contribute/getting-started) – Set up environment'
+    )
+    expect(output).not.toContain('<MenuCard')
+    expect(output).not.toContain('Card.List')
+  })
+
+  it('renders RelatedComponents into a related markdown list', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-related-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    const componentsDir = path.join(docsRoot, 'uilib', 'components')
+    fs.mkdirSync(path.join(componentsDir, 'button'), { recursive: true })
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'button.mdx'),
+      [
+        '---',
+        'title: Button',
+        "category: 'actions'",
+        "description: 'Use Button when people need to confirm an action.'",
+        '---',
+        '',
+        '# Button',
+      ].join('\n')
+    )
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'anchor.mdx'),
+      [
+        '---',
+        'title: Anchor',
+        "category: 'actions'",
+        "description: 'Use Anchor to take people to another page.'",
+        '---',
+        '',
+        '# Anchor',
+      ].join('\n')
+    )
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'button', 'info.mdx'),
+      [
+        '---',
+        'showTabs: true',
+        '---',
+        '',
+        '## Description',
+        '',
+        'Button description.',
+        '',
+        '<RelatedComponents />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: path.join(componentsDir, 'button', 'info.mdx'),
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).toContain('## Related components')
+    expect(output).toContain(
+      'Button is part of the [Actions](/uilib/components/overview/#actions) category.'
+    )
+    expect(output).toContain(
+      '- [Anchor](/uilib/components/anchor/) – to take people to another page.'
+    )
+    expect(output).not.toContain('<RelatedComponents')
+  })
+
+  it('caps RelatedComponents and adds a "See all" link', async () => {
+    const tmpRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'mdx-related-cap-')
+    )
+    const docsRoot = path.join(tmpRoot, 'docs')
+    const componentsDir = path.join(docsRoot, 'uilib', 'components')
+    fs.mkdirSync(path.join(componentsDir, 'current'), { recursive: true })
+
+    // The current page plus 8 siblings in the same category (9 total).
+    const names = [
+      'Current',
+      'Alpha',
+      'Bravo',
+      'Charlie',
+      'Delta',
+      'Echo',
+      'Foxtrot',
+      'Golf',
+      'Hotel',
+    ]
+
+    for (const name of names) {
+      fs.writeFileSync(
+        path.join(componentsDir, `${name.toLowerCase()}.mdx`),
+        [
+          '---',
+          `title: ${name}`,
+          "category: 'content'",
+          `description: '${name} description.'`,
+          '---',
+          '',
+          `# ${name}`,
+        ].join('\n')
+      )
+    }
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'current', 'info.mdx'),
+      ['---', 'showTabs: true', '---', '', '<RelatedComponents />'].join(
+        '\n'
+      )
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: path.join(componentsDir, 'current', 'info.mdx'),
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    // 8 siblings exist, but only the first 6 (alphabetical) are listed.
+    const listedCount = (output.match(/^- \[/gm) || []).length
+    expect(listedCount).toBe(6)
+    expect(output).toContain(
+      '[See all in Content](/uilib/components/overview/#content)'
+    )
+    // Alpha–Foxtrot are shown; Golf and Hotel are beyond the cap.
+    expect(output).toContain('- [Alpha](/uilib/components/alpha/)')
+    expect(output).not.toContain('- [Golf](/uilib/components/golf/)')
+    expect(output).not.toContain('- [Hotel](/uilib/components/hotel/)')
+  })
+
+  it('renders ListComponentsOverview grouped by category', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mdx-overview-'))
+    const docsRoot = path.join(tmpRoot, 'docs')
+    const componentsDir = path.join(docsRoot, 'uilib', 'components')
+    fs.mkdirSync(componentsDir, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'button.mdx'),
+      [
+        '---',
+        'title: Button',
+        "category: 'actions'",
+        "description: 'Use Button to confirm an action.'",
+        '---',
+        '',
+        '# Button',
+      ].join('\n')
+    )
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'checkbox.mdx'),
+      [
+        '---',
+        'title: Checkbox',
+        "category: 'input'",
+        "description: 'Use Checkbox to turn options on or off.'",
+        '---',
+        '',
+        '# Checkbox',
+      ].join('\n')
+    )
+
+    fs.writeFileSync(
+      path.join(componentsDir, 'overview.mdx'),
+      [
+        '---',
+        'title: Overview',
+        '---',
+        '',
+        '# Overview',
+        '',
+        '<ListComponentsOverview />',
+      ].join('\n')
+    )
+
+    const output = await convertMdxToMd({
+      inputPath: path.join(componentsDir, 'overview.mdx'),
+      docsRoot,
+      docsBaseRoot: docsRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).toContain('## Actions')
+    expect(output).toContain('## Input')
+    expect(output).toContain(
+      '- [Button](/uilib/components/button/): Use Button to confirm an action.'
+    )
+    expect(output).toContain(
+      '- [Checkbox](/uilib/components/checkbox/): Use Checkbox to turn options on or off.'
+    )
+    expect(output).toContain('[Eufemia Forms](/uilib/extensions/forms/)')
+    expect(output).not.toContain('<ListComponentsOverview')
+  })
+
+  it('resolves Field.Date PropertiesTable from extracted prop keys', async () => {
+    const repoRoot = path.resolve(process.cwd(), '..', '..')
+    const docsRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src',
+      'docs'
+    )
+    const docsBaseRoot = path.join(
+      repoRoot,
+      'packages',
+      'dnb-design-system-portal',
+      'src'
+    )
+    const inputPath = path.join(
+      docsRoot,
+      'uilib',
+      'extensions',
+      'forms',
+      'feature-fields',
+      'Date',
+      'properties.mdx'
+    )
+
+    const output = await convertMdxToMd({
+      inputPath,
+      docsRoot,
+      docsBaseRoot,
+      prettierConfig: {},
+      includeFrontmatter: false,
+      state: { mdxCache: new Map(), inProgress: new Set() },
+    })
+
+    expect(output).not.toContain('<PropertiesTable')
+    // Field.Date specific property
+    expect(output).toContain('"range"')
+    // Property forwarded from DatePicker via datePickerPropKeys
+    expect(output).toContain('"minDate"')
+  })
 })

--- a/tools/eufemia-llm-metadata/scripts/__tests__/menuCard.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/menuCard.test.ts
@@ -1,0 +1,78 @@
+import { createMenuCardExtension } from '../../src/extensions/mdx/menuCard.ts'
+
+const { replace } = createMenuCardExtension()
+
+describe('menuCard', () => {
+  it('renders MenuCards and drops the wrapping Card.List', async () => {
+    const input = [
+      '<Card.List bottom="small">',
+      '  <MenuCard',
+      '    url="/contribute/rules"',
+      '    about="Code of conduct and Development principles"',
+      '    title="Ground rules"',
+      '    icon={Principles}',
+      '  />',
+      '  <MenuCard',
+      '    url="/contribute/getting-started"',
+      '    about="Set up environment"',
+      '    title="Getting started"',
+      '    icon={GettingStarted}',
+      '  />',
+      '</Card.List>',
+    ].join('\n')
+
+    const output = await replace(input)
+
+    expect(output).toContain(
+      '- [Ground rules](/contribute/rules) – Code of conduct and Development principles'
+    )
+    expect(output).toContain(
+      '- [Getting started](/contribute/getting-started) – Set up environment'
+    )
+    expect(output).not.toContain('<MenuCard')
+    expect(output).not.toContain('Card.List')
+  })
+
+  it('leaves an unrelated Card.List untouched', async () => {
+    const unrelated = [
+      '<Card.List>',
+      '  Some unrelated content.',
+      '</Card.List>',
+    ].join('\n')
+
+    const input = [
+      '<Card.List bottom="small">',
+      '  <MenuCard url="/a" about="About A" title="A" icon={IconA} />',
+      '</Card.List>',
+      '',
+      unrelated,
+    ].join('\n')
+
+    const output = await replace(input)
+
+    expect(output).toContain('- [A](/a) – About A')
+    // The unrelated wrapper (which holds no MenuCards) is preserved verbatim.
+    expect(output).toContain(unrelated)
+  })
+
+  it('renders a MenuCard that is not wrapped in a Card.List', async () => {
+    const input = [
+      'Intro text.',
+      '',
+      '<MenuCard url="/solo" about="Solo card" title="Solo" icon={IconSolo} />',
+    ].join('\n')
+
+    const output = await replace(input)
+
+    expect(output).toContain('- [Solo](/solo) – Solo card')
+    expect(output).not.toContain('<MenuCard')
+  })
+
+  it('omits the reason when no "about" is provided', async () => {
+    const input = '<MenuCard url="/x" title="X" icon={IconX} />'
+
+    const output = await replace(input)
+
+    expect(output).toBe('- [X](/x)')
+  })
+})

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -1525,6 +1525,7 @@ export async function convertMdxToMd({
   outputBody = await applySpecialMdxComponentRenderers(outputBody, {
     findPackageRoot,
     inputDir: path.dirname(inputPath),
+    inputPath,
     docsRoot,
     importsByFile,
     loadModuleDefault,

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/componentCatalog.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/componentCatalog.ts
@@ -68,7 +68,7 @@ const categoryIds = new Set<string>(
   componentCategoryOrder.map(({ id }) => id)
 )
 
-const excludedSlugs = new Set([
+export const excludedSlugs = new Set([
   'uilib/components/fragments',
   'uilib/components/overview',
 ])

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/componentCatalog.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/componentCatalog.ts
@@ -1,0 +1,323 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+/**
+ * Component catalog used to render the portal-global `RelatedComponents`
+ * and `ListComponentsOverview` MDX components into static markdown.
+ *
+ * The category definitions mirror
+ * `packages/dnb-design-system-portal/src/shared/parts/componentCategories.ts`
+ * so the grouping stays in sync with what the website renders.
+ */
+
+export type ComponentCategoryId =
+  | 'actions'
+  | 'input'
+  | 'navigation'
+  | 'feedback'
+  | 'content'
+  | 'other'
+
+export type ComponentCategoryDefinition = {
+  id: ComponentCategoryId
+  title: string
+  description: string
+}
+
+export const componentCategoryOrder: ReadonlyArray<ComponentCategoryDefinition> =
+  [
+    {
+      id: 'actions',
+      title: 'Actions',
+      description:
+        'For things people click to do something, open choices, follow a link, or get help.',
+    },
+    {
+      id: 'input',
+      title: 'Input',
+      description:
+        'For entering information, choosing options, uploading files, or changing values.',
+    },
+    {
+      id: 'navigation',
+      title: 'Navigation',
+      description:
+        'For helping people move between pages, jump to content, or continue through steps.',
+    },
+    {
+      id: 'feedback',
+      title: 'Feedback',
+      description:
+        'For messages and panels that tell people what happened, what is happening, or what needs attention.',
+    },
+    {
+      id: 'content',
+      title: 'Content',
+      description:
+        'For showing information, such as text, numbers, tables, icons, lists, and cards.',
+    },
+    {
+      id: 'other',
+      title: 'Other',
+      description:
+        'For special page behavior that does not fit the groups above.',
+    },
+  ]
+
+const categoryIds = new Set<string>(
+  componentCategoryOrder.map(({ id }) => id)
+)
+
+const excludedSlugs = new Set([
+  'uilib/components/fragments',
+  'uilib/components/overview',
+])
+
+export type ComponentCatalogEntry = {
+  slug: string
+  title: string
+  description: string | null
+  category: ComponentCategoryId
+}
+
+export type ComponentCatalog = {
+  byNormalizedSlug: Map<string, ComponentCatalogEntry>
+  byCategory: Map<ComponentCategoryId, ComponentCatalogEntry[]>
+}
+
+const catalogCache = new Map<string, Promise<ComponentCatalog>>()
+
+export function getComponentCategoryTitle(
+  id: ComponentCategoryId
+): string {
+  return (
+    componentCategoryOrder.find((category) => category.id === id)?.title ??
+    id
+  )
+}
+
+export function normalizeComponentSlug(slug: string): string {
+  return slug
+    .replace(/^\/|\/$/g, '')
+    .replace(/\/(info|demos|properties|events)$/, '')
+}
+
+export function cleanComponentTitle(title: string): string {
+  return title.replace(/\s*\(.*\)\s*$/, '')
+}
+
+export function toRelatedReason(
+  description: string | null
+): string | undefined {
+  if (!description) {
+    return undefined
+  }
+
+  // Turn "Use <Component> to/when …" into a short reason clause.
+  return description.replace(
+    /^Use\s+[A-Z]\S*\s+(?=to\b|when\b|for\b|as\b|if\b)/,
+    ''
+  )
+}
+
+export function loadComponentCatalog(
+  docsRoot: string
+): Promise<ComponentCatalog> {
+  const cached = catalogCache.get(docsRoot)
+
+  if (cached) {
+    return cached
+  }
+
+  const promise = buildComponentCatalog(docsRoot)
+  catalogCache.set(docsRoot, promise)
+
+  return promise
+}
+
+async function buildComponentCatalog(
+  docsRoot: string
+): Promise<ComponentCatalog> {
+  const componentsRoot = path.join(docsRoot, 'uilib', 'components')
+  const entries: ComponentCatalogEntry[] = []
+
+  let files: string[]
+
+  try {
+    files = await findMdxFiles(componentsRoot)
+  } catch {
+    files = []
+  }
+
+  for (const filePath of files) {
+    const relativePath = path
+      .relative(docsRoot, filePath)
+      .replace(/\\/g, '/')
+    const noExt = relativePath.replace(/\.[^/.]+$/, '')
+
+    if (excludedSlugs.has(noExt)) {
+      continue
+    }
+
+    const frontmatter = await readFrontmatter(filePath)
+
+    if (!frontmatter) {
+      continue
+    }
+
+    const title =
+      typeof frontmatter.title === 'string' ? frontmatter.title.trim() : ''
+
+    if (
+      !title ||
+      frontmatter.draft === true ||
+      frontmatter.hideInMenu === true
+    ) {
+      continue
+    }
+
+    const category = getCategoryId(frontmatter.category)
+
+    if (!category) {
+      continue
+    }
+
+    entries.push({
+      slug: `/${noExt}/`,
+      title,
+      description:
+        typeof frontmatter.description === 'string'
+          ? frontmatter.description
+          : null,
+      category,
+    })
+  }
+
+  const byNormalizedSlug = new Map<string, ComponentCatalogEntry>()
+  const byCategory = new Map<
+    ComponentCategoryId,
+    ComponentCatalogEntry[]
+  >()
+
+  for (const entry of entries) {
+    byNormalizedSlug.set(normalizeComponentSlug(entry.slug), entry)
+
+    const group = byCategory.get(entry.category) || []
+    group.push(entry)
+    byCategory.set(entry.category, group)
+  }
+
+  for (const group of byCategory.values()) {
+    group.sort((a, b) => a.title.localeCompare(b.title))
+  }
+
+  return { byNormalizedSlug, byCategory }
+}
+
+async function findMdxFiles(root: string): Promise<string[]> {
+  const files: string[] = []
+
+  async function walk(currentPath: string): Promise<void> {
+    const dirEntries = await fs.readdir(currentPath, {
+      withFileTypes: true,
+    })
+
+    for (const dirEntry of dirEntries) {
+      const fullPath = path.join(currentPath, dirEntry.name)
+
+      if (dirEntry.isDirectory()) {
+        await walk(fullPath)
+        continue
+      }
+
+      if (dirEntry.isFile() && fullPath.endsWith('.mdx')) {
+        files.push(fullPath)
+      }
+    }
+  }
+
+  await walk(root)
+
+  return files
+}
+
+type CatalogFrontmatter = {
+  title?: string | null
+  description?: string | null
+  category?: string | boolean | null
+  draft?: boolean | null
+  hideInMenu?: boolean | null
+}
+
+async function readFrontmatter(
+  filePath: string
+): Promise<CatalogFrontmatter | null> {
+  try {
+    const source = await fs.readFile(filePath, 'utf-8')
+
+    return parseFrontmatter(source)
+  } catch {
+    return null
+  }
+}
+
+function parseFrontmatter(source: string): CatalogFrontmatter | null {
+  const match = source.match(/^---\n([\s\S]*?)\n---/)
+
+  if (!match?.[1]) {
+    return null
+  }
+
+  const frontmatter: CatalogFrontmatter = {}
+
+  for (const line of match[1].split('\n')) {
+    const separatorIndex = line.indexOf(':')
+
+    if (separatorIndex < 0) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex).trim()
+    const rawValue = line.slice(separatorIndex + 1).trim()
+
+    if (key === 'title') {
+      frontmatter.title = parseScalar(rawValue) as string
+    } else if (key === 'description') {
+      frontmatter.description = parseScalar(rawValue) as string
+    } else if (key === 'category') {
+      frontmatter.category = parseScalar(rawValue) as string | boolean
+    } else if (key === 'draft') {
+      frontmatter.draft = rawValue === 'true'
+    } else if (key === 'hideInMenu') {
+      frontmatter.hideInMenu = rawValue === 'true'
+    }
+  }
+
+  return frontmatter
+}
+
+function parseScalar(value: string): string | boolean {
+  if (value === 'true') {
+    return true
+  }
+
+  if (value === 'false') {
+    return false
+  }
+
+  return value.replace(/^['"]|['"]$/g, '')
+}
+
+function getCategoryId(
+  category: string | boolean | null | undefined
+): ComponentCategoryId | undefined {
+  if (category === false) {
+    return undefined
+  }
+
+  if (typeof category === 'string' && categoryIds.has(category)) {
+    return category as ComponentCategoryId
+  }
+
+  return 'other'
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/componentCatalog.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/componentCatalog.ts
@@ -207,7 +207,7 @@ async function buildComponentCatalog(
     byCategory.set(entry.category, group)
   }
 
-  for (const group of byCategory.values()) {
+  for (const group of Array.from(byCategory.values())) {
     group.sort((a, b) => a.title.localeCompare(b.title))
   }
 

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/listComponentsOverview.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/listComponentsOverview.ts
@@ -1,0 +1,78 @@
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import {
+  componentCategoryOrder,
+  loadComponentCatalog,
+  type ComponentCatalog,
+} from './componentCatalog.ts'
+import { escapeMarkdownLinkText, escapeMarkdownLinkUrl } from './utils.ts'
+
+export function createListComponentsOverviewExtension(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'ListComponentsOverview',
+    replace: (content) => replaceListComponentsOverview(content, deps),
+  }
+}
+
+async function replaceListComponentsOverview(
+  content: string,
+  deps: Pick<SpecialMdxRendererDeps, 'docsRoot'>
+) {
+  const regex = /<ListComponentsOverview\b[^>]*\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  const catalog = await loadComponentCatalog(deps.docsRoot)
+  const markdown = renderOverview(catalog)
+
+  if (!markdown) {
+    return content
+  }
+
+  regex.lastIndex = 0
+
+  return content.replace(regex, () => `\n${markdown}\n`)
+}
+
+function renderOverview(catalog: ComponentCatalog): string | null {
+  const sections: string[] = []
+
+  for (const category of componentCategoryOrder) {
+    const entries = catalog.byCategory.get(category.id) || []
+
+    if (entries.length === 0) {
+      continue
+    }
+
+    const lines = [`## ${category.title}`, '', category.description, '']
+
+    if (category.id === 'input') {
+      lines.push(
+        '**NB:** When creating application forms, use [Eufemia Forms](/uilib/extensions/forms/) instead of composing forms from the base components below.',
+        ''
+      )
+    }
+
+    for (const entry of entries) {
+      const link = `[${escapeMarkdownLinkText(entry.title)}](${escapeMarkdownLinkUrl(entry.slug)})`
+
+      lines.push(
+        entry.description ? `- ${link}: ${entry.description}` : `- ${link}`
+      )
+    }
+
+    sections.push(lines.join('\n'))
+  }
+
+  if (sections.length === 0) {
+    return null
+  }
+
+  return sections.join('\n\n')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/menuCard.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/menuCard.ts
@@ -6,8 +6,11 @@ import {
 } from './utils.ts'
 
 /**
- * Renders the portal `MenuCard` navigation cards into a markdown link list
- * and strips the surrounding `Card.List` wrapper, e.g.
+ * Renders the portal `MenuCard` navigation cards into a markdown link list.
+ *
+ * A `Card.List` wrapper is only unwrapped when it actually contains
+ * `MenuCard`s, so unrelated `Card.List` blocks in the same file are left
+ * untouched. For example:
  *
  *   <Card.List>
  *     <MenuCard url="/x" title="X" about="About X" icon={Icon} />
@@ -29,28 +32,35 @@ function replaceMenuCards(content: string) {
     return content
   }
 
-  let output = content.replace(
-    /^[ \t]*<MenuCard\b[\s\S]*?\/>/gm,
-    (tag) => {
-      const attrs = parseSimpleJsxStringAttributes(tag)
-      const url = attrs.url?.trim()
-      const title = attrs.title?.trim()
-      const about = attrs.about?.trim()
+  // Unwrap only the `Card.List` blocks that actually contain `MenuCard`s,
+  // rendering the cards in place and dropping the surrounding wrapper. Other
+  // `Card.List` blocks in the same file are left untouched.
+  const cardListBlock =
+    /^[ \t]*<Card\.List\b[^>]*>[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*<\/Card\.List>[ \t]*$/gm
 
-      if (!url || !title) {
-        return tag
-      }
-
-      const link = `[${escapeMarkdownLinkText(title)}](${escapeMarkdownLinkUrl(url)})`
-
-      return about ? `- ${link} – ${about}` : `- ${link}`
-    }
+  let output = content.replace(cardListBlock, (block, inner) =>
+    inner.includes('<MenuCard') ? renderMenuCardTags(inner) : block
   )
 
-  // Remove the surrounding Card.List wrapper, keeping the rendered list items.
-  output = output
-    .replace(/^[ \t]*<Card\.List\b[^>]*>[ \t]*$/gm, '')
-    .replace(/^[ \t]*<\/Card\.List>[ \t]*$/gm, '')
+  // Render any `MenuCard`s that are not wrapped in a `Card.List`.
+  output = renderMenuCardTags(output)
 
   return output
+}
+
+function renderMenuCardTags(text: string) {
+  return text.replace(/^[ \t]*<MenuCard\b[\s\S]*?\/>/gm, (tag) => {
+    const attrs = parseSimpleJsxStringAttributes(tag)
+    const url = attrs.url?.trim()
+    const title = attrs.title?.trim()
+    const about = attrs.about?.trim()
+
+    if (!url || !title) {
+      return tag
+    }
+
+    const link = `[${escapeMarkdownLinkText(title)}](${escapeMarkdownLinkUrl(url)})`
+
+    return about ? `- ${link} – ${about}` : `- ${link}`
+  })
 }

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/menuCard.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/menuCard.ts
@@ -1,0 +1,56 @@
+import type { SpecialMdxComponentRenderer } from './types.ts'
+import {
+  escapeMarkdownLinkText,
+  escapeMarkdownLinkUrl,
+  parseSimpleJsxStringAttributes,
+} from './utils.ts'
+
+/**
+ * Renders the portal `MenuCard` navigation cards into a markdown link list
+ * and strips the surrounding `Card.List` wrapper, e.g.
+ *
+ *   <Card.List>
+ *     <MenuCard url="/x" title="X" about="About X" icon={Icon} />
+ *   </Card.List>
+ *
+ * becomes
+ *
+ *   - [X](/x) – About X
+ */
+export function createMenuCardExtension(): SpecialMdxComponentRenderer {
+  return {
+    name: 'MenuCard',
+    replace: (content) => replaceMenuCards(content),
+  }
+}
+
+function replaceMenuCards(content: string) {
+  if (!content.includes('<MenuCard')) {
+    return content
+  }
+
+  let output = content.replace(
+    /^[ \t]*<MenuCard\b[\s\S]*?\/>/gm,
+    (tag) => {
+      const attrs = parseSimpleJsxStringAttributes(tag)
+      const url = attrs.url?.trim()
+      const title = attrs.title?.trim()
+      const about = attrs.about?.trim()
+
+      if (!url || !title) {
+        return tag
+      }
+
+      const link = `[${escapeMarkdownLinkText(title)}](${escapeMarkdownLinkUrl(url)})`
+
+      return about ? `- ${link} – ${about}` : `- ${link}`
+    }
+  )
+
+  // Remove the surrounding Card.List wrapper, keeping the rendered list items.
+  output = output
+    .replace(/^[ \t]*<Card\.List\b[^>]*>[ \t]*$/gm, '')
+    .replace(/^[ \t]*<\/Card\.List>[ \t]*$/gm, '')
+
+  return output
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/registry.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/registry.ts
@@ -2,8 +2,11 @@ import { createAvailableCountriesTableExtension } from './availableCountriesTabl
 import { createCardProductsTableExtension } from './cardProductsTable.ts'
 import { createColorTableExtension } from './colorTable.ts'
 import { createListAllIconsExtension } from './listAllIcons.ts'
+import { createListComponentsOverviewExtension } from './listComponentsOverview.ts'
 import { createListSummaryFromEdgesExtension } from './listSummaryFromEdges.ts'
+import { createMenuCardExtension } from './menuCard.ts'
 import { createRadiusTokenTableExtension } from './radiusTokenTable.ts'
+import { createRelatedComponentsExtension } from './relatedComponents.ts'
 import { createTokenExampleExtension } from './tokenExample.ts'
 import { createTokenSectionTableExtension } from './tokenSectionTable.ts'
 import type {
@@ -33,6 +36,9 @@ function createSpecialMdxExtensions(
     createRadiusTokenTableExtension(deps),
     createColorTableExtension(deps),
     createListSummaryFromEdgesExtension(deps),
+    createListComponentsOverviewExtension(deps),
+    createRelatedComponentsExtension(deps),
+    createMenuCardExtension(),
     createListAllIconsExtension(deps),
     createAvailableCountriesTableExtension(deps),
     createCardProductsTableExtension(deps),

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/relatedComponents.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/relatedComponents.ts
@@ -16,7 +16,7 @@ import { escapeMarkdownLinkText, escapeMarkdownLinkUrl } from './utils.ts'
 
 // Mirrors MAX_VISIBLE_RELATED in
 // packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
-const MAX_VISIBLE_RELATED = 6
+export const MAX_VISIBLE_RELATED = 6
 
 export function createRelatedComponentsExtension(
   deps: SpecialMdxRendererDeps

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/relatedComponents.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/relatedComponents.ts
@@ -1,0 +1,113 @@
+import path from 'path'
+import type {
+  SpecialMdxComponentRenderer,
+  SpecialMdxRendererDeps,
+} from './types.ts'
+import {
+  cleanComponentTitle,
+  getComponentCategoryTitle,
+  loadComponentCatalog,
+  normalizeComponentSlug,
+  toRelatedReason,
+  type ComponentCatalog,
+  type ComponentCatalogEntry,
+} from './componentCatalog.ts'
+import { escapeMarkdownLinkText, escapeMarkdownLinkUrl } from './utils.ts'
+
+// Mirrors MAX_VISIBLE_RELATED in
+// packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
+const MAX_VISIBLE_RELATED = 6
+
+export function createRelatedComponentsExtension(
+  deps: SpecialMdxRendererDeps
+): SpecialMdxComponentRenderer {
+  return {
+    name: 'RelatedComponents',
+    replace: (content) => replaceRelatedComponents(content, deps),
+  }
+}
+
+async function replaceRelatedComponents(
+  content: string,
+  deps: Pick<SpecialMdxRendererDeps, 'docsRoot' | 'inputPath'>
+) {
+  const regex = /<RelatedComponents\b[^>]*\/>/g
+
+  if (!regex.test(content)) {
+    return content
+  }
+
+  const catalog = await loadComponentCatalog(deps.docsRoot)
+  const current = findCurrentEntry(catalog, deps)
+
+  if (!current) {
+    return content
+  }
+
+  const markdown = renderRelatedComponents(catalog, current)
+
+  if (!markdown) {
+    return content
+  }
+
+  regex.lastIndex = 0
+
+  return content.replace(regex, () => `\n${markdown}\n`)
+}
+
+function findCurrentEntry(
+  catalog: ComponentCatalog,
+  deps: Pick<SpecialMdxRendererDeps, 'docsRoot' | 'inputPath'>
+): ComponentCatalogEntry | undefined {
+  const relativePath = path
+    .relative(deps.docsRoot, deps.inputPath)
+    .replace(/\\/g, '/')
+  const noExt = relativePath.replace(/\.[^/.]+$/, '')
+
+  return catalog.byNormalizedSlug.get(normalizeComponentSlug(noExt))
+}
+
+function renderRelatedComponents(
+  catalog: ComponentCatalog,
+  current: ComponentCatalogEntry
+): string | null {
+  const related = (catalog.byCategory.get(current.category) || []).filter(
+    (entry) => entry.slug !== current.slug
+  )
+
+  if (related.length === 0) {
+    return null
+  }
+
+  const categoryTitle = getComponentCategoryTitle(current.category)
+  const overviewAnchor = `/uilib/components/overview/#${current.category}`
+  const categoryLink = `[${escapeMarkdownLinkText(categoryTitle)}](${escapeMarkdownLinkUrl(overviewAnchor)})`
+  const visible = related.slice(0, MAX_VISIBLE_RELATED)
+  const hasMore = related.length > visible.length
+
+  const lines = [
+    '## Related components',
+    '',
+    `${cleanComponentTitle(current.title)} is part of the ${categoryLink} category. Other components for similar needs:`,
+    '',
+  ]
+
+  for (const entry of visible) {
+    const reason = toRelatedReason(entry.description)
+    const title = escapeMarkdownLinkText(cleanComponentTitle(entry.title))
+    const url = escapeMarkdownLinkUrl(entry.slug)
+
+    lines.push(
+      reason ? `- [${title}](${url}) – ${reason}` : `- [${title}](${url})`
+    )
+  }
+
+  if (hasMore) {
+    lines.push(
+      '',
+      `[See all in ${escapeMarkdownLinkText(categoryTitle)}](${escapeMarkdownLinkUrl(overviewAnchor)})`
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/types.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/types.ts
@@ -3,6 +3,7 @@ export type SpecialMdxRendererDeps = {
   findPackageRoot: (pkgName: string) => string | null
   toPascalCase: (value: string) => string
   inputDir: string
+  inputPath: string
   docsRoot: string
   importsByFile: Map<string, string[]>
   toSlugAndDir: (

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/utils.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/utils.ts
@@ -18,6 +18,14 @@ export function escapeMarkdownTableCell(value: string) {
   return value.replace(/[\\|]/g, '\\$&').trim()
 }
 
+export function escapeMarkdownLinkText(value: string) {
+  return value.replace(/[\\[\]]/g, '\\$&')
+}
+
+export function escapeMarkdownLinkUrl(value: string) {
+  return value.replace(/[()]/g, (char) => (char === '(' ? '%28' : '%29'))
+}
+
 export function toRgbString(hex: string) {
   try {
     let hexOnly = hex.replace(/^#/, '')


### PR DESCRIPTION
The LLM metadata generator left 124 docs files with unhandled standalone MDX components and silently dropped the `Field.Date` property/event tables, lowering the quality of the generated `*.md` used for LLM consumption.

- Render the portal-global `RelatedComponents`, `ListComponentsOverview` and `MenuCard` into markdown instead of leaving raw JSX in the output.
- Extract `datePickerPropKeys` into its own lightweight module so the docs generator can evaluate `Field.Date` docs without loading the full component (which previously failed and dropped the tables).

No runtime behavior change in `@dnb/eufemia` – `datePickerPropKeys` is still exported from `./Date`.