### PR TITLE
docs(Code): use tabbed sub-pages for info, demos and properties

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code.mdx
@@ -2,44 +2,14 @@
 title: 'Code'
 category: 'Typography'
 description: 'The code and pre element is used for code and syntax highlighting.'
+showTabs: true
 theme: ['sbanken', 'carnegie']
+hideTabs:
+  - title: Events
 ---
 
-import * as Examples from 'Docs/uilib/elements/code/Examples'
+import CodeInfo from 'Docs/uilib/elements/code/info'
+import CodeDemos from 'Docs/uilib/elements/code/demos'
 
-# Code
-
-## Import
-
-```tsx
-import { Code } from '@dnb/eufemia/elements'
-```
-
-## Relevant links
-
-- [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/elements/code)
-- [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/elements/code)
-
-## `code` and `pre` tag usage
-
-Both `code` and `pre` tags are styled.
-
-Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
-
-<Examples.CodeExample />
-
-### Code and Typography
-
-`<code>` and `<pre>` use the [DNBMono](/uilib/typography) font:
-
-```css
-font-family: var(--font-family-monospace);
-```
-
-## Code and Syntax highlighting
-
-[Prism](https://prismjs.com) is a popular Syntax Highlighting tool. DNB has its own **theme** you can use:
-
-- `@dnb/eufemia/style/themes/ui/prism/dnb-prism-theme.js`
-
-You can find the theme and its definitions in the [GitHub repository](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/style/themes/ui/prism/dnb-prism-theme.js).
+<CodeInfo />
+<CodeDemos />

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code/demos.mdx
@@ -1,0 +1,13 @@
+---
+showTabs: true
+---
+
+import { CodeExample } from 'Docs/uilib/elements/code/Examples'
+
+## Demos
+
+### `code` and `pre` tags
+
+Use [Section](/uilib/components/section/demos/#dark-surface) or [Theme.Context](/uilib/usage/customisation/theming/theme#surface-property) with `surface="dark"` to provide dark surface context to supporting components.
+
+<CodeExample />

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code/info.mdx
@@ -1,0 +1,34 @@
+---
+showTabs: true
+---
+
+## Import
+
+```tsx
+import { Code } from '@dnb/eufemia/elements'
+```
+
+## Description
+
+The `code` and `pre` elements are used for code and syntax highlighting. Both `code` and `pre` tags are styled.
+
+## Relevant links
+
+- [Source code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/elements/code)
+- [Docs code](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-design-system-portal/src/docs/uilib/elements/code)
+
+## Code and Typography
+
+`<code>` and `<pre>` use the [DNBMono](/uilib/typography) font:
+
+```css
+font-family: var(--font-family-monospace);
+```
+
+## Code and Syntax highlighting
+
+[Prism](https://prismjs.com) is a popular Syntax Highlighting tool. DNB has its own **theme** you can use:
+
+- `@dnb/eufemia/style/themes/ui/prism/dnb-prism-theme.js`
+
+You can find the theme and its definitions in the [GitHub repository](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/style/themes/ui/prism/dnb-prism-theme.js).

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code/properties.mdx
@@ -1,0 +1,10 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { CodeProperties } from '@dnb/eufemia/src/elements/code/CodeDocs'
+
+## Properties
+
+<PropertiesTable props={CodeProperties} />

--- a/packages/dnb-eufemia/src/elements/code/CodeDocs.ts
+++ b/packages/dnb-eufemia/src/elements/code/CodeDocs.ts
@@ -1,0 +1,9 @@
+import type { PropertiesTableProps } from '../../shared/types'
+
+export const CodeProperties: PropertiesTableProps = {
+  '[Space](/uilib/layout/space/properties)': {
+    doc: 'Spacing properties like `top` or `bottom` are supported.',
+    type: ['string', 'object'],
+    status: 'optional',
+  },
+}


### PR DESCRIPTION
Aligns the Code element docs with all other element docs (blockquote, span, etc.) by splitting the single page into Info, Demos and Properties tabs. Adds CodeProperties (Space) and hides the Events tab.

