### PR TITLE
chore: type implicit-any hook params with real forms types

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/useEventListener.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/useEventListener.ts
@@ -1,7 +1,12 @@
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import DataContext from '../Context'
+import type { EventListenerCall } from '../Context'
 
-export default function useEventListener(id, listener, path = undefined) {
+export default function useEventListener(
+  id: EventListenerCall['type'],
+  listener: EventListenerCall['callback'],
+  path: EventListenerCall['path'] = undefined
+) {
   const { setFieldEventListener } = useContext(DataContext)
 
   useMemo(() => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/useHandleStatus.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/useHandleStatus.ts
@@ -40,6 +40,10 @@ function useShowStatus({
   outerContext,
   hasContentChanged,
   preventUncommittedChanges,
+}: {
+  outerContext: ContextState
+  hasContentChanged: boolean
+  preventUncommittedChanges: boolean
 }) {
   // We just use "showAllErrors" from the outerContext to determine if we should show the status.
   const showAllErrors = outerContext?.showAllErrors

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/useStepAnimation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/useStepAnimation.ts
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
 
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
+import type { StepIndex } from '../Context/types'
 
 export default function useStepAnimation({
   activeIndexRef,
   stepElementRef,
   executeLayoutAnimationRef,
+}: {
+  activeIndexRef: RefObject<StepIndex>
+  stepElementRef: RefObject<HTMLElement>
+  executeLayoutAnimationRef: RefObject<() => void>
 }) {
   const activeIndex = activeIndexRef.current
   const indexRef = useRef(activeIndex)
@@ -20,8 +26,8 @@ export default function useStepAnimation({
     // as it rerenders the children
     window.requestAnimationFrame(() => {
       try {
-        const elements: Array<HTMLElement> =
-          stepElementRef.current.querySelectorAll(
+        const elements =
+          stepElementRef.current.querySelectorAll<HTMLElement>(
             '.dnb-forms-step > *, .dnb-forms-button-row > *'
           )
         elements.forEach((element, i) => {


### PR DESCRIPTION
Replace implicit-any parameters with real types in forms hooks (no new any/unknown):

- useEventListener: type id/listener/path via EventListenerCall indexed access (matches setFieldEventListener's signature).
- useHandleStatus: type useShowStatus's outerContext (ContextState) and boolean params.
- useStepAnimation: type the activeIndexRef/stepElementRef/ executeLayoutAnimationRef RefObject params, and use the typed querySelectorAll<HTMLElement> overload instead of an incorrect Array<HTMLElement> annotation on a NodeList.

