### PR TITLE
chore: use shared FormElementProps type for labelDirection prop

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -52,6 +52,7 @@ import type { SpacingProps } from '../../shared/types'
 import type { InputElement, InputSize } from '../Input'
 import type { SkeletonShow } from '../Skeleton'
 import type { ButtonProps } from '../Button'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import type {
   DatePickerCalendarDay,
@@ -222,7 +223,7 @@ export type DatePickerProps = {
   /**
    *  Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
    */
-  labelDirection?: 'vertical' | 'horizontal'
+  labelDirection?: FormElementProps['labelDirection']
   /**
    * Use `true` to make the label only readable by screen readers.
    */

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -35,6 +35,7 @@ import useId from '../../shared/helpers/useId'
 import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { useSpacing } from '../space/SpacingUtils'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
 import Suffix from '../../shared/helpers/Suffix'
@@ -106,7 +107,7 @@ export type DropdownProps = {
   /**
    * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
    */
-  labelDirection?: 'vertical' | 'horizontal'
+  labelDirection?: FormElementProps['labelDirection']
   /**
    * Use `true` to make the label only readable by screen readers.
    */

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -26,6 +26,7 @@ import type {
 import type { NumberFormatProps } from '../NumberFormat'
 import type { SkeletonShow } from '../Skeleton'
 import type { SpacingProps } from '../../shared/types'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import type { MaskitoOptions } from '@maskito/core'
 
 export type InputMaskedMask = RegExp | Array<RegExp | string> | false
@@ -128,7 +129,7 @@ export type InputMaskedProps = Omit<
     value?: InputMaskedValue
     id?: string
     label?: ReactNode
-    labelDirection?: 'horizontal' | 'vertical'
+    labelDirection?: FormElementProps['labelDirection']
     labelSrOnly?: boolean
     inputState?: string
     autocomplete?: string

--- a/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/segmented-field/types.ts
@@ -2,6 +2,7 @@ import type { FocusEvent, HTMLProps, ReactNode, RefObject } from 'react'
 import type { InputProps } from '../../Input'
 import type { FormStatusState, FormStatusText } from '../../FormStatus'
 import type { SpacingProps } from '../../../shared/types'
+import type { FormElementProps } from '../../../shared/helpers/filterValidProps'
 
 export type OverwriteMode = 'shift' | 'replace'
 
@@ -28,7 +29,7 @@ export type SegmentedFieldValue<T extends string> = {
 
 export type SegmentedFieldProps<T extends string> = {
   label?: ReactNode
-  labelDirection?: 'vertical' | 'horizontal'
+  labelDirection?: FormElementProps['labelDirection']
   inputs: SegmentedFieldItem<T>[]
   values?: SegmentedFieldValue<T>
   overwriteMode?: OverwriteMode

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -34,6 +34,7 @@ import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import { extendPropsWithContext } from '../../shared/helpers/extendPropsWithContext'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import useId from '../../shared/helpers/useId'
 import Suffix from '../../shared/helpers/Suffix'
@@ -151,7 +152,7 @@ export type InputProps = Omit<
     /**
      * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
      */
-    labelDirection?: 'vertical' | 'horizontal'
+    labelDirection?: FormElementProps['labelDirection']
     /**
      * Use `true` to make the label only readable by screen readers.
      */

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -15,6 +15,7 @@ import {
   dispatchCustomElementEvent,
   removeUndefinedProps,
 } from '../../shared/component-helper'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import { useSpacing } from '../space/SpacingUtils'
 import AlignmentHelper from '../../shared/AlignmentHelper'
@@ -48,7 +49,7 @@ export type RadioGroupChangeEvent = {
 
 export type RadioGroupProps = {
   label?: ReactNode
-  labelDirection?: 'vertical' | 'horizontal'
+  labelDirection?: FormElementProps['labelDirection']
   labelSrOnly?: boolean
   labelPosition?: RadioGroupLabelPosition
   title?: string

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -1,6 +1,7 @@
 import type { ElementType, HTMLProps, ReactNode, RefObject } from 'react'
 
 import type { SuffixChildren } from '../../shared/helpers/Suffix'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import type { NumberFormatOptionParams } from '../number-format/NumberUtils'
 import type { SpacingProps } from '../../shared/types'
 import type { SkeletonShow } from '../Skeleton'
@@ -31,7 +32,7 @@ export type SliderProps = {
   /**
    * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
    */
-  labelDirection?: 'vertical' | 'horizontal'
+  labelDirection?: FormElementProps['labelDirection']
 
   /**
    * Use `true` to make the label only readable by screen readers.

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -34,6 +34,7 @@ import {
   dispatchCustomElementEvent,
   convertJsxToString,
 } from '../../shared/component-helper'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { useSpacing } from '../space/SpacingUtils'
@@ -108,7 +109,7 @@ export type TextareaProps = Omit<
     /**
      * Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.
      */
-    labelDirection?: 'vertical' | 'horizontal'
+    labelDirection?: FormElementProps['labelDirection']
     /**
      * Use `true` to make the label only readable by screen readers.
      */

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -30,6 +30,7 @@ import {
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import { useSpacing } from '../space/SpacingUtils'
 
@@ -512,7 +513,7 @@ export type ToggleButtonProps = Omit<
      * Use either the `label` property or provide a custom one.
      */
     label?: string | ReactNode
-    labelDirection?: 'horizontal' | 'vertical'
+    labelDirection?: FormElementProps['labelDirection']
     labelSrOnly?: boolean
     /**
      * The `title` of the input - describing it a bit further for accessibility reasons.

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -25,6 +25,7 @@ import Space from '../Space'
 import Context from '../../shared/Context'
 import Suffix from '../../shared/helpers/Suffix'
 import ToggleButtonGroupContext from './ToggleButtonGroupContext'
+import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
 const toggleButtonGroupDefaultProps: Partial<ToggleButtonGroupProps> = {
@@ -379,7 +380,7 @@ export type ToggleButtonGroupProps = Omit<
      * Use either the `label` property or provide a custom one.
      */
     label?: string | ReactNode
-    labelDirection?: 'horizontal' | 'vertical'
+    labelDirection?: FormElementProps['labelDirection']
     labelSrOnly?: boolean
     /**
      * The `title` of group, describing it a bit further for accessibility reasons.


### PR DESCRIPTION
Replace 8 inline `labelDirection?: 'vertical' | 'horizontal'` unions with the shared `FormElementProps['labelDirection']` type (the same pattern FormLabel already uses) across Dropdown, RadioGroup, Input, Textarea, DatePicker, InputMasked, ToggleButton and ToggleButtonGroup. The resolved type is identical, so there is no API or behavior change.

