### PR TITLE
chore: align timer and dir-entry types with @types/node 22

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/runScreenshotsConditionally/discovery.ts
+++ b/packages/dnb-eufemia/scripts/tools/runScreenshotsConditionally/discovery.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, type Dirent } from 'node:fs'
 import path from 'node:path'
 import {
   IGNORED_ENTITY_SEGMENTS,
@@ -18,7 +18,7 @@ export function collectFilesRecursively(
   const foundFiles: string[] = []
 
   function walkDirectory(directory: string) {
-    let entries: ReturnType<typeof readdirSync>
+    let entries: Dirent[]
 
     try {
       entries = readdirSync(directory, { withFileTypes: true })

--- a/packages/dnb-eufemia/src/components/input-masked/text-mask/InputModeNumber.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/text-mask/InputModeNumber.ts
@@ -7,7 +7,7 @@ import { IS_IOS } from '../../../shared/helpers'
 export default class InputModeNumber {
   inputElement: HTMLInputElement
   labelElement: HTMLLabelElement
-  timeout: NodeJS.Timer
+  timeout: NodeJS.Timeout
   hasFocus: boolean
   focusEventName: string
   blurEventName: string

--- a/packages/dnb-eufemia/src/components/upload/UploadDropzone.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadDropzone.tsx
@@ -27,7 +27,7 @@ export default function UploadDropzone({
   const props = rest as Omit<UploadProps, 'title' | 'onChange' | 'id'>
   const context = useContext(UploadContext)
   const [hover, setHover] = useState(false)
-  const hoverTimeout = useRef<NodeJS.Timer>(undefined)
+  const hoverTimeout = useRef<NodeJS.Timeout>(undefined)
 
   const { onInputUpload, id } = context
 

--- a/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListCell.tsx
@@ -216,7 +216,7 @@ export default UploadFileListCell
 function useExistsHighlight(id: string, file: File) {
   const { internalFiles } = useUpload(id)
   const [exists, updateExists] = useState(false)
-  const timerRef = useRef<NodeJS.Timer>(undefined)
+  const timerRef = useRef<NodeJS.Timeout>(undefined)
 
   const clearTimers = () => {
     clearTimeout(timerRef.current)


### PR DESCRIPTION
The yarn dedupe (#8773) collapsed @types/node to 22.19.19: setTimeout now returns NodeJS.Timeout (not the deprecated NodeJS.Timer), and ReturnType<typeof readdirSync> resolves to the Dirent<NonSharedBuffer>[] overload. Use NodeJS.Timeout and an explicit Dirent[] annotation to restore postbuild:ci and test:types.

