### PR TITLE
ci(deps): enable grouped scheduled updates + guard lockfile dedupe (EDS-823)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,17 +16,18 @@ updates:
       - '/tools/*'
     schedule:
       interval: 'monthly'
-    # Disable scheduled dependency update PRs (too noisy across the monorepo).
-    # Security updates are still opened by Dependabot regardless of this limit.
-    open-pull-requests-limit: 0
+    # Grouped scheduled updates keep build/dev tooling current, which prevents
+    # the kind of rot that silently accumulates Dependabot alerts. Grouping (see
+    # below) keeps PR noise low across the monorepo. Security updates are opened
+    # by Dependabot regardless of this limit.
+    open-pull-requests-limit: 10
     # Match Yarn 4 setup (defaultSemverRangePrefix: "" in .yarnrc.yml) by only
     # widening package.json ranges when the new version requires it.
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
-    # Groups apply to scheduled updates (not security updates). Ready for when
-    # open-pull-requests-limit is raised above 0.
+    # Groups apply to scheduled updates (not security updates).
     groups:
       babel:
         patterns:
@@ -50,6 +51,15 @@ updates:
           - '@testing-library/*'
           - 'playwright'
           - '@playwright/*'
+      # Catch-all: batch all remaining dev-dependency minor/patch bumps into a
+      # single PR (per directory). Major bumps and production dependencies are
+      # still opened individually so they get proper review. Keep this group
+      # LAST — a dependency is assigned to the first group it matches.
+      dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,6 +64,12 @@ jobs:
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
+      - name: Check lockfile is deduplicated
+        # Guards against a plain `yarn install` reintroducing duplicate (and
+        # potentially vulnerable) transitive versions. Run `yarn dedupe` locally
+        # and commit yarn.lock if this fails.
+        run: yarn dedupe --check
+
       - name: Audit dependencies
         run: yarn workspace @dnb/eufemia audit:ci
 


### PR DESCRIPTION
## What

Two forward-looking improvements to how dependencies are kept healthy. Part of **EDS-823** (vulnerability-management routine).

### 1. Re-enable grouped scheduled updates

`open-pull-requests-limit` was **0** — routine version updates were switched off. That's the root cause of the recent alert backlog: with no routine bumps, build/dev tooling rotted (`node-gyp` stuck at 9.4.0, `start-server-and-test` at 2.0.1, `bundlewatch` at 0.4.1, `wait-on` at 7), and each drifted into vulnerable/abandoned territory.

This raises the limit to **10** and adds a catch-all **`dev-dependencies`** group so the monorepo doesn't explode into dozens of PRs:

- Existing `babel` / `types` / `eslint` / `testing` groups stay.
- New `dev-dependencies` group batches all remaining dev-dep **minor/patch** bumps into one PR per directory.
- **Major** bumps and **production** dependencies still open individually, so they get proper review.

Net effect: tooling stays current with a handful of grouped PRs per month instead of a growing alert pile.

### 2. Guard the lockfile against dedupe drift

Adds a `yarn dedupe --check` step to the verify workflow's audit job. We learned during EDS-823 that a plain `yarn install` (without `yarn dedupe`) can silently reintroduce duplicate — and potentially vulnerable — transitive versions. This check fails CI if the lockfile isn't deduplicated, prompting a `yarn dedupe` + commit.

Verified `yarn dedupe --check` **passes on current `main`**, so it won't spuriously block PRs.

## Risk

Low. No dependency versions change here — only the update policy and a CI guard. The main trade-off is a modest, predictable increase in scheduled PRs (mitigated by grouping); the limit can be tuned if it's still too chatty.
