### PR TITLE
fix(Form.useData): type update() value and updater callback param

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/setData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/setData.test.tsx
@@ -27,6 +27,25 @@ describe('setData', () => {
     expect(input).toHaveValue('bar')
   })
 
+  it('types update() value and updater callback param', () => {
+    type Data = { count: number }
+    const { update } = setData<Data>(identifier, { count: 0 })
+
+    // Runtime: direct-value and updater forms work
+    update('/count', 5)
+    expect(getData<Data>(identifier).getValue('/count')).toBe(5)
+    update('/count', (count) => {
+      // The updater's current-value param is precisely typed (was `any`)
+      expectTypeOf(count).toEqualTypeOf<number>()
+      return count + 1
+    })
+    expect(getData<Data>(identifier).getValue('/count')).toBe(6)
+
+    // Wrong-typed value is a compile error (the call runs but is not asserted).
+    // @ts-expect-error /count is a number, not a string
+    update('/count', 'nope')
+  })
+
   it('should set form data after render', () => {
     render(
       <Form.Handler id={identifier}>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
@@ -204,6 +204,54 @@ describe('Form.useData', () => {
     })
   })
 
+  describe('update value type', () => {
+    it('types the updater callback param for typed data', () => {
+      type UIMemberProps = { name: string; age: number }
+      type Data = { members: Partial<UIMemberProps>[]; count: number }
+
+      const { result } = renderHook(() =>
+        useData<Data>(identifier, {
+          members: [{ name: 'Nora' }],
+          count: 0,
+        })
+      )
+
+      // Runtime behavior is unchanged
+      act(() => {
+        result.current.update('/count', (count) => count + 1)
+      })
+      expect(result.current.getValue('/count')).toBe(1)
+
+      // The fix: the updater's current-value param is precisely typed
+      // (it used to be `any`, because `| unknown` collapsed the union).
+      act(() => {
+        result.current.update('/members', (members) => {
+          expectTypeOf(members).toEqualTypeOf<Partial<UIMemberProps>[]>()
+          expectTypeOf(members).not.toBeAny()
+          return members
+        })
+        result.current.update('/count', (count) => {
+          expectTypeOf(count).toEqualTypeOf<number>()
+          return count
+        })
+      })
+    })
+
+    it('keeps the updater param loose (any) for untyped data', () => {
+      const { result } = renderHook(() => useData(identifier))
+
+      act(() => {
+        result.current.update('/x', (value) => {
+          expectTypeOf(value).toBeAny()
+          return value
+        })
+      })
+
+      // Runtime sanity: an unchanged updater result is a no-op
+      expect(result.current.getValue('/x')).toBeUndefined()
+    })
+  })
+
   it('should return "update" method that lets you update the data', () => {
     const props = { key: 'value' }
     const { result } = renderHook(() => useData(identifier, props))

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/__tests__/useData.test.tsx
@@ -205,7 +205,7 @@ describe('Form.useData', () => {
   })
 
   describe('update value type', () => {
-    it('types the updater callback param for typed data', () => {
+    it('types the updater callback param and direct value for typed data', () => {
       type UIMemberProps = { name: string; age: number }
       type Data = { members: Partial<UIMemberProps>[]; count: number }
 
@@ -216,11 +216,17 @@ describe('Form.useData', () => {
         })
       )
 
-      // Runtime behavior is unchanged
+      // Runtime behavior is unchanged (updater form)
       act(() => {
         result.current.update('/count', (count) => count + 1)
       })
       expect(result.current.getValue('/count')).toBe(1)
+
+      // Direct-value form also works and is type-checked
+      act(() => {
+        result.current.update('/count', 5)
+      })
+      expect(result.current.getValue('/count')).toBe(5)
 
       // The fix: the updater's current-value param is precisely typed
       // (it used to be `any`, because `| unknown` collapsed the union).
@@ -234,6 +240,15 @@ describe('Form.useData', () => {
           expectTypeOf(count).toEqualTypeOf<number>()
           return count
         })
+      })
+
+      // Wrong-typed values/returns are compile errors. The calls run (inside
+      // act) but their result is not asserted – they exist only to type-check.
+      act(() => {
+        // @ts-expect-error /count is a number, not a string
+        result.current.update('/count', 'nope')
+        // @ts-expect-error the updater for /count must return a number
+        result.current.update('/count', () => 'nope')
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/setData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/setData.ts
@@ -1,5 +1,6 @@
 import type { JsonObject } from '../../utils/json-pointer'
 import pointer from '../../utils/json-pointer'
+import type { Path } from '../../types'
 import type { SharedStateId } from '../../../../shared/helpers/useSharedState'
 import { createSharedState } from '../../../../shared/helpers/useSharedState'
 import type { UseDataReturnUpdate } from './useData'
@@ -19,7 +20,10 @@ export default function setData<Data>(
     sharedState.extend(data)
   }
 
-  const update: UseDataReturnUpdate<Data> = (path, value = undefined) => {
+  // The runtime resolver takes a plain `Path` and a loose value; cast it to the
+  // public generic signature so the value is checked against the literal path
+  // (`update` maps `P` to `PathType<Data, P>`).
+  const update = ((path: Path, value: unknown = undefined) => {
     const existingData = structuredClone(sharedState.data || {}) as Data &
       JsonObject
 
@@ -35,7 +39,7 @@ export default function setData<Data>(
 
     // Rerender the form with the new data
     sharedState.extend(existingData)
-  }
+  }) as unknown as UseDataReturnUpdate<Data>
 
   return {
     update,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -63,6 +63,14 @@ export type PathType<Data, P extends string> =
     ? any
     : PathValue<Data, P>
 
+/**
+ * Updates the value at `path`, accepting either the new value directly or a
+ * `setState`-style updater callback that receives the current value. The value,
+ * and the updater's argument and return, are all typed as {@link PathType} for
+ * the given path (so `any` for untyped data). Like `getValue`, the current
+ * value is typed optimistically – not `PathType<Data, P> | undefined` – for
+ * ergonomics and to stay consistent with `getValue`.
+ */
 export type UseDataReturnUpdate<Data> = <P extends Path>(
   path: P,
   value:

--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -65,7 +65,9 @@ export type PathType<Data, P extends string> =
 
 export type UseDataReturnUpdate<Data> = <P extends Path>(
   path: P,
-  value: ((value: PathType<Data, P>) => unknown) | unknown
+  value:
+    | PathType<Data, P>
+    | ((value: PathType<Data, P>) => PathType<Data, P>)
 ) => void
 
 export type UseDataReturnGetValue<Data> = <P extends Path>(
@@ -240,8 +242,11 @@ export function useDataReturn<Data = JsonObject>({
     [getDataContext, id, sharedDataRef]
   )
 
-  const update = useCallback<UseDataReturnUpdate<Data>>(
-    (path, value = undefined) => {
+  // The runtime resolver takes a plain `Path` and a loose value; cast it to the
+  // public generic signature so the value is checked against the literal path
+  // (`update` maps `P` to `PathType<Data, P>`).
+  const update = useCallback(
+    (path: Path, value: unknown = undefined) => {
       const existingData = getExistingData()
       const existingValue = pointer.has(existingData, path)
         ? pointer.get(existingData, path)
@@ -264,7 +269,7 @@ export function useDataReturn<Data = JsonObject>({
       }
     },
     [getDataContext, getExistingData, id, sharedDataRef]
-  )
+  ) as unknown as UseDataReturnUpdate<Data>
 
   const remove = useCallback<UseDataReturn<Data>['remove']>(
     (path) => {


### PR DESCRIPTION
## Why

Follow-up to #8811 (which fixes `Form.useData().getValue()` typing). This applies the same fix to the **write** side — `update()`.

`update()`'s `value` parameter was typed as:

```ts
value: ((value: PathType<Data, P>) => unknown) | unknown
```

Because `T | unknown` collapses to `unknown`, the updater callback's current-value argument was untyped (`any`), and the direct value accepted anything — even when `Form.useData<Data>()` is given the full data type.

## What

Type it as a setState-style union:

```ts
value: PathType<Data, P> | ((value: PathType<Data, P>) => PathType<Data, P>)
```

- The updater param (e.g. `(current) => …`) and the direct value are now precise for typed data.
- Untyped data still falls back to `any`, so cast-free ergonomics are preserved.
- The same fix is applied to `Form.setData().update()`.

Note: the direct-value slot must be `PathType<Data, P>` — a bare `| unknown` is exactly what collapses the union — so the direct value is necessarily tightened too. This is consistent with React's `setState` and with the `getValue` fix in #8811.

## Notes

- **Stacked on #8811.** This PR targets `fix/forms-usedata-getvalue-any-collapse` so its diff shows only the `update()` changes. It should merge after #8811 (or be retargeted to `main` once #8811 is merged).
- Type-only change; the implementations are runtime-identical (only type annotations + no-op casts changed).

## Checks

- `tsc` (whole package): 0 errors — no existing `update()` caller breaks.
- ESLint + Prettier: clean.
- 129 `Form/DataContext` tests pass, including new type tests asserting the updater param is precisely typed and not `any`.
