### PR TITLE
chore(test): run DOM-free test files in the node environment

### DIFF
--- a/packages/dnb-eufemia/src/__tests__/index.test.ts
+++ b/packages/dnb-eufemia/src/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/__tests__/lib.test.ts
+++ b/packages/dnb-eufemia/src/__tests__/lib.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/__tests__/style-imports.test.ts
+++ b/packages/dnb-eufemia/src/__tests__/style-imports.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import fs from 'fs'
 import path from 'path'
 import globby from 'globby'

--- a/packages/dnb-eufemia/src/components/__tests__/index.test.ts
+++ b/packages/dnb-eufemia/src/components/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/components/__tests__/lib.test.ts
+++ b/packages/dnb-eufemia/src/components/__tests__/lib.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormatUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/date-format/__tests__/DateFormatUtils.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { DateFormatOptions } from '../DateFormatUtils'
 import {
   formatDate,

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePickerCalc.test.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePickerCalc.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { convertStringToDate } from '../DatePickerCalc'
 
 describe('convertStringToDate', () => {

--- a/packages/dnb-eufemia/src/components/filter/__tests__/formatDateRange.test.ts
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/formatDateRange.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import formatDateRange from '../utils/formatDateRange'
 
 describe('formatDateRange', () => {

--- a/packages/dnb-eufemia/src/components/filter/utils/__tests__/sanitizeUrlFilters.test.ts
+++ b/packages/dnb-eufemia/src/components/filter/utils/__tests__/sanitizeUrlFilters.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { sanitizeUrlFilters } from '../sanitizeUrlFilters'
 
 describe('sanitizeUrlFilters', () => {

--- a/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/utils.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { ReactElement } from 'react'
 import { MainHeading, SubHeading } from '../../../extensions/forms/Form'
 import Heading from '../../Heading'

--- a/packages/dnb-eufemia/src/components/pagination/__tests__/PaginationCalculation.test.ts
+++ b/packages/dnb-eufemia/src/components/pagination/__tests__/PaginationCalculation.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Unit Test
  *

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadVerify.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadVerify.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { verifyFiles, getFileTypeFromExtension } from '../UploadVerify'
 import { createMockFile } from './testHelpers'
 

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/pageResetStrategy.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/pageResetStrategy.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest'
 import { getPageResetStrategyFromMutation } from '../pageResetStrategy'
 

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotEngine.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotEngine.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
 // Mock external dependencies that aren't available outside browser mode

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/summaryOnlyReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/summaryOnlyReporter.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest'
 import type { TestModule } from 'vitest/node'
 

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/themeSelection.client.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/themeSelection.client.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const ENV_KEYS = ['CI', 'GITHUB_REF_NAME', 'GITHUB_REF'] as const

--- a/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-basis.test.ts
+++ b/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-basis.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-components.test.ts
+++ b/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-components.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-elements.test.ts
+++ b/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-elements.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-extensions.test.ts
+++ b/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-extensions.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-icons.test.ts
+++ b/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-icons.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-lib.test.ts
+++ b/packages/dnb-eufemia/src/esm/__tests__/dnb-ui-lib.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/extensions/__tests__/index.test.ts
+++ b/packages/dnb-eufemia/src/extensions/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/extensions/__tests__/lib.test.ts
+++ b/packages/dnb-eufemia/src/extensions/__tests__/lib.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/__tests__/createContext.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/__tests__/createContext.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { PathStrict } from '../..'
 import { Connectors } from '../..'
 import type { GeneralConfig, HandlerConfig } from '../createContext'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/createMinimumAgeVerifier.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/createMinimumAgeVerifier.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { createMinimumAgeVerifier } from '../NationalIdentityNumber'
 
 describe('createMinimumAgeVerifier', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/extractZodSubSchema.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/__tests__/extractZodSubSchema.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import * as z from 'zod'
 import {
   extractZodSubSchema,

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajv.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajv.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { Ajv, makeAjvInstance, enhanceAjvInstance } from '../ajv'
 
 describe('makeAjvInstance', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajvErrors.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajvErrors.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { ErrorObject } from 'ajv/dist/2020.js'
 import { FormError } from '../FormError'
 import {

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/errors.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/errors.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { FormsTranslation } from '../../hooks/useTranslation'
 import type { AdditionalReturnUtils } from '../../../../shared/useTranslation'
 import {

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/zod.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/zod.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { z, zodErrorsToFormErrors } from '../zod'
 import type * as zType from 'zod'
 

--- a/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/json-pointer/__tests__/json-pointer.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { PointerPath } from '../../json-pointer'
 import pointer, {
   compile,

--- a/packages/dnb-eufemia/src/mcp/__tests__/docs-source.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/docs-source.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { createBundledDocsSource, normalizeDocsPath } from '../docs-source'
 import { createDocsTools } from '../mcp-docs-server'
 

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 import fs from 'fs'
 import os from 'os'

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Tests for the Eufemia MCP HTTP server (SSE + Streamable HTTP transports).
  *

--- a/packages/dnb-eufemia/src/plugins/eslint/__tests__/no-deprecated-color-variables.test.ts
+++ b/packages/dnb-eufemia/src/plugins/eslint/__tests__/no-deprecated-color-variables.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { RuleTester } from 'eslint'
 import eslintPlugin from '../../eslint.js'
 

--- a/packages/dnb-eufemia/src/plugins/postcss-font-url-rewrite/__tests__/font-url-rewrite-plugin.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-font-url-rewrite/__tests__/font-url-rewrite-plugin.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { URL } from 'url'
 import postcss from 'postcss'
 import postcssFontUrlRewrite from '../font-url-rewrite-plugin'

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /* eslint-disable vitest/expect-expect */
 
 import postcss from 'postcss'

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/plugin-scope-hash.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/plugin-scope-hash.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import * as BuildInfoJs from '../plugin-scope-hash.js'
 import * as BuildInfoCjs from '../plugin-scope-hash.cjs'
 import * as BuildInfoModule from '../../../shared/build-info/BuildInfo'

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/plugin-utils.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/plugin-utils.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import path from 'path'
 import fs from 'fs'
 import os from 'os'

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/scripts/__tests__/transformToESM.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/scripts/__tests__/transformToESM.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { sync } from 'globby'
 import fs from 'fs-extra'
 import { transform } from 'lebab'

--- a/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-deprecated-color-variables.test.ts
+++ b/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-deprecated-color-variables.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import stylelint from 'stylelint'
 import stylelintPlugin from '../../stylelint.js'
 

--- a/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-undefined-custom-property.test.ts
+++ b/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-undefined-custom-property.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import stylelint from 'stylelint'
 const noUndefinedCustomPropertyPlugin = require('../rules/no-undefined-custom-property.cjs')
 

--- a/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-unused-use.test.ts
+++ b/packages/dnb-eufemia/src/plugins/stylelint/__tests__/no-unused-use.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import stylelint from 'stylelint'
 const noUnusedUsePlugin = require('../rules/no-unused-use.cjs')
 

--- a/packages/dnb-eufemia/src/plugins/stylelint/__tests__/token-name-policy.test.ts
+++ b/packages/dnb-eufemia/src/plugins/stylelint/__tests__/token-name-policy.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import stylelint from 'stylelint'
 import fs from 'fs'
 import os from 'os'

--- a/packages/dnb-eufemia/src/shared/__tests__/detectCountryCode.test.ts
+++ b/packages/dnb-eufemia/src/shared/__tests__/detectCountryCode.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import detectCountryCode from '../detectCountryCode'
 import countryCodes from '../constants/countryCodes'
 import countries from '../../extensions/forms/constants/countries'

--- a/packages/dnb-eufemia/src/shared/__tests__/icuFormatMessage.test.ts
+++ b/packages/dnb-eufemia/src/shared/__tests__/icuFormatMessage.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { icu } from '../icuFormatMessage'
 
 const { isICU, format } = icu

--- a/packages/dnb-eufemia/src/shared/build-info/__tests__/BuildInfo.test.ts
+++ b/packages/dnb-eufemia/src/shared/build-info/__tests__/BuildInfo.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import * as BuildInfo from '../BuildInfo'
 
 describe('BuildInfo', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/assignPropsWithContext.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/assignPropsWithContext.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { assignPropsWithContext } from '../assignPropsWithContext'
 
 describe('assignPropsWithContext', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/clamp.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/clamp.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { clamp } from '../clamp'
 
 describe('clamp', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/debounce.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/debounce.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { wait } from '../../../core/test-utils/testSetup'
 import { debounce, debounceAsync } from '../debounce'
 import { isAsync } from '../isAsync'

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/extendPropsWithContext.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/extendPropsWithContext.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   extendPropsWithContext,
   extendExistingPropsWithContext,

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/filterProps.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/filterProps.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { filterProps } from '../filterProps'
 
 describe('"filterProps" should', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/filterValidProps.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { FormElementProps } from '../filterValidProps'
 import {
   filterValidProps,

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/isAsync.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/isAsync.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { isAsync } from '../isAsync'
 
 describe('isAsync', () => {

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/structuredClone.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/structuredClone.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { structuredClone } from '../structuredClone'
 
 describe('structuredClone', () => {

--- a/packages/dnb-eufemia/src/style/__tests__/Elements.test.ts
+++ b/packages/dnb-eufemia/src/style/__tests__/Elements.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Element Test
  *

--- a/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-basis.test.ts
+++ b/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-basis.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-components.test.ts
+++ b/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-components.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-elements.test.ts
+++ b/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-elements.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-extensions.test.ts
+++ b/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-extensions.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-icons.test.ts
+++ b/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-icons.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *

--- a/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-lib.test.ts
+++ b/packages/dnb-eufemia/src/umd/__tests__/dnb-ui-lib.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Abstract Test
  *


### PR DESCRIPTION
Add a `// @vitest-environment node` docblock to 63 unit test files that never touch the DOM (shared helpers, forms utils, plugins, umd/esm bundle checks, mcp, and pure calculation/util tests). Running them under the node environment instead of jsdom skips the per-file jsdom construction cost.

Measured locally across the 65 affected files (the 63 changed here plus the two SSR files that already opted in): jsdom environment setup dropped from ~200s cumulative to ~30ms, and wall-clock for that subset went 43s -> 24s (~45% less CPU) with all tests green.

The two DOM-dependent files in the same set (MediaQueryUtils, storageReset) are intentionally left on jsdom.

