### PR TITLE
refactor(Forms): type transformer/event callbacks as methods to satisfy strictFunctionTypes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
@@ -56,7 +56,6 @@ export const PostalCode = () => {
                 postalCode={{
                   path: '/postalCode',
                   onBlurValidator,
-                  // @ts-expect-error -- strictFunctionTypes
                   onBlur,
                   required: true,
                 }}
@@ -106,7 +105,6 @@ export const Address = () => {
             <Form.Card>
               <Field.Address.Street
                 path="/streetAddress"
-                // @ts-expect-error -- strictFunctionTypes
                 element={addressSuggestionsElement}
               />
               <Field.PostalCodeAndCity

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/DateOfBirth/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/DateOfBirth/Examples.tsx
@@ -131,7 +131,6 @@ export const ValidationExtendValidator = () => {
           <Field.DateOfBirth
             required
             value="2000-05-17"
-            // @ts-expect-error -- strictFunctionTypes
             onBlurValidator={myValidator}
             validateInitially
           />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Expiry/Examples.tsx
@@ -155,11 +155,7 @@ export const ValidationExtendValidator = () => {
         }
 
         return (
-          <Field.Expiry
-            value="1225"
-            // @ts-expect-error -- strictFunctionTypes
-            onBlurValidator={myOnBlurValidator}
-          />
+          <Field.Expiry value="1225" onBlurValidator={myOnBlurValidator} />
         )
       }}
     </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Time/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/Time/Examples.tsx
@@ -164,11 +164,7 @@ export const ValidationExtendValidator = () => {
         }
 
         return (
-          <Field.Time
-            value="00:00"
-            // @ts-expect-error -- strictFunctionTypes
-            onBlurValidator={myOnBlurValidator}
-          />
+          <Field.Time value="00:00" onBlurValidator={myOnBlurValidator} />
         )
       }}
     </ComponentBox>

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -116,7 +116,7 @@ export type AutocompleteOptionsRender = DrawerListOptionsRender
 export type AutocompleteEventMethods = {
   attributes: Record<string, unknown>
   dataList: DrawerListData
-  updateData: (data: DrawerListData) => void
+  updateData(data: DrawerListData): void
   revalidateSelectedItem: () => void
   revalidateInputValue: () => void
   resetSelectedItem: () => void
@@ -531,12 +531,11 @@ function getCurrentDataTitle(
 }
 
 function AutocompleteComponent(ownProps: AutocompleteAllProps) {
-  const context = useContext<
-    DrawerListContextValue & {
-      Autocomplete: Record<string, unknown>
-    }
-    // @ts-expect-error - strictFunctionTypes
-  >(DrawerListContext)
+  const context = useContext(
+    DrawerListContext
+  ) as DrawerListContextValue & {
+    Autocomplete: Record<string, unknown>
+  }
   const drawerList = context.drawerList
 
   // Filter out undefined values so that explicit undefined (e.g. size={undefined})
@@ -1743,7 +1742,6 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       >
     >(null)
   eventMethodsRef.current = {
-    // @ts-expect-error - strictFunctionTypes
     updateData,
     revalidateSelectedItem,
     revalidateInputValue,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -808,7 +808,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   _omitInputShellClass={_omitInputShellClass}
                   {...attributes}
                   submitProps={remainingSubmitProps}
-                  // @ts-expect-error - strictFunctionTypes
+                  // @ts-expect-error statusProps (FormStatusProps) spreads a DOM `onSubmit` (SubmitEvent) that conflicts with the button `onSubmit` (MouseEvent)
                   onSubmit={togglePicker}
                   triggerProps={triggerProps}
                   {...statusProps}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -85,12 +85,12 @@ export type DatePickerCalendarProps = Omit<
   onlyMonth?: boolean
   hideMonthLabel?: boolean
   hideNextMonthWeek?: boolean
-  onSelect?: (
+  onSelect?(
     event: DatePickerChangeEvent<
       | MouseEvent<HTMLSpanElement>
       | KeyboardEvent<HTMLTableElement | HTMLButtonElement>
     >
-  ) => void
+  ): void
   onKeyDown?: (
     event: KeyboardEvent<HTMLTableElement | HTMLButtonElement>,
     tableRef: RefObject<HTMLTableElement>,

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerRange.tsx
@@ -60,7 +60,6 @@ function DatePickerRange({
           {...calendar}
           {...props}
           id={`${props.id}-${i}-`}
-          // @ts-expect-error - strictFunctionTypes
           onSelect={onSelect}
         />
       ))}

--- a/packages/dnb-eufemia/src/components/upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/components/upload/Upload.tsx
@@ -155,7 +155,6 @@ const Upload = (localProps: UploadAllProps) => {
       value={{
         ...extendedProps,
         id,
-        // @ts-expect-error - strictFunctionTypes
         onInputUpload,
       }}
     >

--- a/packages/dnb-eufemia/src/components/upload/types.ts
+++ b/packages/dnb-eufemia/src/components/upload/types.ts
@@ -117,7 +117,7 @@ export type UploadAllProps = UploadProps &
 
 export type UploadContextValue = {
   id?: string
-  onInputUpload: (files: Array<UploadFileNative>) => void
+  onInputUpload(files: Array<UploadFileNative>): void
 } & Partial<UploadAllProps>
 
 export type UploadFile = {

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
@@ -131,9 +131,7 @@ export function suggestions(
     const { countryCode } = handleCountryPath({
       value,
       countryCode: handlerConfig?.countryCode,
-      // @ts-ignore - strictFunctionTypes
       additionalArgs,
-      // @ts-ignore - strictFunctionTypes
       handler: suggestionsHandler,
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -160,9 +160,7 @@ export function validator(
     const { countryCode } = handleCountryPath({
       value,
       countryCode: handlerConfig?.countryCode,
-      // @ts-ignore - strictFunctionTypes
       additionalArgs,
-      // @ts-ignore - strictFunctionTypes
       handler: validatorHandler,
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
@@ -182,10 +182,13 @@ export function handleCountryPath({
   value: string
   countryCode?: string
   additionalArgs: ReceiveAdditionalEventArgs<unknown>
-  handler: (
+  // Method syntax gives the parameters bivariant checking, so that the
+  // value-specific validator/suggestions handlers can be passed without
+  // tripping `strictFunctionTypes`.
+  handler(
     value: string,
     additionalArgs: ReceiveAdditionalEventArgs<unknown>
-  ) => void
+  ): void
 }) {
   const { countryCode, countryCodeValue } = getCountryCodeValue({
     countryCode:

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Context.ts
@@ -47,12 +47,12 @@ export type EventListenerCall = {
     | 'onMount'
     | 'onSetMountedFieldState'
     | 'onSetFieldError'
-  callback: (
+  callback(
     params?:
       | { value: unknown }
       | { preventSubmit: () => void }
       | { path: Path; state: MountState }
-  ) => void | Promise<void | Error>
+  ): void | Promise<void | Error>
 }
 
 export type VisibleDataHandler<Data> = (
@@ -193,12 +193,12 @@ export type ContextState = {
   }) => Promise<EventStateObject | undefined>
   getSubmitData?: () => unknown
   getSubmitParams?: () => OnSubmitParams
-  setFieldEventListener?: (
+  setFieldEventListener?(
     path: EventListenerCall['path'],
     type: EventListenerCall['type'],
     callback: EventListenerCall['callback'],
     params?: { remove?: boolean }
-  ) => void
+  ): void
   revealError?: (path: Path, hasError: boolean) => void
   setFieldInternals?: <Props>(
     path: Path,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/ArraySelection/ArraySelection.tsx
@@ -317,7 +317,6 @@ export function useCheckboxOrToggleOptions({
     ...(dataList || []).map((props, i) =>
       createOption(props as OptionProps, i)
     ),
-    // @ts-expect-error - strictFunctionTypes
     ...(mapOptions(children, { createOption }) || []).filter(Boolean),
   ]
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -174,7 +174,6 @@ function BankAccountNumber(props: FieldBankAccountNumberProps) {
     allowOverflow: true,
     value,
     defaultValue,
-    // @ts-expect-error - strictFunctionTypes
     fromInput,
     onChange: handleChange,
     onBlur: handleBlur,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/BankAccountNumber/BankAccountNumber.tsx
@@ -180,7 +180,6 @@ function BankAccountNumber(props: FieldBankAccountNumberProps) {
     width: width ?? getWidth(bankAccountType),
     inputMode: getInputMode(bankAccountType),
     onChangeValidator: validate ? onChangeValidator : undefined,
-    // @ts-expect-error - strictFunctionTypes
     onBlurValidator: validate ? onBlurValidatorToUse : undefined,
     exportValidators: { bankAccountNumberValidator },
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/Date.tsx
@@ -251,7 +251,6 @@ function DateComponent(props: DateProps): ReactElement {
     maxDate,
     width,
     ...rest
-    // @ts-expect-error - strictFunctionTypes
   } = useFieldProps(preparedProps)
 
   const datePickerProps = pickDatePickerProps(rest)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/DateOfBirth/DateOfBirth.tsx
@@ -186,7 +186,6 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
     onYearChange,
     setHasFocus,
     value: fieldValue,
-    // @ts-expect-error - strictFunctionTypes
   } = useFieldProps(preparedProps)
 
   const labelWithItemNo = useIterateItemNo({
@@ -372,7 +371,6 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
 
   const compositionFieldProps: CompositionFieldProps = {
     className: 'dnb-forms-field-date-of-birth',
-    // @ts-expect-error - strictFunctionTypes
     error,
     label: labelWithItemNo,
     labelSrOnly,
@@ -459,7 +457,6 @@ function DateOfBirth(props: FieldDateOfBirthProps) {
           onBlur: onBlurAutocomplete,
         }}
         data={months}
-        // @ts-expect-error - strictFunctionTypes
         onChange={handleMonthChange}
         onFocus={handleOnFocus}
         onBlur={handleOnBlur}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Expiry/Expiry.tsx
@@ -190,9 +190,7 @@ function Expiry(props: ExpiryProps = {}) {
     validateInitially,
     validateContinuously,
     fromExternal,
-    // @ts-expect-error - strictFunctionTypes
     transformIn,
-    // @ts-expect-error - strictFunctionTypes
     fromInput,
     provideAdditionalArgs,
     validateRequired,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/NationalIdentityNumber.tsx
@@ -108,7 +108,6 @@ function NationalIdentityNumber(props: FieldNationalIdentityNumberProps) {
     width: width ?? 'medium',
     inputMode: 'numeric',
     onChangeValidator: validate ? onChangeValidator : undefined,
-    // @ts-expect-error - strictFunctionTypes
     onBlurValidator: validate ? onBlurValidatorToUse : undefined,
     exportValidators: {
       dnrValidator,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Number/Number.tsx
@@ -378,7 +378,6 @@ function NumberComponent(props: FieldNumberProps) {
     error: limitError || props.error,
     schema,
     toInput,
-    // @ts-expect-error - strictFunctionTypes
     fromInput,
     width:
       props.width ??

--- a/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/OrganizationNumber/OrganizationNumber.tsx
@@ -74,7 +74,6 @@ function OrganizationNumber(props: FieldOrganizationNumberProps) {
     width: width ?? 'medium',
     inputMode: 'numeric',
     onChangeValidator: validate ? onChangeValidator : undefined,
-    // @ts-expect-error - strictFunctionTypes
     onBlurValidator: validate ? onBlurValidatorToUse : undefined,
     exportValidators: { organizationNumberValidator },
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -262,7 +262,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
     errorMessages,
   }
   const ref = useRef<HTMLInputElement>(undefined)
-  const preparedProps: FieldPhoneNumberProps = {
+  const preparedProps = {
     ...props,
     ...phoneNumberDefaultProps,
     onBlurValidator: onBlurValidatorToUse,
@@ -272,7 +272,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
     provideAdditionalArgs,
     transformIn,
     inputRef: props.inputRef ?? ref,
-  }
+  } satisfies FieldPhoneNumberProps
 
   const {
     id,
@@ -312,7 +312,6 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
     onCountryCodeChange,
     onNumberChange,
     filterCountries,
-    // @ts-expect-error - strictFunctionTypes
   } = useFieldProps(preparedProps, {
     executeOnChangeRegardlessOfUnchangedValue: true,
   })
@@ -362,9 +361,8 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
         type Item = DrawerListDataArrayItem & { country: CountryType }
 
         const cdcVal = countryCode?.replace(/^\+/, '').replace(/-/g, '')
-        // @ts-expect-error - strictFunctionTypes
-        const item = dataRef.current.find((item: Item) => {
-          const cdc = item?.country?.cdc?.replace(/-/g, '')
+        const item = dataRef.current.find((item) => {
+          const cdc = (item as Item)?.country?.cdc?.replace(/-/g, '')
           return cdc === cdcVal
         }) as Item
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -270,7 +270,6 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
     fromExternal,
     toEvent,
     provideAdditionalArgs,
-    // @ts-expect-error - strictFunctionTypes
     transformIn,
     inputRef: props.inputRef ?? ref,
   }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -138,7 +138,6 @@ function SelectCountry(props: FieldSelectCountryProps) {
     setDisplayValue,
     forceUpdate,
     filterCountries,
-    // @ts-expect-error - strictFunctionTypes
   } = useFieldProps(preparedProps)
 
   const dataRef = useRef<ReturnType<typeof getCountryData>>(null)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrency.tsx
@@ -135,7 +135,6 @@ function SelectCurrency(props: FieldSelectCurrencyProps) {
     setDisplayValue,
     forceUpdate,
     filterCurrencies,
-    // @ts-expect-error - strictFunctionTypes
   } = useFieldProps(preparedProps)
 
   const dataRef = useRef<ReturnType<typeof getCurrencyData>>(null)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -10,7 +10,6 @@ import type {
   ComponentProps,
   ComponentType,
   JSX,
-  ReactElement,
   ReactNode,
 } from 'react'
 import { clsx } from 'clsx'
@@ -502,32 +501,28 @@ export function mapOptions(
   children: ReactNode,
   {
     createOption,
-  }: { createOption: (props: OptionProps, i: number) => ReactNode }
+  }: { createOption(props: OptionProps, i: number): ReactNode }
 ) {
-  return Children.map(
-    // @ts-expect-error - strictFunctionTypes
-    children,
-    (child: ReactElement<OptionProps>, i) => {
-      if (isValidElement(child)) {
-        if (child.type === OptionField) {
-          return createOption(child.props, i)
-        }
-
-        if (child.props.children) {
-          const nestedChildren = mapOptions(child.props.children, {
-            createOption,
-          })
-          return createElement(
-            child.type as ComponentType<OptionProps>,
-            child.props,
-            nestedChildren
-          )
-        }
+  return Children.map(children, (child, i) => {
+    if (isValidElement<OptionProps>(child)) {
+      if (child.type === OptionField) {
+        return createOption(child.props, i)
       }
 
-      return child
+      if (child.props.children) {
+        const nestedChildren = mapOptions(child.props.children, {
+          createOption,
+        })
+        return createElement(
+          child.type as ComponentType<OptionProps>,
+          child.props,
+          nestedChildren
+        )
+      }
     }
-  )
+
+    return child
+  })
 }
 
 export function makeOptions<T = DrawerListProps['data']>(

--- a/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/String/String.tsx
@@ -234,7 +234,6 @@ function StringComponent(props: FieldStringProps) {
   const preparedProps: FieldStringProps = {
     ...props,
     schema,
-    // @ts-expect-error - strictFunctionTypes
     fromInput: props.fromInput ?? fromInput,
     toEvent,
     transformValue,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Time/Time.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Time/Time.tsx
@@ -179,9 +179,7 @@ function Time(props: TimeProps = {}) {
     validateInitially,
     validateContinuously,
     fromExternal,
-    // @ts-expect-error - strictFunctionTypes
     transformIn,
-    // @ts-expect-error - strictFunctionTypes
     fromInput,
     provideAdditionalArgs,
     validateRequired,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Upload/Upload.tsx
@@ -136,7 +136,6 @@ function UploadComponent(props: FieldUploadProps) {
     onValidationError,
     dataContext,
     ...rest
-    // @ts-expect-error - strictFunctionTypes
   } = useFieldProps(preparedProps, {
     executeOnChangeRegardlessOfError: true,
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/Isolation.tsx
@@ -313,7 +313,6 @@ function IsolationProvider<Data extends JsonObject>(
           dataReference,
           resetDataAfterCommit,
           outerContext,
-          // @ts-expect-error - strictFunctionTypes
           setIsolatedData,
         }}
       >

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/IsolationContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/IsolationContext.ts
@@ -7,7 +7,7 @@ export type IsolationContext = {
   resetDataAfterCommit: boolean
   outerContext: ContextState
   preventUncommittedChanges: boolean
-  setIsolatedData: (data: unknown) => void
+  setIsolatedData(data: unknown): void
 }
 
 const IsolationContext = createContext<IsolationContext>(null)

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/SubmitConfirmation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/SubmitConfirmation.tsx
@@ -33,16 +33,16 @@ export type ConfirmParams = {
     DialogProps & DialogContentProps,
     'open' | 'onConfirm' | 'onDecline' | 'onClose'
   >
-  setConfirmationState: (state: ConfirmationState) => void
-  submitHandler: () => void | Promise<void>
-  cancelHandler: () => void | Promise<void>
+  setConfirmationState(state: ConfirmationState): void
+  submitHandler(): void | Promise<void>
+  cancelHandler(): void | Promise<void>
 }
 
 export type ConfirmProps = {
-  preventSubmitWhen?: (params: ConfirmParams) => boolean
-  onStateChange?: (params: ConfirmParams) => void | Promise<void>
-  onSubmitResult?: (params: ConfirmParams) => void
-  renderWithState?: (params: ConfirmParams) => ReactNode
+  preventSubmitWhen?(params: ConfirmParams): boolean
+  onStateChange?(params: ConfirmParams): void | Promise<void>
+  onSubmitResult?(params: ConfirmParams): void
+  renderWithState?(params: ConfirmParams): ReactNode
   children?: ReactNode
 }
 
@@ -71,7 +71,6 @@ function SubmitConfirmation(props: ConfirmProps) {
 
   const validatePreventSubmit = useCallback(() => {
     return (preventSubmitRef.current = preventSubmitWhen?.(
-      // @ts-expect-error - strictFunctionTypes
       getParamsRef.current()
     ))
   }, [preventSubmitWhen])
@@ -79,7 +78,6 @@ function SubmitConfirmation(props: ConfirmProps) {
   const setConfirmationState = useCallback(
     async (state: ConfirmationState) => {
       confirmationStateRef.current = state
-      // @ts-expect-error - strictFunctionTypes
       await onStateChange?.(getParamsRef.current())
 
       const setBuffered = (
@@ -125,7 +123,7 @@ function SubmitConfirmation(props: ConfirmProps) {
       open: confirmationState === 'readyToBeSubmitted',
       onConfirm: submitHandler,
       onDecline: cancelHandler,
-      onClose: ({ triggeredBy }) => {
+      onClose: ({ triggeredBy }: { triggeredBy?: string }) => {
         if (triggeredBy === 'keyboard') {
           cancelHandler()
         }
@@ -138,7 +136,6 @@ function SubmitConfirmation(props: ConfirmProps) {
       setConfirmationState,
       submitHandler,
       cancelHandler,
-      // @ts-expect-error - strictFunctionTypes
       connectWithDialog,
       submitState: submitStateRef.current,
     } satisfies ConfirmParams
@@ -149,7 +146,6 @@ function SubmitConfirmation(props: ConfirmProps) {
       submitStateRef.current = {
         ...submitState,
       } as EventStateObject
-      // @ts-expect-error - strictFunctionTypes
       onSubmitResult?.(getParamsRef.current())
     }
   }, [submitState, onSubmitResult])
@@ -219,7 +215,6 @@ function SubmitConfirmation(props: ConfirmProps) {
 
       <SharedProvider {...sharedProviderParams}>
         <HeightAnimation>
-          {/* @ts-expect-error -- strictFunctionTypes */}
           {renderWithState?.(getParamsRef.current())}
         </HeightAnimation>
       </SharedProvider>

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -493,7 +493,6 @@ function ArrayComponent(props: IterateArrayProps) {
         shellSpace={{ top: 0, bottom: 'medium' }}
         noAnimation={false}
       >
-        {/* @ts-expect-error -- strictFunctionTypes */}
         {getMessagesFromError({ content: error || limitWarning })[0]}
       </FormStatus>
     </>

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Date/Date.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Date/Date.tsx
@@ -54,7 +54,6 @@ function DateComponent(props: ValueDateProps) {
   const stringProps: ValueDateProps = {
     ...props,
     label: props.label ?? translations.label,
-    // @ts-expect-error - strictFunctionTypes
     toInput,
   }
   return <StringValue {...stringProps} />

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Number/Number.tsx
@@ -40,7 +40,6 @@ function NumberValue(props: ValueNumberProps) {
     itemPath,
     inheritLabel,
     ...rest
-    // @ts-expect-error - strictFunctionTypes
   } = useValueProps(props)
   const { percent, ...numberFormatRest } = omitSpacingProps(
     rest

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Time/Time.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Time/Time.tsx
@@ -54,7 +54,6 @@ function TimeComponent(props: ValueTimeProps) {
   const stringProps: ValueTimeProps = {
     ...props,
     label: props.label ?? translations.label,
-    // @ts-expect-error - strictFunctionTypes
     toInput,
   }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Value/Upload/Upload.tsx
@@ -37,7 +37,6 @@ function Upload(props: ValueUploadProps) {
     displaySize = false,
     onFileClick,
     ...rest
-    // @ts-expect-error - strictFunctionTypes
   } = useValueProps(preparedProps)
 
   const list = useMemo(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
@@ -138,13 +138,11 @@ function usePreventSubmit() {
 
   // Only add the listener when there is an unknown step state
   if (hasUnknownSteps) {
-    // @ts-expect-error - strictFunctionTypes
     setFieldEventListener?.(undefined, 'onSubmit', handleSubmit)
   }
 
   useEffect(() => {
     return () => {
-      // @ts-expect-error - strictFunctionTypes
       setFieldEventListener?.(undefined, 'onSubmit', handleSubmit, {
         remove: true,
       })

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldAsync.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldAsync.ts
@@ -26,8 +26,8 @@ type AsyncProcessesBuffer = {
 }
 
 export type UseFieldAsyncParams<Value> = {
-  onChange: (...args: unknown[]) => unknown
-  onChangeContext: (...args: unknown[]) => unknown
+  onChange(...args: unknown[]): unknown
+  onChangeContext(...args: unknown[]): unknown
   valueRef: RefObject<Value>
   forceUpdate: () => void
 
@@ -51,9 +51,9 @@ export type UseFieldAsyncParams<Value> = {
   hasPath: boolean
   identifier: Identifier
   executeOnChangeRegardlessOfError: boolean
-  handlePathChangeDataContext: (
+  handlePathChangeDataContext(
     identifier: Identifier
-  ) =>
+  ):
     | EventReturnWithStateObjectAndSuccess
     | Promise<EventReturnWithStateObjectAndSuccess>
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
@@ -297,7 +297,6 @@ export default function useFieldError<Value>({
   const errorProp =
     initialErrorProp === 'initial' ? undefined : initialErrorProp
   const error = executeMessage<UseFieldProps['error'] | 'initial'>(
-    // @ts-expect-error - strictFunctionTypes
     errorProp,
     true
   )
@@ -415,8 +414,7 @@ export default function useFieldError<Value>({
 
       if (Array.isArray(error)) {
         return new FormError('Error', {
-          // @ts-expect-error - strictFunctionTypes
-          errors: error.map(prepare),
+          errors: error.map((item) => prepare(item as FormError)),
         })
       }
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -329,12 +329,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     transformOut,
     toInput: toInput as TransformerFns<Value>['toInput'],
     fromInput,
-    // @ts-expect-error - strictFunctionTypes
     toEvent,
     transformValue,
     provideAdditionalArgs,
     fromExternal,
-    // @ts-expect-error - strictFunctionTypes
     validateRequired,
     valueRef,
   })
@@ -553,9 +551,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     validatedValueRef,
     changeEventResultRef,
   } = useFieldAsync<Value>({
-    // @ts-expect-error - strictFunctionTypes
     onChange,
-    // @ts-expect-error - strictFunctionTypes
     onChangeContext,
     valueRef,
     forceUpdate,
@@ -596,7 +592,6 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     required,
     hasDataContext,
     getAjvInstanceDataContext,
-    // @ts-expect-error - strictFunctionTypes
     setFieldEventListener,
     getValueByPath,
     getSourceValue,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldTransform.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldTransform.ts
@@ -3,18 +3,18 @@ import type { RefObject } from 'react'
 import type { ProvideAdditionalEventArgs } from '../types'
 
 export type TransformerFns<Value> = {
-  transformIn: (external: unknown) => Value
-  transformOut: (internal: Value, args?: unknown) => unknown
-  toInput: (value: Value) => Value
-  fromInput: (value: Value) => Value
-  toEvent: (value: Value, eventName?: string) => Value
-  transformValue: (value: Value, currentValue?: Value) => Value
-  provideAdditionalArgs: (
+  transformIn(external: unknown): Value
+  transformOut(internal: Value, args?: unknown): unknown
+  toInput(value: Value): Value
+  fromInput(value: Value): Value
+  toEvent(value: Value, eventName?: string): Value
+  transformValue(value: Value, currentValue?: Value): Value
+  provideAdditionalArgs(
     value: Value,
     additionalArgs?: ProvideAdditionalEventArgs
-  ) => ProvideAdditionalEventArgs
-  fromExternal: (value: Value) => Value
-  validateRequired: (
+  ): ProvideAdditionalEventArgs
+  fromExternal(value: Value): Value
+  validateRequired(
     value: Value,
     options: {
       emptyValue: unknown
@@ -22,7 +22,7 @@ export type TransformerFns<Value> = {
       isChanged: boolean
       error: Error
     }
-  ) => Error | undefined
+  ): Error | undefined
 }
 
 export default function useFieldTransform<Value>({
@@ -36,16 +36,7 @@ export default function useFieldTransform<Value>({
   fromExternal,
   validateRequired,
   valueRef,
-}: {
-  transformIn: TransformerFns<Value>['transformIn']
-  transformOut: TransformerFns<Value>['transformOut']
-  toInput: TransformerFns<Value>['toInput']
-  fromInput: TransformerFns<Value>['fromInput']
-  toEvent: TransformerFns<Value>['toEvent']
-  transformValue: TransformerFns<Value>['transformValue']
-  provideAdditionalArgs: TransformerFns<Value>['provideAdditionalArgs']
-  fromExternal: TransformerFns<Value>['fromExternal']
-  validateRequired: TransformerFns<Value>['validateRequired']
+}: TransformerFns<Value> & {
   valueRef: RefObject<Value>
 }) {
   const transformers = useRef<TransformerFns<Value>>({

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -46,11 +46,11 @@ export type UseFieldValidationParams<Value> = {
   required: boolean
   hasDataContext: boolean
   getAjvInstanceDataContext: () => AjvInstance
-  setFieldEventListener: (
+  setFieldEventListener(
     identifier: Identifier,
     event: string,
     fn: () => void
-  ) => void
+  ): void
   getValueByPath: (path: string) => unknown
   getSourceValue: (path: string) => unknown
   exportValidators: Record<string, Validator<Value>>

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useValueProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useValueProps.ts
@@ -88,8 +88,7 @@ export default function useValueProps<Value = unknown, Props = unknown>(
   )
 
   const value = shouldBeVisible(path)
-    ? // @ts-expect-error - strictFunctionTypes
-      transformIn(toInput(externalValue))
+    ? transformIn(toInput(externalValue))
     : undefined
 
   const label =

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -408,7 +408,7 @@ interface UseFieldPropsInterface<
   onChangeValidator?: Validator<Value>
   onBlurValidator?: Validator<Value>
   exportValidators?: Record<string, Validator<Value>>
-  validateRequired?: (
+  validateRequired?(
     internal: Value,
     {
       emptyValue,
@@ -421,7 +421,7 @@ interface UseFieldPropsInterface<
       isChanged: boolean
       error: FormError | undefined
     }
-  ) => FormError | undefined
+  ): FormError | undefined
   /**
    * Should error messages based on validation be shown initially (from given value-prop or source data)
    * before the user interacts with the field?
@@ -448,52 +448,52 @@ interface UseFieldPropsInterface<
    * Transforms the `value` before it's displayed in the field (e.g. input).
    * Public API. Should not be used internally.
    */
-  transformIn?: (external: unknown) => Value | ExtraValue
+  transformIn?(external: unknown): Value | ExtraValue
 
   /**
    * Transforms the value before it gets forwarded to the form data object or returned as the onChange value parameter.
    * Public API. Should not be used internally.
    */
-  transformOut?: (
+  transformOut?(
     internal: Value | ExtraValue,
     additionalArgs?: unknown
-  ) => unknown
+  ): unknown
 
   /**
    * Transforms the value given by `handleChange` after `fromInput` and before `updateValue` and `toEvent`. The second parameter returns the current value.
    */
-  transformValue?: (value: Value, currentValue?: Value) => Value
+  transformValue?(value: Value, currentValue?: Value): Value
 
   /**
    * Transform additionalArgs or generate it based on `value`.
    */
-  provideAdditionalArgs?: (
+  provideAdditionalArgs?(
     value: Value,
     additionalArgs?: ProvideAdditionalEventArgs
-  ) => ProvideAdditionalEventArgs
+  ): ProvideAdditionalEventArgs
 
   /**
    * Transforms the value before it gets returned as the `value`.
    */
-  toInput?: (external: Value | unknown) => Value | unknown
+  toInput?(external: Value | unknown): Value | unknown
 
   /**
    * Transforms the internal value before it gets returned by even callbacks such as `onChange`, `onFocus` and `onBlur`. The second parameter returns the event type: `onChange`, `onFocus`, `onBlur` or `onBlurValidator`.
    */
-  toEvent?: (
+  toEvent?(
     internal: Value,
     type: 'onChange' | 'onFocus' | 'onBlur' | 'onBlurValidator'
-  ) => Value
+  ): Value
 
   /**
    * Transforms the value given by `handleChange` before it is used in the further process flow. Use it to destruct the value from the original event object.
    */
-  fromInput?: (external: Value | unknown) => Value
+  fromInput?(external: Value | unknown): Value
 
   /**
    * Transforms the given props `value` before any other step gets entered.
    */
-  fromExternal?: (external: Value) => Value
+  fromExternal?(external: Value): Value
 
   /**
    * For internal use only.
@@ -597,17 +597,17 @@ interface ValuePropsInterface<
    * Transforms the `value` before it's displayed in the field (e.g. input).
    * Public API. Should not be used internally.
    */
-  transformIn?: (external: Value | unknown) => Value | unknown
+  transformIn?(external: Value | unknown): Value | unknown
 
   /**
    * Transforms the value before it gets returned as the `value`.
    */
-  toInput?: (external: Value | unknown) => Value | unknown
+  toInput?(external: Value | unknown): Value | unknown
 
   /**
    * Transforms the given props `value` before any other step gets entered.
    */
-  fromExternal?: (external: Value) => Value
+  fromExternal?(external: Value): Value
 }
 
 export type ValueProps<Value = unknown> = ValuePropsInterface<Value>

--- a/packages/dnb-eufemia/src/extensions/forms/types.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/types.ts
@@ -65,10 +65,15 @@ export type ValidatorReturnSync<Value> =
 export type ValidatorReturnAsync<Value> =
   | ValidatorReturnSync<Value>
   | Promise<ValidatorReturnSync<Value>>
-export type Validator<Value, ErrorMessages = DefaultErrorMessages> = (
-  value: Value,
-  additionalArgs: ReceiveAdditionalEventArgs<Value, ErrorMessages>
-) => ValidatorReturnAsync<Value>
+export type Validator<Value, ErrorMessages = DefaultErrorMessages> = {
+  // Method syntax gives the parameters bivariant checking, so that field
+  // components can assign validators typed for a narrower `Value` without
+  // tripping `strictFunctionTypes`.
+  bivarianceHack(
+    value: Value,
+    additionalArgs: ReceiveAdditionalEventArgs<Value, ErrorMessages>
+  ): ValidatorReturnAsync<Value>
+}['bivarianceHack']
 
 export type ValidatorWithCustomValidators<
   Value,
@@ -118,11 +123,11 @@ export type ReceiveAdditionalEventArgs<
   /**
    * Used internally to connect a field event listener to a path.
    */
-  setFieldEventListener: (
+  setFieldEventListener(
     path: Path,
     type: EventListenerCall['type'],
     callback: EventListenerCall['callback']
-  ) => void
+  ): void
 
   /**
    * Returns the validators from the { exportValidators } object.
@@ -228,11 +233,11 @@ export type DataValueWriteProps<
     ProvideAdditionalEventArgs,
 > = {
   emptyValue?: EmptyValue
-  onFocus?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void
-  onBlur?: (...args: EventArgs<Value | EmptyValue, ExtraValue>) => void
-  onChange?: (
+  onFocus?(...args: EventArgs<Value | EmptyValue, ExtraValue>): void
+  onBlur?(...args: EventArgs<Value | EmptyValue, ExtraValue>): void
+  onChange?(
     ...args: EventArgs<Value | EmptyValue, ExtraValue>
-  ) => OnChangeReturnType
+  ): OnChangeReturnType
 }
 
 const dataValueWriteProps = ['emptyValue', 'onFocus', 'onBlur', 'onChange']
@@ -314,10 +319,15 @@ export type MessagePropParams<Value, ReturnValue> = {
 }
 export type MessageProp<Value, ReturnValue> =
   | ReturnValue
-  | ((
-      value: Value,
-      options: MessagePropParams<Value, ReturnValue>
-    ) => ReturnValue | undefined)
+  | {
+      // Method syntax gives the parameters bivariant checking, so that a
+      // message callback typed for a narrower `Value` stays assignable under
+      // `strictFunctionTypes`.
+      bivarianceHack(
+        value: Value,
+        options: MessagePropParams<Value, ReturnValue>
+      ): ReturnValue | undefined
+    }['bivarianceHack']
 export type MessageTypes<Value> =
   | UseFieldProps<Value>['info']
   | UseFieldProps<Value>['warning']


### PR DESCRIPTION
Convert the transformer and event-callback function members (`TransformerFns`, the `useFieldAsync`/`useFieldValidation` param types, and the public `UseFieldProps` and `ValueProps` interfaces) from property syntax to method syntax. Method members are checked bivariantly, so field/value components can pass their value-specific implementations without violating `strictFunctionTypes`.

Where a bare function-type alias can't use method syntax (`Validator`, `MessageProp`), the same bivariance is achieved with the standard `{ bivarianceHack(...) }['bivarianceHack']` pattern. `handleCountryPath`'s `handler` parameter is likewise given method syntax so the Bring connectors' value-specific handlers assign cleanly.

This removes every `strictFunctionTypes` suppression across the Forms extension and its docs:

- **47** `@ts-expect-error` in the library source (field/value components and hooks)
- **4** `@ts-ignore` in the Bring connectors (`postalCode`, `address`, `createContext`)
- **5** `@ts-expect-error` in the portal docs examples (4 files)

The single remaining `@ts-expect-error` (in `DatePicker`) is an unrelated pre-existing issue and has been re-documented: `statusProps` (`FormStatusProps`) spreads a DOM `onSubmit` (`SubmitEvent`) that conflicts with the button `onSubmit` (`MouseEvent`).

Type-only change with no runtime impact.