### PR TITLE
fix(GlobalError): prevent status-code translation keys leaking to DOM

### DIFF
--- a/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/GlobalError.tsx
@@ -87,6 +87,8 @@ export type GlobalErrorTranslationContent = {
 export type GlobalErrorTranslation = {
   404?: GlobalErrorTranslationContent
   500?: GlobalErrorTranslationContent
+  errorMessageCode?: ReactNode
+  help?: ReactNode
 }
 
 const globalErrorDefaultProps: Partial<GlobalErrorAllProps> = {
@@ -100,12 +102,17 @@ export default function GlobalError(localProps: GlobalErrorAllProps) {
   const translation = context.getTranslation(localProps)
     .GlobalError as GlobalErrorTranslation
 
+  // Exclude the status-code lookup objects (e.g. `404` and `500`) so they are
+  // not merged in as props and forwarded to the DOM element, where they would
+  // trigger "Invalid attribute name" warnings.
+  const { 404: _404, 500: _500, ...generalTranslation } = translation
+
   // Extract additional props from global context
   const allProps = extendPropsWithContext(
     localProps,
     globalErrorDefaultProps,
     context?.GlobalError,
-    translation,
+    generalTranslation,
     translation[
       localProps.statusCode || globalErrorDefaultProps.statusCode
     ],

--- a/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
+++ b/packages/dnb-eufemia/src/components/global-error/__tests__/GlobalError.test.tsx
@@ -21,6 +21,29 @@ const props: GlobalErrorAllProps = {
 }
 
 describe('GlobalError', () => {
+  // Keep this test first: React can suppress the "Invalid attribute name"
+  // warning after the first render that triggers it. Running before any other
+  // GlobalError render ensures the warning is emitted if the regression exists.
+  it('should not forward status-code translation keys as DOM attributes', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    render(<GlobalError statusCode="404" />)
+
+    const invalidAttributeWarnings = consoleError.mock.calls.filter(
+      (call) =>
+        call.some(
+          (arg) =>
+            typeof arg === 'string' &&
+            arg.includes('Invalid attribute name')
+        )
+    )
+    expect(invalidAttributeWarnings).toHaveLength(0)
+
+    consoleError.mockRestore()
+  })
+
   it('has default text for 404', () => {
     render(<GlobalError statusCode="404" />)
 


### PR DESCRIPTION
The whole GlobalError translation object (including the `404` and `500` status lookup objects) was merged into the props and spread onto the root DOM element, causing React to log "Invalid attribute name: `404`/`500`" warnings during rendering.

Exclude the numeric status-code lookup keys before merging so only the general translation fields (errorMessageCode, help) are forwarded, and complete the GlobalErrorTranslation type accordingly. Add a regression test guarding against the warning.

