### PR TITLE
chore(build): build cjs/es/esm bundles in parallel

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/postbuild.sh
+++ b/packages/dnb-eufemia/scripts/postbuild/postbuild.sh
@@ -6,13 +6,28 @@ echo 'Postbuild started ...'
 
 yarn build:types:definitions
 yarn prettier:other:write
-yarn build:cjs
+
+# Build the cjs/es/esm bundles in parallel. Each pass is independent: it only
+# reads from ./src (and the shared compiled CSS) and writes to its own
+# ./build/<format> directory, so running them concurrently cuts this phase from
+# the sum of all three down to roughly the slowest single pass. The background
+# PIDs are collected and waited on individually so a failure in any pass still
+# fails the build (set -e turns the non-zero `wait` into an exit).
+babel_pids=()
+yarn build:cjs &
+babel_pids+=($!)
 if [ -z "$BUILD_MINI" ]; then
-  yarn build:es
-  yarn build:esm
+  yarn build:es &
+  babel_pids+=($!)
+fi
+yarn build:esm &
+babel_pids+=($!)
+for pid in "${babel_pids[@]}"; do
+  wait "$pid"
+done
+
+if [ -z "$BUILD_MINI" ]; then
   yarn build:docs
-else
-  yarn build:esm
 fi
 yarn build:lebab
 # yarn build:resources # Can be enabled in future if needed


### PR DESCRIPTION
The cjs, es and esm Babel passes are independent: each only reads ./src (and the shared compiled CSS) and writes to its own ./build/<format> directory, yet postbuild.sh ran them one after another (roughly 3x a single pass).

Run them concurrently and wait on each background PID individually so a failing pass still fails the build (set -e turns the non-zero wait into an exit). The MINI build keeps its cjs+esm subset.

Verified: prebuild + postbuild:ci pass (test:postbuild 31/31 green); the postbuild dropped to ~189s locally.

