### PR TITLE
chore: correct typos and duplicated words in comments and tests

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -2309,7 +2309,7 @@ describe('Autocomplete component', () => {
     expect(input.value).toBe('Kontonummer: 123456789')
   })
 
-  it('should update input value when data prop goes from emtpy to unempty and value is given', async () => {
+  it('should update input value when data prop goes from empty to unempty and value is given', async () => {
     const { rerender } = render(<Autocomplete {...mockProps} data={[]} />)
 
     const input = document.querySelector('.dnb-input__input')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/__tests__/ArraySelection.test.tsx
@@ -336,7 +336,7 @@ describe('ArraySelection', () => {
       )
     })
 
-    it('has correct elements when "checkbox" is provided provided', () => {
+    it('has correct elements when "checkbox" is provided', () => {
       render(
         <Field.ArraySelection>
           <Field.Option value="option1">Option 1</Field.Option>
@@ -837,7 +837,7 @@ describe('ArraySelection', () => {
         expect(options[1].textContent).toBe('title b')
       })
 
-      it(`has correct elements when "${testVariant}" is provided provided`, () => {
+      it(`has correct elements when "${testVariant}" is provided`, () => {
         render(
           <Field.ArraySelection variant={testVariant}>
             <Field.Option value="option1">Option 1</Field.Option>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/SubmitConfirmation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/SubmitConfirmation.tsx
@@ -183,7 +183,7 @@ function SubmitConfirmation(props: ConfirmProps) {
 
       submitStateRef.current = undefined
 
-      // Prevent the form form from being submitted
+      // Prevent the form from being submitted
       preventSubmit()
 
       await setConfirmationState('readyToBeSubmitted')

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -1,5 +1,5 @@
 /**
- * Web Context Context
+ * Web Context
  *
  */
 


### PR DESCRIPTION
- Form.SubmitConfirmation: remove duplicated word in preventSubmit comment
- shared/Context: remove duplicated word in file header comment
- Field.ArraySelection: fix duplicated word in two test descriptions
- Autocomplete: fix 'emtpy' typo in test description

