### PR TITLE
chore(InputMasked): type util props with InputMaskedProps

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMaskedUtils.ts
@@ -13,6 +13,7 @@ import type { NumberFormatValue } from '../number-format/NumberUtils'
 import { warn } from '../../shared/component-helper'
 import { IS_IOS } from '../../shared/helpers'
 import { safeSetSelection } from './text-mask/safeSetSelection'
+import type { InputMaskedProps } from './InputMasked'
 
 const enableLocaleSupportWhen = [
   'asNumber',
@@ -38,7 +39,7 @@ const NUMBER_MINUS = '-|−|‐|‒|–|—|―'
  * @returns Boolean
  */
 export const isRequestingLocaleSupport = (
-  props: Record<string, any>
+  props: InputMaskedProps
 ): boolean => {
   return Object.entries(props).some(
     ([k, v]) =>
@@ -53,7 +54,7 @@ export const isRequestingLocaleSupport = (
  * @returns Boolean
  */
 export const isRequestingNumberMask = (
-  props: Record<string, any>
+  props: InputMaskedProps
 ): boolean => {
   return Object.entries(props).some(
     ([k, v]) =>
@@ -327,7 +328,7 @@ export const handlePercentMask = ({
   locale,
   maskParams,
 }: {
-  props: Record<string, any>
+  props: InputMaskedProps
   locale: string
   maskParams: InputMaskParams
 }) => {

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMaskedUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/InputMaskedUtils.test.ts
@@ -117,7 +117,7 @@ describe('isRequestingLocaleSupport', () => {
 
   it('should return false when props do not include any enableNumberMaskWhen keys', () => {
     const props = {
-      asSomething: true,
+      disabled: true,
     }
     const result = isRequestingLocaleSupport(props)
     expect(result).toBe(false)
@@ -140,7 +140,7 @@ describe('isRequestingNumberMask', () => {
 
   it('should return false when props do not include any enableNumberMaskWhen keys', () => {
     const props = {
-      asSomething: true,
+      disabled: true,
     }
     const result = isRequestingNumberMask(props)
     expect(result).toBe(false)


### PR DESCRIPTION
Replace `Record<string, any>` with the real `InputMaskedProps` type on the InputMasked utility functions that read component props (isRequestingLocaleSupport, isRequestingNumberMask, handlePercentMask).

Update two tests to assert against a valid non-trigger prop instead of an arbitrary key, preserving their original intent. Type-only change with no runtime impact.

