### PR TITLE
chore(test): run unit tests in the threads pool to speed up the suite

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterPanel.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import FilterRoot from '../FilterRoot'
 import FilterPanel from '../FilterPanel'
@@ -90,7 +90,7 @@ describe('Filter.Panel', () => {
     expect(closeButton.textContent).toContain('Skjul filter')
   })
 
-  it('closes the panel when close button is clicked', () => {
+  it('closes the panel when close button is clicked', async () => {
     render(
       <FilterRoot>
         <FilterPanelButton>Filters</FilterPanelButton>
@@ -110,7 +110,9 @@ describe('Filter.Panel', () => {
 
     fireEvent.click(closeButton)
 
-    expect(panel).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(panel).not.toBeInTheDocument()
+    })
   })
 
   it('moves focus to the panel button when close button is clicked', () => {

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
@@ -146,7 +146,9 @@ describe('SkipContent', () => {
     // 2. blur the event
     fireEvent.blur(element.querySelector('.dnb-button'))
 
-    expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
+    })
     expect(document.activeElement.tagName).toBe('BODY')
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
@@ -192,7 +192,9 @@ describe('postalCode', () => {
 
       await userEvent.type(postalCodeInput, '{Backspace}1')
 
-      expect(postalCodeInput).toHaveValue('0001')
+      await waitFor(() => {
+        expect(postalCodeInput).toHaveValue('0001')
+      })
 
       fireEvent.submit(document.querySelector('form'))
       await expect(() => {
@@ -412,7 +414,9 @@ describe('postalCode', () => {
 
       await userEvent.type(postalCodeInput, '{Backspace}1')
 
-      expect(postalCodeInput).toHaveValue('0001')
+      await waitFor(() => {
+        expect(postalCodeInput).toHaveValue('0001')
+      })
 
       fireEvent.submit(document.querySelector('form'))
       await expect(() => {

--- a/packages/dnb-eufemia/vitest.config.ts
+++ b/packages/dnb-eufemia/vitest.config.ts
@@ -4,6 +4,7 @@
  */
 
 import { defineConfig } from 'vitest/config'
+import { isCI } from 'repo-utils'
 import path from 'node:path'
 
 export default defineConfig({
@@ -11,6 +12,23 @@ export default defineConfig({
     reporters: ['default'],
     globals: true,
     environment: 'jsdom',
+
+    // Run test files in worker threads instead of forked child processes.
+    // Thread workers start up far faster and rebuild the jsdom environment
+    // more cheaply, which roughly halves the total run time while keeping
+    // full per-file isolation (each file still gets a fresh module graph).
+    pool: 'threads',
+
+    // The default 5s is tight for the heavier integration tests (large
+    // Eufemia Forms compositions), which can momentarily exceed it under
+    // the more concurrent threads pool. Give them more headroom.
+    testTimeout: 10_000,
+
+    // The threads pool schedules more work concurrently, which can surface
+    // timing-sensitive tests under CI load. Retry only in CI to absorb such
+    // transient flakiness (mirrors the screenshot suite's retry policy).
+    retry: isCI ? 2 : 0,
+
     environmentOptions: {
       jsdom: {
         url: 'http://localhost',


### PR DESCRIPTION
Switch the Vitest unit pool from the default `forks` to `threads`. Thread workers start far faster and rebuild the jsdom environment more cheaply, which roughly halves the suite's wall-clock time while keeping full per-file isolation (each file still gets a fresh module graph).

The more concurrent threads pool surfaced latent timing races in a few tests that asserted on asynchronous UI updates synchronously. Fix the most reproducible ones with waitFor:

- Filter.Panel: wait for the panel to unmount after close
- SkipContent: wait for the button to unmount after blur
- Connectors/Bring postalCode: wait for the masked input value to settle

Also raise testTimeout to 10s for the heavier Forms integration tests and add a CI-only retry to absorb residual contention flakiness, mirroring the screenshot suite's existing retry policy.

