### PR TITLE
fix(Form.useData): return precise value types from getValue 

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/getData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/getData.test.tsx
@@ -132,6 +132,33 @@ describe('getData', () => {
     expect(getData(identifier).getValue('/does-not-exist')).toBeUndefined()
   })
 
+  it('infers precise getValue return types from the data generic', () => {
+    type Data = {
+      deep: { foo: string }
+      count: number
+      list: Array<{ id: number }>
+    }
+    render(
+      <Form.Handler id={identifier}>
+        <Field.String path="/deep/foo" value="existing value" />
+      </Form.Handler>
+    )
+
+    const { getValue, data } = getData<Data>(identifier)
+
+    // Runtime behavior is unchanged
+    expect(getValue('/deep/foo')).toBe('existing value')
+
+    // The fix: precise types instead of collapsing to `any`
+    expectTypeOf(getValue('/deep/foo')).toEqualTypeOf<string>()
+    expectTypeOf(getValue('/count')).toEqualTypeOf<number>()
+    expectTypeOf(getValue('/list/0/id')).toEqualTypeOf<number>()
+    expectTypeOf(data).toEqualTypeOf<Data>()
+
+    // The bug was getValue collapsing to `any`; assert it no longer does
+    expectTypeOf(getValue('/count')).not.toBeAny()
+  })
+
   describe('filterData', () => {
     it('should provide filterData handler', () => {
       type Data = { foo: string }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
@@ -129,6 +129,27 @@ describe('Form.useData', () => {
   })
 
   describe('getValue return type', () => {
+    // Mirrors the originally reported scenario: getValue on a top-level array
+    // path used to collapse to `any`; it must resolve to the full array type.
+    it('resolves a top-level array path to the full array type', () => {
+      type UIMemberProps = { name: string; age: number; active: boolean }
+      type Data = { members: Partial<UIMemberProps>[] }
+
+      const { result } = renderHook(() =>
+        useData<Data>(identifier, { members: [{ name: 'Nora' }] })
+      )
+
+      // Runtime behavior is unchanged
+      expect(result.current.getValue('/members')).toEqual([
+        { name: 'Nora' },
+      ])
+
+      // Previously `any`; now the precise array type from the report
+      const formMembers = result.current.getValue('/members')
+      expectTypeOf(formMembers).toEqualTypeOf<Partial<UIMemberProps>[]>()
+      expectTypeOf(formMembers).not.toBeAny()
+    })
+
     it('infers precise value types from typed initial data', () => {
       type MemberData = {
         name: string

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
@@ -13,6 +13,7 @@ import { DataContext, Field, Form, Wizard, Iterate } from '../../..'
 import type { FilterData } from '../../../DataContext/Context'
 import Provider from '../../../DataContext/Provider'
 import useData from '../useData'
+import type { PathType } from '../useData'
 
 describe('Form.useData', () => {
   let identifier: string
@@ -125,6 +126,61 @@ describe('Form.useData', () => {
     const { result } = renderHook(() => useData(identifier))
 
     expect(result.current.getValue('/does-not-exist')).toBe(undefined)
+  })
+
+  describe('getValue return type', () => {
+    it('infers precise value types from typed initial data', () => {
+      type MemberData = {
+        name: string
+        age: number
+        address?: { street: string }
+        members: Array<{ id: number }>
+      }
+      const initialData: MemberData = {
+        name: 'Nora',
+        age: 42,
+        address: { street: 'Main' },
+        members: [{ id: 1 }],
+      }
+      const { result } = renderHook(() => useData(identifier, initialData))
+
+      // Runtime behavior is unchanged
+      expect(result.current.getValue('/name')).toBe('Nora')
+
+      // The fix: getValue no longer collapses to `any` for typed data
+      expectTypeOf(
+        result.current.getValue('/name')
+      ).toEqualTypeOf<string>()
+      expectTypeOf(result.current.getValue('/age')).toEqualTypeOf<number>()
+      expectTypeOf(
+        result.current.getValue('/address/street')
+      ).toEqualTypeOf<string>()
+      expectTypeOf(
+        result.current.getValue('/members/0/id')
+      ).toEqualTypeOf<number>()
+      expectTypeOf(result.current.data).toEqualTypeOf<MemberData>()
+
+      // The bug was getValue collapsing to `any`; assert it no longer does
+      expectTypeOf(result.current.getValue('/name')).not.toBeAny()
+
+      // The exported PathType resolver used by getValue
+      expectTypeOf<
+        PathType<MemberData, '/address/street'>
+      >().toEqualTypeOf<string>()
+      expectTypeOf<
+        PathType<MemberData, '/members/0/id'>
+      >().toEqualTypeOf<number>()
+    })
+
+    it('falls back to any for untyped (JsonObject) data', () => {
+      const { result } = renderHook(() => useData(identifier))
+
+      // Runtime: a non-existent path returns undefined
+      expect(result.current.getValue('/anything')).toBeUndefined()
+
+      // Type: untyped data keeps cast-free `any` ergonomics
+      expectTypeOf(result.current.getValue('/anything')).toBeAny()
+    })
   })
 
   it('should return "update" method that lets you update the data', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/getData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/getData.ts
@@ -36,13 +36,13 @@ export default function getData<Data>(
     (data, options) =>
       sharedAttachments.data?.visibleDataHandler?.(data, options)
 
-  const getValue = (path: Path) => {
+  const getValue = ((path: Path) => {
     if (pointer.has(data, path)) {
       return pointer.get(data, path)
     }
 
     return undefined
-  }
+  }) as unknown as UseDataReturnGetValue<Data>
 
   return {
     data,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/getData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/getData.ts
@@ -36,6 +36,9 @@ export default function getData<Data>(
     (data, options) =>
       sharedAttachments.data?.visibleDataHandler?.(data, options)
 
+  // The runtime resolver takes a plain `Path`; cast it to the public generic
+  // signature so callers get the value type resolved from the literal path
+  // (`getValue` maps `P` to `PathType<Data, P>`).
   const getValue = ((path: Path) => {
     if (pointer.has(data, path)) {
       return pointer.get(data, path)

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../shared/helpers/useSharedState'
 import useMountEffect from '../../../../shared/helpers/useMountEffect'
 import type { Path } from '../../types'
+import type { PathValue } from '../../typed-paths'
 import type {
   ContextState,
   FilterData,
@@ -28,17 +29,33 @@ import type { DataContextRef } from '../../DataContext/DataContextRefContext'
 import type { SharedAttachments } from '../../DataContext/Provider'
 import { structuredClone } from '../../../../shared/helpers/structuredClone'
 
-type PathImpl<T, P extends string> = P extends `${infer Key}/${infer Rest}`
-  ? Key extends keyof T
-    ? Rest extends ''
-      ? T[Key]
-      : PathImpl<T[Key], Rest>
-    : never
-  : T[P & keyof T]
+type IsAny<T> = 0 extends 1 & T ? true : false
 
-export type PathType<T, P extends string> = P extends `/${infer Rest}`
-  ? PathImpl<T, Rest>
-  : never
+type IsUnknownOrNever<T> =
+  IsAny<T> extends true
+    ? false
+    : [T] extends [never]
+      ? true
+      : unknown extends T
+        ? true
+        : false
+
+/**
+ * Resolves the value type located at the JSON Pointer path `P` in `Data`,
+ * reusing the shared {@link PathValue} resolver from the typed-paths support.
+ *
+ * When `Data` is a concrete type – e.g. passed explicitly to `useData`/`getData`
+ * as a generic (or `RegisteredFormData` from the typed-paths `Register`) – this
+ * yields the precise value type. It falls back to `any` when the type cannot be
+ * resolved (for example the default untyped `JsonObject` data, or an explicit
+ * `any`), so untyped usage stays cast-free while typed data no longer collapses
+ * to `any` (which is what the previous `PathType<Data, P> | any` union always
+ * did).
+ */
+export type PathType<Data, P extends string> =
+  IsUnknownOrNever<PathValue<Data, P>> extends true
+    ? any
+    : PathValue<Data, P>
 
 export type UseDataReturnUpdate<Data> = <P extends Path>(
   path: P,
@@ -47,7 +64,7 @@ export type UseDataReturnUpdate<Data> = <P extends Path>(
 
 export type UseDataReturnGetValue<Data> = <P extends Path>(
   path: P
-) => PathType<Data, P> | any
+) => PathType<Data, P>
 
 export type UseDataReturnFilterData<Data> = (
   filterDataHandler: FilterData,
@@ -298,8 +315,8 @@ export function useDataReturn<Data = JsonObject>({
     ]
   )
 
-  const getValue = useCallback<UseDataReturn<Data>['getValue']>(
-    (path) => {
+  const getValue = useCallback(
+    (path: Path) => {
       const dataContext = getDataContext()
 
       if (!id && dataContext?.getDataValue) {
@@ -314,7 +331,7 @@ export function useDataReturn<Data = JsonObject>({
       return undefined
     },
     [getCurrentData, getDataContext, id]
-  )
+  ) as UseDataReturn<Data>['getValue']
 
   useMountEffect(() => {
     if (id && !sharedDataRef.current?.hadInitialData && initialData) {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -315,6 +315,9 @@ export function useDataReturn<Data = JsonObject>({
     ]
   )
 
+  // The runtime resolver takes a plain `Path`; cast it to the public generic
+  // signature so callers get the value type resolved from the literal path
+  // (`getValue` maps `P` to `PathType<Data, P>`).
   const getValue = useCallback(
     (path: Path) => {
       const dataContext = getDataContext()
@@ -331,7 +334,7 @@ export function useDataReturn<Data = JsonObject>({
       return undefined
     },
     [getCurrentData, getDataContext, id]
-  ) as UseDataReturn<Data>['getValue']
+  ) as unknown as UseDataReturn<Data>['getValue']
 
   useMountEffect(() => {
     if (id && !sharedDataRef.current?.hadInitialData && initialData) {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -52,10 +52,11 @@ type IsUnknownOrNever<T> =
  * untyped usage stays cast-free while typed data no longer collapses to `any`
  * (which is what the previous `PathType<Data, P> | any` union always did).
  *
- * Note: `useData`/`getData` default their `Data` generic to `JsonObject`, so a
- * globally registered form data type (via the typed-paths `Register`) is not
- * adopted automatically here – pass `RegisteredFormData` (or your own type)
- * explicitly to get precise `getValue` types.
+ * Note: a globally registered form data type (via the typed-paths `Register`)
+ * is not adopted automatically here – `useData` defaults its `Data` generic to
+ * `JsonObject`, and `getData` leaves it unresolved when omitted. Pass
+ * `RegisteredFormData` (or your own type) explicitly – or, for `useData`, let
+ * it infer from `initialData` – to get precise `getValue` types.
  */
 export type PathType<Data, P extends string> =
   IsUnknownOrNever<PathValue<Data, P>> extends true

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -44,13 +44,18 @@ type IsUnknownOrNever<T> =
  * Resolves the value type located at the JSON Pointer path `P` in `Data`,
  * reusing the shared {@link PathValue} resolver from the typed-paths support.
  *
- * When `Data` is a concrete type – e.g. passed explicitly to `useData`/`getData`
- * as a generic (or `RegisteredFormData` from the typed-paths `Register`) – this
- * yields the precise value type. It falls back to `any` when the type cannot be
- * resolved (for example the default untyped `JsonObject` data, or an explicit
- * `any`), so untyped usage stays cast-free while typed data no longer collapses
- * to `any` (which is what the previous `PathType<Data, P> | any` union always
- * did).
+ * When `Data` is a concrete type, this yields the precise value type. `Data`
+ * becomes concrete when it is passed explicitly as a generic
+ * (`useData<MyData>()` / `getData<MyData>()`) or inferred from the passed
+ * `initialData`. It falls back to `any` when the type cannot be resolved (for
+ * example the default untyped `JsonObject` data, or an explicit `any`), so
+ * untyped usage stays cast-free while typed data no longer collapses to `any`
+ * (which is what the previous `PathType<Data, P> | any` union always did).
+ *
+ * Note: `useData`/`getData` default their `Data` generic to `JsonObject`, so a
+ * globally registered form data type (via the typed-paths `Register`) is not
+ * adopted automatically here – pass `RegisteredFormData` (or your own type)
+ * explicitly to get precise `getValue` types.
  */
 export type PathType<Data, P extends string> =
   IsUnknownOrNever<PathValue<Data, P>> extends true


### PR DESCRIPTION
## Why

`Form.useData().getValue()` returned `any` instead of the precise value type — even when the hook was given the full data type via `Form.useData<Data>()`.

The return type was:

```ts
getValue: <P extends Path>(path: P) => PathType<Data, P> | any
```

A `T | any` union always collapses to `any` in TypeScript, so the resolved `PathType<Data, P>` was discarded. (Reported case: `getValue('/members')` yielded `any` instead of `Partial<UIMemberProps>[]`.)

## What

Replace the collapsing union with a guarded resolver built on the shared `PathValue` type from the typed-paths support (#8649):

```ts
export type PathType<Data, P extends string> =
  IsUnknownOrNever<PathValue<Data, P>> extends true ? any : PathValue<Data, P>
```

- Typed data (explicit generic, inferred, or `RegisteredFormData`) yields the precise value type.
- Untyped `JsonObject` data falls back to `any`, so existing untyped usage stays cast-free.
- The same type powers `Form.getData().getValue()`.

The default stays `JsonObject` (not `RegisteredFormData`): a `declare module` `Register` augmentation is global to the compilation, so defaulting to it would mistype every untyped `useData()` in multi-form apps. Registered users opt in via `Form.useData<RegisteredFormData>()`.

## Notes

- Type-only change; runtime behavior is unchanged.
- Consumers may see new (correct) type errors where code previously relied on `any` — that's the fix catching real mismatches.
- Follow-up #8813 applies the same fix to `update()` (the write side).

## Checks

- `tsc` (whole package): 0 errors
- ESLint + Prettier: clean
- Tests pass, including a regression test mirroring the reported scenario (`getValue('/members')` on `{ members: Partial<UIMemberProps>[] }` resolves to the full array type, not `any`).
