### PR TITLE
docs(contributing): note yarn dedupe after dependency changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,14 @@ Install [Node.js](https://nodejs.org) and [yarn](https://yarnpkg.com).
 
    `cd eufemia && yarn install`
 
+## Managing dependencies
+
+When you add, remove, or upgrade a dependency, run `yarn dedupe` afterwards and commit the updated `yarn.lock`:
+
+`yarn dedupe`
+
+CI enforces a deduplicated lockfile (via a `yarn dedupe --check` step). A plain `yarn install` can leave duplicate — and occasionally vulnerable — transitive versions in the tree, so deduplicating keeps the dependency graph lean and the lockfile consistent across contributors.
+
 ## Use `main` and the _GitHub Flow_
 
 1. Make sure you run `git checkout main` - as **main** is the working branch


### PR DESCRIPTION
## What

Adds a short **Managing dependencies** section to `CONTRIBUTING.md` telling contributors to run `yarn dedupe` and commit `yarn.lock` after adding, removing, or upgrading a dependency.

## Why

CI enforces a deduplicated lockfile via the `yarn dedupe --check` step (added in #8780, still active). A plain `yarn install` can leave duplicate — and occasionally vulnerable — transitive versions in the tree, which the check will flag. Documenting the one-line workflow prevents a surprising CI failure and keeps the dependency graph lean.

Docs-only; no code or dependency changes.