### PR TITLE
chore: add manual runner-experiment workflow to explore lifting the runner ceiling

### DIFF
--- a/.github/workflows/visual-regression-runner-experiment.yml
+++ b/.github/workflows/visual-regression-runner-experiment.yml
@@ -18,23 +18,16 @@ name: Visual Regression — Runner Experiment
 # runner group; if the label is not available the job will simply stay queued.
 
 on:
+  # Auto-runs on this exploration branch so we can gather comparative data now.
+  # (workflow_dispatch is only dispatchable once a workflow is on the default
+  # branch, so push is used here to trigger from the feature branch.)
+  push:
+    branches:
+      - explore/visual-regression-runner-ceiling
   workflow_dispatch:
-    inputs:
-      runner:
-        description: 'runs-on label (macos-15-xlarge, macos-15-large, macos-26, ubuntu-latest, or a runner-group name)'
-        required: true
-        default: 'macos-15-xlarge'
-      workers:
-        description: 'PLAYWRIGHT_SCREENSHOT_WORKERS (e.g. 100%, 8, 12)'
-        required: false
-        default: '100%'
-      update_snapshots:
-        description: 'Regenerate baselines for this platform instead of comparing (recommended for non macos-26 runners)'
-        type: boolean
-        default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runner }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -50,15 +43,33 @@ env:
   ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
   ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
   ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-  PLAYWRIGHT_SCREENSHOT_WORKERS: ${{ inputs.workers }}
+  # 100% auto-scales the worker count to the runner's vCPUs.
+  PLAYWRIGHT_SCREENSHOT_WORKERS: '100%'
 
 jobs:
   experiment:
-    name: Screenshots on ${{ inputs.runner }} (${{ inputs.workers }} workers)
+    name: ${{ matrix.label }}
 
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ matrix.runner }}
 
-    timeout-minutes: 60
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Strategic option: Linux is ~8x cheaper and highly concurrent. Runs in
+          # update mode because Linux rendering differs from the macOS baselines —
+          # this measures timing and uploads the Linux baselines as an artifact.
+          - label: linux (ubuntu-latest)
+            runner: ubuntu-latest
+            update: 'true'
+          # Larger arm64 macOS runner (5-core M2 Pro). Compare mode shows how far
+          # its rendering drifts from the macos-26 baselines (and whether the org
+          # has larger runners enabled at all — otherwise this job stays queued).
+          - label: macos-xlarge (macos-15-xlarge)
+            runner: macos-15-xlarge
+            update: 'false'
 
     steps:
       - name: Git checkout
@@ -70,9 +81,8 @@ jobs:
       - name: Report runner hardware
         shell: bash
         run: |
-          echo "Runner label : ${{ inputs.runner }}"
-          echo "Workers      : ${{ inputs.workers }}"
-          echo "Update mode  : ${{ inputs.update_snapshots }}"
+          echo "Runner label : ${{ matrix.runner }}"
+          echo "Update mode  : ${{ matrix.update }}"
           echo "OS           : $(uname -a)"
           if sysctl -n hw.ncpu >/dev/null 2>&1; then
             echo "CPU cores    : $(sysctl -n hw.ncpu)"
@@ -96,7 +106,7 @@ jobs:
       - name: Run screenshots (full suite)
         shell: bash
         run: |
-          if [[ "${{ inputs.update_snapshots }}" == "true" ]]; then
+          if [[ "${{ matrix.update }}" == "true" ]]; then
             yarn workspace dnb-design-system-portal test:screenshots:ci:update
           else
             yarn workspace dnb-design-system-portal test:screenshots:ci
@@ -106,14 +116,14 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: experiment-diff-${{ inputs.runner }}
+          name: experiment-diff-${{ matrix.runner }}
           path: ./packages/dnb-eufemia/visual-diff-report/**
           retention-days: 3
 
       - name: Upload regenerated baselines (update mode)
-        if: ${{ inputs.update_snapshots }}
+        if: ${{ matrix.update == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: experiment-baselines-${{ inputs.runner }}
+          name: experiment-baselines-${{ matrix.runner }}
           path: ./packages/dnb-eufemia/src/**/__image_snapshots__/**
           retention-days: 3

--- a/.github/workflows/visual-regression-runner-experiment.yml
+++ b/.github/workflows/visual-regression-runner-experiment.yml
@@ -1,0 +1,119 @@
+name: Visual Regression — Runner Experiment
+
+# Manual, non-production experiment for exploring how to "lift the runner
+# ceiling" for the visual-regression suite (follow-up to the sharding work in
+# PR #8767). It runs the FULL screenshot suite on a runner of your choosing so
+# you can compare timing, available concurrency, and rendering consistency across:
+#   - larger arm64 macOS runners   (macos-15-xlarge = 5-core M2 Pro, $0.102/min)
+#   - Intel macOS large runners    (macos-15-large  = 12-core x64,   $0.077/min)
+#   - Linux runners                (ubuntu-latest / larger — ~8x cheaper, highly
+#                                    concurrent; the strategic option)
+#
+# Baselines are currently rendered on macos-26 (arm64 / M1). Any other platform
+# (different arch, chip, macOS version, or Linux) will very likely mismatch — set
+# "update_snapshots: true" to regenerate baselines for that platform (uploaded as
+# an artifact, NOT committed) and measure timing without failing on diffs.
+#
+# Larger runners require a GitHub Team / Enterprise Cloud plan and an org-level
+# runner group; if the label is not available the job will simply stay queued.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'runs-on label (macos-15-xlarge, macos-15-large, macos-26, ubuntu-latest, or a runner-group name)'
+        required: true
+        default: 'macos-15-xlarge'
+      workers:
+        description: 'PLAYWRIGHT_SCREENSHOT_WORKERS (e.g. 100%, 8, 12)'
+        required: false
+        default: '100%'
+      update_snapshots:
+        description: 'Regenerate baselines for this platform instead of comparing (recommended for non macos-26 runners)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runner }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ github.token }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
+  ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+  ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+  ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
+  ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+  PLAYWRIGHT_SCREENSHOT_WORKERS: ${{ inputs.workers }}
+
+jobs:
+  experiment:
+    name: Screenshots on ${{ inputs.runner }} (${{ inputs.workers }} workers)
+
+    runs-on: ${{ inputs.runner }}
+
+    timeout-minutes: 60
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Capture the actual hardware so timings can be correlated with the runner.
+      - name: Report runner hardware
+        shell: bash
+        run: |
+          echo "Runner label : ${{ inputs.runner }}"
+          echo "Workers      : ${{ inputs.workers }}"
+          echo "Update mode  : ${{ inputs.update_snapshots }}"
+          echo "OS           : $(uname -a)"
+          if sysctl -n hw.ncpu >/dev/null 2>&1; then
+            echo "CPU cores    : $(sysctl -n hw.ncpu)"
+            echo "Memory (GB)  : $(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 ))"
+          else
+            echo "CPU cores    : $(nproc)"
+            free -h || true
+          fi
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}
+
+      - name: Install Playwright browsers
+        run: yarn workspace @dnb/eufemia playwright install --with-deps firefox
+
+      - name: Build portal
+        run: yarn workspace dnb-design-system-portal build:visual-test
+
+      - name: Run screenshots (full suite)
+        shell: bash
+        run: |
+          if [[ "${{ inputs.update_snapshots }}" == "true" ]]; then
+            yarn workspace dnb-design-system-portal test:screenshots:ci:update
+          else
+            yarn workspace dnb-design-system-portal test:screenshots:ci
+          fi
+
+      - name: Upload diff report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: experiment-diff-${{ inputs.runner }}
+          path: ./packages/dnb-eufemia/visual-diff-report/**
+          retention-days: 3
+
+      - name: Upload regenerated baselines (update mode)
+        if: ${{ inputs.update_snapshots }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: experiment-baselines-${{ inputs.runner }}
+          path: ./packages/dnb-eufemia/src/**/__image_snapshots__/**
+          retention-days: 3


### PR DESCRIPTION
The sharded visual-regression job is capped by the ~3 concurrent macOS runners in the shared org pool. This adds a workflow_dispatch-only experiment that runs the full screenshot suite on a parameterized runner label (macos-*-xlarge, macos-*-large, ubuntu-latest, or a runner-group name) with configurable workers and an optional update mode, so we can empirically compare timing, concurrency and rendering consistency across candidate runners before committing to a direction. It does not touch the production visual-regression workflow.

