### PR TITLE
chore(NumberFormat): make number-format utils strictNullChecks-safe

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
@@ -130,8 +130,8 @@ export const prepareMinus = (
   }
 
   // check for first and second char
-  const first = display[0]
-  const second = display[1]
+  const first = display.charAt(0)
+  const second = display.charAt(1)
 
   // Seems to be the invalid replacement
   if (first === '-' && second === '-') {

--- a/packages/dnb-eufemia/src/components/number-format/utils/iOS.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/iOS.ts
@@ -6,8 +6,10 @@ export function runIOSSelectionFix() {
   try {
     const selection = window.getSelection()
     const range = document.createRange()
-    selection.removeAllRanges()
-    selection.addRange(range)
+    if (selection) {
+      selection.removeAllRanges()
+      selection.addRange(range)
+    }
   } catch (e) {
     //
   }


### PR DESCRIPTION
Guard the possibly-null window.getSelection() result in the iOS selection fix, and use charAt() (which returns a string) for first/second char reads so empty input no longer yields undefined. Both changes are behaviour- preserving and remove the strictNullChecks violations in these files. Step toward enabling the strictNullChecks compiler flag.

