### PR TITLE
chore: fix minor grammar in docs, tests, and comments

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/demos.mdx
@@ -56,7 +56,7 @@ By default the logo will use the inherited `font-size` to set its height.
 
 #### Alternative inherited height
 
-You can chose to let the height be set by the inherited `height` instead by setting the `inheritSize` property.
+You can choose to let the height be set by the inherited `height` instead by setting the `inheritSize` property.
 
 <LogoInheritHeightExample />
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeLibStyles.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeLibStyles.test.ts
@@ -39,7 +39,7 @@ describe('makeLibStyles transform main SCSS to CSS', () => {
     expect(global.css[0]).toMatch(new RegExp('.dnb-button\\s?{'))
   })
 
-  it('has to contain a icon selector as it is a dependency', () => {
+  it('has to contain an icon selector as it is a dependency', () => {
     expect(global.css[0]).toMatch(new RegExp('.dnb-icon\\s?{'))
   })
 

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -273,7 +273,7 @@ describe('Checkbox component', () => {
     expect(onChange).toHaveBeenCalledWith(true)
   })
 
-  it('has "onChange" event which will trigger on a input change', () => {
+  it('has "onChange" event which will trigger on an input change', () => {
     const myEvent = vi.fn()
     render(<Checkbox onChange={myEvent} checked={false} />)
     screen.getByRole('checkbox').click()

--- a/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/__tests__/FormLabel.test.tsx
@@ -338,7 +338,7 @@ describe('FormLabel component', () => {
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 
-  it('should validate with ARIA rules as a label with a input', async () => {
+  it('should validate with ARIA rules as a label with an input', async () => {
     const Comp = render(
       <>
         <FormLabel text="Text" forId="input" />

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -1056,7 +1056,7 @@ describe('Input ARIA', () => {
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 
-  it('should validate with ARIA rules as a input with a label', async () => {
+  it('should validate with ARIA rules as an input with a label', async () => {
     const Comp = render(
       <>
         <label htmlFor="input">text</label>

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -36,7 +36,7 @@ describe('Radio component', () => {
     expect(document.querySelector('input').value).toBe(value)
   })
 
-  it('has "onChange" event which will trigger on a input change', () => {
+  it('has "onChange" event which will trigger on an input change', () => {
     const myEvent = vi.fn()
     render(<Radio onChange={myEvent} checked={false} group={null} />)
     fireEvent.click(document.querySelector('input'))

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -39,7 +39,7 @@ describe('Switch component', () => {
     expect(document.querySelector('input').value).toBe(value)
   })
 
-  it('has "onChange" event which will trigger on a input change', () => {
+  it('has "onChange" event which will trigger on an input change', () => {
     const myEvent = vi.fn()
 
     render(<Switch onChange={myEvent} checked={false} />)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Password/__tests__/Password.test.tsx
@@ -251,7 +251,7 @@ describe('Password component', () => {
     )
   })
 
-  it('should validate with ARIA rules as a input with a label', async () => {
+  it('should validate with ARIA rules as an input with a label', async () => {
     const result = render(
       <Field.Password id="input" label="label" value="some value" />
     )

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -263,7 +263,7 @@ describe('DrawerList component', () => {
 
       keydown('Enter')
       await waitFor(() => {
-        // onChange and onSelect is not called when attempting to chose a disabled item
+        // onChange and onSelect is not called when attempting to choose a disabled item
         expect(onChange).toHaveBeenCalledTimes(0)
         expect(onSelect).toHaveBeenCalledTimes(2)
       })

--- a/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
+++ b/packages/dnb-eufemia/src/style/core/helper-classes/helper-classes.scss
@@ -67,7 +67,7 @@
 
   font-size: var(--font-size-basis);
   line-height: var(--line-height-basis);
-  word-break: normal; // because of "kr" usage together with "stretch" on a input/textarea
+  word-break: normal; // because of "kr" usage together with "stretch" on an input/textarea
 }
 
 .dnb-page-background {


### PR DESCRIPTION
- Correct "a input"/"a icon" to "an input"/"an icon" (article before vowel sound)
- Correct "chose" to "choose" (verb form) in Logo docs and a DrawerList comment

