### PR TITLE
chore(shared): type string params in component-helper utilities

### DIFF
--- a/packages/dnb-eufemia/src/fragments/text-counter/TextCounter.tsx
+++ b/packages/dnb-eufemia/src/fragments/text-counter/TextCounter.tsx
@@ -42,7 +42,7 @@ export default function TextCounter(localProps: TextCounterProps) {
     const count =
       variant === 'down' || isExceeded ? Math.abs(max - length) : length
     const key = `character${
-      isExceeded ? 'Exceeded' : toPascalCase(variant)
+      isExceeded ? 'Exceeded' : toPascalCase(String(variant))
     }`
 
     return context

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -90,7 +90,7 @@ export function extendDeep(target = {}, ...sources) {
 
 export const dispatchCustomElementEvent = (
   src,
-  eventName,
+  eventName: string,
   eventObjectOrig: any = undefined
 ) => {
   let ret = undefined
@@ -113,7 +113,7 @@ export const dispatchCustomElementEvent = (
 }
 
 // transform my_component to MyComponent
-export const toPascalCase = (s) =>
+export const toPascalCase = (s: string) =>
   s
     .split(/_/g)
     .reduce(
@@ -127,7 +127,7 @@ export const toPascalCase = (s) =>
     )
 
 // transform MyComponent to my-component
-export const toKebabCase = (str) =>
+export const toKebabCase = (str: string) =>
   str.replace(/\B[A-Z]/g, (letter) => `-${letter}`).toLowerCase()
 
 export function toCapitalized(str) {


### PR DESCRIPTION
Replace implicit-any parameters with explicit `string` types on the string utilities `dispatchCustomElementEvent` (eventName), `toPascalCase`, and `toKebabCase`.

This surfaced a latent `string | boolean` value passed to `toPascalCase` in TextCounter, now coerced with `String()` (behaviour-preserving; the regex guard already guaranteed a string at runtime).

