### PR TITLE
chore(docs): correct breadcrumb hierarchy and broken hrefs in forms docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext.mdx
@@ -6,8 +6,6 @@ showTabs: false
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
-  - text: All features
-    href: /uilib/extensions/forms/all-features/
   - text: DataContext
     href: /uilib/extensions/forms/DataContext/
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/At.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/At.mdx
@@ -13,8 +13,6 @@ tabs:
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
-  - text: All features
-    href: /uilib/extensions/forms/all-features/
   - text: DataContext
     href: /uilib/extensions/forms/DataContext/
   - text: At

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Context.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Context.mdx
@@ -6,8 +6,6 @@ hideInMenu: true
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
-  - text: All features
-    href: /uilib/extensions/forms/all-features/
   - text: DataContext
     href: /uilib/extensions/forms/DataContext/
   - text: Context

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Provider.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/DataContext/Provider.mdx
@@ -15,8 +15,6 @@ tabs:
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
-  - text: All features
-    href: /uilib/extensions/forms/all-features/
   - text: DataContext
     href: /uilib/extensions/forms/DataContext/
   - text: Provider

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/SubmitIndicator.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/SubmitIndicator.mdx
@@ -14,7 +14,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.SubmitIndicator
+  - text: SubmitIndicator
     href: /uilib/extensions/forms/Form/SubmitIndicator/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Visibility.mdx
@@ -16,7 +16,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.Visibility
+  - text: Visibility
     href: /uilib/extensions/forms/Form/Visibility/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/clearData.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/clearData.mdx
@@ -10,7 +10,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.clearData
+  - text: clearData
     href: /uilib/extensions/forms/Form/clearData/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/getData.mdx
@@ -12,7 +12,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.getData
+  - text: getData
     href: /uilib/extensions/forms/Form/getData/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/setData.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/setData.mdx
@@ -12,7 +12,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.setData
+  - text: setData
     href: /uilib/extensions/forms/Form/setData/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useData.mdx
@@ -12,7 +12,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.useData
+  - text: useData
     href: /uilib/extensions/forms/Form/useData/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useDataValue.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useDataValue.mdx
@@ -10,7 +10,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.useDataValue
+  - text: useDataValue
     href: /uilib/extensions/forms/Form/useDataValue/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSnapshot.mdx
@@ -14,7 +14,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.useSnapshot
+  - text: useSnapshot
     href: /uilib/extensions/forms/Form/useSnapshot/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useSubmit.mdx
@@ -14,7 +14,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.useSubmit
+  - text: useSubmit
     href: /uilib/extensions/forms/Form/useSubmit/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useTranslation.mdx
@@ -14,7 +14,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.useTranslation
+  - text: useTranslation
     href: /uilib/extensions/forms/Form/useTranslation/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/useValidation.mdx
@@ -12,7 +12,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Form
     href: /uilib/extensions/forms/Form/
-  - text: Form.useValidation
+  - text: useValidation
     href: /uilib/extensions/forms/Form/useValidation/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Count.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Count.mdx
@@ -12,8 +12,6 @@ tabs:
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
-  - text: Extended features
-    href: /uilib/extensions/forms/
   - text: Iterate
     href: /uilib/extensions/forms/Iterate/
   - text: Count

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/ItemNo.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/ItemNo.mdx
@@ -10,8 +10,6 @@ tabs:
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
-  - text: Extended features
-    href: /uilib/extensions/forms/
   - text: Iterate
     href: /uilib/extensions/forms/Iterate/
   - text: ItemNo

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Visibility.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Visibility.mdx
@@ -16,7 +16,7 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Iterate
     href: /uilib/extensions/forms/Iterate/
-  - text: Iterate.Visibility
+  - text: Visibility
     href: /uilib/extensions/forms/Iterate/Visibility/
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/best-practices-on-forms.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/best-practices-on-forms.mdx
@@ -3,7 +3,7 @@ breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
   - text: Best Practices on Forms
-    href: /uilib/extensions/forms/best-practice-on-forms/
+    href: /uilib/extensions/forms/best-practices-on-forms/
 ---
 
 # Best Practices on Forms

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge.mdx
@@ -14,7 +14,7 @@ breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
   - text: Blocks
-    href: /uilib/extensions/forms/blocks/
+    href: /uilib/extensions/forms/blocks/collection/
   - text: ChildrenWithAge
     href: /uilib/extensions/forms/blocks/ChildrenWithAge/
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/blocks/ChildrenWithAge.mdx
@@ -14,8 +14,9 @@ breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
   - text: Blocks
-    href: /uilib/extensions/forms/blocks/collection/
+    href: /uilib/extensions/forms/blocks/
   - text: ChildrenWithAge
+    href: /uilib/extensions/forms/blocks/ChildrenWithAge/
 ---
 
 import Info from 'Docs/uilib/extensions/forms/blocks/ChildrenWithAge/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Provider.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Provider.mdx
@@ -15,8 +15,8 @@ breadcrumb:
     href: /uilib/extensions/forms/
   - text: Feature fields
     href: /uilib/extensions/forms/feature-fields/
-  - text: Field.Provider
-    href: /uilib/extensions/forms/feature-fields/Provider
+  - text: Provider
+    href: /uilib/extensions/forms/feature-fields/Provider/
 ---
 
 import Info from 'Docs/uilib/extensions/forms/feature-fields/Provider/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Time.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Time.mdx
@@ -18,6 +18,7 @@ breadcrumb:
   - text: Feature fields
     href: /uilib/extensions/forms/feature-fields/
   - text: Time
+    href: /uilib/extensions/forms/feature-fields/Time/
 ---
 
 import Info from 'Docs/uilib/extensions/forms/feature-fields/Time/info'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/intro-examples.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/intro-examples.mdx
@@ -8,7 +8,7 @@ breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/
   - text: Examples
-    href: /uilib/extensions/intro-examples/
+    href: /uilib/extensions/forms/intro-examples/
 ---
 
 import * as Examples from './Examples'


### PR DESCRIPTION
- Remove non-ancestor 'All features' crumb from DataContext, At, Context, Provider

- Remove duplicate 'Extended features' crumb from Iterate.Count and Iterate.ItemNo

- Fix typo href best-practice-on-forms -> best-practices-on-forms

- Point Blocks crumb to /blocks/ and add missing ChildrenWithAge href

- Add missing Field.Time crumb href

- Add missing forms/ segment to intro-examples crumb href

