### PR TITLE
chore(test): shorten toNeverResolve timeout to speed up the suite

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest/setupVitest.ts
+++ b/packages/dnb-eufemia/src/core/vitest/setupVitest.ts
@@ -23,9 +23,19 @@ beforeEach(() => {
 })
 
 expect.extend({
-  async toNeverResolve(callable: () => void | Promise<void>) {
+  async toNeverResolve(
+    callable: () => void | Promise<void>,
+    options?: { timeout?: number; interval?: number }
+  ) {
+    // This matcher asserts that a condition never becomes true, so
+    // waitFor always polls for the full duration. The default waitFor
+    // timeout (1000ms) made every assertion needlessly slow; a short
+    // window is enough to confirm the negative. Callers can opt into a
+    // longer window via options when a slower condition must be ruled out.
+    const { timeout = 100, interval = 20 } = options ?? {}
+
     try {
-      await waitFor(callable)
+      await waitFor(callable, { timeout, interval })
       return {
         pass: false,
         message: () => 'Expected the function to reject, but it resolved.',

--- a/packages/dnb-eufemia/vitest.d.ts
+++ b/packages/dnb-eufemia/vitest.d.ts
@@ -11,7 +11,10 @@ declare namespace matchers {
 declare module 'vitest' {
   interface Matchers<T> {
     toHaveNoViolations(): T;
-    toNeverResolve(): Promise<T>;
+    toNeverResolve(options?: {
+      timeout?: number;
+      interval?: number;
+    }): Promise<T>;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -19,6 +22,9 @@ declare module 'vitest' {
 
   interface AsymmetricMatchersContaining {
     toHaveNoViolations(): void;
-    toNeverResolve(): void;
+    toNeverResolve(options?: {
+      timeout?: number;
+      interval?: number;
+    }): void;
   }
 }


### PR DESCRIPTION
The toNeverResolve matcher asserts that a condition never becomes true, so waitFor always polls for its full timeout. It used waitFor's default 1000ms, making each negative assertion take ~1s. Used inside it.each loops this dominated suite time (e.g. createMinimumAgeValidator.test.tsx: ~200 such cases). Default the matcher to a 100ms window (with an optional override) which is enough to confirm the negative.

