### PR TITLE
fix: restore the attributes prop merge on form input elements

### DIFF
--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -24,6 +24,7 @@ import {
   getStatusState,
   combineDescribedBy,
   extendPropsWithContext,
+  mergeAttributes,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
@@ -91,6 +92,7 @@ export type CheckboxProps = {
   suffix?: ReactNode
   value?: string
   element?: ElementType
+  attributes?: Record<string, unknown>
   /**
    * If set to `true`, an overlaying skeleton with animation will be shown.
    */
@@ -160,6 +162,7 @@ function Checkbox(localProps: CheckboxProps) {
     onChange,
     onClick,
     ref: refProp,
+    attributes,
     ...rest
   } = props as typeof props & {
     labelDirection?: 'vertical' | 'horizontal'
@@ -296,9 +299,13 @@ function Checkbox(localProps: CheckboxProps) {
     }
 
     return removeSpaceProps(
-      domAttributes as SpacingProps & Record<string, unknown>
+      mergeAttributes(
+        domAttributes as SpacingProps & Record<string, unknown>,
+        attributes
+      )
     )
   }, [
+    attributes,
     context,
     disabled,
     id,

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -404,6 +404,17 @@ describe('Checkbox component', () => {
     expect(input).not.toHaveAttribute('left')
   })
 
+  it('should merge the attributes prop onto the input element', () => {
+    render(<Checkbox attributes={{ 'data-foo': 'bar' }} />)
+
+    const input = document.querySelector('input')
+
+    // The public `attributes` prop is applied to the input element, and the
+    // raw object is never forwarded as an `attributes` DOM attribute
+    expect(input).toHaveAttribute('data-foo', 'bar')
+    expect(input).not.toHaveAttribute('attributes')
+  })
+
   it('should inherit formElement vertical label', () => {
     render(
       <Provider

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -211,6 +211,7 @@ export type InputProps = Omit<
      * Provide the Input element with any attributes by using an Object `inputAttributes={{size:'2'}}` or a JSON Object `inputAttributes='{"size":"2"}'`. **NB:** Keep in mind, that also every not listed component property will be sent along and set as an Input element attribute.
      */
     inputAttributes?: InputInputAttributes
+    attributes?: Record<string, unknown>
     /**
      * By providing a new component we can change the internally used element. Also supports a string only, like `inputElement="input"`.
      */
@@ -573,6 +574,9 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   const {
     onSubmitBlur, //eslint-disable-line
     onSubmitFocus, //eslint-disable-line
+    // The public `attributes` prop must be merged onto the input element, not
+    // spread as a raw `attributes` object. Extract it so it does not leak.
+    attributes: attributesProp,
     ...attributes
   } = inputSubmitButtonAttributes
 
@@ -691,6 +695,8 @@ function InputComponent({ ref, ...restProps }: InputProps) {
   if (inputParams.disabled === true) {
     inputParams['aria-disabled'] = true
   }
+
+  mergeAttributes(inputParams, attributesProp)
 
   if (InputElement && typeof InputElement === 'function') {
     InputElement = (

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -813,6 +813,17 @@ describe('Input with clear button', () => {
     )
   })
 
+  it('should merge the attributes prop onto the input element', () => {
+    render(<Input attributes={{ 'data-foo': 'bar' }} />)
+
+    const input = document.querySelector('input')
+
+    // The public `attributes` prop is applied to the input element, and the
+    // raw object is never forwarded as an `attributes` DOM attribute
+    expect(input).toHaveAttribute('data-foo', 'bar')
+    expect(input).not.toHaveAttribute('attributes')
+  })
+
   it('should inherit formElement vertical label', () => {
     render(
       <Provider formElement={{ labelDirection: 'vertical' }}>

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -23,6 +23,7 @@ import {
   combineDescribedBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
+  mergeAttributes,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
@@ -97,6 +98,7 @@ export type RadioProps = {
   value?: string
   skeleton?: SkeletonShow
   readOnly?: boolean
+  attributes?: Record<string, unknown>
   className?: string
   children?: RadioChildren
   onChange?: (event: RadioChangeEvent) => void
@@ -426,6 +428,13 @@ function RadioComponent({ ref: externalRef, ...ownProps }: RadioProps) {
   if (inputParams.disabled === true) {
     inputParams['aria-disabled'] = true
   }
+
+  // Merge the public `attributes` prop onto the input element, then drop the raw
+  // object and non-DOM props (e.g. `labelDirection`) that the ownProps
+  // re-application above may have put on inputParams, so they don't leak to the DOM.
+  mergeAttributes(inputParams, inputParams.attributes)
+  delete inputParams.attributes
+  delete inputParams.labelDirection
 
   inputParams = removeSpaceProps(inputParams)
 

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -148,6 +148,30 @@ describe('Radio component', () => {
     expect(input).not.toHaveAttribute('left')
   })
 
+  it('should merge the attributes prop onto the input element', () => {
+    render(<Radio attributes={{ 'data-foo': 'bar' }} />)
+
+    const input = document.querySelector('input')
+
+    // The public `attributes` prop is applied to the input element, and the
+    // raw object is never forwarded as an `attributes` DOM attribute
+    expect(input).toHaveAttribute('data-foo', 'bar')
+    expect(input).not.toHaveAttribute('attributes')
+  })
+
+  it('should not forward labelDirection to the input element', () => {
+    // labelDirection is not a public Radio prop, but formElement context / JS
+    // consumers can supply it; it must not leak onto the input element.
+    const props: RadioProps & { labelDirection?: string } = {
+      labelDirection: 'horizontal',
+    }
+    render(<Radio {...props} />)
+
+    expect(document.querySelector('input')).not.toHaveAttribute(
+      'labeldirection'
+    )
+  })
+
   it('should support inline styling', () => {
     render(<Radio style={{ color: 'red' }} />)
 

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -32,6 +32,7 @@ import {
   warn,
   dispatchCustomElementEvent,
   convertJsxToString,
+  mergeAttributes,
 } from '../../shared/component-helper'
 import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
@@ -160,6 +161,7 @@ export type TextareaProps = Omit<
     autoResizeMaxRows?: TextareaAutoresizeMaxRows
     textareaClassName?: string
     readOnly?: boolean
+    attributes?: Record<string, unknown>
     rows?: TextareaRows
     cols?: TextareaCols
     className?: string
@@ -253,6 +255,9 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     value: _value,
     textareaElement: _textareaElement,
     ref: _ref,
+    // The public `attributes` prop must be merged onto the textarea element, not
+    // spread as a raw `attributes` object. Extract it so it does not leak.
+    attributes: attributesProp,
     ...attributes
   } = props
 
@@ -547,6 +552,8 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
   if (textareaParams.disabled === true) {
     textareaParams['aria-disabled'] = true
   }
+
+  mergeAttributes(textareaParams, attributesProp)
 
   if (TextareaElement && typeof TextareaElement === 'function') {
     TextareaElement = TextareaElement(textareaParams, textareaRef)

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
@@ -251,6 +251,17 @@ describe('Textarea component', () => {
     )
   })
 
+  it('should merge the attributes prop onto the textarea element', () => {
+    render(<Textarea attributes={{ 'data-foo': 'bar' }} />)
+
+    const textarea = document.querySelector('textarea')
+
+    // The public `attributes` prop is applied to the textarea element, and the
+    // raw object is never forwarded as an `attributes` DOM attribute
+    expect(textarea).toHaveAttribute('data-foo', 'bar')
+    expect(textarea).not.toHaveAttribute('attributes')
+  })
+
   it('should accept props like autoResize via provider', () => {
     render(
       <Provider Textarea={{ autoResize: true }}>


### PR DESCRIPTION
## Summary

The removal of the shared `validateDOMAttributes` helper in #8759 also removed the merge of the public `attributes` prop on the main input elements of **Input**, **Checkbox**, **Radio** and **Textarea**.

As a result, passing `attributes={{ 'data-foo': 'bar' }}` to these components:

- **silently dropped** the intended attribute (`data-foo` never reached the element), and
- **leaked the raw object** onto the DOM as `attributes="[object Object]"`.

React emits **no warning** for this, so the failure was invisible to the existing test suite — the guard tests added in #8759 only asserted that spacing props don't leak, never that the `attributes` prop merges.

`Switch`, `RadioGroup`, `FormStatus` and `Icon` were migrated correctly in #8759 and are unaffected.

## Root cause

`validateDOMAttributes(props, params)` did several jobs; one was merging the public `attributes` prop into the DOM params (and deleting the raw key). For these four components the merge was not reconstructed — only the spacing-strip (`removeSpaceProps`) and `aria-disabled` handling were.

## Changes

- Re-merge the `attributes` prop via `mergeAttributes` onto the input/textarea element for **Input**, **Checkbox**, **Radio** and **Textarea**, and keep the raw object from being forwarded to the DOM.
- **Radio**: additionally drop `labelDirection`, which the existing `ownProps` re-application can otherwise forward to the `<input>` as an invalid DOM attribute.
- Type `attributes?: Record<string, unknown>` on `InputProps`, `CheckboxProps`, `RadioProps` and `TextareaProps` (consistent with how `Switch`, `RadioGroup`, `FormStatus` and `Icon` already type it).

## Tests

- Added a regression test per component asserting that `attributes={{ 'data-foo': 'bar' }}` is applied to the element **and** that no raw `attributes` attribute is forwarded.
- Added a Radio test asserting `labelDirection` does not leak onto the input.

## Verification

- `yarn test:types` — 0 errors
- Input / Checkbox / Radio / Textarea suites green (incl. InputMasked)
- Prettier + ESLint clean

## Notes

- The `attributes` prop was already handled at runtime before #8759; this restores that behavior and makes the prop explicit in the types. No runtime change for consumers who don't use `attributes`.
