### PR TITLE
fix(Form.Element): avoid invalid DOM id warning for non-string id

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Element/Element.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Element/Element.tsx
@@ -35,6 +35,7 @@ function FormElementComponent(props: FormElementProps) {
   const {
     children,
     className,
+    id: idProp,
     onSubmit,
     preventDefaultOnSubmit = true,
     ...restProps
@@ -89,6 +90,7 @@ function FormElementComponent(props: FormElementProps) {
       element="form"
       className={clsx('dnb-forms-form', className)}
       onSubmit={onSubmitHandler}
+      id={typeof idProp === 'string' ? idProp : undefined}
       aria-labelledby={
         combineLabelledBy(
           restProps,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Element/Element.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Element/Element.tsx
@@ -90,6 +90,8 @@ function FormElementComponent(props: FormElementProps) {
       element="form"
       className={clsx('dnb-forms-form', className)}
       onSubmit={onSubmitHandler}
+      // The id can be a non-string value (e.g. a function reference used as a shared-state id).
+      // Only forward a string to the DOM, to avoid React's "Invalid value for prop `id`" warning.
       id={typeof idProp === 'string' ? idProp : undefined}
       aria-labelledby={
         combineLabelledBy(

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Element/__tests__/Element.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Element/__tests__/Element.test.tsx
@@ -191,4 +191,15 @@ describe('Form.Element', () => {
     const formElement = document.querySelector('form')
     expect(formElement).not.toHaveAttribute('id')
   })
+
+  it('should set a string "id" on the form element', () => {
+    render(
+      <Form.Element id="my-form-id">
+        <Form.SubmitButton>Submit</Form.SubmitButton>
+      </Form.Element>
+    )
+
+    const formElement = document.querySelector('form')
+    expect(formElement).toHaveAttribute('id', 'my-form-id')
+  })
 })


### PR DESCRIPTION
### Summary

`Form.Element` spread its `id` prop directly onto the rendered `<form>` element. When a non-string `id` was provided, React logged:

> Invalid value for prop `id` on `<form>` tag. Either remove it from the element, or pass a string or number value to keep it in the DOM.

React then silently dropped the attribute, so the test still passed but emitted a noisy `stderr` warning (seen in `Element.test.tsx > should ensure that only a string can be set as the id`).

### Root cause

A Form-level `id` can be a `SharedStateId` — `string | (() => void) | Promise<() => void> | Context<any> | Record<string, unknown>` — so a **function reference** is a valid identity key (used by `Form.useData` and friends). On `Form.Element`, such a non-string value was forwarded to the DOM, which only accepts a string `id`.

### Fix

Only forward the `id` to the DOM `<form>` when it is a string:

```tsx
id={typeof idProp === 'string' ? idProp : undefined}
```

A short comment documents why the guard is needed, since `FormElementProps['id']` is typed as `string` and the check would otherwise look redundant.

### Testing

- Added a positive test asserting a string `id` is set on the form element.
- The existing negative test (function `id` → no `id` attribute) now passes **without** the React warning.
- `Form.Element` (10 tests) and `Form.Handler` (59 tests) suites pass; Prettier + ESLint clean.
