### PR TITLE
chore(docs): add missing main heading to portal pages

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy/tokens.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy/tokens.mdx
@@ -2,6 +2,8 @@
 title: 'Design tokens (WIP)'
 ---
 
+# Design tokens (WIP)
+
 ## Description
 
 ---

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/accessibility/checklist.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/accessibility/checklist.mdx
@@ -2,7 +2,7 @@
 title: 'Checklist for designers'
 ---
 
-## Accessibility checklist for designers
+# Accessibility checklist for designers
 
 Building an accessible interface starts at the UX stage of design. Much of the DNB Design System's styling and development has taken accessibility into consideration to a certain extent (see [UI Library Accessibility](/uilib/usage/accessibility)). However, each interface design comes with its own challenges and requirements.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/form-set-row-deprecation-v11.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/form-set-row-deprecation-v11.mdx
@@ -3,7 +3,7 @@ import {
   FormSetAlternativeForms,
 } from 'Docs/uilib/layout/Examples'
 
-## Deprecation
+# Deprecation
 
 To replace FormSet or FormRow, use the Eufemia [Provider](/uilib/usage/customisation/provider-info) and [Flex](/uilib/layout/flex) as well as the Eufemia [Forms Extension](/uilib/extensions/forms).
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
@@ -7,6 +7,8 @@ theme: ['sbanken', 'carnegie']
 
 import * as Examples from 'Docs/uilib/elements/code/Examples'
 
+# Code
+
 ## Import
 
 ```tsx

--- a/packages/dnb-design-system-portal/src/docs/uilib/shared/media-query/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/shared/media-query/properties.mdx
@@ -1,9 +1,11 @@
 ---
-showTabs: true
+title: 'Media Query'
 ---
 
 import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
 import { MediaQueryProperties } from '@dnb/eufemia/src/shared/MediaQueryDocs'
+
+# Media Query
 
 ## Properties
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/focus.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/focus.mdx
@@ -5,6 +5,8 @@ description: 'Accessibility helpers to handle focus management and Skip Link usa
 
 import * as Examples from 'Docs/uilib/usage/accessibility/Examples'
 
+# Focus / Skip Link
+
 ## Focus styling tokens
 
 For keyboard focus styling, use the action-focus family:
@@ -21,7 +23,7 @@ Here is an example of how it should look when implemented:
 
 <Examples.FocusExample />
 
-# Focus Management
+## Focus Management
 
 Focus is an important part of keyboard-only and screen reader navigation.
 


### PR DESCRIPTION
Several non-tab documentation pages started with an H2 instead of a top-level H1, so they had no main heading like other docs. Add (or promote to) a main H1 so they follow the same heading pattern. Heading text is unchanged, so existing anchor links are preserved.

- focus: add H1 and demote the stray Focus Management H1 to H2
- code: add H1
- tokens: add H1
- quickguide checklist for designers: promote first H2 to H1
- form-set-row deprecation: promote H2 to H1

