### PR TITLE
chore: parallelize lint across workspaces and cache ESLint results

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -119,10 +119,57 @@ jobs:
             tools/*/node_modules
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
+      # Persist ESLint's --cache between runs so unchanged files are skipped.
+      # The key is unique per commit (always a miss), so restore-keys pulls
+      # the most recent prior cache and ESLint only re-lints what changed; a
+      # fresh entry is then saved at the end of the job.
+      - name: Use ESLint cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: packages/dnb-eufemia/.eslintcache
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-eslint-eufemia-${{ github.sha }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-eslint-eufemia-
+
       - name: Run lint
-        run: |
-          yarn workspace @dnb/eufemia lint:ci
-          yarn workspace dnb-design-system-portal lint:ci
+        run: yarn workspace @dnb/eufemia lint:ci
+
+  lint-portal:
+    name: Run portal lint
+    needs: setup
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 10
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: 'package.json'
+
+      - name: Use node_modules cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            tools/*/node_modules
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Use ESLint cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: packages/dnb-design-system-portal/.eslintcache
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-eslint-portal-${{ github.sha }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-eslint-portal-
+
+      - name: Run lint
+        run: yarn workspace dnb-design-system-portal lint:ci
 
   typecheck:
     name: Run type checks

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -23,7 +23,7 @@
     "build:version": "node ./scripts/version.js --new-version",
     "build:visual-test": "IS_VISUAL_TEST=1 node vite/prod/prerender.mjs",
     "clean": "rm -rf ./public",
-    "lint": "eslint --quiet --cache .",
+    "lint": "eslint --quiet --cache --cache-strategy content .",
     "lint:ci": "NODE_ENV=test yarn lint:js && yarn lint:styles && yarn prettier:check && yarn prettier:package",
     "lint:js": "yarn lint",
     "lint:styles": "stylelint './src/**/*.scss'",

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -48,7 +48,7 @@
     "icons:commit": "babel-node --extensions .js,.ts,.tsx ./scripts/figma/tasks/commitChanges",
     "icons:convert": "babel-node --extensions .js,.ts,.tsx ./scripts/tools/convertIcons && babel-node --extensions .js,.ts,.tsx ./scripts/figma/updateIcons",
     "icons:dev": "nodemon --exec 'babel-node --extensions .js,.ts,.tsx ./scripts/tools/convertIcons' --ext ts --ignore '/icons/**' --ignore '*.json'",
-    "lint": "eslint --quiet --cache ./src ./scripts",
+    "lint": "eslint --quiet --cache --cache-strategy content ./src ./scripts",
     "lint:ci": "yarn lint:lockfile && yarn lint:js && yarn lint:styles && yarn prettier:check && yarn prettier:package",
     "lint:js": "yarn lint",
     "lint:lockfile": "yarn lockfile-lint --path ../../yarn.lock --type yarn --allowed-schemes https: npm: workspace: patch: --allowed-hosts yarn github.com codeload.github.com",


### PR DESCRIPTION
Split the single lint job into two parallel jobs: `lint` (@dnb/eufemia, keeps the existing "Run lint" check) and `lint-portal` (dnb-design-system-portal), so the two workspaces lint concurrently instead of sequentially.

Persist each workspace's `.eslintcache` across runs via actions/cache (unique key per commit + restore-keys for the latest prior cache), so ESLint only re-lints changed files. Locally, eufemia ESLint dropped ~69s cold to ~22s warm.

Expected lint stage: ~118s -> ~40-55s. 

NOTE for reviewers: this adds a new "Run portal lint" status check — add it to branch protection's required checks alongside "Run lint".

