### PR TITLE
chore: make typecheck incremental and cache TS build info

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -152,6 +152,20 @@ jobs:
             tools/*/node_modules
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
+      # Persist TypeScript's incremental build info so unchanged files are
+      # skipped on type-check. Unique key per commit + restore-keys pulls the
+      # latest prior build info; tsc re-checks only what changed (and falls
+      # back to a full check if the cache is missing or stale).
+      - name: Use TypeScript build-info cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            packages/dnb-eufemia/tsconfig.tsbuildinfo
+            packages/dnb-design-system-portal/tsconfig.tsbuildinfo
+            tools/eufemia-llm-metadata/tsconfig.tsbuildinfo
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-tsbuildinfo-${{ github.sha }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-tsbuildinfo-
+
       - name: Run type checks
         run: |
           yarn workspace @dnb/eufemia test:types

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 package-lock.json
 completions.json
 .eslintcache
+*.tsbuildinfo
 .DS_Store
 .history
 *not_in_use*

--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -47,7 +47,7 @@
     "test:screenshots:ci": "start-server-and-test serve http://localhost:8000 'yarn workspace @dnb/eufemia test:screenshots:ci'",
     "test:screenshots:ci:conditional": "start-server-and-test serve http://localhost:8000 'yarn workspace @dnb/eufemia test:screenshots:ci:conditional'",
     "test:screenshots:ci:update": "start-server-and-test serve http://localhost:8000 'yarn workspace @dnb/eufemia test:screenshots:ci:update'",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
     "test:types:watch": "tsc --noEmit --watch",
     "test:update": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/runVitest.ts --update=true",
     "test:watch": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/runVitest.ts --watch"

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -85,7 +85,7 @@
     "test:screenshots:update": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runScreenshotVitest.ts --update=true",
     "test:screenshots:watch": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runScreenshotVitest.ts --watch",
     "test:scripts": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runVitest.ts --preset=scripts",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
     "test:types:watch": "tsc --noEmit --watch",
     "test:update": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runVitest.ts --update=true",
     "test:watch": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runVitest.ts --watch",

--- a/tools/eufemia-llm-metadata/package.json
+++ b/tools/eufemia-llm-metadata/package.json
@@ -9,7 +9,7 @@
   "license": "SEE LICENSE IN LICENSE FILE",
   "scripts": {
     "test": "vitest run",
-    "test:types": "../../node_modules/.bin/tsc --noEmit",
+    "test:types": "../../node_modules/.bin/tsc --noEmit --incremental --tsBuildInfoFile tsconfig.tsbuildinfo",
     "lint": "node ../../node_modules/.bin/eslint **/*.ts",
     "generate": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/run-llm-metadata.ts"
   },


### PR DESCRIPTION
Add `--incremental --tsBuildInfoFile tsconfig.tsbuildinfo` to the `test:types` scripts of @dnb/eufemia, dnb-design-system-portal and eufemia-llm-metadata so `tsc --noEmit` reuses prior results, and cache the per-workspace build-info files in the typecheck CI job (unique key per commit + restore-keys). Gitignore `*.tsbuildinfo`.

Locally, eufemia type-check dropped ~55s (full) to ~18s on a warm build-info. tsc falls back to a full check when the cache is missing or stale, so correctness is preserved.

