### PR TITLE
chore(markdown-tables-utils): enable strict TypeScript type-checking

### DIFF
--- a/tools/markdown-tables-utils/markdownTablesUtils.ts
+++ b/tools/markdown-tables-utils/markdownTablesUtils.ts
@@ -1,4 +1,4 @@
-export function extractMarkdownTables(md) {
+export function extractMarkdownTables(md: string) {
   const tables = []
   const lines = md.split('\n')
   let inFence = false
@@ -41,13 +41,13 @@ export function extractMarkdownTables(md) {
   return tables
 }
 
-function isTableSeparator(line) {
+function isTableSeparator(line: string) {
   // Simplified pattern to prevent ReDoS - match table separator rows
   // Pattern: optional leading pipe, then one or more cells with dashes/colons, optional trailing pipe
   return /^\s*\|?\s*(:?-+:?\s*\|)+\s*:?-+:?\s*\|?\s*$/.test(line)
 }
 
-function splitTableRow(line) {
+function splitTableRow(line: string) {
   let text = line.trim()
   if (text.startsWith('|')) {
     text = text.slice(1)
@@ -86,7 +86,7 @@ function splitTableRow(line) {
   return cells.map((cell) => renderMarkdownInline(cell))
 }
 
-function renderMarkdownInline(input) {
+function renderMarkdownInline(input: string) {
   if (typeof input !== 'string') {
     return input
   }

--- a/tools/markdown-tables-utils/package.json
+++ b/tools/markdown-tables-utils/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "test": "vitest run",
+    "test:types": "../../node_modules/.bin/tsc --noEmit",
     "lint": "node ../../node_modules/.bin/eslint **/*.ts"
   },
   "devDependencies": {

--- a/tools/markdown-tables-utils/tsconfig.json
+++ b/tools/markdown-tables-utils/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "lib": ["es2022"],
+    "types": ["node", "vitest/globals"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Add a strict tsconfig.json and test:types script, and type the four previously implicit-any string parameters. No behavior change; tests pass.

