### PR TITLE
chore: avoid re-running JSON.stringify for memo keys on every render

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/hooks/useFilter.ts
+++ b/packages/dnb-eufemia/src/components/filter/hooks/useFilter.ts
@@ -7,6 +7,7 @@ import {
 } from 'react'
 import { useSharedState } from '../../../shared/helpers/useSharedState'
 import { debounceAsync } from '../../../shared/helpers/debounce'
+import useStableMemoKey from '../../../shared/helpers/useStableMemoKey'
 import type { FilterState, FilterValue } from '../FilterContext'
 import { FilterContext } from '../FilterContext'
 
@@ -132,7 +133,7 @@ export function useFilterAsync<T>(
     ) as DebouncedFetcher
   }
 
-  const filtersKey = JSON.stringify(state.filters)
+  const filtersKey = useStableMemoKey(state.filters)
   const search = state.search
 
   useEffect(() => {

--- a/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
+++ b/packages/dnb-eufemia/src/components/portal-root/PortalRoot.tsx
@@ -22,6 +22,7 @@ import Context from '../../shared/Context'
 import { getThemeClasses } from '../../shared/Theme'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
+import useStableMemoKey from '../../shared/helpers/useStableMemoKey'
 
 type SelectorOptions = {
   /**
@@ -65,7 +66,7 @@ export function PortalRootProvider(
   const { id, insideSelector, beforeSelector, children, ...rest } = props
 
   const hasRest = Object.keys(rest).length > 0
-  const restKey = hasRest ? JSON.stringify(rest) : ''
+  const restKey = useStableMemoKey(rest)
 
   const value = useMemo(
     () => ({

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/useStableMemoKey.test.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/useStableMemoKey.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react'
+import useStableMemoKey from '../useStableMemoKey'
+
+describe('useStableMemoKey', () => {
+  it('should return the JSON representation of the object', () => {
+    const { result } = renderHook(() =>
+      useStableMemoKey({ a: 1, b: 'text' })
+    )
+    expect(result.current).toBe(JSON.stringify({ a: 1, b: 'text' }))
+  })
+
+  it('should return "{}" for undefined, null and empty input', () => {
+    expect(renderHook(() => useStableMemoKey()).result.current).toBe('{}')
+    expect(renderHook(() => useStableMemoKey(null)).result.current).toBe(
+      '{}'
+    )
+    expect(renderHook(() => useStableMemoKey({})).result.current).toBe(
+      '{}'
+    )
+  })
+
+  it('should keep the same key when a new but shallow-equal object is passed', () => {
+    const { result, rerender } = renderHook(
+      ({ obj }) => useStableMemoKey(obj),
+      { initialProps: { obj: { a: 1, b: 2 } as Record<string, unknown> } }
+    )
+
+    const first = result.current
+
+    // New object reference, identical shallow content
+    rerender({ obj: { a: 1, b: 2 } })
+
+    expect(result.current).toBe(first)
+  })
+
+  it('should update the key when a value changes', () => {
+    const { result, rerender } = renderHook(
+      ({ obj }) => useStableMemoKey(obj),
+      { initialProps: { obj: { a: 1 } as Record<string, unknown> } }
+    )
+
+    expect(result.current).toBe(JSON.stringify({ a: 1 }))
+
+    rerender({ obj: { a: 2 } })
+
+    expect(result.current).toBe(JSON.stringify({ a: 2 }))
+  })
+
+  it('should not call JSON.stringify again while the input stays shallow-equal', () => {
+    const spy = vi.spyOn(JSON, 'stringify')
+
+    const { rerender } = renderHook(({ obj }) => useStableMemoKey(obj), {
+      initialProps: { obj: { a: 1 } as Record<string, unknown> },
+    })
+
+    const callsAfterMount = spy.mock.calls.length
+
+    rerender({ obj: { a: 1 } })
+    rerender({ obj: { a: 1 } })
+
+    expect(spy.mock.calls.length).toBe(callsAfterMount)
+
+    // A real change re-serializes
+    rerender({ obj: { a: 2 } })
+    expect(spy.mock.calls.length).toBe(callsAfterMount + 1)
+
+    spy.mockRestore()
+  })
+
+  it('should produce a key that can be parsed back into the object', () => {
+    const object = { a: 1, b: ['x', 'y'], c: { nested: true } }
+    const { result } = renderHook(() => useStableMemoKey(object))
+
+    expect(JSON.parse(result.current)).toEqual(object)
+  })
+})

--- a/packages/dnb-eufemia/src/shared/helpers/useStableMemoKey.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/useStableMemoKey.ts
@@ -1,0 +1,30 @@
+import { useRef } from 'react'
+import { shallowEqual } from './useSharedState'
+
+/**
+ * Returns a stable string key derived from a (shallow) object, suitable for
+ * use as a `useMemo`/`useEffect` dependency – or for reconstructing the object
+ * with `JSON.parse`.
+ *
+ * The relatively expensive `JSON.stringify` is only recomputed when the
+ * object's shallow contents change (checked with the cheaper `shallowEqual`).
+ * On renders where the input is shallow-equal to the previous one, the cached
+ * key is returned without serializing again.
+ *
+ * The returned value equals `JSON.stringify(object ?? {})`, so it is a drop-in
+ * replacement for calling `JSON.stringify` on every render.
+ */
+export default function useStableMemoKey(
+  object?: Record<string, unknown> | null
+): string {
+  const cacheRef = useRef<{ object: unknown; key: string } | null>(null)
+
+  if (
+    !cacheRef.current ||
+    !shallowEqual(cacheRef.current.object, object)
+  ) {
+    cacheRef.current = { object, key: JSON.stringify(object ?? {}) }
+  }
+
+  return cacheRef.current.key
+}


### PR DESCRIPTION
Add a useStableMemoKey hook that caches the JSON.stringify result and only recomputes it when the input's shallow contents change (via shallowEqual). Use it in PortalRootProvider and useFilterAsync, which previously serialized their dependency object on every render.

