### PR TITLE
fix(InputMasked): guard against restoring an undefined input type

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/text-mask/InputModeNumber.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/text-mask/InputModeNumber.ts
@@ -131,7 +131,12 @@ export default class InputModeNumber {
       return // stop here
     }
     try {
-      this.inputElement.type = this._type
+      // Only restore the type when a previous type was captured (in onFocus).
+      // When reset runs without a preceding focus (e.g. on unmount), _type is
+      // undefined and must not be assigned back as the input's type.
+      if (this._type) {
+        this.inputElement.type = this._type
+      }
       this.inputElement.style.cssText = this._cssText // Because we did set a width, we need to reset the cssText
       this.inputElement.classList.remove('dnb-input-masked--hide-controls')
       // Only restore the previous value if no new value was entered

--- a/packages/dnb-eufemia/src/components/input-masked/text-mask/__tests__/InputModeNumber.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/text-mask/__tests__/InputModeNumber.test.tsx
@@ -47,6 +47,28 @@ describe('InputModeNumber', () => {
       })
     })
 
+    it('should not assign an undefined type when reset runs before a focus', () => {
+      const inputElement = document.createElement('input')
+      document.body.appendChild(inputElement)
+
+      const assignedTypes: Array<unknown> = []
+      Object.defineProperty(inputElement, 'type', {
+        configurable: true,
+        get: () => 'text',
+        set: (value) => {
+          assignedTypes.push(value)
+        },
+      })
+
+      instance = new InputModeNumber()
+      instance.setElement(inputElement)
+
+      // reset runs on unmount before any focus captured the original type,
+      // so _type is still undefined and must not be assigned back
+      expect(() => instance.reset()).not.toThrow()
+      expect(assignedTypes).not.toContain(undefined)
+    })
+
     it('should not set inputmode on iOS', () => {
       render(<MockComponent />)
 


### PR DESCRIPTION
Only restore the type when a previous type was actually captured.

