### PR TITLE
chore(security): add vulnerability-management routine + team ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,24 @@ When you add, remove, or upgrade a dependency, run `yarn dedupe` afterwards and 
 
 CI enforces a deduplicated lockfile (via a `yarn dedupe --check` step). A plain `yarn install` can leave duplicate — and occasionally vulnerable — transitive versions in the tree, so deduplicating keeps the dependency graph lean and the lockfile consistent across contributors.
 
+### Before adding a dependency
+
+Prefer fewer dependencies — a little code we own usually beats a new runtime dependency. Before adding one (especially a runtime dependency), be ready to justify it in the pull request:
+
+- **Purpose** — what it does, and why native code or a small internal helper won't do.
+- **Size & complexity** — its footprint and how many transitive dependencies it pulls in.
+- **Maintenance health** — recent releases, active maintainers, open-issue health.
+- **License** — compatible with DNB policy.
+- **Alternatives considered** — what else you evaluated.
+
+Remove dependencies once they are no longer used — the cheapest vulnerability to handle is the one on code you deleted.
+
+## Security
+
+Found a security vulnerability? Please report it **privately** — see [`SECURITY.md`](./SECURITY.md). Do not open a public issue or pull request.
+
+Maintainers: the routine for triaging Dependabot alerts and other advisories — detection, triage, response targets, and review cadence — is documented in [`docs/vulnerability-management.md`](./docs/vulnerability-management.md).
+
 ## Use `main` and the _GitHub Flow_
 
 1. Make sure you run `git checkout main` - as **main** is the working branch

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,92 @@
-# Reporting Security Issues
+# Security Policy
 
-If you discover a security issue in @dnb/eufemia, please report it by sending an
-email to [tobias.hoegh@dnb.no](mailto:tobias.hoegh@dnb.no).
+## Reporting a vulnerability
 
-This will allow us to assess the risk, and make a fix available before we add a
-bug report to the GitHub repository.
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
 
-Thanks for helping out.
+Report it privately using one of the following, in order of preference:
+
+1. **GitHub private vulnerability reporting** — go to the
+   [Security tab](https://github.com/dnbexperience/eufemia/security) and choose
+   **"Report a vulnerability"**. This keeps the report private and lets us
+   collaborate on a fix and a coordinated disclosure. Prefer this route: it
+   reaches the whole maintainer team, so it does not depend on one person being
+   available.
+2. **Email** — if that form is unavailable, the Eufemia Security Champion at
+   [anders.langseth@dnb.no](mailto:anders.langseth@dnb.no), or a maintainer at
+   [tobias.hoegh@dnb.no](mailto:tobias.hoegh@dnb.no).
+
+Please include, where possible:
+
+- The affected package and version (`@dnb/eufemia`, the docs portal, or the MCP
+  server).
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof of concept.
+- Any known mitigations.
+
+## What to expect
+
+| Stage                                    | Target                          |
+| ---------------------------------------- | ------------------------------- |
+| Acknowledgement of your report           | within **3 business days**      |
+| Initial assessment (severity + validity) | within **5 business days**      |
+| Fix or mitigation plan communicated      | depends on severity — see below |
+
+If your report indicates a critical, actively exploitable issue, say so in the
+subject or title — we treat those ahead of the queue rather than waiting out the
+acknowledgement window.
+
+Response targets for confirmed issues are driven by severity **and** whether the
+vulnerable code ships to consumers (see
+[the vulnerability-management routine](./docs/vulnerability-management.md)). They
+are in **calendar days** and run from the point we **confirm** the issue, not
+from when it was reported:
+
+| Severity (in shipped code) | Target to fix / mitigate       |
+| -------------------------- | ------------------------------ |
+| Critical                   | Within 3 days — hotfix release |
+| High                       | Within 7 days                  |
+| Moderate                   | Within 30 days                 |
+| Low                        | Within 60 days                 |
+
+Issues that only affect development, build, or CI tooling (not the published
+artifacts) are handled on a best-effort/routine basis.
+
+Every target above sits strictly inside DNB's internal flaw-remediation limits
+(SI-02: Critical within 1 month, all others within 3 months), so meeting ours
+also satisfies those.
+
+We will keep you informed throughout, and — unless you prefer to remain
+anonymous — credit you once a fix is released.
+
+## Supported versions
+
+| Version         | Security fixes                                          |
+| --------------- | ------------------------------------------------------- |
+| `11.x` (latest) | Yes — all severities                                    |
+| `10.x`          | Critical only — last release was `10.104.2` in May 2026 |
+| `9.x` and older | No                                                      |
+
+Fixes for all severities are released against the **latest** published major of
+`@dnb/eufemia` (`11.x`). For `10.x` we backport fixes for **critical**
+vulnerabilities only; less-severe issues will not be patched there, so please
+plan to upgrade. Majors below `10.x` are end-of-life — there is no maintained
+release line to publish a fix from, so upgrade to a supported major.
+
+## Ownership
+
+Vulnerability management for this repository is owned by the Eufemia **Security
+Champion** — **Anders Langseth** ([@langz](https://github.com/langz)) — following
+DNB's Security Champion model. The Champion is accountable for the review cadence,
+acts as liaison to DNB's central Vulnerability Management team, and reports
+Eufemia's vulnerability status upward. Deferrals and exceptions are signed off by
+the team's risk owner rather than by the Champion, and recorded for auditability.
+Day-to-day triage of incoming reports and Dependabot alerts can rotate across the
+Eufemia maintainers, per the routine linked below.
+
+## For maintainers
+
+The internal process for triaging and responding to Dependabot alerts and other
+advisories lives in
+[`docs/vulnerability-management.md`](./docs/vulnerability-management.md).

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -45,30 +45,25 @@ If those are clean, no consumer-facing vulnerability exists regardless of what
 the full dev-tree audit reports.
 
 The portal ships a **static build**, so its published surface is the built
-HTML/CSS/JS rather than an npm tree — but part of that tree does end up in the
-bundle. Its runtime dependencies are more than just `@dnb/eufemia`:
-`@emotion/*`, `@mdx-js/react`, `algoliasearch`, `clsx`, `react` and `react-dom`
-are there too, and several of them — `algoliasearch` powers the site search, for
-instance — are compiled into JavaScript that runs in a visitor's browser.
-Auditing it is therefore worthwhile both because a compromised build tool could
-taint the output _and_ because some of it genuinely ships:
+HTML/CSS/JS rather than an npm tree. Vite can bundle packages from either
+`dependencies` or `devDependencies`; the manifest section does not determine
+whether code reaches a visitor's browser. For example, `algoliasearch`,
+`react-markdown`, `react-router`, and `prism-react-renderer` are imported by
+browser code. Auditing the portal is therefore worthwhile both because a
+compromised build tool could taint the output and because some dependencies
+genuinely ship:
 
 ```bash
 yarn workspace dnb-design-system-portal npm audit --recursive --environment production --severity low
 ```
 
-Reading that audit needs one extra step, because linking the `@dnb/eufemia`
-_workspace_ makes it also traverse that library's build-time
-**devDependencies**, which a real npm consumer never installs. So don't treat
-every portal finding as shipped — or as tooling. Check where the package comes
-from:
-
-- Listed in the **portal's own** `dependencies` (e.g. `algoliasearch`) → it ships
-  to visitors' browsers; treat it as shipped code.
-- Reached only through `@dnb/eufemia`'s build-time deps (e.g. `postcss` →
-  `nanoid`) → build tooling.
-
-`yarn why <package>` settles which case you are in. The portal is deliberately
+Reading that audit needs one extra step, because `--environment production`
+does not model a bundled application: it excludes browser imports declared as
+`devDependencies`, while linking the `@dnb/eufemia` workspace can also report
+packages that a real npm consumer never installs. So don't classify a portal
+finding from its manifest section alone. Use `yarn why <package>` to find its
+owners, then inspect the portal's client-side import graph and built output to
+decide whether it ships. The portal is deliberately
 **not** in the CI audit gate: because its production audit re-reports
 `@dnb/eufemia`'s build-time tree, a blocking gate there would fail mostly on
 tooling. Its browser-shipped dependencies are still watched — Dependabot alerts
@@ -168,13 +163,14 @@ target you can measure is auditable, where "promptly" or "immediately" is not.
 1. **Bump the direct dependency** to a patched, in-range version. Simplest and
    cleanest.
 2. **Force a patched _transitive_ version** with a Yarn `resolution` when a
-   parent pins an old version. Use an **exact descriptor** — Yarn 4 ignores
-   broad range selectors:
+   parent pins an old version. Use a bare package name only when the patched
+   version is compatible with every occurrence; it overrides all matching
+   descriptors. Otherwise target each affected descriptor explicitly:
    ```jsonc
    // package.json (root)
    "resolutions": {
-     "some-dep@npm:^1.2.3": "1.2.9"   // works
-     // "some-dep": "1.2.9"           // may be ignored for multi-major trees
+     "some-dep@npm:^1.2.3": "1.2.9" // targeted override
+     // "some-dep": "1.2.9" // global override
    }
    ```
 3. **Replace an abandoned dependency** with a maintained equivalent when it has
@@ -345,7 +341,7 @@ yarn why <package>
 yarn dedupe && yarn dedupe --check
 
 # List / dismiss Dependabot alerts (dismissal is a security-dashboard write)
-gh api /repos/dnbexperience/eufemia/dependabot/alerts?state=open
+gh api '/repos/dnbexperience/eufemia/dependabot/alerts?state=open'
 gh api -X PATCH /repos/dnbexperience/eufemia/dependabot/alerts/<n> \
   -f state=dismissed -f dismissed_reason=not_used -f dismissed_comment="…"
 ```

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -1,0 +1,351 @@
+# Vulnerability management routine
+
+_Audience: Eufemia maintainers. This is the internal process for detecting,
+triaging, and responding to dependency advisories and other security findings.
+For how **external** reporters contact us, see [`SECURITY.md`](../SECURITY.md)._
+
+> This file is the source of truth. It is mirrored to the
+> [EDS **Security** page in Confluence](https://dnb-asa.atlassian.net/wiki/spaces/EDS/pages/2033516679)
+> _(DNB-internal)_ for org-wide visibility — change it here first, then refresh
+> that page.
+
+## Guiding principle: separate _what ships_ from _what builds_
+
+Every triage and prioritisation decision starts with one question:
+
+**Does the vulnerable code end up in a published artifact, or is it only
+development / build / CI tooling?**
+
+The artifacts that reach an end user are:
+
+- `@dnb/eufemia` — the npm package (published). Its production dependencies
+  install directly into every consuming app, so they run in consumers'
+  production.
+- `@dnb/eufemia-mcp` — the Eufemia MCP server's **AWS Lambda** deployment
+  (`tools/mcp-lambda`; **not** npm-published).
+- `dnb-design-system-portal` — the docs site (a deployed static site; **not**
+  npm-published, no backend). What reaches users is the **built static
+  output** (HTML/CSS/JS) — which does include some of its runtime dependencies
+  (see below).
+
+Everything else — bundlers, linters, test runners, codegen, doc tooling — is
+**not shipped**. A vulnerability there cannot reach a consumer's runtime, so it
+is lower priority than the same severity in shipped code. Most Dependabot alerts
+this repo sees are build/dev tooling.
+
+To check what actually ships, audit the two workspaces whose production tree
+**is** the shipped runtime:
+
+```bash
+yarn workspace @dnb/eufemia npm audit --recursive --environment production --severity low
+yarn workspace @dnb/eufemia-mcp npm audit --recursive --environment production --severity low
+```
+
+If those are clean, no consumer-facing vulnerability exists regardless of what
+the full dev-tree audit reports.
+
+The portal ships a **static build**, so its published surface is the built
+HTML/CSS/JS rather than an npm tree — but part of that tree does end up in the
+bundle. Its runtime dependencies are more than just `@dnb/eufemia`:
+`@emotion/*`, `@mdx-js/react`, `algoliasearch`, `clsx`, `react` and `react-dom`
+are there too, and several of them — `algoliasearch` powers the site search, for
+instance — are compiled into JavaScript that runs in a visitor's browser.
+Auditing it is therefore worthwhile both because a compromised build tool could
+taint the output _and_ because some of it genuinely ships:
+
+```bash
+yarn workspace dnb-design-system-portal npm audit --recursive --environment production --severity low
+```
+
+Reading that audit needs one extra step, because linking the `@dnb/eufemia`
+_workspace_ makes it also traverse that library's build-time
+**devDependencies**, which a real npm consumer never installs. So don't treat
+every portal finding as shipped — or as tooling. Check where the package comes
+from:
+
+- Listed in the **portal's own** `dependencies` (e.g. `algoliasearch`) → it ships
+  to visitors' browsers; treat it as shipped code.
+- Reached only through `@dnb/eufemia`'s build-time deps (e.g. `postcss` →
+  `nanoid`) → build tooling.
+
+`yarn why <package>` settles which case you are in. The portal is deliberately
+**not** in the CI audit gate: because its production audit re-reports
+`@dnb/eufemia`'s build-time tree, a blocking gate there would fail mostly on
+tooling. Its browser-shipped dependencies are still watched — Dependabot alerts
+and the Snyk pull-request check cover every workspace — they just don't block a
+merge. If a portal-owned runtime dependency does carry a high or critical
+advisory, treat it as **shipped code** on the matrix below, not as tooling.
+
+## Detection & prevention
+
+These run continuously — you rarely need to hunt for issues:
+
+| Source                      | What it covers                                                                                         | Where                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| **Dependabot alerts**       | Known advisories in dependencies (the source of truth)                                                 | [Security tab](https://github.com/dnbexperience/eufemia/security/dependabot) |
+| **CodeQL**                  | Static analysis of our own code                                                                        | on push, on PRs opened against `main`, + weekly (`codeql-analysis.yml`)      |
+| **CI audit gate**           | Fails PRs on **high/critical advisories in shipped deps**                                              | `verify.yml` → `audit:ci` (see below)                                        |
+| **CI dedupe guard**         | Stops a plain `yarn install` re-introducing duplicate/vulnerable versions                              | `verify.yml` → `yarn dedupe --check`                                         |
+| **Install age gate**        | Refuses npm versions published less than **3 days** ago — blocks hijacked releases before they land    | `.yarnrc.yml` → `npmMinimalAgeGate: 3d`                                      |
+| **Dependabot security PRs** | Auto-PRs for fixable advisories (open even while scheduled version updates are disabled)               | PRs                                                                          |
+| **Snyk**                    | Third-party SCA on every pull request (pre-merge feedback on newly introduced vulnerable dependencies) | `security/snyk` PR check                                                     |
+
+The **install age gate** is the one preventive control here: most malicious npm
+releases (typosquats, hijacked maintainer accounts) are detected and unpublished
+within hours, so refusing anything younger than three days keeps them out of the
+lockfile rather than reacting after the fact. It applies to every install,
+including Dependabot's.
+
+> **Control coverage is reviewed, not assumed.** The table above is the
+> authoritative list of what runs today. Verify against the repository's
+> **Settings → Code security** rather than assuming a GitHub default is switched
+> on — some are not. Because this file is public, the full control inventory, its
+> mapping to DNB's SECARC requirements, and any open gaps live on the EDS
+> **Security** page in Confluence and are reviewed at the monthly triage. Do not
+> enumerate missing controls here.
+
+> **`yarn npm audit` vs Dependabot:** the local `yarn audit` also surfaces npm
+> **deprecation notices** (e.g. `glob`, `inflight`) which are _not_ security
+> vulnerabilities. Dependabot correctly ignores these. Do not spend effort
+> "fixing" deprecation notices — treat the Dependabot dashboard as the
+> authoritative list of real advisories.
+
+## Triage — decision tree
+
+For each new alert:
+
+1. **Is it a real advisory or noise?**
+   On the Dependabot dashboard → real. A `yarn audit` _deprecation_ notice with
+   no CVE/GHSA → not a vulnerability; ignore.
+2. **Does it ship?** Run the production audit above.
+   - In a published artifact's runtime → high priority.
+   - Dev/build/CI only → low priority.
+3. **Is the vulnerable code path actually reachable?**
+   Read the advisory. Example: an advisory in a bundler's _dev-server_ does not
+   apply when we only use that tool as a _bundler_.
+4. Map severity × exposure to the response matrix.
+
+> **Don't dismiss a "low" on its severity alone.** Several low-severity findings
+> can chain into a serious attack path, so reason **assume-breach** (an attacker
+> already holds some access) when judging reachability. Exposure alone —
+> "internal-only" or "dev tooling" — does not by itself set priority; the blast
+> radius is often wider than it looks. _(DNB, SECC Vulnerability and Patch
+> Management.)_
+
+## Response matrix (response targets)
+
+|              | Ships in a runtime artifact    | Dev / build / CI only         |
+| ------------ | ------------------------------ | ----------------------------- |
+| **Critical** | Within 3 days — hotfix release | Within 7 days                 |
+| **High**     | Within 7 days                  | Within 30 days                |
+| **Moderate** | Within 30 days — prioritised   | Best-effort / quarterly batch |
+| **Low**      | Within 60 days — best-effort   | Best-effort / quarterly batch |
+
+The **CI audit gate blocks** on high/critical in shipped deps (see below);
+everything else is tracked but non-blocking. Shipped **Moderate** and **Low**
+findings still carry a deadline — unlike dev/build tooling, they are never parked
+in the quarterly batch, because shipped code has to stay inside the ceiling
+below. Every cell is a number (in **calendar days**) for the same reason: a
+target you can measure is auditable, where "promptly" or "immediately" is not.
+
+> **DNB compliance ceiling (SI-02 Flaw Remediation).** DNB's
+> flaw-remediation limits are **Critical within 1 month** and **all others
+> within 3 months** of discovery. Every shipped-code target above sits strictly
+> inside it — 3, 7, 30 and 60 days against a 30-day Critical and 90-day
+> everything-else limit — which is what lets us say our targets _satisfy_ SI-02
+> rather than merely coincide with it.
+> **We apply this ceiling to findings in shipped code:** non-shipped dev/build/CI
+> tooling is not part of a production artifact, so it is prioritised on the
+> matrix cadence above — tracked to closure, which is why its low/moderate
+> advisories may sit in a quarterly batch — rather than against this ceiling.
+> Eufemia's shipped-code targets are **deliberately stricter and take
+> precedence**; the DNB limits are an absolute maximum we must never exceed for
+> shipped code, cited here for auditability. Deferring past them requires
+> risk-owner sign-off (see the response ladder).
+
+## Response ladder (prefer earlier options)
+
+1. **Bump the direct dependency** to a patched, in-range version. Simplest and
+   cleanest.
+2. **Force a patched _transitive_ version** with a Yarn `resolution` when a
+   parent pins an old version. Use an **exact descriptor** — Yarn 4 ignores
+   broad range selectors:
+   ```jsonc
+   // package.json (root)
+   "resolutions": {
+     "some-dep@npm:^1.2.3": "1.2.9"   // works
+     // "some-dep": "1.2.9"           // may be ignored for multi-major trees
+   }
+   ```
+3. **Replace an abandoned dependency** with a maintained equivalent when it has
+   no fix and drags in vulnerable/deprecated transitives (e.g. we replaced
+   `fontmin` with `fonteditor-core`).
+4. **Bump the parent tool** when _it_ pins the vulnerable version, so upgrading it
+   pulls in the patched transitive.
+5. **Suppress only as a last resort — never to tidy the dashboard.** Dismissing a
+   Dependabot alert is acceptable **only** when it is a genuine risk judgment (the
+   vulnerable path is _not applicable / not reachable_ in our usage, or a
+   compensating control fully mitigates it) **and** the finding is not shipped.
+   Use `not_used` or `tolerable_risk` with a clear comment, and follow the
+   "can't be fixed yet" rules below. Never dismiss or snooze a finding merely to
+   clear the dashboard.
+
+**Always prefer a fix over suppression when a fix exists** — a dismissal masks the
+issue; a fix leaves a clean audit trail.
+
+### When a finding can't be fixed yet
+
+For advisories with no available fix (breaking upgrade, EOL/abandoned dependency,
+vendor-dependent fix), do **not** make them disappear — per DNB's standard (SECC
+_Vulnerability and Patch Management_):
+
+- **Keep the alert open and visible.** An unfixed, still-exploitable vulnerability
+  is a real risk whether or not anyone is looking at it.
+- **Apply a mitigation** while it stays open — a usage/configuration change,
+  isolating the affected path, or scheduling a replacement.
+- **Get risk-owner sign-off.** Any deferral must be agreed with the named risk
+  owner — who is **not** the Security Champion (see _Cadence & ownership_) — and
+  **documented for auditability**. This is a DNB requirement (SI-02 Flaw
+  Remediation), not optional.
+- **Put EOL/unmaintained components on an upgrade roadmap** — "no fix exists" is a
+  lifecycle problem, not a closed ticket.
+
+### After any dependency change
+
+Always run `yarn dedupe` and commit the updated `yarn.lock`. A plain
+`yarn install` can re-introduce duplicate (and vulnerable) transitive versions;
+CI enforces this via `yarn dedupe --check`.
+
+## Communicate & learn
+
+When a fixed vulnerability **shipped to consumers** (it was in a published
+artifact's runtime), close the loop — per DNB's response and post-incident
+guidance (SECC _Vulnerability and Patch Management_; EDS _Risks_):
+
+- **Ship the fix as a patch release** inside the response target above.
+- **Backport a Critical fix to the previous still-supported major.** The
+  [supported-versions policy](../SECURITY.md) keeps `10.x` on **critical** fixes,
+  so a shipped _Critical_ means a patch release on both the latest major and
+  `10.x` — each inside its response target.
+- **Publish a GitHub Security Advisory** for the affected package — what
+  happened, affected and fixed versions, severity/impact, and upgrade guidance —
+  rather than a silent release, so downstream teams can react.
+- **Tell DNB's consuming teams directly.** An advisory on GitHub reaches the
+  public, but the DNB applications that ship `@dnb/eufemia` are the consumers who
+  actually have to act. Post the minimum safe version in the EDS channel and put
+  it in the release notes — don't rely on teams watching this repository.
+- **Capture the root cause** (why the dependency was there, why it wasn't caught
+  earlier) and **update this routine or the dependency policy** if a new rule
+  would have prevented it.
+
+Advisories that only affected dev/build/CI tooling don't need consumer
+communication — record the fix and move on.
+
+## Cadence & ownership
+
+| Frequency     | Action                                                                                                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Weekly**    | Glance at the Dependabot dashboard; action anything shipped/high.                                                                                    |
+| **Monthly**   | Triage all open alerts against the matrix; fix, mitigate, or (rarely) dismiss with risk-owner sign-off.                                              |
+| **Quarterly** | **Dependency-freshness review** — `yarn upgrade-interactive` + `yarn dedupe`, focused on build/dev tooling, so nothing rots into an unfixable state. |
+
+**Owner — Security Champion:** Anders Langseth
+([@langz](https://github.com/langz)) owns vulnerability management for Eufemia,
+following DNB's Security Champion model. The Champion is accountable for the
+cadence above, is the liaison to DNB's central Vulnerability Management team, and
+reports status upward (see _Reporting to DNB_). Day-to-day triage can rotate
+across the Eufemia maintainers.
+
+**Risk owner — not the same person.** A deferral is a decision to carry risk, so
+it is signed off by the EDS **risk owner** (the team's accountable lead), not by
+the Champion who requests it. One person must never both ask for and grant an
+exception — that is the first thing an audit looks for. Record who currently holds
+the risk-owner role, and each signed-off deferral, on the EDS **Security** page
+in Confluence. The Champion prepares the case (finding, exposure, mitigation,
+upgrade plan); the risk owner accepts or rejects it.
+
+> **Why the quarterly review matters:** scheduled Dependabot _version_ updates
+> for the **npm** ecosystem are intentionally disabled to reduce PR noise
+> (`dependabot.yml` `open-pull-requests-limit: 0`; GitHub Actions still gets
+> grouped monthly updates). Dependabot still opens **security** PRs, but nothing
+> keeps ordinary npm tooling current — so it silently drifts until a fix
+> requires a major bump. The quarterly freshness review is the deliberate
+> counterweight. (Alternatively, re-enable grouped scheduled npm updates.)
+
+### Reporting to DNB
+
+Eufemia is a **public `github.com`** repository, so its Dependabot status sits
+outside DNB's internal vulnerability-scanning coverage. To avoid a central blind
+spot, the **Security Champion** reports Eufemia's open-alert status (count +
+severity, shipped vs tooling) to DNB's central Vulnerability Management team at
+the monthly review, and confirms whether the repository can be onboarded to
+DNB's central reporting as that capability expands.
+
+## The CI audit gate
+
+`verify.yml` audits the shipped (production) dependency tree of the **two gated
+workspaces** — `@dnb/eufemia` (the published library) and `@dnb/eufemia-mcp` (the
+deployed Lambda) — with a native Yarn 4 audit; each workspace's `audit:ci` runs:
+
+```
+yarn npm audit --recursive --environment production --severity high
+```
+
+- `--recursive` — include **transitive** dependencies, not just the direct ones
+  (most advisories live in transitive deps).
+- `--environment production` — audit **shipped (production) dependencies only**,
+  matching the guiding principle. Dev/build/CI tooling advisories don't block CI
+  (they're tracked via Dependabot instead).
+- `--severity high` — fail the build on **high or critical** advisories.
+- **Exceptions:** if a high/critical shipped advisory has no fix yet, add it to
+  Yarn's `.yarnrc.yml` under `npmAuditIgnoreAdvisories` (with a comment: owner +
+  reason + tracking link) to unblock while it's tracked. Remove it once fixed.
+- **Whole-gate bypass (`--skip-audit`):** the audit job is skipped whenever
+  `--skip-audit` appears **anywhere in the head commit message** — subject or
+  body. `verify.yml` runs on `push` only, so `github.event.pull_request` is never
+  populated and the PR-title half of the job's condition never fires; the commit
+  message is the only path that works. Note it skips **more than the audit**: the
+  lockfile-dedupe guard (`yarn dedupe --check`) is a step in the _same_ `audit`
+  job, so a bypassed push also drops the check that stops a plain `yarn install`
+  re-introducing duplicate (and potentially vulnerable) transitive versions. It
+  is an escape hatch for landing unrelated urgent work while the gate is red —
+  **not** a way to merge a shipped-dep advisory. Prefer a per-advisory
+  `npmAuditIgnoreAdvisories` entry (above), which stays tracked and auditable. If
+  you must use `--skip-audit`, say why in the PR and open a follow-up so the gate
+  goes green again.
+- **Careful — the match is a plain substring over the whole message**, not just
+  the subject line. So merely _mentioning_ the flag in a commit body skips the
+  audit for that push, even when the commit has nothing to do with
+  dependencies — a real risk when a commit message documents the flag. When
+  referring to it in a commit message, write it without the leading dashes, or
+  keep the mention out of the message entirely. A more robust design would
+  match only the subject line of the head commit in `verify.yml`.
+
+The same audit runs again outside the PR gate: `release.yml` audits `@dnb/eufemia`
+at publish time and `mcp-lambda.yml` audits `@dnb/eufemia-mcp` at deploy time, so
+the shipped tree is re-checked before each artifact goes out.
+
+> We use native `yarn npm audit` rather than a wrapper because it is transparent
+> and verifiable under Yarn 4 — it exits non-zero on real advisories at or above
+> the threshold, and zero when the shipped tree is clean.
+
+## Reference: useful commands
+
+```bash
+# What actually ships (per published workspace)
+yarn workspace @dnb/eufemia npm audit --recursive --environment production --severity low
+
+# Full dev-tree audit (includes non-shipped tooling + deprecation noise)
+yarn npm audit --all --recursive
+
+# Trace who pulls a vulnerable package (find the real parent, not just the label)
+yarn why <package>
+
+# Reconcile the lockfile after changing dependencies
+yarn dedupe && yarn dedupe --check
+
+# List / dismiss Dependabot alerts (dismissal is a security-dashboard write)
+gh api /repos/dnbexperience/eufemia/dependabot/alerts?state=open
+gh api -X PATCH /repos/dnbexperience/eufemia/dependabot/alerts/<n> \
+  -f state=dismissed -f dismissed_reason=not_used -f dismissed_comment="…"
+```


### PR DESCRIPTION
## What

Docs-only. Brings Eufemia's security process in line with DNB's internal standards (SECC _Vulnerability and Patch Management_, SECARC, SI-02 Flaw Remediation).

- **`SECURITY.md`** — how to report privately (GitHub advisory first, email fallback), response targets (Critical 3d / High 7d / Moderate 30d / Low 60d, calendar days from confirmation), supported versions (`11.x` all severities, `10.x` **critical-only**), and the Security Champion / risk-owner split.
- **`docs/vulnerability-management.md`** — the maintainer routine: separate _what ships_ from _what builds_, triage decision tree, severity × exposure response matrix, the native `yarn npm audit` gate, and review cadence.
- **`CONTRIBUTING.md`** — a "before adding a dependency" checklist and a Security section linking both.

## Notes

Every factual claim was checked against the actual workflows, manifests, and live repo settings — audit gate is green. Companion to #8808 (native audit gate, merged), #8812, and #8930.

**Sources** (DNB-internal, SSO): [SECC/2032337941](https://dnb-asa.atlassian.net/wiki/spaces/SECC/pages/2032337941) · [SECARC/135177479](https://dnb-asa.atlassian.net/wiki/spaces/SECARC/pages/135177479) · [EDS/1326776462](https://dnb-asa.atlassian.net/wiki/spaces/EDS/pages/1326776462)