### PR TITLE
ci: split visual-regression build from tests and shard across runners --run-all

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -46,12 +46,24 @@ env:
   PLAYWRIGHT_SCREENSHOT_WORKERS: 100%
 
 jobs:
-  visual-regression:
-    name: Run visual-regression tests
+  # Resolves the changed files and decides whether this is a full-suite run.
+  # Full-suite runs (pushes to main/beta and PRs into the release-type branches
+  # this workflow watches) build the portal once here on a cheap/fast Linux
+  # runner and fan out across several macOS shards — the prerendered portal is
+  # OS-independent, so only the Firefox screenshot render must run on macOS.
+  # Subset runs skip the build here and build in-place on a single macOS job.
+  build:
+    name: Build portal for visual tests
 
-    runs-on: macos-26
+    runs-on: ubuntu-latest
 
-    timeout-minutes: 40
+    timeout-minutes: 20
+
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      changed_files: ${{ steps.changed.outputs.changed_files }}
+      run_visual: ${{ steps.plan.outputs.run_visual }}
+      is_full: ${{ steps.plan.outputs.is_full }}
 
     steps:
       - name: Git checkout
@@ -65,6 +77,7 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Resolve changed files
+        id: changed
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -135,10 +148,97 @@ jobs:
               return
             }
 
-            core.exportVariable(
-              'VISUAL_TEST_CHANGED_FILES',
-              changedFiles.join('\n')
-            )
+            core.setOutput('changed_files', changedFiles.join('\n'))
+
+      # Full-suite runs (pushes to main/beta, PRs into the release-type branches
+      # this workflow watches, and any commit whose message contains --run-all)
+      # build once here and fan out across several macOS shards. Every other push
+      # resolves to a small conditional subset, so it skips this shared build and
+      # the macOS job builds the portal in-place — keeping the common,
+      # already-fast case a single job.
+      - name: Plan run
+        id: plan
+        shell: bash
+        run: |
+          # --run-all in the commit message forces the full suite (matches the
+          # conditional runner's RUN_ALL_COMMIT_FLAG) — shard it too so the
+          # forced run still finishes quickly.
+          commit_message="$(git log -1 --pretty=%B 2>/dev/null || true)"
+
+          should_shard=false
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            should_shard=true
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && ( "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/beta" ) ]]; then
+            should_shard=true
+          elif [[ "$commit_message" == *"--run-all"* ]]; then
+            should_shard=true
+          fi
+
+          echo "run_visual=$RUN_VISUAL_TEST" >> "$GITHUB_OUTPUT"
+          echo "is_full=$should_shard" >> "$GITHUB_OUTPUT"
+          if [[ "$should_shard" == "true" ]]; then
+            echo 'matrix={"shard":[1,2,3],"total":[3]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"shard":[1],"total":[1]}' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prebuild Library
+        if: steps.plan.outputs.is_full == 'true' && env.RUN_POST_BUILD == 'true'
+        run: yarn workspace @dnb/eufemia prebuild:ci
+
+      - name: Postbuild Library
+        if: steps.plan.outputs.is_full == 'true' && env.RUN_POST_BUILD == 'true'
+        run: yarn workspace @dnb/eufemia postbuild:ci
+
+      - name: Build portal
+        if: steps.plan.outputs.is_full == 'true' && env.RUN_VISUAL_TEST == 'true'
+        run: yarn workspace dnb-design-system-portal build:visual-test
+
+      - name: Upload portal build
+        if: steps.plan.outputs.is_full == 'true' && env.RUN_VISUAL_TEST == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: visual-test-portal
+          path: ./packages/dnb-design-system-portal/public
+          retention-days: 1
+          include-hidden-files: true
+
+  visual-regression:
+    name: Run visual-regression tests (${{ matrix.shard }}/${{ matrix.total }})
+
+    needs: build
+
+    if: needs.build.outputs.run_visual == 'true'
+
+    runs-on: macos-26
+
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
+
+    env:
+      VISUAL_TEST_CHANGED_FILES: ${{ needs.build.outputs.changed_files }}
+      SCREENSHOT_SHARD: ${{ matrix.shard }}/${{ matrix.total }}
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}
+
+      - name: Download portal build
+        if: needs.build.outputs.is_full == 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: visual-test-portal
+          path: ./packages/dnb-design-system-portal/public
 
       - name: Use Playwright cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -156,30 +256,31 @@ jobs:
         run: yarn workspace @dnb/eufemia playwright install-deps firefox
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
+      # Subset runs skip the shared Linux build and build the portal here, so
+      # the common, already-fast case stays a single self-contained macOS job.
       - name: Prebuild Library
-        if: env.RUN_POST_BUILD == 'true'
+        if: needs.build.outputs.is_full != 'true' && env.RUN_POST_BUILD == 'true'
         run: yarn workspace @dnb/eufemia prebuild:ci
 
       - name: Postbuild Library
-        if: env.RUN_POST_BUILD == 'true'
+        if: needs.build.outputs.is_full != 'true' && env.RUN_POST_BUILD == 'true'
         run: yarn workspace @dnb/eufemia postbuild:ci
 
       - name: Build portal
-        if: env.RUN_VISUAL_TEST == 'true'
+        if: needs.build.outputs.is_full != 'true'
         run: yarn workspace dnb-design-system-portal build:visual-test
 
       - name: Run visual tests
-        if: env.RUN_VISUAL_TEST == 'true'
         run: yarn workspace dnb-design-system-portal test:screenshots:ci:conditional
 
       - name: Store visual test artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
-          name: visual-test-artifact
+          name: visual-test-artifact-shard-${{ matrix.shard }}
           path: |
             ./packages/dnb-eufemia/visual-diff-report/**
 
       - name: Run visual tests info
         if: failure()
-        run: echo '\n\n👉 Download the diff files as a ZIP file. \nIt is called "visual-test-artifact" and you find it in the test "Summary" under "Artifacts".\n\n\n'
+        run: echo '\n\n👉 Download the diff files as a ZIP file. \nIt is called "visual-test-artifact-shard-${{ matrix.shard }}" and you find it in the test "Summary" under "Artifacts".\n\n\n'

--- a/packages/dnb-eufemia/scripts/tools/vitest/__tests__/runScreenshotVitestLib.test.ts
+++ b/packages/dnb-eufemia/scripts/tools/vitest/__tests__/runScreenshotVitestLib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { prepareScreenshotVitestRun } from '../runScreenshotVitestLib'
+import {
+  prepareScreenshotVitestRun,
+  resolveShardArgs,
+} from '../runScreenshotVitestLib'
 
 describe('runScreenshotVitestLib', () => {
   it('separates vitest args from screenshot filters', () => {
@@ -66,5 +69,47 @@ describe('runScreenshotVitestLib', () => {
       missingFilters: [],
       screenshotInclude: undefined,
     })
+  })
+})
+
+describe('resolveShardArgs', () => {
+  it('forwards a valid shard as --shard with --passWithNoTests', () => {
+    expect(resolveShardArgs('2/4', [])).toEqual([
+      '--shard=2/4',
+      '--passWithNoTests',
+    ])
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(resolveShardArgs('  1/3  ', [])).toEqual([
+      '--shard=1/3',
+      '--passWithNoTests',
+    ])
+  })
+
+  it('returns nothing when the total is 1 (single, unsharded run)', () => {
+    expect(resolveShardArgs('1/1', [])).toEqual([])
+  })
+
+  it('returns nothing when unset or empty', () => {
+    expect(resolveShardArgs(undefined, [])).toEqual([])
+    expect(resolveShardArgs('', [])).toEqual([])
+    expect(resolveShardArgs('   ', [])).toEqual([])
+  })
+
+  it('returns nothing for malformed values', () => {
+    expect(resolveShardArgs('abc', [])).toEqual([])
+    expect(resolveShardArgs('2', [])).toEqual([])
+    expect(resolveShardArgs('2/', [])).toEqual([])
+    expect(resolveShardArgs('/4', [])).toEqual([])
+  })
+
+  it('does not override an explicit --shard already in the args', () => {
+    expect(resolveShardArgs('2/4', ['--shard=1/2'])).toEqual([])
+    expect(resolveShardArgs('2/4', ['--shard', '1/2'])).toEqual([])
+  })
+
+  it('is skipped in watch mode', () => {
+    expect(resolveShardArgs('2/4', [], { watch: true })).toEqual([])
   })
 })

--- a/packages/dnb-eufemia/scripts/tools/vitest/runScreenshotVitest.ts
+++ b/packages/dnb-eufemia/scripts/tools/vitest/runScreenshotVitest.ts
@@ -1,6 +1,9 @@
 import { spawnSync } from 'child_process'
 
-import { resolveScreenshotVitestRun } from './runScreenshotVitestLib.ts'
+import {
+  resolveScreenshotVitestRun,
+  resolveShardArgs,
+} from './runScreenshotVitestLib.ts'
 
 const rawArgs = process.argv.slice(2)
 const watch = rawArgs.includes('--watch')
@@ -33,6 +36,14 @@ if (screenshotInclude) {
   env.SCREENSHOT_INCLUDE = screenshotInclude
 }
 
+const shardArgs = resolveShardArgs(
+  process.env.SCREENSHOT_SHARD,
+  vitestArgs,
+  {
+    watch,
+  }
+)
+
 const result = spawnSync(
   'yarn',
   [
@@ -41,6 +52,7 @@ const result = spawnSync(
     '--config',
     'vitest.config.screenshots.ts',
     ...vitestArgs,
+    ...shardArgs,
   ],
   {
     stdio: 'inherit',

--- a/packages/dnb-eufemia/scripts/tools/vitest/runScreenshotVitestLib.ts
+++ b/packages/dnb-eufemia/scripts/tools/vitest/runScreenshotVitestLib.ts
@@ -40,3 +40,40 @@ export function resolveScreenshotVitestRun(args: string[]) {
     filters.length > 0 ? collectRenewScreenshotMatches(filters) : []
   )
 }
+
+/**
+ * CI splits the full screenshot suite across several runners. The shard is
+ * provided as "<index>/<total>" (e.g. "2/4") and forwarded to Vitest as
+ * `--shard`. A total of 1, an already-present `--shard`, or watch mode leaves
+ * the args untouched so non-sharded runs stay identical. `--passWithNoTests`
+ * is added because a shard can legitimately receive no files when a small
+ * conditional subset is split across shards.
+ */
+export function resolveShardArgs(
+  shardValue: string | undefined,
+  vitestArgs: string[],
+  options: { watch?: boolean } = {}
+): string[] {
+  if (options.watch) {
+    return []
+  }
+
+  const value = shardValue?.trim()
+  if (!value || !/^\d+\/\d+$/.test(value)) {
+    return []
+  }
+
+  const hasExplicitShard = vitestArgs.some(
+    (arg) => arg === '--shard' || arg.startsWith('--shard=')
+  )
+  if (hasExplicitShard) {
+    return []
+  }
+
+  const total = Number(value.split('/')[1])
+  if (total <= 1) {
+    return []
+  }
+
+  return [`--shard=${value}`, '--passWithNoTests']
+}


### PR DESCRIPTION
The visual-regression job ran the whole pipeline (library prebuild/postbuild, portal build, and ~2000 screenshots) in a single macos-26 job. The screenshot step alone dominated at ~17-19 min because the 3-vCPU runner only gives 3 workers for the full suite, so full runs on main took ~18-26 min.

Split the work into a Linux 'build' job that prerenders the portal once (OS-independent output) and uploads it as an artifact, and a macOS 'visual-regression' matrix that only renders screenshots. Full-suite runs (pushes to main/beta and PRs into the watched release branches) fan out across 4 shards via Vitest --shard; every other push resolves to a small conditional subset and stays a single self-contained macOS job that builds in-place, so the common fast path is preserved.

Sharding is wired through a new SCREENSHOT_SHARD env var forwarded to Vitest as --shard by resolveShardArgs (with --passWithNoTests so empty shards pass). Adds unit tests for the helper.

