### PR TITLE
chore(shared): type implicit-any params and locals in shared helpers

### DIFF
--- a/packages/dnb-eufemia/src/shared/IsolatedStyleScope.tsx
+++ b/packages/dnb-eufemia/src/shared/IsolatedStyleScope.tsx
@@ -129,7 +129,7 @@ export default function IsolatedStyleScope(
 export function getCurrentStyleScopeElement(
   currentElement: HTMLElement,
   scopeHash = 'auto',
-  fallback = null
+  fallback: Element | null = null
 ) {
   if (scopeHash === 'auto') {
     scopeHash = getStyleScopeHash()

--- a/packages/dnb-eufemia/src/shared/helpers/InteractionInvalidation.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/InteractionInvalidation.ts
@@ -55,7 +55,7 @@ export class InteractionInvalidation {
     this._nodesToInvalidate = null
   }
 
-  _runInvalidation(targetElement: TargetElement | TargetSelector) {
+  _runInvalidation(targetElement: TargetElement | TargetSelector): void {
     if (typeof document === 'undefined') {
       return undefined // stop here
     }
@@ -94,7 +94,7 @@ export class InteractionInvalidation {
     }
   }
 
-  _revertInvalidation() {
+  _revertInvalidation(): void {
     if (!Array.isArray(this._nodesToInvalidate)) {
       return undefined // stop here
     }

--- a/packages/dnb-eufemia/src/shared/helpers/debounce.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/debounce.ts
@@ -46,12 +46,12 @@ export function debounce<T extends any[], R>(
     async = false,
   }: DebouncedOptions = {}
 ): DebouncedFunction<T, R> & ReturnHelpers {
-  let timeout
+  let timeout: ReturnType<typeof setTimeout>
   let recall
   let resolvePromise
   let rejectPromise
   let canceled = false
-  const customCancels = []
+  const customCancels: Array<() => void> = []
 
   const cancel = () => {
     canceled = true
@@ -64,7 +64,7 @@ export function debounce<T extends any[], R>(
     })
   }
 
-  const addCancelEvent = (fn) => {
+  const addCancelEvent = (fn: () => void) => {
     if (!customCancels.includes(fn)) {
       customCancels.push(fn)
     }
@@ -85,7 +85,7 @@ export function debounce<T extends any[], R>(
     inst.cancel = cancel
     inst.addCancelEvent = addCancelEvent
 
-    const later = (callNow) => {
+    const later = (callNow?: boolean) => {
       timeout = null
       if (callNow || !immediate) {
         try {


### PR DESCRIPTION
Replace implicit-any parameters, locals and return types with real types in foundational shared helpers (no new any/unknown):

- debounce: type timeout (ReturnType<typeof setTimeout>), customCancels (Array<() => void>), addCancelEvent's fn and later's callNow params.
- InteractionInvalidation: annotate _runInvalidation/_revertInvalidation return type as void.
- IsolatedStyleScope: type getCurrentStyleScopeElement's fallback param as Element | null.

