### PR TITLE
chore: type genuinely-clean implicit-any params in stable components

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionStore.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionStore.ts
@@ -23,7 +23,7 @@ export class AccordionStore {
   addInstance(instance: AccordionStoreInstance) {
     this._instances.push(instance)
   }
-  removeInstance(instance) {
+  removeInstance(instance: AccordionStoreInstance) {
     this._instances = this._instances.filter((inst) => inst !== instance)
   }
 }

--- a/packages/dnb-eufemia/src/components/modal/parts/ModalHeader.tsx
+++ b/packages/dnb-eufemia/src/components/modal/parts/ModalHeader.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useContext } from 'react'
-import type { HTMLProps, ReactNode } from 'react'
+import type { HTMLProps, ReactElement, ReactNode } from 'react'
 import { clsx } from 'clsx'
 import { findElementInChildren } from '../../../shared/component-helper'
 import type { SectionProps } from '../../section/Section'
@@ -47,9 +47,12 @@ export default function ModalHeader({
   Omit<HTMLProps<HTMLElement>, 'size' | 'title' | 'children'>) {
   const context = useContext(ModalContext)
 
-  const customHeader = findElementInChildren(children, (cur) => {
-    return cur.type === 'h1' || cur.type === H1
-  })
+  const customHeader = findElementInChildren(
+    children,
+    (cur: ReactElement) => {
+      return cur.type === 'h1' || cur.type === H1
+    }
+  )
 
   const usedTitle = title || context.title
   const showTitle = !customHeader && usedTitle

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import type { HTMLProps, ReactNode } from 'react'
+import type { ComponentProps, HTMLProps, ReactNode } from 'react'
 import { clsx } from 'clsx'
 import {
   extendExistingPropsWithContext,
@@ -200,7 +200,7 @@ function Skeleton(props: SkeletonProps) {
 
 export default Skeleton
 
-function Exclude(props) {
+function Exclude(props: ComponentProps<typeof Provider>) {
   return <Provider {...props} skeleton={false} />
 }
 

--- a/packages/dnb-eufemia/src/components/skeleton/SkeletonHelper.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/SkeletonHelper.tsx
@@ -50,7 +50,7 @@ export const createSkeletonClass = (
   method: SkeletonMethods,
   skeleton: SkeletonShow,
   context?: SkeletonContextValue,
-  className = null
+  className: string = null
 ) => {
   if (skeleton || (skeleton !== false && context?.skeleton)) {
     return clsx(

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionHead.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionHead.tsx
@@ -83,7 +83,7 @@ export function TableAccordionHead(allProps: TableAccordionHeadProps) {
   let headerContent = Children.toArray(children)
 
   const addContent = useCallback(
-    (content) => {
+    (content: ReturnType<typeof Children.toArray>[number]) => {
       if (tableContext.allProps.accordionChevronPlacement === 'right') {
         headerContent.push(content)
       } else {


### PR DESCRIPTION
Types 5 previously implicit-any parameters with their real types (no any/unknown), reducing noImplicitAny errors 2475 -> 2470 toward eventually enabling the flag. Type-only changes; baseline tsc green; skeleton/accordion/table/modal tests pass.

