### PR TITLE
chore: standardize default-props and memo/inner-component naming

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -69,7 +69,7 @@ export default function AccordionContent(props: AccordionContentProps) {
     )
   }
 
-  return <AccordionContentInner {...props} />
+  return <AccordionContentComponent {...props} />
 }
 
 function AccordionContentStandalone({
@@ -122,7 +122,7 @@ function AccordionContentStandalone({
   )
 }
 
-function AccordionContentInner(props: AccordionContentProps) {
+function AccordionContentComponent(props: AccordionContentProps) {
   const context = useContext<AccordionContextValue>(AccordionContext)
   const {
     id,

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -84,7 +84,7 @@ export type AnchorAllProps = AnchorProps &
   Omit<HTMLProps<HTMLAnchorElement>, 'ref'> &
   SpacingProps
 
-const defaultProps: AnchorProps = {
+const anchorDefaultProps: AnchorProps = {
   noAnimation: false,
   noStyle: false,
   noHover: false,
@@ -94,11 +94,11 @@ const defaultProps: AnchorProps = {
   disabled: false,
 }
 
-export function AnchorInstance(localProps: AnchorAllProps) {
+export function AnchorComponent(localProps: AnchorAllProps) {
   const context = useContext(Context)
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    anchorDefaultProps,
     { skeleton: context?.skeleton },
     context?.getTranslation(localProps as AnchorAllProps).Anchor,
     context?.Anchor
@@ -264,7 +264,7 @@ export function AnchorInstance(localProps: AnchorAllProps) {
 }
 
 function Anchor(props: AnchorAllProps) {
-  return <AnchorInstance {...props} />
+  return <AnchorComponent {...props} />
 }
 
 withComponentMarkers(Anchor, {

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -483,7 +483,7 @@ function Autocomplete(props: AutocompleteAllProps) {
 
   return (
     <DrawerListProvider {...providerProps}>
-      <AutocompleteInstance {...props} id={_id} />
+      <AutocompleteComponent {...props} id={_id} />
     </DrawerListProvider>
   )
 }
@@ -530,7 +530,7 @@ function getCurrentDataTitle(
   })
 }
 
-function AutocompleteInstance(ownProps: AutocompleteAllProps) {
+function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const context = useContext<
     DrawerListContextValue & {
       Autocomplete: Record<string, unknown>

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -108,7 +108,7 @@ export type AvatarProps = Omit<HTMLProps<HTMLElement>, 'size'> & {
 
 export type AvatarAllProps = AvatarProps & SpacingProps
 
-const defaultProps: Partial<AvatarAllProps> = {
+const avatarDefaultProps: Partial<AvatarAllProps> = {
   size: 'medium',
   variant: 'primary',
   skeleton: false,
@@ -123,7 +123,7 @@ const Avatar = (localProps: AvatarAllProps) => {
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    avatarDefaultProps,
     context?.Avatar,
     { skeleton: context?.skeleton },
     avatarGroupContext

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -74,7 +74,7 @@ export type AvatarGroupProps = {
 
 export type AvatarGroupAllProps = AvatarGroupProps & SpacingProps
 
-const defaultProps: Partial<AvatarGroupAllProps> = {
+const avatarGroupDefaultProps: Partial<AvatarGroupAllProps> = {
   maxElements: 4,
   size: 'medium',
   variant: 'primary',
@@ -103,7 +103,7 @@ const AvatarGroup = (localProps: AvatarGroupAllProps) => {
     ...props
   } = extendPropsWithContext(
     localProps,
-    defaultProps,
+    avatarGroupDefaultProps,
     context?.AvatarGroup,
     {
       skeleton: context?.skeleton,

--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -80,7 +80,7 @@ export type BadgeAllProps = BadgeProps &
 
 type BadgeElemProps = BadgeAllProps & { context: ContextProps }
 
-export const defaultProps: BadgeAllProps = {
+export const badgeDefaultProps: BadgeAllProps = {
   skeleton: false,
   variant: 'information',
   status: 'default',
@@ -95,7 +95,7 @@ function Badge(localProps: BadgeAllProps) {
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    badgeDefaultProps,
     context?.Badge,
     { skeleton: context?.skeleton }
   )
@@ -139,8 +139,8 @@ function propGuard(
     if (props.variant !== 'information') {
       return fn({
         ...props,
-        subtle: defaultProps.subtle,
-        status: defaultProps.status,
+        subtle: badgeDefaultProps.subtle,
+        status: badgeDefaultProps.status,
       })
     }
     return fn(props)

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -139,7 +139,7 @@ export type BreadcrumbAllProps = BreadcrumbProps &
   SpacingProps &
   Omit<HTMLProps<HTMLElement>, keyof BreadcrumbProps>
 
-const defaultProps: Partial<BreadcrumbAllProps> = {
+const breadcrumbDefaultProps: Partial<BreadcrumbAllProps> = {
   skeleton: false,
   collapsed: true,
   spacing: false,
@@ -152,7 +152,7 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    breadcrumbDefaultProps,
     context?.translation?.Breadcrumb,
     context?.Breadcrumb,
     { skeleton: context?.skeleton }

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -115,7 +115,7 @@ export type CheckboxProps = {
     'ref' | 'label' | 'size' | 'onChange' | 'onClick'
   >
 
-const defaultProps: CheckboxProps = {
+const checkboxDefaultProps: CheckboxProps = {
   statusState: 'error',
 }
 
@@ -125,7 +125,7 @@ function Checkbox(localProps: CheckboxProps) {
   const extractPropsFromContext = useCallback(() => {
     return extendPropsWithContext(
       localProps,
-      defaultProps,
+      checkboxDefaultProps,
       context.Checkbox,
       {
         skeleton: context?.Checkbox,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -364,7 +364,7 @@ export type DatePickerAllProps = DatePickerProps &
     | 'start'
   >
 
-const defaultProps: Partial<DatePickerAllProps> = {
+const datePickerDefaultProps: Partial<DatePickerAllProps> = {
   hideNavigation: false,
   hideDays: false,
   onlyMonth: false,
@@ -387,7 +387,7 @@ const defaultProps: Partial<DatePickerAllProps> = {
 }
 
 function DatePicker(externalProps: DatePickerAllProps) {
-  const props = { ...defaultProps, ...externalProps }
+  const props = { ...datePickerDefaultProps, ...externalProps }
 
   const {
     preventClose,
@@ -562,7 +562,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
   // use only the props from context, who are available here anyway
   const extendedProps = extendPropsWithContext(
     props,
-    defaultProps,
+    datePickerDefaultProps,
     { skeleton: context?.skeleton },
     context.getTranslation(props).DatePicker,
     pickFormElementProps(context?.formElement),

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -120,7 +120,7 @@ type DayObject = {
   className?: string
 }
 
-const defaultProps: DatePickerCalendarProps = {
+const datePickerCalendarDefaultProps: DatePickerCalendarProps = {
   hideNavigation: false,
   hideDays: false,
   onlyMonth: false,
@@ -134,7 +134,7 @@ const arrowKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']
 const keysToHandle = ['Enter', 'Space', ...arrowKeys]
 
 function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
-  const props = { ...defaultProps, ...restOfProps }
+  const props = { ...datePickerCalendarDefaultProps, ...restOfProps }
 
   const {
     updateDates,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -111,14 +111,14 @@ export type DatePickerInvalidDates = {
   invalidEndDate?: string
 }
 
-const defaultProps: DatePickerInputProps = {
+const datePickerInputDefaultProps: DatePickerInputProps = {
   separatorRegExp: /[-/ ]/g,
   statusState: 'error',
   open: false,
 }
 
 function DatePickerInput(externalProps: DatePickerInputProps) {
-  const props = { ...defaultProps, ...externalProps }
+  const props = { ...datePickerInputDefaultProps, ...externalProps }
 
   const {
     maskOrder: defaultMaskOrder,

--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -15,7 +15,7 @@ import DialogAction from './parts/DialogAction'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
-const defaultProps: Partial<DialogProps & DialogContentProps> = {
+const dialogDefaultProps: Partial<DialogProps & DialogContentProps> = {
   variant: 'information',
   spacing: true,
 }
@@ -25,7 +25,7 @@ function Dialog(localProps: DialogProps & DialogContentProps) {
 
   const propsWithContext = extendPropsWithContext(
     localProps,
-    defaultProps,
+    dialogDefaultProps,
     context?.Dialog
   )
 

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -196,7 +196,7 @@ const dropdownDefaultProps: Partial<DropdownAllProps> = {
   open: false,
 }
 
-const DropdownInstance = memo(function DropdownInstance({
+const DropdownComponent = memo(function DropdownComponent({
   externalRef,
   externalButtonRef,
   ...ownProps
@@ -716,7 +716,7 @@ function Dropdown({ ref, buttonRef, ...props }: DropdownAllProps) {
       ignoreEvents={false}
       preventSelection={preventSelection}
     >
-      <DropdownInstance
+      <DropdownComponent
         {...props}
         id={id}
         externalRef={ref}

--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -89,7 +89,7 @@ export type GlobalErrorTranslation = {
   500?: GlobalErrorTranslationContent
 }
 
-const defaultProps: Partial<GlobalErrorAllProps> = {
+const globalErrorDefaultProps: Partial<GlobalErrorAllProps> = {
   statusCode: '404',
 }
 
@@ -103,10 +103,12 @@ export default function GlobalError(localProps: GlobalErrorAllProps) {
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    globalErrorDefaultProps,
     context?.GlobalError,
     translation,
-    translation[localProps.statusCode || defaultProps.statusCode],
+    translation[
+      localProps.statusCode || globalErrorDefaultProps.statusCode
+    ],
     { skeleton: context?.skeleton }
   )
 

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.tsx
@@ -80,7 +80,9 @@ const globalStatusControllerDefaultProps: Partial<GlobalStatusControllerProps> =
   }
 
 // This is the Update controller
-function GlobalStatusController(ownProps: GlobalStatusControllerProps) {
+function GlobalStatusControllerComponent(
+  ownProps: GlobalStatusControllerProps
+) {
   const props = {
     ...globalStatusControllerDefaultProps,
     ...removeUndefinedProps({ ...ownProps }),
@@ -127,11 +129,11 @@ function GlobalStatusController(ownProps: GlobalStatusControllerProps) {
   return null
 }
 
-const MemoizedGlobalStatusController = memo(
-  GlobalStatusController
-) as MemoExoticComponent<typeof GlobalStatusController> & {
-  Remove: typeof MemoizedGlobalStatusRemove
-  Update: typeof MemoizedGlobalStatusController
+const GlobalStatusController = memo(
+  GlobalStatusControllerComponent
+) as MemoExoticComponent<typeof GlobalStatusControllerComponent> & {
+  Remove: typeof GlobalStatusRemove
+  Update: typeof GlobalStatusController
 }
 
 type GlobalStatusRemovePropsLocal = {
@@ -145,7 +147,9 @@ const globalStatusRemoveDefaultProps: Partial<GlobalStatusRemovePropsLocal> =
     id: 'main',
   }
 
-function GlobalStatusRemove(ownProps: GlobalStatusRemovePropsLocal) {
+function GlobalStatusRemoveComponent(
+  ownProps: GlobalStatusRemovePropsLocal
+) {
   const props = {
     ...globalStatusRemoveDefaultProps,
     ...removeUndefinedProps({ ...ownProps }),
@@ -176,14 +180,14 @@ function GlobalStatusRemove(ownProps: GlobalStatusRemovePropsLocal) {
   return null
 }
 
-const MemoizedGlobalStatusRemove = memo(GlobalStatusRemove)
+const GlobalStatusRemove = memo(GlobalStatusRemoveComponent)
 
-MemoizedGlobalStatusController.Remove = MemoizedGlobalStatusRemove
-MemoizedGlobalStatusController.Update = MemoizedGlobalStatusController
+GlobalStatusController.Remove = GlobalStatusRemove
+GlobalStatusController.Update = GlobalStatusController
 
-withComponentMarkers(MemoizedGlobalStatusController, {
+withComponentMarkers(GlobalStatusController, {
   _supportsSpacingProps: true,
 })
 
-export default MemoizedGlobalStatusController
-export { MemoizedGlobalStatusRemove as GlobalStatusRemove }
+export default GlobalStatusController
+export { GlobalStatusRemove as GlobalStatusRemove }

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusController.tsx
@@ -190,4 +190,4 @@ withComponentMarkers(GlobalStatusController, {
 })
 
 export default GlobalStatusController
-export { GlobalStatusRemove as GlobalStatusRemove }
+export { GlobalStatusRemove }

--- a/packages/dnb-eufemia/src/components/help-button/HelpButton.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButton.tsx
@@ -12,7 +12,7 @@ import type { ButtonProps } from '../button/Button'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
-const defaultProps: Partial<HelpButtonProps> = {
+const helpButtonDefaultProps: Partial<HelpButtonProps> = {
   variant: 'secondary',
   iconPosition: 'left',
 }
@@ -23,7 +23,7 @@ export type HelpButtonProps = {
 
 export default function HelpButton(localProps: HelpButtonProps) {
   const context = useContext(Context)
-  const props = extendPropsWithContext(localProps, defaultProps)
+  const props = extendPropsWithContext(localProps, helpButtonDefaultProps)
 
   const { children, render, ...params } = props
 

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -63,7 +63,7 @@ export type HelpButtonInlineSharedStateDataProps = {
   focusOnOpen?: boolean
 }
 
-function HelpButtonInline(props: HelpButtonInlineProps) {
+function HelpButtonInlineComponent(props: HelpButtonInlineProps) {
   const {
     contentId,
     size,
@@ -331,14 +331,14 @@ function HelpButtonInlineContentComponent(
   )
 }
 
-const MemoizedHelpButtonInline = memo(HelpButtonInline)
-export default MemoizedHelpButtonInline
+const HelpButtonInline = memo(HelpButtonInlineComponent)
+export default HelpButtonInline
 
 export const HelpButtonInlineContent = memo(
   HelpButtonInlineContentComponent
 )
 
-withComponentMarkers(MemoizedHelpButtonInline, {
+withComponentMarkers(HelpButtonInline, {
   _supportsSpacingProps: true,
 })
 withComponentMarkers(HelpButtonInlineContent, {

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInstance.tsx
@@ -14,7 +14,7 @@ import { useSpacing } from '../space/SpacingUtils'
 import type { ButtonProps } from '../button/Button'
 import Button from '../button/Button'
 
-const defaultProps: Partial<ButtonProps> = {
+const helpButtonInstanceDefaultProps: Partial<ButtonProps> = {
   variant: 'secondary',
   iconPosition: 'left',
 }
@@ -25,7 +25,7 @@ export default function HelpButtonInstance(localProps: ButtonProps) {
   // use only the props from context, who are available here anyway
   const props = extendPropsWithContext(
     localProps,
-    defaultProps,
+    helpButtonInstanceDefaultProps,
     context.HelpButton
   )
 

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -112,7 +112,7 @@ export type InfoCardAllProps = InfoCardProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'title'> &
   SpacingProps
 
-export const defaultProps = {
+export const infoCardDefaultProps = {
   centered: false,
   dropShadow: true,
   skeleton: false,
@@ -125,7 +125,7 @@ const InfoCard = (localProps: InfoCardAllProps) => {
 
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    infoCardDefaultProps,
     {
       skeleton: context?.skeleton,
     },

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -186,7 +186,7 @@ function InputMasked({ ref, ...restProps }: InputMaskedProps) {
 
     return extendPropsWithContext(
       propsWithRef,
-      defaultProps,
+      inputMaskedDefaultProps,
       contextInputMasked
     )
   }, [contextInputMasked, restProps, ref])
@@ -199,7 +199,7 @@ function InputMasked({ ref, ...restProps }: InputMaskedProps) {
 }
 
 const { onKeyDown: _, ...inputBaseDefaults } = inputDefaultProps
-const defaultProps: Partial<InputMaskedProps> = {
+const inputMaskedDefaultProps: Partial<InputMaskedProps> = {
   ...inputBaseDefaults,
   mask: null,
   numberMask: null,

--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -66,7 +66,7 @@ export type LogoProps = {
 } & SpacingProps &
   Omit<HTMLProps<HTMLElement>, 'ref' | 'size'>
 
-const defaultProps: Partial<LogoProps> = {
+const logoDefaultProps: Partial<LogoProps> = {
   inheritSize: false,
 }
 
@@ -75,7 +75,7 @@ function Logo(localProps: LogoProps) {
 
   const props = extendPropsWithContext(
     localProps,
-    defaultProps,
+    logoDefaultProps,
     context.Logo
   )
 

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
@@ -206,7 +206,7 @@ function runFix(comp: unknown, className: string): ReactNode {
   return <span className={className}>{comp as ReactNode}</span>
 }
 
-function NumberFormat(ownProps: NumberFormatAllProps) {
+function NumberFormatComponent(ownProps: NumberFormatAllProps) {
   const context = useContext(Context) as ContextProps
 
   // Apply defaults early so callbacks see proper values
@@ -596,8 +596,8 @@ function NumberFormat(ownProps: NumberFormatAllProps) {
   )
 }
 
-const MemoizedNumberFormat = memo(NumberFormat)
+const NumberFormat = memo(NumberFormatComponent)
 
-withComponentMarkers(MemoizedNumberFormat, { _supportsSpacingProps: true })
+withComponentMarkers(NumberFormat, { _supportsSpacingProps: true })
 
-export default MemoizedNumberFormat
+export default NumberFormat

--- a/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/PaginationProvider.tsx
@@ -24,7 +24,7 @@ import {
 
 import PaginationContext from './PaginationContext'
 
-const PaginationProvider = (props: any) => {
+const PaginationProviderComponent = (props: any) => {
   const sharedContext = useContext(Context)
 
   // ---- Derive state from props ----
@@ -660,6 +660,6 @@ const PaginationProvider = (props: any) => {
   )
 }
 
-const MemoizedPaginationProvider = memo(PaginationProvider)
+const PaginationProvider = memo(PaginationProviderComponent)
 
-export default MemoizedPaginationProvider
+export default PaginationProvider

--- a/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
@@ -81,7 +81,7 @@ export function PortalRootProvider(
   return <PortalRootContext value={value}>{children}</PortalRootContext>
 }
 
-function PortalRootInstance(props: PortalRootProps = {}): ReactNode {
+function PortalRootComponent(props: PortalRootProps = {}): ReactNode {
   const {
     id: idProp,
     insideSelector: insideSelectorProp,
@@ -220,7 +220,7 @@ export function getOrCreatePortalElement({
   return elem
 }
 function PortalRoot(props: PortalRootProps) {
-  return <PortalRootInstance {...props} />
+  return <PortalRootComponent {...props} />
 }
 PortalRoot.Provider = PortalRootProvider
 

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -146,7 +146,7 @@ const parseChecked = (state: string | boolean | null | undefined) =>
 /**
  * The radio component is our enhancement of the classic radio button.
  */
-function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
+function RadioComponent({ ref: externalRef, ...ownProps }: RadioProps) {
   const groupContext = useContext(RadioGroupContext)
   const context = useContext(Context)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -517,7 +517,7 @@ function RadioInner({ ref: externalRef, ...ownProps }: RadioProps) {
   )
 }
 
-const Radio = memo(RadioInner) as unknown as typeof RadioInner & {
+const Radio = memo(RadioComponent) as unknown as typeof RadioComponent & {
   Group: typeof RadioGroup
   parseChecked: typeof parseChecked
 }

--- a/packages/dnb-eufemia/src/components/section/Section.tsx
+++ b/packages/dnb-eufemia/src/components/section/Section.tsx
@@ -115,16 +115,16 @@ type SectionReturnParams = Record<string, unknown> & {
   style: CSSProperties
 }
 
-const defaultProps: Partial<SectionAllProps> = {
+const sectionDefaultProps: Partial<SectionAllProps> = {
   element: 'section',
 }
 
-function SectionInstance(localProps: SectionAllProps) {
+function SectionComponent(localProps: SectionAllProps) {
   return <Space {...SectionParams(localProps)} />
 }
 
 export default function Section(props: SectionAllProps) {
-  return <SectionInstance {...props} />
+  return <SectionComponent {...props} />
 }
 
 export function SectionParams(
@@ -135,7 +135,7 @@ export function SectionParams(
   // use only the props from context, who are available here anyway
   const props = extendPropsWithContext(
     localProps,
-    defaultProps,
+    sectionDefaultProps,
     context.Section,
     { surface: localProps?.surface ?? context?.theme?.surface }
   )

--- a/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderProvider.tsx
@@ -29,7 +29,7 @@ import type {
   SliderThumbState,
 } from './types'
 
-const defaultProps: Partial<SliderAllProps> = {
+const sliderDefaultProps: Partial<SliderAllProps> = {
   statusState: 'error',
   min: 0,
   max: 100,
@@ -44,7 +44,7 @@ export function SliderProvider(localProps: SliderAllProps) {
   const context = useContext(Context)
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    sliderDefaultProps,
     { skeleton: context?.skeleton },
     pickFormElementProps(context?.formElement),
     context?.getTranslation(localProps).Slider,

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -65,9 +65,9 @@ export type SpaceProps = {
 export type SpaceAllProps = SpaceProps &
   Omit<HTMLProps<HTMLElement>, 'ref'>
 
-const defaultProps: Partial<SpaceAllProps> = {}
+const spaceDefaultProps: Partial<SpaceAllProps> = {}
 
-function SpaceInstance(localProps: SpaceAllProps) {
+function SpaceComponent(localProps: SpaceAllProps) {
   const context = useContext<ContextProps & SpacingProps>(Context)
 
   // consume the space context
@@ -75,7 +75,7 @@ function SpaceInstance(localProps: SpaceAllProps) {
     ? // use only the props from context, who are available here anyway
       extendPropsWithContext(
         localProps,
-        defaultProps,
+        spaceDefaultProps,
         { space: context.space },
         { skeleton: context?.skeleton }
       )
@@ -134,7 +134,7 @@ function SpaceInstance(localProps: SpaceAllProps) {
 }
 
 function Space(props: SpaceAllProps) {
-  return <SpaceInstance {...props} />
+  return <SpaceComponent {...props} />
 }
 
 Space.ResponsiveContext = SpaceResponsive

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -115,7 +115,7 @@ export type SwitchProps = {
   > &
   SpacingProps
 
-const defaultProps: Partial<SwitchProps> = {
+const switchDefaultProps: Partial<SwitchProps> = {
   statusState: 'error',
 }
 
@@ -382,7 +382,7 @@ function Switch(props: SwitchProps) {
   function extractPropsFromContext() {
     return extendPropsWithContext(
       props,
-      defaultProps,
+      switchDefaultProps,
       { skeleton: context?.skeleton },
       pickFormElementProps(context?.formElement),
       context.Switch

--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -105,7 +105,7 @@ export type TableAllProps = TableProps &
     ref?: Ref<HTMLElement>
   }
 
-const defaultProps: Partial<TableAllProps> = {
+const tableDefaultProps: Partial<TableAllProps> = {
   size: 'large',
   variant: 'generic',
 }
@@ -115,7 +115,7 @@ const Table = (componentProps: TableAllProps) => {
 
   const allProps = extendPropsWithContext(
     componentProps,
-    defaultProps,
+    tableDefaultProps,
     context?.Table,
     {
       skeleton: context?.skeleton,

--- a/packages/dnb-eufemia/src/components/tag/Tag.tsx
+++ b/packages/dnb-eufemia/src/components/tag/Tag.tsx
@@ -82,7 +82,7 @@ export type TagProps = {
   addIconTitle?: string
 }
 
-const defaultProps: Partial<TagProps> = {
+const tagDefaultProps: Partial<TagProps> = {
   omitOnKeyUpDeleteEvent: false,
 }
 
@@ -98,7 +98,7 @@ const Tag = (
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    tagDefaultProps,
     context?.translation?.Tag,
     context?.Tag,
     tagGroupContext

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -42,7 +42,7 @@ export type TagGroupProps = {
   skeleton?: SkeletonShow
 }
 
-const defaultProps: Partial<TagGroupProps> = {
+const tagGroupDefaultProps: Partial<TagGroupProps> = {
   skeleton: false,
 }
 
@@ -59,9 +59,14 @@ const TagGroup = (
     className,
     children: childrenProp,
     ...props
-  } = extendPropsWithContext(localProps, defaultProps, context?.TagGroup, {
-    skeleton: context?.skeleton,
-  })
+  } = extendPropsWithContext(
+    localProps,
+    tagGroupDefaultProps,
+    context?.TagGroup,
+    {
+      skeleton: context?.skeleton,
+    }
+  )
 
   let children = childrenProp
 

--- a/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
+++ b/packages/dnb-eufemia/src/components/term-definition/TermDefinition.tsx
@@ -48,7 +48,7 @@ export type TermDefinitionAllProps = TermDefinitionProps &
   SpacingProps &
   HTMLAttributes<HTMLSpanElement>
 
-const defaultProps: Partial<TermDefinitionAllProps> = {
+const termDefinitionDefaultProps: Partial<TermDefinitionAllProps> = {
   placement: 'bottom',
 }
 
@@ -59,7 +59,7 @@ export default function TermDefinition(
 
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    termDefinitionDefaultProps,
     { skeleton: context?.skeleton },
     context?.TermDefinition
   )

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -636,11 +636,11 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
 
 TextareaComponent.displayName = 'Textarea'
 
-const MemoizedTextarea = memo(TextareaComponent)
+const Textarea = memo(TextareaComponent)
 
-withComponentMarkers(MemoizedTextarea, {
+withComponentMarkers(Textarea, {
   _formElement: true,
   _supportsSpacingProps: true,
 })
 
-export default MemoizedTextarea
+export default Textarea

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -45,7 +45,7 @@ export type TimelineAllProps = TimelineProps &
     ref?: Ref<HTMLOListElement>
   }
 
-const defaultProps: Partial<TimelineAllProps> = {
+const timelineDefaultProps: Partial<TimelineAllProps> = {
   skeleton: false,
 }
 
@@ -56,7 +56,7 @@ const Timeline = (localProps: TimelineAllProps) => {
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    timelineDefaultProps,
     context?.Timeline,
     {
       skeleton: context?.skeleton,

--- a/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/TimelineItem.tsx
@@ -66,7 +66,7 @@ export type TimelineItemProps = {
 export type TimelineItemAllProps = TimelineItemProps &
   Omit<AllHTMLAttributes<HTMLLIElement>, 'title' | 'name'>
 
-const defaultProps: Partial<TimelineItemAllProps> = {
+const timelineItemDefaultProps: Partial<TimelineItemAllProps> = {
   skeleton: false,
 }
 
@@ -78,7 +78,7 @@ const TimelineItem = (localProps: TimelineItemAllProps) => {
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    timelineItemDefaultProps,
     context?.TimelineItem,
     { skeleton: context?.skeleton },
     timelineContext

--- a/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
@@ -13,7 +13,7 @@ import useId from '../../shared/helpers/useId'
 import { useSpacing } from '../space/SpacingUtils'
 import TooltipWithEvents from './TooltipWithEvents'
 import {
-  defaultProps,
+  tooltipDefaultProps,
   getPropsFromTooltipProp,
   getTargetElement,
   injectTooltipSemantic,
@@ -97,7 +97,7 @@ function resolveProps(
   >
 
   return {
-    ...defaultProps,
+    ...tooltipDefaultProps,
     ...localProps,
     ...inherited,
     ...tooltipTranslation,

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipHelpers.tsx
@@ -17,7 +17,7 @@ export function injectTooltipSemantic(params) {
   return params
 }
 
-export const defaultProps: Partial<TooltipAllProps> = {
+export const tooltipDefaultProps: Partial<TooltipAllProps> = {
   size: 'default',
   placement: 'top',
   arrow: 'center',

--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -18,7 +18,7 @@ import HeightAnimation from '../height-animation/HeightAnimation'
 import UploadFileInput from './UploadFileInput'
 import useUpload from './useUpload'
 import UploadDropzone from './UploadDropzone'
-import { UploadContext, defaultProps } from './UploadContext'
+import { UploadContext, uploadDefaultProps } from './UploadContext'
 import { verifyFiles } from './UploadVerify'
 
 import type { UploadFile, UploadAllProps } from './types'
@@ -27,7 +27,7 @@ import UploadInfo from './UploadInfo'
 import FormLabel from '../FormLabel'
 
 export type * from './types'
-export { defaultProps }
+export { uploadDefaultProps as defaultProps }
 
 const Upload = (localProps: UploadAllProps) => {
   const context = useContext(Context)
@@ -42,7 +42,7 @@ const Upload = (localProps: UploadAllProps) => {
 
   const extendedProps = extendPropsWithContext(
     localProps,
-    defaultProps,
+    uploadDefaultProps,
     { skeleton: context?.skeleton },
     pickFormElementProps(context?.formElement),
     translations,

--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -27,7 +27,7 @@ import UploadInfo from './UploadInfo'
 import FormLabel from '../FormLabel'
 
 export type * from './types'
-export { uploadDefaultProps as defaultProps }
+export { uploadDefaultProps }
 
 const Upload = (localProps: UploadAllProps) => {
   const context = useContext(Context)

--- a/packages/dnb-eufemia/src/components/upload/UploadContext.ts
+++ b/packages/dnb-eufemia/src/components/upload/UploadContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react'
 import type { UploadContextValue } from './types'
 
-export const defaultProps: Partial<UploadContextValue> = {
+export const uploadDefaultProps: Partial<UploadContextValue> = {
   fileMaxSize: 5,
   filesAmountLimit: 100,
   download: false,

--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { defaultProps, UploadContext } from './UploadContext'
+import { uploadDefaultProps, UploadContext } from './UploadContext'
 import Lead from '../../elements/Lead'
 import P from '../../elements/P'
 import Dl from '../../elements/Dl'
@@ -46,7 +46,7 @@ const UploadInfo = () => {
     isAcceptedFileTypeListOfStrings && fileMaxSize
 
   const displayFilesAmountLimitItem =
-    filesAmountLimit < defaultProps.filesAmountLimit
+    filesAmountLimit < uploadDefaultProps.filesAmountLimit
 
   const displayAcceptedFileFormatsTable =
     !displayAcceptedFileFormatsListItem &&

--- a/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
+++ b/packages/dnb-eufemia/src/components/visually-hidden/VisuallyHidden.tsx
@@ -23,7 +23,7 @@ export type VisuallyHiddenProps = {
 export type VisuallyHiddenAllProps = VisuallyHiddenProps &
   HTMLProps<HTMLSpanElement>
 
-const defaultProps: Partial<VisuallyHiddenAllProps> = {
+const visuallyHiddenDefaultProps: Partial<VisuallyHiddenAllProps> = {
   focusable: false,
   element: 'span',
 }
@@ -36,7 +36,7 @@ const VisuallyHidden = (localProps: VisuallyHiddenAllProps) => {
   const { element, children, className, focusable, ...props } =
     extendPropsWithContext(
       localProps,
-      defaultProps,
+      visuallyHiddenDefaultProps,
       context?.VisuallyHidden
     )
 

--- a/packages/dnb-eufemia/src/elements/Element.tsx
+++ b/packages/dnb-eufemia/src/elements/Element.tsx
@@ -49,13 +49,13 @@ export type ElementAllProps = ElementProps &
 
 type Attributes = Record<string, unknown>
 
-export const defaultProps = {
+export const elementDefaultProps = {
   skeletonMethod: 'font',
 }
 
 function Element(localProps: ElementAllProps) {
   const context = useContext(Context)
-  const props = extendPropsWithContext(localProps, defaultProps, {
+  const props = extendPropsWithContext(localProps, elementDefaultProps, {
     skeleton: context?.skeleton,
   })
 

--- a/packages/dnb-eufemia/src/elements/__tests__/Element.test.tsx
+++ b/packages/dnb-eufemia/src/elements/__tests__/Element.test.tsx
@@ -6,7 +6,7 @@
 import { axeComponent } from '../../core/test-utils/testSetup'
 import { render } from '@testing-library/react'
 import type { ElementAllProps } from '../Element'
-import Element, { defaultProps } from '../Element'
+import Element, { elementDefaultProps } from '../Element'
 import { Provider } from '../../shared'
 
 const myPElement = (props) => <p {...props} />
@@ -118,7 +118,7 @@ describe('Element', () => {
   })
 
   it('does not have ref null inside default props', () => {
-    expect(defaultProps['ref']).toBe(undefined)
+    expect(elementDefaultProps['ref']).toBe(undefined)
   })
 
   it('should validate with ARIA rules as an Element element', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
@@ -131,7 +131,7 @@ export function suggestions(
     const { countryCode } = handleCountryPath({
       value,
       countryCode: handlerConfig?.countryCode,
-      // @ts-expect-error - strictFunctionTypes
+      // @ts-ignore - strictFunctionTypes
       additionalArgs,
       // @ts-ignore - strictFunctionTypes
       handler: suggestionsHandler,

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
@@ -133,7 +133,7 @@ export function suggestions(
       countryCode: handlerConfig?.countryCode,
       // @ts-expect-error - strictFunctionTypes
       additionalArgs,
-      // @ts-expect-error - strictFunctionTypes
+      // @ts-ignore - strictFunctionTypes
       handler: suggestionsHandler,
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -160,7 +160,7 @@ export function validator(
     const { countryCode } = handleCountryPath({
       value,
       countryCode: handlerConfig?.countryCode,
-      // @ts-expect-error - strictFunctionTypes
+      // @ts-ignore - strictFunctionTypes
       additionalArgs,
       // @ts-ignore - strictFunctionTypes
       handler: validatorHandler,

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -162,7 +162,7 @@ export function validator(
       countryCode: handlerConfig?.countryCode,
       // @ts-expect-error - strictFunctionTypes
       additionalArgs,
-      // @ts-expect-error - strictFunctionTypes
+      // @ts-ignore - strictFunctionTypes
       handler: validatorHandler,
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -257,14 +257,14 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
     props.onBlurValidator === false || props.pattern || props.schema
       ? undefined
       : (props.onBlurValidator ?? norwegianPhoneNumberLengthValidator)
-  const defaultProps: Partial<FieldPhoneNumberProps> = {
+  const phoneNumberDefaultProps: Partial<FieldPhoneNumberProps> = {
     ...(schema ? { schema } : {}),
     errorMessages,
   }
   const ref = useRef<HTMLInputElement>(undefined)
   const preparedProps: FieldPhoneNumberProps = {
     ...props,
-    ...defaultProps,
+    ...phoneNumberDefaultProps,
     onBlurValidator: onBlurValidatorToUse,
     validateRequired,
     fromExternal,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Element/Element.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Element/Element.tsx
@@ -21,10 +21,10 @@ export type FormElementProps = Omit<
   }
 
 export default function FormElement(props: FormElementProps) {
-  return <FormElementInstance {...props} />
+  return <FormElementComponent {...props} />
 }
 
-function FormElementInstance(props: FormElementProps) {
+function FormElementComponent(props: FormElementProps) {
   const id = useId()
   const dataContext = useContext(DataContext)
   const { submitState, restHandlerProps } = dataContext || {}

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -318,7 +318,7 @@ function DrawerList(props: DrawerListAllProps) {
   const drawerListContext = useContext(DrawerListContext)
 
   if (drawerListContext?.drawerList) {
-    return <DrawerListInstance {...props} />
+    return <DrawerListComponent {...props} />
   }
 
   const { data, children, ...rest } = props
@@ -333,13 +333,13 @@ function DrawerList(props: DrawerListAllProps) {
           : undefined)
       }
     >
-      <DrawerListInstance {...props} />
+      <DrawerListComponent {...props} />
     </DrawerListProvider>
   )
 }
 DrawerList.blurDelay = DrawerListProvider.blurDelay // some ms more than "DrawerListSlideDown 200ms"
 
-const DrawerListInstance = memo(function DrawerListInstance(
+const DrawerListComponent = memo(function DrawerListComponent(
   ownProps: DrawerListAllProps
 ) {
   const context = useContext(DrawerListContext)


### PR DESCRIPTION
Unify inconsistent internal naming conventions across components:

- Rename plain `defaultProps` objects to `<name>DefaultProps` (avoids
  confusion with React's deprecated static `defaultProps`).
- Rename unwrapped implementation components from `Instance`/`Inner`
  suffixes to a consistent `<Name>Component` suffix.
- Remove the `Memoized` prefix so memoized components use the clean public
  name via `const <Name> = memo(<Name>Component)`.

These are internal-only renames with no public API changes.

Intentional exceptions (documented in code context):
- Input: the `Input` wrapper already uses the clean name.
- ToggleButton, Pagination: `*Component` already exist as exported types.
- ModalInner: a genuine modal sub-part, not an implementation suffix.
- SliderInstance, HelpButtonInstance: standalone architectural files.