### PR TITLE
chore: lazy-load sass and jest-axe in testSetup

### DIFF
--- a/packages/dnb-eufemia/src/core/test-utils/testSetup.ts
+++ b/packages/dnb-eufemia/src/core/test-utils/testSetup.ts
@@ -2,16 +2,10 @@
  * Shared test utilities for Vitest.
  */
 
-import { axe, toHaveNoViolations } from 'jest-axe'
 import path from 'path'
-import * as sass from 'sass'
 import { vi } from 'vitest'
 
 import type { Options } from 'sass'
-
-export { axe, toHaveNoViolations }
-
-expect.extend(toHaveNoViolations)
 
 export const wait = (t: number) => new Promise((r) => setTimeout(r, t))
 
@@ -20,6 +14,12 @@ export const loadScss = (
   options: Partial<Options<'sync'>> & { data?: string } = {}
 ) => {
   try {
+    // Loaded lazily so test files that only use other helpers don't pay
+    // sass's import cost. loadScss is synchronous, so a sync require is
+    // required here (a dynamic import() would force it to become async).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+    const sass = require('sass') as typeof import('sass')
+
     const { data, ...sassOptions } = options
     const importPath2 = path.resolve(__dirname, '../../style/core/')
 
@@ -126,6 +126,11 @@ export const axeComponent = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...components: any[]
 ) => {
+  // Loaded lazily so test files that never run accessibility checks don't
+  // pay jest-axe's (axe-core) import cost.
+  const { axe, toHaveNoViolations } = await import('jest-axe')
+  expect.extend(toHaveNoViolations)
+
   const html = components
     .map((Component: { container?: HTMLElement } | HTMLElement) => {
       if (Component instanceof HTMLElement) {


### PR DESCRIPTION
Both libraries were imported at the top level of testSetup, so every one of the ~185 files importing it paid to load both (sass ~1.3s, jest-axe ~0.5s cold) even when using neither. Defer each to the helper that needs it: sass via a sync require inside loadScss, jest-axe via dynamic import inside axeComponent (which also registers the toHaveNoViolations matcher on first use).

The .toHaveNoViolations() type comes from vitest.d.ts, not jest-axe, so types are unaffected. No test imports axe/toHaveNoViolations directly from testSetup, so the re-export and top-level expect.extend could be removed.

Biggest win is the dev/watch inner loop and single-file/sharded runs, where files that don't use a given library no longer load it.

