### PR TITLE
refactor(Dialog): export DialogAllProps to standardize prop-type naming

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/naming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/naming.mdx
@@ -24,6 +24,33 @@ The DNB Design System Eufemia uses the following naming conventions.
 
 Components exported as part of a namespace (e.g. `Field.String`, `Form.Handler`, `Iterate.Array`) use **pascal case** for both folders and files to mirror the public API structure.
 
+## Component prop types
+
+Prop types follow a consistent naming convention using the component name in **pascal case**:
+
+- `XxxProps` – the component's own, individually documented props. This is the type consumers import.
+- `XxxAllProps` – the complete set of props the component accepts. It combines `XxxProps` with the shared props the component composes on top, such as `SpacingProps` and forwarded element/HTML attributes. Export it whenever a component adds props beyond its own, and use it as the type of the component function and the `xxxDefaultProps` object.
+- `xxxDefaultProps` – the object holding the component's default prop values, named in **camel case**.
+
+```tsx
+export type BadgeProps = {
+  /* ...individually documented props... */
+}
+
+export type BadgeAllProps = BadgeProps &
+  SpacingProps &
+  Omit<HTMLProps<HTMLElement>, 'content' | 'label'>
+
+export const badgeDefaultProps: BadgeAllProps = {
+  variant: 'information',
+  // ...
+}
+
+function Badge(localProps: BadgeAllProps) {
+  /* ... */
+}
+```
+
 ## CSS / SCSS
 
 - CSS classes and the files containing the styles use **kebab case**.

--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -15,6 +15,8 @@ import DialogAction from './parts/DialogAction'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
+export type * from './types'
+
 const dialogDefaultProps: Partial<DialogAllProps> = {
   variant: 'information',
   spacing: true,

--- a/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/Dialog.tsx
@@ -8,19 +8,19 @@ import DialogContent from './DialogContent'
 import DialogBody from './parts/DialogBody'
 import DialogHeader from './parts/DialogHeader'
 import DialogNavigation from './parts/DialogNavigation'
-import type { DialogProps, DialogContentProps } from './types'
+import type { DialogAllProps } from './types'
 import { clsx } from 'clsx'
 import Context from '../../shared/Context'
 import DialogAction from './parts/DialogAction'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
-const dialogDefaultProps: Partial<DialogProps & DialogContentProps> = {
+const dialogDefaultProps: Partial<DialogAllProps> = {
   variant: 'information',
   spacing: true,
 }
 
-function Dialog(localProps: DialogProps & DialogContentProps) {
+function Dialog(localProps: DialogAllProps) {
   const context = useContext(Context)
 
   const propsWithContext = extendPropsWithContext(

--- a/packages/dnb-eufemia/src/components/dialog/types.ts
+++ b/packages/dnb-eufemia/src/components/dialog/types.ts
@@ -107,3 +107,5 @@ export type DialogContentProps = Omit<DialogActionProps, 'children'> & {
    */
   children?: ReactNode | ((props: DialogContentProps) => ReactNode)
 }
+
+export type DialogAllProps = DialogProps & DialogContentProps


### PR DESCRIPTION
Introduce a DialogAllProps type (DialogProps & DialogContentProps) and use it for the component signature and default props, matching the XxxAllProps convention used across the library. Also document the XxxProps / XxxAllProps / xxxDefaultProps naming convention in the contribute style guide.

