### PR TITLE
chore(deps): replace figma-js with native fetch client

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -192,7 +192,6 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-security": "4.0.0",
-    "figma-js": "1.14.0",
     "fontmin": "2.0.3",
     "fs-extra": "10.0.0",
     "globals": "17.6.0",

--- a/packages/dnb-eufemia/scripts/figma/helpers/__tests__/figmaClient.test.js
+++ b/packages/dnb-eufemia/scripts/figma/helpers/__tests__/figmaClient.test.js
@@ -1,0 +1,146 @@
+/**
+ * Figma client test
+ *
+ */
+
+import '../../../../src/core/test-utils/testSetup'
+import { createFigmaClient } from '../figmaClient'
+
+describe('createFigmaClient', () => {
+  const token = 'test-figma-token'
+  let fetchMock
+
+  const mockResponse = (
+    data,
+    { ok = true, status = 200, statusText = 'OK' } = {}
+  ) => ({
+    ok,
+    status,
+    statusText,
+    json: async () => data,
+    text: async () =>
+      typeof data === 'string' ? data : JSON.stringify(data),
+  })
+
+  const lastRequest = () => {
+    const [url, options] = fetchMock.mock.calls.at(-1)
+    const parsed = new URL(url)
+    return {
+      method: options.method,
+      headers: options.headers,
+      href: parsed.href,
+      pathname: parsed.pathname,
+      params: Object.fromEntries(parsed.searchParams.entries()),
+    }
+  }
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(mockResponse({}))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('sends the personal access token as the X-Figma-Token header', async () => {
+    const client = createFigmaClient({ personalAccessToken: token })
+    await client.client.get('files/ABC/versions')
+
+    expect(lastRequest().headers).toEqual({ 'X-Figma-Token': token })
+  })
+
+  it('uses an Authorization bearer header for OAuth access tokens', async () => {
+    const client = createFigmaClient({ accessToken: 'oauth-token' })
+    await client.client.get('me')
+
+    expect(lastRequest().headers).toEqual({
+      Authorization: 'Bearer oauth-token',
+    })
+  })
+
+  it('resolves client.get() against the v1 base url and returns { data }', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ versions: [{ id: '123' }] })
+    )
+    const client = createFigmaClient({ personalAccessToken: token })
+
+    const result = await client.client.get('files/ABC/versions')
+
+    const request = lastRequest()
+    expect(request.method).toBe('GET')
+    expect(request.href).toBe(
+      'https://api.figma.com/v1/files/ABC/versions'
+    )
+    expect(result).toEqual({ data: { versions: [{ id: '123' }] } })
+  })
+
+  it('file() requests the file endpoint with an empty ids param', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ name: 'Doc', lastModified: 'x' })
+    )
+    const client = createFigmaClient({ personalAccessToken: token })
+
+    const result = await client.file('ABC')
+
+    const request = lastRequest()
+    expect(request.pathname).toBe('/v1/files/ABC')
+    expect(request.params).toEqual({ ids: '' })
+    expect(result).toEqual({ data: { name: 'Doc', lastModified: 'x' } })
+  })
+
+  it('fileImages() joins ids into a comma separated list and forwards params', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ images: { '1:23': 'https://x/y.svg' } })
+    )
+    const client = createFigmaClient({ personalAccessToken: token })
+
+    const result = await client.fileImages('ABC', {
+      ids: ['1:23', '4:56'],
+      format: 'svg',
+    })
+
+    const request = lastRequest()
+    expect(request.pathname).toBe('/v1/images/ABC')
+    // Node ids are percent-encoded on the wire but decode back to the
+    // same comma separated list the Figma API expects.
+    expect(request.params).toEqual({ ids: '1:23,4:56', format: 'svg' })
+    expect(result).toEqual({
+      data: { images: { '1:23': 'https://x/y.svg' } },
+    })
+  })
+
+  it('throws on a non-2xx response and surfaces the Figma error body', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse(
+        { status: 403, err: 'Invalid token' },
+        {
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+        }
+      )
+    )
+    const client = createFigmaClient({ personalAccessToken: token })
+
+    await expect(client.file('ABC')).rejects.toThrow(
+      /403 Forbidden: Invalid token/
+    )
+  })
+
+  it('truncates an oversized error body in the thrown message', async () => {
+    const hugeBody = 'x'.repeat(5000)
+    fetchMock.mockResolvedValue(
+      mockResponse(hugeBody, {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
+    )
+    const client = createFigmaClient({ personalAccessToken: token })
+
+    await expect(client.file('ABC')).rejects.toThrow(
+      /500 Internal Server Error: x{500}\.\.\. for/
+    )
+  })
+})

--- a/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
+++ b/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
@@ -6,12 +6,12 @@
 import fs from 'fs-extra'
 import https from 'https'
 import path from 'path'
-import { Client } from 'figma-js'
 import traverse from 'traverse'
 import { isDeepStrictEqual } from 'node:util'
 import { ErrorHandler, ERROR_HARMLESS } from '../../lib/error'
 import { log } from '../../lib'
 import crypto from 'crypto'
+import { createFigmaClient } from './figmaClient'
 
 /**
  * Convert an [r, g, b] array (0–255) to a hex color string.
@@ -36,7 +36,7 @@ try {
   // .env is optional — CI provides env vars directly
 }
 
-const Figma = Client({
+const Figma = createFigmaClient({
   personalAccessToken: process.env.FIGMA_TOKEN,
 })
 

--- a/packages/dnb-eufemia/scripts/figma/helpers/figmaClient.ts
+++ b/packages/dnb-eufemia/scripts/figma/helpers/figmaClient.ts
@@ -1,0 +1,147 @@
+/**
+ * Minimal Figma REST API client built on the native `fetch`.
+ *
+ * Replaces the unmaintained `figma-js` package (which pulled in a vulnerable
+ * `axios@0.21.x`). It reproduces the exact behavior of the subset of the
+ * `figma-js` "Client" that our icon tooling relies on:
+ * - base URL `https://api.figma.com/v1/`
+ * - `X-Figma-Token` auth header (or `Authorization: Bearer` for OAuth tokens)
+ * - array `ids` are joined into a comma separated list
+ * - resolves with `{ data }` on success and throws on a non-2xx response,
+ *   surfacing the Figma error body (`{ err }`) when present
+ */
+
+export type CreateFigmaClientOptions = {
+  personalAccessToken?: string
+  accessToken?: string
+  apiRoot?: string
+}
+
+type QueryValue = string | number | undefined | null
+type QueryParams = Record<string, QueryValue>
+
+export type FigmaResponse<Data> = {
+  data: Data
+}
+
+export type FigmaImagesResponse = {
+  err: string | null
+  images: Record<string, string>
+}
+
+export type FigmaFileResponse = Record<string, unknown>
+
+export type FigmaClient = {
+  client: {
+    get: <Data = unknown>(
+      endpoint: string,
+      config?: { params?: QueryParams }
+    ) => Promise<FigmaResponse<Data>>
+  }
+  file: (
+    fileId: string,
+    params?: { ids?: string[] }
+  ) => Promise<FigmaResponse<FigmaFileResponse>>
+  fileImages: (
+    fileId: string,
+    params: { ids: string[]; format?: string }
+  ) => Promise<FigmaResponse<FigmaImagesResponse>>
+}
+
+/**
+ * Read a failed response body and extract the most useful error message.
+ * Figma returns errors as JSON (e.g. `{ "status": 403, "err": "..." }`), but
+ * we fall back to the raw text for non-JSON responses (e.g. a 500 HTML page).
+ */
+async function readErrorDetail(
+  response: Response
+): Promise<string | undefined> {
+  let raw: string
+  try {
+    raw = await response.text()
+  } catch {
+    return undefined
+  }
+
+  if (!raw) {
+    return undefined
+  }
+
+  let detail = raw
+  try {
+    const body = JSON.parse(raw) as {
+      err?: string
+      message?: string
+    } | null
+    detail = body?.err ?? body?.message ?? raw
+  } catch {
+    // Not JSON (e.g. an HTML error page) — fall back to the raw text
+  }
+
+  // Guard against embedding an unexpectedly large body in the error message
+  const maxLength = 500
+  return detail.length > maxLength
+    ? `${detail.slice(0, maxLength)}...`
+    : detail
+}
+
+export function createFigmaClient({
+  personalAccessToken,
+  accessToken,
+  apiRoot = 'api.figma.com',
+}: CreateFigmaClientOptions = {}): FigmaClient {
+  const baseURL = `https://${apiRoot}/v1/`
+  const headers: Record<string, string> = accessToken
+    ? { Authorization: `Bearer ${accessToken}` }
+    : { 'X-Figma-Token': personalAccessToken as string }
+
+  const get = async <Data = unknown>(
+    endpoint: string,
+    { params }: { params?: QueryParams } = {}
+  ): Promise<FigmaResponse<Data>> => {
+    const url = new URL(endpoint, baseURL)
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        // Mirror axios, which omits null/undefined params but keeps empty strings
+        if (value === undefined || value === null) {
+          continue
+        }
+        url.searchParams.set(key, String(value))
+      }
+    }
+
+    const response = await fetch(url, { method: 'GET', headers })
+
+    if (!response.ok) {
+      const detail = await readErrorDetail(response)
+      throw new Error(
+        `Figma API request failed with ${response.status} ${
+          response.statusText
+        }${detail ? `: ${detail}` : ''} for ${url.pathname}${url.search}`
+      )
+    }
+
+    return { data: (await response.json()) as Data }
+  }
+
+  return {
+    client: { get },
+
+    file: (fileId, params = {}) =>
+      get<FigmaFileResponse>(`files/${fileId}`, {
+        params: {
+          ...params,
+          ids: params.ids ? params.ids.join(',') : '',
+        },
+      }),
+
+    fileImages: (fileId, params) =>
+      get<FigmaImagesResponse>(`images/${fileId}`, {
+        params: {
+          ...params,
+          ids: params.ids.join(','),
+        },
+      }),
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,7 +2361,6 @@ __metadata:
     eslint-plugin-react: "npm:7.37.5"
     eslint-plugin-react-hooks: "npm:7.1.1"
     eslint-plugin-security: "npm:4.0.0"
-    figma-js: "npm:1.14.0"
     fontmin: "npm:2.0.3"
     fs-extra: "npm:10.0.0"
     globals: "npm:17.6.0"
@@ -6974,15 +6973,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
-  dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10/da644592cb6f8f9f8c64fdabd7e1396d6769d7a4c1ea5f8ae8beb5c2eb90a823e3a574352b0b934ac62edc762c0f52647753dc54f7d07279127a7e5c4cd20272
-  languageName: node
-  linkType: hard
-
 "axios@npm:^0.27.2":
   version: 0.27.2
   resolution: "axios@npm:0.27.2"
@@ -10634,15 +10624,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figma-js@npm:1.14.0":
-  version: 1.14.0
-  resolution: "figma-js@npm:1.14.0"
-  dependencies:
-    axios: "npm:^0.21.1"
-  checksum: 10/25c363f8929dd3d75ea8bc44b49e2769a08e861a778f7778b3ae50c7f99751628b96f961625f831717cdf0df4d135e168fc525d33f519cc82f0670de7eaaf0aa
-  languageName: node
-  linkType: hard
-
 "figures@npm:^2.0.0":
   version: 2.0.0
   resolution: "figures@npm:2.0.0"
@@ -10838,7 +10819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.14.9, follow-redirects@npm:^1.15.4":
+"follow-redirects@npm:^1.14.9, follow-redirects@npm:^1.15.4":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:


### PR DESCRIPTION
figma-js is unmaintained and pulled in a vulnerable axios@0.21.x. Replace the small subset of the Figma REST API used by the icon tooling with a native fetch-based client (createFigmaClient) that reproduces the same request behavior, and drop the figma-js dependency.

