### PR TITLE
chore(security): SBOM per release + Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
     # Match Yarn 4 setup (defaultSemverRangePrefix: "" in .yarnrc.yml) by only
     # widening package.json ranges when the new version requires it.
     versioning-strategy: increase-if-necessary
+    # Supply-chain guard (DNB "cool-off period"): wait before adopting a freshly
+    # published version, so a compromised release isn't picked up immediately.
+    # Cooldown applies to version updates ONLY and never delays security updates.
+    # Scheduled version updates are disabled above (limit 0), so this block is
+    # currently inert; it takes effect only if that limit is later raised.
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
@@ -64,6 +72,11 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 5
+    # Supply-chain guard: let a new action release settle before updating to it.
+    # Active here (version updates are enabled above), extending GitHub's
+    # built-in 3-day version-update cooldown to 7; never delays security updates.
+    cooldown:
+      default-days: 7
     labels:
       - 'dependencies'
     commit-message:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ permissions:
   contents: write # Required for semantic-release to push tags and changelog
   issues: write # Required for semantic-release to comment on issues
   pull-requests: write # Required for semantic-release to comment on PRs
-  id-token: write # Required for npm provenance and SBOM attestation signing
-  attestations: write # Required to record the release SBOM attestation
+  id-token: write # Required for npm provenance
 
 env:
   GH_EMAIL: ${{ secrets.GH_EMAIL }}
@@ -38,6 +37,10 @@ jobs:
     name: Run release and deploy
 
     runs-on: ubuntu-latest
+
+    outputs:
+      released: ${{ steps.release-info.outputs.released }}
+      tarball: ${{ steps.pack.outputs.tarball }}
 
     steps:
       - name: Git checkout
@@ -90,13 +93,11 @@ jobs:
           endsWith(github.ref, '.x'))
         run: yarn workspace @dnb/eufemia publish:ci
 
-      # Release supply-chain artifacts: a CycloneDX SBOM of the published
-      # library's production dependencies plus a vulnerability report.
-      # Non-blocking (continue-on-error) — the "Audit dependencies" step above
-      # is the release gate, not this. See docs/sbom.md for what these files
-      # are, where they are stored, and why.
-      - name: Generate SBOM and vulnerability report
-        id: sbom
+      # Capture the published version so the least-privilege SBOM job below can
+      # target the matching GitHub Release and stamp the SBOM. Empty or the
+      # placeholder version means nothing was published.
+      - name: Capture released version
+        id: release-info
         continue-on-error: true
         if: github.repository == 'dnbexperience/eufemia' &&
           (github.ref == 'refs/heads/release' ||
@@ -105,37 +106,105 @@ jobs:
           github.ref == 'refs/heads/next' ||
           endsWith(github.ref, '.x'))
         working-directory: packages/dnb-eufemia
-        env:
-          # Runs untrusted third-party code (the CycloneDX generator via
-          # `yarn dlx`) and needs none of the workflow's credentials. Blank
-          # every secret the workflow-level `env:` injects so none can reach it.
-          # Keep this list in sync with that `env:` block.
-          GH_EMAIL: ''
-          GH_NAME: ''
-          GH_TOKEN: ''
-          NODE_AUTH_TOKEN: ''
-          FIGMA_TOKEN: ''
-          FIGMA_ICONS_FILE: ''
-          ALGOLIA_APP_ID: ''
-          ALGOLIA_INDEX_NAME: ''
-          ALGOLIA_SEARCH_KEY: ''
-          ALGOLIA_API_KEY: ''
         run: |
-          # Generated from the source workspace, not the published build/
-          # package: the CycloneDX plugin needs a Yarn project, and direct
-          # runtime deps are identical either way. Generator version pinned for
-          # reproducibility — bump deliberately, as yarn dlx is not covered by
-          # Dependabot.
+          released="$(node -p "require('./build/package.json').version")"
+          echo "released=$released" >> "$GITHUB_OUTPUT"
+
+      # Pack the published files into a tarball to serve as the attestation
+      # subject. `--ignore-scripts` keeps it side-effect free (no lifecycle
+      # scripts run) and uses the same build/ output semantic-release publishes.
+      - name: Pack the released library (attestation subject)
+        id: pack
+        continue-on-error: true
+        if: steps.release-info.outputs.released != '' &&
+          steps.release-info.outputs.released != '0.0.0-development'
+        working-directory: packages/dnb-eufemia
+        run: |
+          tarball="$(cd build && npm pack --ignore-scripts --pack-destination .. | tail -1)"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          echo "Packed attestation subject: $tarball"
+
+      # Upload the packed tarball so the separate attestation job can bind the
+      # SBOM to it. Short retention: it only needs to outlive this workflow run.
+      - name: Upload attestation subject
+        continue-on-error: true
+        if: steps.pack.outputs.tarball != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-tarball
+          path: packages/dnb-eufemia/${{ steps.pack.outputs.tarball }}
+          retention-days: 1
+
+  # Generate the CycloneDX SBOM and vulnerability report. This runs untrusted
+  # third-party code (the CycloneDX generator via `yarn dlx`), so it lives in
+  # its own job with only `contents: read` — none of the release job's OIDC or
+  # attestation-writing credentials exist here. Blanking secrets alone would not
+  # remove those job credentials, which is why generation is isolated rather than
+  # kept inline. Non-blocking (every step is continue-on-error), so a failure
+  # here never affects the release. See docs/sbom.md for what these files are,
+  # where they are stored, and why.
+  sbom:
+    name: Generate release SBOM
+    needs: action
+    if: needs.action.outputs.released != '' &&
+      needs.action.outputs.released != '0.0.0-development'
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+
+    # This job runs untrusted third-party code (the CycloneDX generator). Blank
+    # every secret the workflow-level `env:` injects so none can reach it. Keep
+    # this list in sync with that `env:` block.
+    env:
+      GH_EMAIL: ''
+      GH_NAME: ''
+      GH_TOKEN: ''
+      NODE_AUTH_TOKEN: ''
+      FIGMA_TOKEN: ''
+      FIGMA_ICONS_FILE: ''
+      ALGOLIA_APP_ID: ''
+      ALGOLIA_INDEX_NAME: ''
+      ALGOLIA_SEARCH_KEY: ''
+      ALGOLIA_API_KEY: ''
+
+    steps:
+      - name: Git checkout
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup dependencies
+        continue-on-error: true
+        uses: ./.github/actions/setup
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}
+
+      - name: Generate SBOM and vulnerability report
+        continue-on-error: true
+        working-directory: packages/dnb-eufemia
+        env:
+          RELEASED_VERSION: ${{ needs.action.outputs.released }}
+        run: |
+          # Generated from the source workspace: the CycloneDX plugin needs a
+          # Yarn project, and direct runtime deps are identical to the published
+          # package. Generator version pinned for reproducibility — bump
+          # deliberately and keep it in sync with verify.yml, as yarn dlx is not
+          # covered by Dependabot.
           yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
             --output-format JSON --spec-version 1.6 \
             --production --mc-type library --output-file sbom.cdx.json
 
           # CycloneDX stamps the main component with the manifest's
           # 0.0.0-development placeholder; overwrite it with the version
-          # semantic-release actually published (in build/package.json).
+          # semantic-release actually published.
           node -e '
             const fs = require("fs")
-            const released = require("./build/package.json").version
+            const released = process.env.RELEASED_VERSION
             const file = "sbom.cdx.json"
             const sbom = JSON.parse(fs.readFileSync(file, "utf8"))
             const component = sbom.metadata && sbom.metadata.component
@@ -147,9 +216,6 @@ jobs:
             }
             fs.writeFileSync(file, JSON.stringify(sbom, null, 2) + "\n")
             console.log("SBOM main component version: " + released)
-            if (released === "0.0.0-development") {
-              console.warn("WARNING: no real version was published; SBOM version left as placeholder")
-            }
           '
 
           # Vulnerability report over the same production scope. yarn npm audit
@@ -174,10 +240,9 @@ jobs:
             }
             // Identify the report the way the SBOM identifies itself, so the
             // file stays traceable once downloaded away from its release.
-            const manifest = require("./build/package.json")
             const meta = {
-              component: manifest.name,
-              version: manifest.version,
+              component: require("./package.json").name,
+              version: process.env.RELEASED_VERSION,
               generatedAt: new Date().toISOString(),
               scope: "production dependencies, including transitive",
               tool: "yarn npm audit",
@@ -211,44 +276,8 @@ jobs:
             console.log(report.error ? report.error : report.summary)
           ' "$audit_exit"
 
-          # Publish the released version so the next step can attach the files
-          # to the matching GitHub Release; empty/placeholder means no release.
-          released="$(node -p "require('./build/package.json').version")"
-          echo "released=$released" >> "$GITHUB_OUTPUT"
-
-      # Pack the published files into a tarball to serve as the attestation
-      # subject. `--ignore-scripts` keeps it side-effect free (no lifecycle
-      # scripts run) and uses the same build/ output semantic-release publishes.
-      - name: Pack the released library (attestation subject)
-        id: pack
-        continue-on-error: true
-        if: steps.sbom.outputs.released != '' &&
-          steps.sbom.outputs.released != '0.0.0-development'
-        working-directory: packages/dnb-eufemia
-        run: |
-          tarball="$(cd build && npm pack --ignore-scripts --pack-destination .. | tail -1)"
-          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
-          echo "Packed attestation subject: $tarball"
-
-      # Sign a CycloneDX SBOM attestation (Sigstore-backed) binding the SBOM to
-      # the packed release artifact. Complements npm provenance; verify with
-      # `gh attestation verify <tarball> --repo dnbexperience/eufemia`.
-      - name: Attest the SBOM
-        continue-on-error: true
-        if: steps.pack.outputs.tarball != ''
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: packages/dnb-eufemia/${{ steps.pack.outputs.tarball }}
-          sbom-path: packages/dnb-eufemia/sbom.cdx.json
-
       - name: Upload SBOM and vulnerability report
         continue-on-error: true
-        if: github.repository == 'dnbexperience/eufemia' &&
-          (github.ref == 'refs/heads/release' ||
-          github.ref == 'refs/heads/beta' ||
-          github.ref == 'refs/heads/alpha' ||
-          github.ref == 'refs/heads/next' ||
-          endsWith(github.ref, '.x'))
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-and-vulnerability-report
@@ -257,20 +286,60 @@ jobs:
             packages/dnb-eufemia/vulnerability-report.json
           retention-days: 90
 
-      # Attach both files to the GitHub Release (tag "v<version>") so they
+  # Attest and publish the release SBOM. This job holds the OIDC and
+  # attestation-writing credentials but runs only trusted, first-party actions
+  # against the artifacts produced above — the untrusted generator never runs
+  # here. Non-blocking (every step is continue-on-error).
+  attest:
+    name: Attest and publish release SBOM
+    needs: [action, sbom]
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+
+    permissions:
+      contents: write # Attach assets to the GitHub Release
+      id-token: write # Sign the SBOM attestation
+      attestations: write # Record the SBOM attestation
+
+    steps:
+      - name: Download attestation subject
+        continue-on-error: true
+        if: needs.action.outputs.tarball != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-tarball
+          path: packages/dnb-eufemia
+
+      - name: Download SBOM and vulnerability report
+        continue-on-error: true
+        if: needs.action.outputs.tarball != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: sbom-and-vulnerability-report
+          path: packages/dnb-eufemia
+
+      # Sign a CycloneDX SBOM attestation (Sigstore-backed) binding the SBOM to
+      # the packed release artifact. Complements npm provenance; verify with
+      # `gh attestation verify <tarball> --repo dnbexperience/eufemia`.
+      - name: Attest the SBOM
+        continue-on-error: true
+        if: needs.action.outputs.tarball != ''
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: packages/dnb-eufemia/${{ needs.action.outputs.tarball }}
+          sbom-path: packages/dnb-eufemia/sbom.cdx.json
+
+      # Attach all three files to the GitHub Release (tag "v<version>") so they
       # persist beyond the 90-day artifact. --clobber keeps re-runs idempotent.
       - name: Attach SBOM and vulnerability report to the GitHub Release
         continue-on-error: true
-        # "released" is only set after the generate step's own repo/branch
-        # checks pass, so they need not be repeated here.
-        if: steps.sbom.outputs.released != '' &&
-          steps.sbom.outputs.released != '0.0.0-development'
+        if: needs.action.outputs.tarball != ''
         working-directory: packages/dnb-eufemia
         env:
-          RELEASED_VERSION: ${{ steps.sbom.outputs.released }}
-          # The packed tarball is the attestation subject; attaching it lets
-          # anyone verify the SBOM attestation with `gh attestation verify`.
-          PACKED_TARBALL: ${{ steps.pack.outputs.tarball }}
+          RELEASED_VERSION: ${{ needs.action.outputs.released }}
+          PACKED_TARBALL: ${{ needs.action.outputs.tarball }}
         run: |
           gh release upload "v$RELEASED_VERSION" \
             sbom.cdx.json vulnerability-report.json \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,169 @@ jobs:
           github.ref == 'refs/heads/next' ||
           endsWith(github.ref, '.x'))
         run: yarn workspace @dnb/eufemia publish:ci
+
+      # Produce the supply-chain compliance artifacts for the published library:
+      # a CycloneDX SBOM of its production (shipped) dependencies, plus a
+      # vulnerability report. Runs after publish, and continue-on-error keeps a
+      # post-publish SBOM hiccup from marking an already-successful release as
+      # failed — the "Audit dependencies" step above is the real release gate.
+      # Required by DNB (SECARC "Requirements for Application Security": an SBOM
+      # accompanied by a vulnerability report per release). The two files are
+      # both attached to the GitHub Release (durable, tied to the version) and
+      # uploaded as a workflow artifact — see the two steps that follow.
+      - name: Generate SBOM and vulnerability report
+        id: sbom
+        continue-on-error: true
+        if: github.repository == 'dnbexperience/eufemia' &&
+          (github.ref == 'refs/heads/release' ||
+          github.ref == 'refs/heads/beta' ||
+          github.ref == 'refs/heads/alpha' ||
+          github.ref == 'refs/heads/next' ||
+          endsWith(github.ref, '.x'))
+        working-directory: packages/dnb-eufemia
+        env:
+          # This step runs third-party code fetched at release time (yarn dlx)
+          # and needs no credentials of its own. Keep every token that can write
+          # to something this workflow publishes out of its environment.
+          NODE_AUTH_TOKEN: ''
+          GH_TOKEN: ''
+          ALGOLIA_API_KEY: ''
+        run: |
+          # SBOM of the published library's production (shipped) dependencies.
+          # Generated from the source workspace: the CycloneDX Yarn plugin needs
+          # a Yarn project, and the published build/ package is a plain package.
+          # The direct runtime "dependencies" are the same either way (publish
+          # preparation only strips dev-time fields), so this is a build-time
+          # SBOM: transitive versions are the ones this repo's lockfile and root
+          # "resolutions" produce — what we actually build, test and ship.
+          # Generator pinned for reproducible releases (bump deliberately — yarn
+          # dlx isn't covered by Dependabot). --mc-type library: it's a library.
+          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
+            --output-format JSON --spec-version 1.6 \
+            --production --mc-type library --output-file sbom.cdx.json
+
+          # CycloneDX stamps the main component with the workspace manifest
+          # version, which is a fixed 0.0.0-development placeholder. Overwrite it
+          # with the version semantic-release actually published (written to
+          # build/package.json) so the SBOM identifies the released component.
+          node -e '
+            const fs = require("fs")
+            const released = require("./build/package.json").version
+            const file = "sbom.cdx.json"
+            const sbom = JSON.parse(fs.readFileSync(file, "utf8"))
+            const component = sbom.metadata && sbom.metadata.component
+            if (!component) throw new Error("SBOM is missing metadata.component")
+            const placeholder = component.version
+            component.version = released
+            if (typeof component.purl === "string") {
+              component.purl = component.purl.split(placeholder).join(released)
+            }
+            fs.writeFileSync(file, JSON.stringify(sbom, null, 2) + "\n")
+            console.log("SBOM main component version: " + released)
+            if (released === "0.0.0-development") {
+              console.warn("WARNING: no real version was published; SBOM version left as placeholder")
+            }
+          '
+
+          # Accompanying vulnerability report over the same recursive production
+          # scope as the SBOM. Non-fatal: the "Audit dependencies" step above is
+          # the actual release gate. Yarn's `npm audit --json` emits an NDJSON
+          # stream (one advisory per line), so normalise it into a single JSON
+          # document like the SBOM. The audit exit status is captured so an
+          # audit that could not run is never recorded as a clean result.
+          audit_exit=0
+          audit_stream="$(yarn npm audit --environment production --recursive --json)" || audit_exit=$?
+          printf '%s' "$audit_stream" | node -e '
+            const fs = require("fs")
+            const exitCode = Number(process.argv[1])
+            const raw = fs.readFileSync(0, "utf8")
+            const advisories = []
+            for (const line of raw.split("\n")) {
+              const trimmed = line.trim()
+              if (!trimmed) continue
+              try {
+                advisories.push(JSON.parse(trimmed))
+              } catch {
+                // Ignore any non-JSON noise Yarn may interleave.
+              }
+            }
+            // Identify the report the way the SBOM identifies itself, so the
+            // file stays traceable once downloaded away from its release.
+            const manifest = require("./build/package.json")
+            const meta = {
+              component: manifest.name,
+              version: manifest.version,
+              generatedAt: new Date().toISOString(),
+              scope: "production dependencies, including transitive",
+              tool: "yarn npm audit",
+            }
+            let report
+            if (exitCode !== 0 && advisories.length === 0) {
+              // Non-zero exit and nothing parseable -> the audit could not run
+              // (e.g. a registry or network failure). Record the failure
+              // instead of a misleading clean result.
+              report = {
+                ...meta,
+                error: "audit could not be completed",
+                exitCode,
+              }
+            } else {
+              report = {
+                ...meta,
+                summary: advisories.length
+                  ? advisories.length + " advisory record(s) reported by yarn"
+                    + " npm audit. These include deprecation notices as well as"
+                    + " security vulnerabilities; check the severity and details"
+                    + " of each record."
+                  : "No known vulnerabilities in production dependencies.",
+                advisories,
+              }
+            }
+            fs.writeFileSync(
+              "vulnerability-report.json",
+              JSON.stringify(report, null, 2) + "\n"
+            )
+            console.log(report.error ? report.error : report.summary)
+          ' "$audit_exit"
+
+          # Expose the version semantic-release actually published so the next
+          # step can attach these files to the matching GitHub Release (tagged
+          # "v<version>"). A placeholder/empty value means no real release
+          # happened, and that step is skipped.
+          released="$(node -p "require('./build/package.json').version")"
+          echo "released=$released" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SBOM and vulnerability report
+        continue-on-error: true
+        if: github.repository == 'dnbexperience/eufemia' &&
+          (github.ref == 'refs/heads/release' ||
+          github.ref == 'refs/heads/beta' ||
+          github.ref == 'refs/heads/alpha' ||
+          github.ref == 'refs/heads/next' ||
+          endsWith(github.ref, '.x'))
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sbom-and-vulnerability-report
+          path: |
+            packages/dnb-eufemia/sbom.cdx.json
+            packages/dnb-eufemia/vulnerability-report.json
+          retention-days: 90
+
+      # Durability: attach the same two files to the GitHub Release that
+      # semantic-release just created (tag "v<version>"), so they live with the
+      # release permanently instead of expiring with the 90-day workflow
+      # artifact above. --clobber keeps re-runs idempotent. Skipped when no real
+      # version was published, and non-fatal like the steps above.
+      - name: Attach SBOM and vulnerability report to the GitHub Release
+        continue-on-error: true
+        # The version output is only written once the step above has generated
+        # both files, which already implies its repository and branch checks.
+        if: steps.sbom.outputs.released != '' &&
+          steps.sbom.outputs.released != '0.0.0-development'
+        working-directory: packages/dnb-eufemia
+        env:
+          RELEASED_VERSION: ${{ steps.sbom.outputs.released }}
+        run: |
+          gh release upload "v$RELEASED_VERSION" \
+            sbom.cdx.json vulnerability-report.json \
+            --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Attest the SBOM
         continue-on-error: true
         if: steps.pack.outputs.tarball != ''
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: packages/dnb-eufemia/${{ steps.pack.outputs.tarball }}
           sbom-path: packages/dnb-eufemia/sbom.cdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
       # accompanied by a vulnerability report per release). The two files are
       # both attached to the GitHub Release (durable, tied to the version) and
       # uploaded as a workflow artifact — see the two steps that follow.
+      # What these files are and where to find them: docs/sbom.md.
       - name: Generate SBOM and vulnerability report
         id: sbom
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,164 @@ jobs:
           endsWith(github.ref, '.x'))
         run: yarn workspace @dnb/eufemia publish:ci
 
+      # Release supply-chain artifacts: a CycloneDX SBOM of the published
+      # library's production dependencies plus a vulnerability report.
+      # Non-blocking (continue-on-error) — the "Audit dependencies" step above
+      # is the release gate, not this. See docs/sbom.md for what these files
+      # are, where they are stored, and why.
+      - name: Generate SBOM and vulnerability report
+        id: sbom
+        continue-on-error: true
+        if: github.repository == 'dnbexperience/eufemia' &&
+          (github.ref == 'refs/heads/release' ||
+          github.ref == 'refs/heads/beta' ||
+          github.ref == 'refs/heads/alpha' ||
+          github.ref == 'refs/heads/next' ||
+          endsWith(github.ref, '.x'))
+        working-directory: packages/dnb-eufemia
+        env:
+          # Runs untrusted third-party code (the CycloneDX generator via
+          # `yarn dlx`) and needs none of the workflow's credentials. Blank
+          # every secret the workflow-level `env:` injects so none can reach it.
+          # Keep this list in sync with that `env:` block.
+          GH_EMAIL: ''
+          GH_NAME: ''
+          GH_TOKEN: ''
+          NODE_AUTH_TOKEN: ''
+          FIGMA_TOKEN: ''
+          FIGMA_ICONS_FILE: ''
+          ALGOLIA_APP_ID: ''
+          ALGOLIA_INDEX_NAME: ''
+          ALGOLIA_SEARCH_KEY: ''
+          ALGOLIA_API_KEY: ''
+        run: |
+          # Generated from the source workspace, not the published build/
+          # package: the CycloneDX plugin needs a Yarn project, and direct
+          # runtime deps are identical either way. Generator version pinned for
+          # reproducibility — bump deliberately, as yarn dlx is not covered by
+          # Dependabot.
+          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
+            --output-format JSON --spec-version 1.6 \
+            --production --mc-type library --output-file sbom.cdx.json
+
+          # CycloneDX stamps the main component with the manifest's
+          # 0.0.0-development placeholder; overwrite it with the version
+          # semantic-release actually published (in build/package.json).
+          node -e '
+            const fs = require("fs")
+            const released = require("./build/package.json").version
+            const file = "sbom.cdx.json"
+            const sbom = JSON.parse(fs.readFileSync(file, "utf8"))
+            const component = sbom.metadata && sbom.metadata.component
+            if (!component) throw new Error("SBOM is missing metadata.component")
+            const placeholder = component.version
+            component.version = released
+            if (typeof component.purl === "string") {
+              component.purl = component.purl.split(placeholder).join(released)
+            }
+            fs.writeFileSync(file, JSON.stringify(sbom, null, 2) + "\n")
+            console.log("SBOM main component version: " + released)
+            if (released === "0.0.0-development") {
+              console.warn("WARNING: no real version was published; SBOM version left as placeholder")
+            }
+          '
+
+          # Vulnerability report over the same production scope. yarn npm audit
+          # emits NDJSON (one advisory per line); normalise it into a single
+          # JSON document, capturing the exit status so an audit that could not
+          # run is never recorded as a clean result.
+          audit_exit=0
+          audit_stream="$(yarn npm audit --environment production --recursive --json)" || audit_exit=$?
+          printf '%s' "$audit_stream" | node -e '
+            const fs = require("fs")
+            const exitCode = Number(process.argv[1])
+            const raw = fs.readFileSync(0, "utf8")
+            const advisories = []
+            for (const line of raw.split("\n")) {
+              const trimmed = line.trim()
+              if (!trimmed) continue
+              try {
+                advisories.push(JSON.parse(trimmed))
+              } catch {
+                // Ignore any non-JSON noise Yarn may interleave.
+              }
+            }
+            // Identify the report the way the SBOM identifies itself, so the
+            // file stays traceable once downloaded away from its release.
+            const manifest = require("./build/package.json")
+            const meta = {
+              component: manifest.name,
+              version: manifest.version,
+              generatedAt: new Date().toISOString(),
+              scope: "production dependencies, including transitive",
+              tool: "yarn npm audit",
+            }
+            let report
+            if (exitCode !== 0 && advisories.length === 0) {
+              // Non-zero exit and nothing parseable -> the audit could not run
+              // (e.g. a registry or network failure). Record the failure
+              // instead of a misleading clean result.
+              report = {
+                ...meta,
+                error: "audit could not be completed",
+                exitCode,
+              }
+            } else {
+              report = {
+                ...meta,
+                summary: advisories.length
+                  ? advisories.length + " advisory record(s) reported by yarn"
+                    + " npm audit. These include deprecation notices as well as"
+                    + " security vulnerabilities; check the severity and details"
+                    + " of each record."
+                  : "No known vulnerabilities in production dependencies.",
+                advisories,
+              }
+            }
+            fs.writeFileSync(
+              "vulnerability-report.json",
+              JSON.stringify(report, null, 2) + "\n"
+            )
+            console.log(report.error ? report.error : report.summary)
+          ' "$audit_exit"
+
+          # Publish the released version so the next step can attach the files
+          # to the matching GitHub Release; empty/placeholder means no release.
+          released="$(node -p "require('./build/package.json').version")"
+          echo "released=$released" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SBOM and vulnerability report
+        continue-on-error: true
+        if: github.repository == 'dnbexperience/eufemia' &&
+          (github.ref == 'refs/heads/release' ||
+          github.ref == 'refs/heads/beta' ||
+          github.ref == 'refs/heads/alpha' ||
+          github.ref == 'refs/heads/next' ||
+          endsWith(github.ref, '.x'))
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sbom-and-vulnerability-report
+          path: |
+            packages/dnb-eufemia/sbom.cdx.json
+            packages/dnb-eufemia/vulnerability-report.json
+          retention-days: 90
+
+      # Attach both files to the GitHub Release (tag "v<version>") so they
+      # persist beyond the 90-day artifact. --clobber keeps re-runs idempotent.
+      - name: Attach SBOM and vulnerability report to the GitHub Release
+        continue-on-error: true
+        # "released" is only set after the generate step's own repo/branch
+        # checks pass, so they need not be repeated here.
+        if: steps.sbom.outputs.released != '' &&
+          steps.sbom.outputs.released != '0.0.0-development'
+        working-directory: packages/dnb-eufemia
+        env:
+          RELEASED_VERSION: ${{ steps.sbom.outputs.released }}
+        run: |
+          gh release upload "v$RELEASED_VERSION" \
+            sbom.cdx.json vulnerability-report.json \
+            --clobber --repo "$GITHUB_REPOSITORY"
+
   deploy-portal:
     name: Deploy portal to GitHub Pages
     needs: action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ permissions:
   contents: write # Required for semantic-release to push tags and changelog
   issues: write # Required for semantic-release to comment on issues
   pull-requests: write # Required for semantic-release to comment on PRs
-  id-token: write # Required for npm provenance
+  id-token: write # Required for npm provenance and SBOM attestation signing
+  attestations: write # Required to record the release SBOM attestation
 
 env:
   GH_EMAIL: ${{ secrets.GH_EMAIL }}
@@ -215,6 +216,31 @@ jobs:
           released="$(node -p "require('./build/package.json').version")"
           echo "released=$released" >> "$GITHUB_OUTPUT"
 
+      # Pack the published files into a tarball to serve as the attestation
+      # subject. `--ignore-scripts` keeps it side-effect free (no lifecycle
+      # scripts run) and uses the same build/ output semantic-release publishes.
+      - name: Pack the released library (attestation subject)
+        id: pack
+        continue-on-error: true
+        if: steps.sbom.outputs.released != '' &&
+          steps.sbom.outputs.released != '0.0.0-development'
+        working-directory: packages/dnb-eufemia
+        run: |
+          tarball="$(cd build && npm pack --ignore-scripts --pack-destination .. | tail -1)"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          echo "Packed attestation subject: $tarball"
+
+      # Sign a CycloneDX SBOM attestation (Sigstore-backed) binding the SBOM to
+      # the packed release artifact. Complements npm provenance; verify with
+      # `gh attestation verify <tarball> --repo dnbexperience/eufemia`.
+      - name: Attest the SBOM
+        continue-on-error: true
+        if: steps.pack.outputs.tarball != ''
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: packages/dnb-eufemia/${{ steps.pack.outputs.tarball }}
+          sbom-path: packages/dnb-eufemia/sbom.cdx.json
+
       - name: Upload SBOM and vulnerability report
         continue-on-error: true
         if: github.repository == 'dnbexperience/eufemia' &&
@@ -242,9 +268,13 @@ jobs:
         working-directory: packages/dnb-eufemia
         env:
           RELEASED_VERSION: ${{ steps.sbom.outputs.released }}
+          # The packed tarball is the attestation subject; attaching it lets
+          # anyone verify the SBOM attestation with `gh attestation verify`.
+          PACKED_TARBALL: ${{ steps.pack.outputs.tarball }}
         run: |
           gh release upload "v$RELEASED_VERSION" \
             sbom.cdx.json vulnerability-report.json \
+            ${PACKED_TARBALL:+"$PACKED_TARBALL"} \
             --clobber --repo "$GITHUB_REPOSITORY"
 
   deploy-portal:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -78,6 +78,64 @@ jobs:
           yarn workspace @dnb/eufemia audit:ci
           yarn workspace @dnb/eufemia-mcp audit:ci
 
+      - name: Verify SBOM + audit generation (release smoke test)
+        # release.yml generates a CycloneDX SBOM and a vulnerability report after
+        # every publish — but that workflow only runs on release branches, so PR
+        # CI never exercises it. Run the two external generators here so a broken
+        # plugin, a changed flag, or an altered `yarn npm audit --json` output
+        # shape is caught on the PR instead of mid-release. Keep the pinned
+        # generator version below in sync with release.yml. The release-only
+        # version stamp and GitHub-Release upload are not exercised here.
+        working-directory: packages/dnb-eufemia
+        env:
+          # Same hardening as release.yml: the generator runs third-party code
+          # fetched via `yarn dlx` and needs no credentials of its own.
+          NODE_AUTH_TOKEN: ''
+          GH_TOKEN: ''
+          ALGOLIA_API_KEY: ''
+        run: |
+          # Pinned version MUST match the one in release.yml.
+          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
+            --output-format JSON --spec-version 1.6 \
+            --production --mc-type library --output-file sbom.cdx.json
+
+          # Assert the SBOM has the shape release consumers expect.
+          node -e '
+            const sbom = require("./sbom.cdx.json")
+            if (sbom.bomFormat !== "CycloneDX" || sbom.specVersion !== "1.6") {
+              throw new Error(
+                "unexpected SBOM format: " + sbom.bomFormat + " " + sbom.specVersion
+              )
+            }
+            if (!(sbom.metadata && sbom.metadata.component)) {
+              throw new Error("SBOM is missing metadata.component")
+            }
+            const count = (sbom.components || []).length
+            if (count === 0) throw new Error("SBOM lists no components")
+            console.log("SBOM OK: CycloneDX 1.6, " + count + " production components")
+          '
+
+          # Assert `yarn npm audit --json` still emits parseable per-line JSON
+          # (the NDJSON shape release.yml relies on). Non-gating: audit:ci above
+          # is the real gate, so a non-zero exit (advisories present) is fine
+          # here as long as every line parses.
+          audit_exit=0
+          audit_stream="$(yarn npm audit --environment production --recursive --json)" || audit_exit=$?
+          printf '%s' "$audit_stream" | node -e '
+            const fs = require("fs")
+            let records = 0
+            for (const line of fs.readFileSync(0, "utf8").split("\n")) {
+              const trimmed = line.trim()
+              if (!trimmed) continue
+              JSON.parse(trimmed) // throws if the NDJSON assumption breaks
+              records++
+            }
+            console.log("audit --json parsed: " + records + " record(s), exit " + process.argv[1])
+          ' "$audit_exit"
+
+          # Generated file is gitignored; remove it so the tree stays clean.
+          rm -f sbom.cdx.json
+
   lint:
     name: Run lint
     needs: setup

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,6 +47,19 @@ jobs:
 
     timeout-minutes: 10
 
+    # This job runs untrusted third-party code (the CycloneDX generator via
+    # `yarn dlx` in the SBOM smoke test below). verify.yml has no workflow-level
+    # `env:` (see the note at the top of this file), so no secrets reach this job
+    # today; these blanks are defense-in-depth in case a workflow-level `env:` is
+    # ever added, so the untrusted code still cannot read them.
+    env:
+      GH_EMAIL: ''
+      GH_NAME: ''
+      GH_TOKEN: ''
+      NPM_TOKEN: ''
+      FIGMA_TOKEN: ''
+      FIGMA_ICONS_FILE: ''
+
     steps:
       - name: Git checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -71,6 +84,61 @@ jobs:
         run: |
           yarn workspace @dnb/eufemia audit:ci
           yarn workspace @dnb/eufemia-mcp audit:ci
+
+      - name: Verify SBOM + audit generation (release smoke test)
+        # release.yml generates a CycloneDX SBOM and a vulnerability report after
+        # every publish — but that workflow only runs on release branches, so PR
+        # CI never exercises it. Run the two external generators here so a broken
+        # plugin, a changed flag, or an altered `yarn npm audit --json` output
+        # shape is caught on the PR instead of mid-release. Keep the pinned
+        # generator version below in sync with release.yml. The release-only
+        # version stamp and GitHub-Release upload are not exercised here.
+        working-directory: packages/dnb-eufemia
+        # The generator runs third-party code fetched via `yarn dlx` and needs no
+        # credentials of its own; the job-level `env:` above defensively blanks
+        # secrets, so none can reach it.
+        run: |
+          # Pinned version MUST match the one in release.yml.
+          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
+            --output-format JSON --spec-version 1.6 \
+            --production --mc-type library --output-file sbom.cdx.json
+
+          # Assert the SBOM has the shape release consumers expect.
+          node -e '
+            const sbom = require("./sbom.cdx.json")
+            if (sbom.bomFormat !== "CycloneDX" || sbom.specVersion !== "1.6") {
+              throw new Error(
+                "unexpected SBOM format: " + sbom.bomFormat + " " + sbom.specVersion
+              )
+            }
+            if (!(sbom.metadata && sbom.metadata.component)) {
+              throw new Error("SBOM is missing metadata.component")
+            }
+            const count = (sbom.components || []).length
+            if (count === 0) throw new Error("SBOM lists no components")
+            console.log("SBOM OK: CycloneDX 1.6, " + count + " production components")
+          '
+
+          # Assert `yarn npm audit --json` still emits parseable per-line JSON
+          # (the NDJSON shape release.yml relies on). Non-gating: audit:ci above
+          # is the real gate, so a non-zero exit (advisories present) is fine
+          # here as long as every line parses.
+          audit_exit=0
+          audit_stream="$(yarn npm audit --environment production --recursive --json)" || audit_exit=$?
+          printf '%s' "$audit_stream" | node -e '
+            const fs = require("fs")
+            let records = 0
+            for (const line of fs.readFileSync(0, "utf8").split("\n")) {
+              const trimmed = line.trim()
+              if (!trimmed) continue
+              JSON.parse(trimmed) // throws if the NDJSON assumption breaks
+              records++
+            }
+            console.log("audit --json parsed: " + records + " record(s), exit " + process.argv[1])
+          ' "$audit_exit"
+
+          # Generated file is gitignored; remove it so the tree stays clean.
+          rm -f sbom.cdx.json
 
   lint:
     name: Run lint

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ yarn-error.log*
 
 # IDE
 .idea
+
+# Generated supply-chain artifacts (SBOM + vulnerability report)
+packages/dnb-eufemia/sbom.cdx.json
+packages/dnb-eufemia/vulnerability-report.json

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 # IDE
 .idea
 
-# Generated supply-chain artifacts (SBOM + vulnerability report)
+# Generated supply-chain artifacts (SBOM, vulnerability report, packed tarball)
 packages/dnb-eufemia/sbom.cdx.json
 packages/dnb-eufemia/vulnerability-report.json
+packages/dnb-eufemia/dnb-eufemia-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ yarn-error.log*
 
 # IDE
 .idea
+
+# Generated supply-chain artifacts (SBOM + vulnerability report)
+packages/dnb-eufemia/sbom.cdx.json
+packages/dnb-eufemia/vulnerability-report.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,13 @@ vulnerabilities only; less-severe issues will not be patched there, so please
 plan to upgrade. Majors below `10.x` are end-of-life — there is no maintained
 release line to publish a fix from, so upgrade to a supported major.
 
+## Software Bill of Materials (SBOM)
+
+Every release of `@dnb/eufemia` ships a CycloneDX **SBOM** and a **vulnerability
+report** as GitHub Release assets, so you can see exactly which components a
+version contains and scope the impact of a new advisory. See
+[`docs/sbom.md`](./docs/sbom.md).
+
 ## Ownership
 
 Vulnerability management for this repository is owned by the Eufemia **Security

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,0 +1,70 @@
+# Software Bill of Materials (SBOM)
+
+Every release of `@dnb/eufemia` is accompanied by a **Software Bill of
+Materials (SBOM)** and a **vulnerability report**, attached to the GitHub
+Release. This page explains what they are, where to find them, and what
+they are for.
+
+## What an SBOM is
+
+An SBOM is a machine-readable inventory of every third-party component
+that goes into the published library — its direct **and** transitive
+production dependencies, each at its exact version. Think of it as
+the ingredients list for a given `@dnb/eufemia` release.
+
+Eufemia's SBOM is generated in the [CycloneDX](https://cyclonedx.org/)
+1.6 JSON format — a widely supported standard that security scanners and
+inventory tools (for example [Dependency-Track][dt], Grype or Trivy) can
+read directly.
+
+The **vulnerability report** is a companion file listing any known
+advisories against those same production dependencies at release time —
+security vulnerabilities as well as any deprecation notices.
+
+[dt]: https://dependencytrack.org/
+
+## Where it is stored
+
+Both files are produced by the release workflow
+([`.github/workflows/release.yml`](../.github/workflows/release.yml))
+**after** the package is published, and are kept in two places:
+
+| Location                                                              | File(s)                                      | Lifetime                           |
+| --------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------- |
+| The **GitHub Release** for the version (tag `v<version>`), as assets  | `sbom.cdx.json`, `vulnerability-report.json` | Permanent — lives with the release |
+| The release **workflow run artifact** `sbom-and-vulnerability-report` | both files                                   | 90 days                            |
+
+The GitHub Release is the durable, canonical copy. To fetch it for a
+specific version:
+
+```bash
+# available on releases from this feature onwards; use the tag you need
+gh release download vX.Y.Z --repo dnbexperience/eufemia \
+  --pattern 'sbom.cdx.json' --pattern 'vulnerability-report.json'
+```
+
+(or download them from the release page under **Assets**).
+
+## What it is used for
+
+- **Supply-chain transparency** — see exactly which components, at which
+  versions, make up a given release, without cloning or building it.
+- **Vulnerability response** — when a new advisory lands on a
+  dependency, the SBOM lets you check which shipped versions of
+  `@dnb/eufemia` are affected and scope the impact quickly.
+- **Automated scanning** — the CycloneDX file feeds straight into
+  inventory and vulnerability-scanning tools.
+- **Compliance** — DNB's _Requirements for Application Security_ (SECARC)
+  require an SBOM and a vulnerability report for each release.
+
+## Notes
+
+- **Scope:** production (shipped) dependencies only, including
+  transitive ones. Development and build tooling is excluded — it never
+  reaches consumers.
+- The SBOM's main component is stamped with the version that was actually
+  published, so the file is self-describing once downloaded.
+- Generating these files is **non-blocking**. The gate that can stop a
+  release is the pre-publish dependency audit, not this step; if
+  generation ever fails, the release still completes and the artifacts
+  can be regenerated afterwards.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -55,12 +55,26 @@ gh release download vX.Y.Z --repo dnbexperience/eufemia \
 The SBOM is signed with a [Sigstore][sigstore]-backed attestation issued
 by the release workflow, so you can confirm it was produced by this
 repository's CI and has not been tampered with. Download the packed
-artifact and its SBOM from the release, then verify:
+artifact from the release, then verify it.
+
+`gh attestation verify` defaults to the SLSA provenance predicate, so pass
+the CycloneDX SBOM predicate type explicitly — it carries the SBOM's spec
+version (`v1.6` here):
 
 ```bash
 gh release download vX.Y.Z --repo dnbexperience/eufemia \
   --pattern 'dnb-eufemia-*.tgz'
-gh attestation verify dnb-eufemia-X.Y.Z.tgz --repo dnbexperience/eufemia
+
+gh attestation verify dnb-eufemia-X.Y.Z.tgz --repo dnbexperience/eufemia \
+  --predicate-type https://cyclonedx.org/bom/v1.6
+```
+
+To inspect the attested SBOM contents, add `--format json`:
+
+```bash
+gh attestation verify dnb-eufemia-X.Y.Z.tgz --repo dnbexperience/eufemia \
+  --predicate-type https://cyclonedx.org/bom/v1.6 \
+  --format json --jq '.[].verificationResult.statement.predicate'
 ```
 
 This complements the [npm provenance][provenance] published with the

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,0 +1,69 @@
+# Software Bill of Materials (SBOM)
+
+Every release of `@dnb/eufemia` ships with a **Software Bill of
+Materials (SBOM)** and an accompanying **vulnerability report**. This
+page explains what they are, where to find them, and what they are for.
+
+## What an SBOM is
+
+An SBOM is a machine-readable inventory of every third-party component
+that goes into the published library — its direct **and** transitive
+production dependencies, each pinned to an exact version. Think of it as
+the ingredients list for a given `@dnb/eufemia` release.
+
+Eufemia's SBOM is generated in the [CycloneDX](https://cyclonedx.org/)
+1.6 JSON format — a widely supported standard that security scanners and
+inventory tools (for example [Dependency-Track][dt], Grype or Trivy) can
+read directly.
+
+The **vulnerability report** is a companion file that lists any known
+advisories against those same production dependencies at the time of the
+release.
+
+[dt]: https://dependencytrack.org/
+
+## Where it is stored
+
+Both files are produced by the release workflow
+([`.github/workflows/release.yml`](../.github/workflows/release.yml))
+**after** the package is published, and are kept in two places:
+
+| Location                                                              | File(s)                                      | Lifetime                           |
+| --------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------- |
+| The **GitHub Release** for the version (tag `v<version>`), as assets  | `sbom.cdx.json`, `vulnerability-report.json` | Permanent — lives with the release |
+| The release **workflow run artifact** `sbom-and-vulnerability-report` | both files                                   | 90 days                            |
+
+The GitHub Release is the durable, canonical copy. To fetch it for a
+specific version:
+
+```bash
+# replace with the version you want, e.g. v11.9.0
+gh release download v11.9.0 --repo dnbexperience/eufemia \
+  --pattern 'sbom.cdx.json' --pattern 'vulnerability-report.json'
+```
+
+(or download them from the release page under **Assets**).
+
+## What it is used for
+
+- **Supply-chain transparency** — see exactly which components, at which
+  versions, make up a given release, without cloning or building it.
+- **Vulnerability response** — when a new advisory lands on a
+  dependency, the SBOM lets you check which shipped versions of
+  `@dnb/eufemia` are affected and scope the impact quickly.
+- **Automated scanning** — the CycloneDX file feeds straight into
+  inventory and vulnerability-scanning tools.
+- **Compliance** — DNB's _Requirements for Application Security_ (SECARC)
+  require an SBOM and a vulnerability report for each release.
+
+## Notes
+
+- **Scope:** production (shipped) dependencies only, including
+  transitive ones. Development and build tooling is excluded — it never
+  reaches consumers.
+- The SBOM's main component is stamped with the version that was actually
+  published, so the file is self-describing once downloaded.
+- Generating these files is **non-blocking**. The gate that can stop a
+  release is the pre-publish dependency audit, not this step; if
+  generation ever fails, the release still completes and the artifacts
+  can be regenerated afterwards.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -2,8 +2,9 @@
 
 Every release of `@dnb/eufemia` is accompanied by a **Software Bill of
 Materials (SBOM)** and a **vulnerability report**, attached to the GitHub
-Release. This page explains what they are, where to find them, and what
-they are for.
+Release. The SBOM is also **cryptographically attested** (Sigstore-backed)
+so its authenticity can be verified. This page explains what they are, where
+to find them, and what they are for.
 
 ## What an SBOM is
 
@@ -29,10 +30,14 @@ Both files are produced by the release workflow
 ([`.github/workflows/release.yml`](../.github/workflows/release.yml))
 **after** the package is published, and are kept in two places:
 
-| Location                                                              | File(s)                                      | Lifetime                           |
-| --------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------- |
-| The **GitHub Release** for the version (tag `v<version>`), as assets  | `sbom.cdx.json`, `vulnerability-report.json` | Permanent — lives with the release |
-| The release **workflow run artifact** `sbom-and-vulnerability-report` | both files                                   | 90 days                            |
+| Location                                                              | File(s)                                                                   | Lifetime                           |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------- |
+| The **GitHub Release** for the version (tag `v<version>`), as assets  | `sbom.cdx.json`, `vulnerability-report.json`, `dnb-eufemia-<version>.tgz` | Permanent — lives with the release |
+| The release **workflow run artifact** `sbom-and-vulnerability-report` | `sbom.cdx.json`, `vulnerability-report.json`                              | 90 days                            |
+
+The `.tgz` is the packed release artifact that the SBOM attestation is
+bound to (see [Verifying the attestation](#verifying-the-attestation));
+`npm` remains the canonical source for installing the package.
 
 The GitHub Release is the durable, canonical copy. To fetch it for a
 specific version:
@@ -44,6 +49,25 @@ gh release download vX.Y.Z --repo dnbexperience/eufemia \
 ```
 
 (or download them from the release page under **Assets**).
+
+## Verifying the attestation
+
+The SBOM is signed with a [Sigstore][sigstore]-backed attestation issued
+by the release workflow, so you can confirm it was produced by this
+repository's CI and has not been tampered with. Download the packed
+artifact and its SBOM from the release, then verify:
+
+```bash
+gh release download vX.Y.Z --repo dnbexperience/eufemia \
+  --pattern 'dnb-eufemia-*.tgz'
+gh attestation verify dnb-eufemia-X.Y.Z.tgz --repo dnbexperience/eufemia
+```
+
+This complements the [npm provenance][provenance] published with the
+package itself.
+
+[sigstore]: https://www.sigstore.dev/
+[provenance]: https://docs.npmjs.com/generating-provenance-statements
 
 ## What it is used for
 

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,14 +1,15 @@
 # Software Bill of Materials (SBOM)
 
-Every release of `@dnb/eufemia` ships with a **Software Bill of
-Materials (SBOM)** and an accompanying **vulnerability report**. This
-page explains what they are, where to find them, and what they are for.
+Every release of `@dnb/eufemia` is accompanied by a **Software Bill of
+Materials (SBOM)** and a **vulnerability report**, attached to the GitHub
+Release. This page explains what they are, where to find them, and what
+they are for.
 
 ## What an SBOM is
 
 An SBOM is a machine-readable inventory of every third-party component
 that goes into the published library — its direct **and** transitive
-production dependencies, each pinned to an exact version. Think of it as
+production dependencies, each at its exact version. Think of it as
 the ingredients list for a given `@dnb/eufemia` release.
 
 Eufemia's SBOM is generated in the [CycloneDX](https://cyclonedx.org/)
@@ -16,9 +17,9 @@ Eufemia's SBOM is generated in the [CycloneDX](https://cyclonedx.org/)
 inventory tools (for example [Dependency-Track][dt], Grype or Trivy) can
 read directly.
 
-The **vulnerability report** is a companion file that lists any known
-advisories against those same production dependencies at the time of the
-release.
+The **vulnerability report** is a companion file listing any known
+advisories against those same production dependencies at release time —
+security vulnerabilities as well as any deprecation notices.
 
 [dt]: https://dependencytrack.org/
 
@@ -37,8 +38,8 @@ The GitHub Release is the durable, canonical copy. To fetch it for a
 specific version:
 
 ```bash
-# replace with the version you want, e.g. v11.9.0
-gh release download v11.9.0 --repo dnbexperience/eufemia \
+# available on releases from this feature onwards; use the tag you need
+gh release download vX.Y.Z --repo dnbexperience/eufemia \
   --pattern 'sbom.cdx.json' --pattern 'vulnerability-report.json'
 ```
 

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -62,6 +62,11 @@ gh release download vX.Y.Z --repo dnbexperience/eufemia \
 - **Scope:** production (shipped) dependencies only, including
   transitive ones. Development and build tooling is excluded — it never
   reaches consumers.
+- **Resolved versions:** the dependency tree is resolved in Eufemia's
+  monorepo, so transitive versions reflect what Eufemia builds and tests
+  against — including any dependency `resolutions` pinned at the
+  repository root. A fresh install elsewhere may resolve some transitive
+  dependencies to other versions within the same permitted ranges.
 - The SBOM's main component is stamped with the version that was actually
   published, so the file is self-describing once downloaded.
 - Generating these files is **non-blocking**. The gate that can stop a

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -58,22 +58,23 @@ repository's CI and has not been tampered with. Download the packed
 artifact from the release, then verify it.
 
 `gh attestation verify` defaults to the SLSA provenance predicate, so pass
-the CycloneDX SBOM predicate type explicitly — it carries the SBOM's spec
-version (`v1.6` here):
+the CycloneDX SBOM predicate type explicitly. Attestations record CycloneDX
+SBOMs under the version-agnostic `https://cyclonedx.org/bom` predicate type,
+regardless of the SBOM's spec version:
 
 ```bash
 gh release download vX.Y.Z --repo dnbexperience/eufemia \
   --pattern 'dnb-eufemia-*.tgz'
 
 gh attestation verify dnb-eufemia-X.Y.Z.tgz --repo dnbexperience/eufemia \
-  --predicate-type https://cyclonedx.org/bom/v1.6
+  --predicate-type https://cyclonedx.org/bom
 ```
 
 To inspect the attested SBOM contents, add `--format json`:
 
 ```bash
 gh attestation verify dnb-eufemia-X.Y.Z.tgz --repo dnbexperience/eufemia \
-  --predicate-type https://cyclonedx.org/bom/v1.6 \
+  --predicate-type https://cyclonedx.org/bom \
   --format json --jq '.[].verificationResult.statement.predicate'
 ```
 

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -84,6 +84,7 @@ These run continuously — you rarely need to hunt for issues:
 | **Install age gate**        | Refuses npm versions published less than **3 days** ago — blocks hijacked releases before they land    | `.yarnrc.yml` → `npmMinimalAgeGate: 3d`                                      |
 | **Dependabot security PRs** | Auto-PRs for fixable advisories (open even while scheduled version updates are disabled)               | PRs                                                                          |
 | **Snyk**                    | Third-party SCA on every pull request (pre-merge feedback on newly introduced vulnerable dependencies) | `security/snyk` PR check                                                     |
+| **Release SBOM**            | Per-release CycloneDX SBOM + advisory report; scopes which shipped versions an advisory affects        | `release.yml` → GitHub Release assets ([SBOM docs](./sbom.md))               |
 
 The **install age gate** is the one preventive control here: most malicious npm
 releases (typosquats, hijacked maintainer accounts) are detected and unpublished


### PR DESCRIPTION
Two supply-chain controls from the DNB internal-standards review (EDS-823). Neither relaxes an existing Eufemia gate.

**SBOM + vulnerability report per release** — after publish, `release.yml` generates a CycloneDX 1.6 SBOM of `@dnb/eufemia`'s production dependencies plus a production-scope vulnerability report, attaches both to the GitHub Release, and uploads them as a workflow artifact. Runs with `continue-on-error`, so it can never block a release — the pre-publish audit stays the gate. `verify.yml` runs the same generators as a non-gating PR-CI smoke test, so a broken plugin, flag, or `yarn npm audit --json` shape is caught on the PR.

**Dependabot cooldown** — a cool-off period so freshly published versions settle before adoption (npm 7d / 3d patch, forward-looking behind `open-pull-requests-limit: 0`; github-actions 7d, active). Version updates only; never delays security updates.

Also documents the SBOM in `docs/sbom.md` and gitignores the generated files. Companion to #8807.

---

**Sources** — DNB internal security standards (SSO-gated; DNB staff only): [SECARC/135177479](https://dnb-asa.atlassian.net/wiki/spaces/SECARC/pages/135177479) · [SECC/2032337941](https://dnb-asa.atlassian.net/wiki/spaces/SECC/pages/2032337941) · [SECC/1907851772](https://dnb-asa.atlassian.net/wiki/spaces/SECC/pages/1907851772)