### PR TITLE
chore: revert remove deprecated validateDOMAttributes helper (#8759)

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -229,7 +229,10 @@ How you make [spacing](/uilib/layout/space) support available varies from case t
 ```tsx
 import { Context } from '../../shared'
 import { clsx } from 'clsx'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import { useSpacing } from '../space/SpacingUtils'
 
 import type { SpacingProps } from '../../shared/types'
@@ -252,9 +255,10 @@ function MyComponent(props: ComponentAllProps) {
     // ...
   )
 
-  // This hook applies spacing classes and CSS custom properties to the root
-  // element props, and strips the spacing properties (space, top, right,
-  // bottom, left, innerSpace, noCollapse) so only valid HTML attributes remain.
+  // This helper will remove e.g. all spacing properties so you get only valid HTML attributes
+  validateDOMAttributes(props, rest)
+
+  // This hook applies spacing classes and CSS custom properties to the root element props
   const rootParams = useSpacing(props, {
     ...rest,
     className: clsx('dnb-my-component', className),

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -17,6 +17,7 @@ import { clsx } from 'clsx'
 import {
   findElementInChildren,
   extendPropsWithContext,
+  validateDOMAttributes,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import { useSpacing } from '../space/SpacingUtils'
@@ -403,7 +404,7 @@ function AccordionDefault({
 
     contentRef,
 
-    ..._restOfExtendedProps
+    ...restOfExtendedProps
   } = extendedProps
 
   const mainParams = useSpacing(extendedProps, {
@@ -420,6 +421,9 @@ function AccordionDefault({
   if (disabled) {
     mainParams.onClick = handleDisabledClick
   }
+
+  // to remove spacing props
+  validateDOMAttributes(props, restOfExtendedProps)
 
   const extendedPropsForContext = extendPropsWithContext(
     props,

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -14,13 +14,14 @@ import type { HTMLProps, ReactNode, RefObject } from 'react'
 import { clsx } from 'clsx'
 import {
   warn,
+  validateDOMAttributes,
   processChildren,
   getClosestParent,
 } from '../../shared/component-helper'
 import { useMediaQuery } from '../../shared'
 import type { AccordionContextValue } from './AccordionContext'
 import AccordionContext from './AccordionContext'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import HeightAnimation from '../height-animation/HeightAnimation'
 import type { SpacingProps } from '../../shared/types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
@@ -99,6 +100,7 @@ function AccordionContentStandalone({
     className: clsx('dnb-accordion__content', className),
     ...rest,
   })
+  validateDOMAttributes(props, wrapperParams)
 
   return (
     <AccordionTertiaryContent
@@ -232,7 +234,7 @@ function AccordionContentComponent(props: AccordionContentProps) {
 
   const wrapperParams = {
     className: clsx('dnb-accordion__content', className),
-    ...removeSpaceProps(rest),
+    ...rest,
   }
 
   const keepInDOMContent = keepInDOM || preventRerender
@@ -251,6 +253,10 @@ function AccordionContentComponent(props: AccordionContentProps) {
     innerParams.disabled = true
     innerParams['aria-hidden'] = true
   }
+
+  // to remove spacing props
+  validateDOMAttributes(props, wrapperParams)
+  validateDOMAttributes(null, innerParams)
 
   const animate = !noAnimation && (singleContainer ? isSmallScreen : true)
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -9,9 +9,10 @@ import type { HTMLProps, RefObject } from 'react'
 import { clsx } from 'clsx'
 import {
   extendPropsWithContext,
+  validateDOMAttributes,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import useId from '../../shared/helpers/useId'
 
 import Context from '../../shared/Context'
@@ -109,7 +110,12 @@ const AccordionGroup = (props: AccordionGroupProps) => {
     ),
   })
 
-  const params = removeSpaceProps(restOfExtendedProps)
+  const params = {
+    ...restOfExtendedProps,
+  }
+
+  // also used for code markup simulation
+  validateDOMAttributes(props, params)
 
   const fallbackGroup = useId()
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -12,7 +12,10 @@ import type {
 } from 'react'
 import type { SpacingProps } from '../../shared/types'
 
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import IconPrimary from '../icon-primary/IconPrimary'
 import Icon from '../icon/Icon'
 import { chevron_down, chevron_up } from '../../icons'
@@ -397,6 +400,8 @@ export const AccordionHeader = ({
   }
 
   skeletonDOMAttributes(headerParams, skeleton, context)
+
+  validateDOMAttributes(props, headerParams)
 
   let Element = 'div'
 

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -44,18 +44,18 @@ import type { SpacingProps } from '../../shared/types'
 import {
   warn,
   extendPropsWithContext,
+  validateDOMAttributes,
   dispatchCustomElementEvent,
   getStatusState,
   combineDescribedBy,
   escapeRegexChars,
   getClosestParent,
-  removeNullProps,
 } from '../../shared/component-helper'
 import { IS_MAC, debounce, hasSelectedText } from '../../shared/helpers'
 import useId from '../../shared/helpers/useId'
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import Suffix from '../../shared/helpers/Suffix'
@@ -2338,8 +2338,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const hasVisibleListContent = drawerList.data.length > 0
   const isExpanded = Boolean(open) && hasVisibleListContent
 
-  const cleanedAttributes = removeNullProps(removeSpaceProps(attributes))
-  attributesRef.current = cleanedAttributes
+  attributesRef.current = validateDOMAttributes(null, attributes)
   Object.assign(drawerList.attributes, attributesRef.current)
 
   const mainParams = useSpacing(props, {
@@ -2390,7 +2389,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     iconPosition: iconPosition,
     disabled,
     skeleton,
-    ...cleanedAttributes,
+    ...attributes,
   }
 
   if (!(parseFloat(String(selectedItem)) > -1)) {
@@ -2468,6 +2467,9 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     showStatus || suffix || currentDataItem?.suffixValue
       ? `${id}-inner`
       : null
+
+  validateDOMAttributes(null, mainParams)
+  validateDOMAttributes(null, shellParams)
 
   // VoiceOver support helper
   const voiceOverActiveItem = (() => {

--- a/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/Avatar.tsx
@@ -24,6 +24,7 @@ import Context from '../../shared/Context'
 import type { SpacingProps } from '../../shared/types'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import {
+  validateDOMAttributes,
   extendPropsWithContext,
   warn,
 } from '../../shared/component-helper'
@@ -180,6 +181,8 @@ const Avatar = (localProps: AvatarAllProps) => {
       `Avatar group required: An Avatar requires an Avatar.Group with label description as a parent component. This is to ensure correct semantics and accessibility.`
     )
   }
+
+  validateDOMAttributes(allProps, props)
 
   const style = {
     '--avatar-background-color': getColor(backgroundColor),

--- a/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarGroup.tsx
@@ -3,11 +3,14 @@ import type { HTMLProps, ReactNode } from 'react'
 import { clsx } from 'clsx'
 
 // Components
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { AvatarSizes, AvatarVariants } from './Avatar'
 
 // Shared
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import Context from '../../shared/Context'
 import type { SpacingProps } from '../../shared/types'
 import type { SkeletonShow } from '../skeleton/Skeleton'
@@ -133,14 +136,12 @@ const AvatarGroup = (localProps: AvatarGroupAllProps) => {
     className: clsx('dnb-avatar__group', className),
   })
 
-  // Remove spacing props so they don't leak onto the DOM element or
-  // propagate to the child Avatars through the context value below.
-  const cleanProps = removeSpaceProps(props)
-  const { skeleton, ...attributes } = cleanProps
+  // validateDOMAttributes mutates props, so call it after useSpacing
+  const { skeleton, ...attributes } = validateDOMAttributes({}, props)
 
   return (
     <AvatarGroupContext
-      value={{ ...cleanProps, variant, size, color, backgroundColor }}
+      value={{ ...props, variant, size, color, backgroundColor }}
     >
       <span {...rootProps} {...attributes}>
         <span className="dnb-sr-only">{label}</span>

--- a/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
+++ b/packages/dnb-eufemia/src/components/avatar/__tests__/Avatar.test.tsx
@@ -20,29 +20,6 @@ describe('Avatar', () => {
     expect(document.querySelector('.dnb-avatar')).toBeInTheDocument()
   })
 
-  it('should support spacing props without forwarding them to the DOM or child avatars', () => {
-    render(
-      <Avatar.Group label="label" top="2rem">
-        <Avatar>A</Avatar>
-      </Avatar.Group>
-    )
-
-    const group = document.querySelector('.dnb-avatar__group')
-
-    // Spacing becomes a class on the group wrapper
-    expect(group.classList).toContain('dnb-space__top--large')
-
-    // ...but the spacing prop must not leak onto the wrapper element
-    expect(group).not.toHaveAttribute('top')
-
-    // ...and must not propagate to the child avatars
-    const avatar = document.querySelector('.dnb-avatar')
-    expect(Array.from(avatar.classList)).not.toContain(
-      'dnb-space__top--large'
-    )
-    expect(avatar).not.toHaveAttribute('top')
-  })
-
   it('renders children as text', () => {
     const children = 'E'
     render(

--- a/packages/dnb-eufemia/src/components/badge/Badge.tsx
+++ b/packages/dnb-eufemia/src/components/badge/Badge.tsx
@@ -4,7 +4,7 @@ import type { CSSProperties, HTMLProps, JSX, ReactNode } from 'react'
 import { clsx } from 'clsx'
 
 // Components
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 
 // Shared
@@ -15,6 +15,7 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import {
   warn,
   extendPropsWithContext,
+  validateDOMAttributes,
 } from '../../shared/component-helper'
 import useNumberFormat from '../number-format/useNumberFormat'
 
@@ -167,8 +168,8 @@ const BadgeElem = propGuard((props: BadgeElemProps) => {
     return null
   }
 
-  // remove spacing props so they don't leak onto the DOM element
-  const domAttributes = removeSpaceProps(restProps)
+  // to remove spacing props, etc.
+  validateDOMAttributes(props, restProps)
 
   const skeletonClasses = createSkeletonClass('shape', skeleton, context)
   const contentIsNum = typeof contentProp === 'number'
@@ -200,7 +201,7 @@ const BadgeElem = propGuard((props: BadgeElemProps) => {
         skeletonClasses,
         className
       )}
-      {...domAttributes}
+      {...restProps}
     >
       {label && <span className="dnb-sr-only">{label} </span>}
       {content}

--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -44,6 +44,7 @@ import type { BreadcrumbItemProps } from './BreadcrumbItem'
 import BreadcrumbItem from './BreadcrumbItem'
 import {
   convertJsxToString,
+  validateDOMAttributes,
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import { BreadcrumbMultiple } from './BreadcrumbMultiple'
@@ -222,6 +223,8 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
 
     return variant
   }, [data, items, variant])
+
+  validateDOMAttributes(allProps, props)
 
   const navProps = useSpacing(allProps, {
     ...props,

--- a/packages/dnb-eufemia/src/components/button/Button.tsx
+++ b/packages/dnb-eufemia/src/components/button/Button.tsx
@@ -21,7 +21,7 @@ import {
   convertJsxToString,
   extendExistingPropsWithContext,
   removeUndefinedProps,
-  removeNullProps,
+  validateDOMAttributes,
   processChildren,
   getStatusState,
   combineDescribedBy,
@@ -287,7 +287,6 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
     element,
     selected,
     id: _id, // excluded so the default `null` does not override the resolvedId
-    ref: _ref, // excluded so the default `null` does not override the forwarded ref
     ...attributes
   } = props
 
@@ -446,15 +445,8 @@ function Button({ ref, transitionState, ...restProps }: ButtonProps) {
 
   skeletonDOMAttributes(params, skeleton, context)
 
-  if (params.disabled === true) {
-    params['aria-disabled'] = true
-  }
-
-  // Strip the `null` default props (e.g. `to`, `target`, `rel`) so they are
-  // not forwarded to the element. React ignores `null` DOM attributes, but a
-  // custom `element` component (e.g. a router Link) would treat `to={null}`
-  // as a real prop and navigate to the wrong location.
-  removeNullProps(params)
+  // also used for code markup simulation
+  validateDOMAttributes(restProps, params)
 
   return (
     <>

--- a/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
+++ b/packages/dnb-eufemia/src/components/button/__tests__/Button.test.tsx
@@ -297,28 +297,6 @@ describe('Button component', () => {
       expect(document.querySelector('a')).not.toHaveAttribute('href')
     })
 
-    it('does not forward null default props (such as "to") to a custom element', () => {
-      const receivedProps: Record<string, unknown> = {}
-      const CustomElement = (elementProps: Record<string, unknown>) => {
-        Object.assign(receivedProps, elementProps)
-        return <span className="custom-element" />
-      }
-
-      render(
-        <Button
-          text="Go"
-          element={CustomElement}
-          href="/local/path"
-          icon={null}
-        />
-      )
-
-      // The href has to be forwarded, but the null "to" default must be
-      // stripped – otherwise a router Link would navigate to to={null}
-      expect(receivedProps.href).toBe('/local/path')
-      expect('to' in receivedProps).toBe(false)
-    })
-
     describe('disabled', () => {
       it('should validate with ARIA rules as a anchor', async () => {
         const Comp = render(<Button {...props} href="https://url" />)

--- a/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/Checkbox.tsx
@@ -21,12 +21,13 @@ import type {
 } from 'react'
 import { clsx } from 'clsx'
 import {
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -146,7 +147,6 @@ function Checkbox(localProps: CheckboxProps) {
     size,
     label,
     labelPosition,
-    labelDirection,
     labelSrOnly,
     title,
     element,
@@ -161,9 +161,7 @@ function Checkbox(localProps: CheckboxProps) {
     onClick,
     ref: refProp,
     ...rest
-  } = props as typeof props & {
-    labelDirection?: 'vertical' | 'horizontal'
-  }
+  } = props
 
   const [, forceUpdate] = useReducer(() => ({}), {})
   const id = useId(idProp)
@@ -265,7 +263,7 @@ function Checkbox(localProps: CheckboxProps) {
   const showStatus = getStatusState(status)
 
   /**
-   * Adds aria attributes, applies skeletonDOMAttributes, strips spacing props and returns the result
+   * Adds aria attributes, calls validateDOMAttributes and skeletonDOMAttributes and returns the result
    */
   const handleInputAttributes = useCallback(() => {
     const inputParams = {
@@ -286,17 +284,10 @@ function Checkbox(localProps: CheckboxProps) {
       inputParams['aria-readonly'] = inputParams.readOnly = true
     }
 
-    const domAttributes = skeletonDOMAttributes(
-      inputParams,
-      skeleton,
-      context
-    )
-    if (domAttributes.disabled === true) {
-      domAttributes['aria-disabled'] = true
-    }
-
-    return removeSpaceProps(
-      domAttributes as SpacingProps & Record<string, unknown>
+    // also used for code markup simulation
+    return validateDOMAttributes(
+      props,
+      skeletonDOMAttributes(inputParams, skeleton, context)
     )
   }, [
     context,

--- a/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/dnb-eufemia/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -381,29 +381,6 @@ describe('Checkbox component', () => {
     )
   })
 
-  it('should not forward spacing props to the input element', () => {
-    render(
-      <Checkbox
-        top="2rem"
-        right="2rem"
-        bottom="2rem"
-        left="2rem"
-        space="small"
-        innerSpace="small"
-      />
-    )
-
-    const input = document.querySelector('input')
-
-    // Spacing props must become wrapper classes, never DOM attributes on the input
-    expect(input).not.toHaveAttribute('space')
-    expect(input).not.toHaveAttribute('innerSpace')
-    expect(input).not.toHaveAttribute('top')
-    expect(input).not.toHaveAttribute('right')
-    expect(input).not.toHaveAttribute('bottom')
-    expect(input).not.toHaveAttribute('left')
-  })
-
   it('should inherit formElement vertical label', () => {
     render(
       <Provider

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -27,9 +27,10 @@ import {
   extendPropsWithContext,
   getStatusState,
   combineDescribedBy,
+  validateDOMAttributes,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { skeletonDOMAttributes } from '../skeleton/SkeletonHelper'
 
 import Context from '../../shared/Context'
@@ -698,12 +699,11 @@ function DatePicker(externalProps: DatePickerAllProps) {
       'dnb-date-picker__container--show-footer'
   )
 
-  const remainingDOMProps = removeSpaceProps(attributes)
-  const remainingSubmitProps = submitParams
-  const remainingPickerProps = skeletonDOMAttributes(
-    pickerParams,
-    skeleton,
-    context
+  const remainingDOMProps = validateDOMAttributes(props, attributes)
+  const remainingSubmitProps = validateDOMAttributes(null, submitParams)
+  const remainingPickerProps = validateDOMAttributes(
+    null,
+    skeletonDOMAttributes(pickerParams, skeleton, context)
   )
 
   return (

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerInput.tsx
@@ -28,9 +28,7 @@ import Button from '../button/Button'
 import type { ButtonProps } from '../Button'
 import Input, { SubmitButton } from '../input/Input'
 import type { InputElement, InputSize } from '../Input'
-import { warn } from '../../shared/component-helper'
-import { removeSpaceProps } from '../space/SpacingUtils'
-import type { SpacingProps } from '../../shared/types'
+import { warn, validateDOMAttributes } from '../../shared/component-helper'
 import { convertStringToDate } from './DatePickerCalc'
 import DatePickerContext from './DatePickerContext'
 
@@ -153,12 +151,8 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
     triggerProps,
     _omitInputShellClass,
 
-    ...restAttributes
+    ...attributes
   } = props
-
-  const attributes = removeSpaceProps(
-    restAttributes as SpacingProps & Record<string, unknown>
-  )
   const [focusState, setFocusState] = useState<string>('virgin')
 
   const invalidDatesRef = useRef<DatePickerInvalidDates>({
@@ -891,6 +885,9 @@ function DatePickerInput(externalProps: DatePickerInputProps) {
         : translation.openPickerText,
     [selectedDateTitle, translation]
   )
+
+  validateDOMAttributes(props, attributes)
+  validateDOMAttributes(null, submitProps)
 
   const SubmitElement: ElementType = useMemo(
     () => (showInput ? SubmitButton : Button),

--- a/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/DialogContent.tsx
@@ -6,7 +6,10 @@
 import { useContext } from 'react'
 import type { JSX, ReactElement } from 'react'
 import { clsx } from 'clsx'
-import { findElementInChildren } from '../../shared/component-helper'
+import {
+  findElementInChildren,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import ScrollView from '../../fragments/scroll-view/ScrollView'
 import DialogHeader from './parts/DialogHeader'
 import DialogNavigation from './parts/DialogNavigation'
@@ -113,6 +116,8 @@ export default function DialogContent({
     hideConfirm,
     status,
   }
+
+  validateDOMAttributes({}, contentParams)
 
   return (
     <div {...contentParams}>

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -20,13 +20,13 @@ import type {
 } from 'react'
 import { clsx } from 'clsx'
 import {
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
   convertJsxToString,
   removeUndefinedProps,
-  removeNullProps,
 } from '../../shared/component-helper'
 import { extendPropsWithContext } from '../../shared/helpers/extendPropsWithContext'
 import useMountEffect from '../../shared/helpers/useMountEffect'
@@ -34,7 +34,7 @@ import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLay
 import useId from '../../shared/helpers/useId'
 import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 
@@ -504,9 +504,10 @@ const DropdownComponent = memo(function DropdownComponent({
   const { id, selectedItem, direction, open } = context.drawerList
   const showStatus = getStatusState(status)
 
-  const cleanedAttributes = removeNullProps(removeSpaceProps(attributes))
-
-  Object.assign(context.drawerList.attributes, cleanedAttributes)
+  Object.assign(
+    context.drawerList.attributes,
+    validateDOMAttributes(null, attributes)
+  )
 
   const mainParams = useSpacing(props, {
     className: clsx(
@@ -534,11 +535,9 @@ const DropdownComponent = memo(function DropdownComponent({
     ),
     id,
     disabled,
-    'aria-haspopup': (handleAsMenu ? true : 'listbox') as
-      | boolean
-      | 'listbox',
+    'aria-haspopup': handleAsMenu ? true : 'listbox',
     'aria-expanded': open,
-    ...cleanedAttributes,
+    ...attributes,
     onFocus: onFocusHandler,
     onBlur: onBlurHandler,
     onClick: onClickHandler,
@@ -565,8 +564,12 @@ const DropdownComponent = memo(function DropdownComponent({
     )
   }
 
+  // also used for code markup simulation
+  validateDOMAttributes(null, mainParams)
+  validateDOMAttributes(ownProps, triggerParams)
+
   // make it possible to grab the rest attributes and return it with all events
-  attributesRef.current = cleanedAttributes
+  attributesRef.current = validateDOMAttributes(null, attributes)
 
   return (
     <span ref={setRootRef} {...mainParams}>

--- a/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
+++ b/packages/dnb-eufemia/src/components/form-label/FormLabel.tsx
@@ -13,7 +13,10 @@ import {
 } from 'react'
 import type { HTMLAttributes, ReactNode, Ref, RefObject } from 'react'
 import { clsx } from 'clsx'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import { useSpacing } from '../space/SpacingUtils'
 import {
   createSkeletonClass,
@@ -228,6 +231,7 @@ function FormLabel(localProps: FormLabelAllProps) {
   }, [forId, labelRef])
 
   skeletonDOMAttributes(params, skeleton, context)
+  validateDOMAttributes(localProps, params)
 
   return <Element {...params}>{content}</Element>
 }

--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -17,7 +17,7 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 import { useTheme, Context } from '../../shared'
 import useId from '../../shared/helpers/useId'
 import {
-  mergeAttributes,
+  validateDOMAttributes,
   processChildren,
   extendPropsWithContext,
   removeUndefinedProps,
@@ -501,7 +501,6 @@ function FormStatusComponent(
     role,
     icon: _icon,
     iconSize: _iconSize,
-    attributes,
     ...rest
   } = restOfProps
 
@@ -548,7 +547,9 @@ function FormStatusComponent(
 
   skeletonDOMAttributes(params, skeleton, context)
 
-  mergeAttributes(params, attributes)
+  // also used for code markup simulation
+  validateDOMAttributes(restOwnProps, params)
+  validateDOMAttributes(null, textParams)
 
   return (
     <HeightAnimation

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
@@ -307,17 +307,6 @@ describe('FormStatus component', () => {
     )
   })
 
-  it('should forward the attributes prop to the form status element', () => {
-    render(
-      <FormStatus attributes={{ 'data-foo': 'bar' }}>test</FormStatus>
-    )
-
-    expect(document.querySelector('.dnb-form-status')).toHaveAttribute(
-      'data-foo',
-      'bar'
-    )
-  })
-
   it('should support "shellSpace" spacing props', () => {
     const { rerender } = render(
       <FormStatus shellSpace={{ top: '2rem' }}>test</FormStatus>

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -26,6 +26,7 @@ import Context from '../../shared/Context'
 import {
   warn,
   makeUniqueId,
+  validateDOMAttributes,
   dispatchCustomElementEvent,
 } from '../../shared/component-helper'
 import { extendPropsWithContext } from '../../shared/helpers/extendPropsWithContext'
@@ -38,7 +39,7 @@ import {
   skeletonDOMAttributes,
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import Hr from '../../elements/hr/Hr'
 import GlobalStatusController, {
   GlobalStatusInterceptor,
@@ -722,12 +723,13 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
 
   const params = {
     className: clsx('dnb-global-status', `dnb-global-status--${state}`),
-    ...removeSpaceProps(
-      attributes as SpacingProps & Record<string, unknown>
-    ),
+    ...attributes,
   }
 
   skeletonDOMAttributes(params, skeleton, context)
+
+  // also used for code markup simulation
+  validateDOMAttributes(ownProps, params)
 
   const itemsRenderHandler = (rawItem: GlobalStatusItem, i: number) => {
     const item = typeof rawItem === 'string' ? { text: rawItem } : rawItem

--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -6,6 +6,7 @@
 import { useContext, useEffect, useRef, useState } from 'react'
 import type { HTMLProps, JSX, ReactNode } from 'react'
 import { clsx } from 'clsx'
+import { validateDOMAttributes } from '../../shared/component-helper'
 import '../../shared/helpers'
 import { useSpacing } from '../space/SpacingUtils'
 import type { HeadingContextValue } from './HeadingContext'
@@ -274,6 +275,8 @@ export default function Heading(props: HeadingAllProps) {
       attributes['aria-level'] = String(level)
     }
   }
+
+  validateDOMAttributes(props, attributes)
 
   if (typeof context?.skeleton !== 'undefined') {
     skeleton = context.skeleton

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -9,14 +9,13 @@ import type {
 import { clsx } from 'clsx'
 import {
   warn,
-  mergeAttributes,
-  removeNullProps,
+  validateDOMAttributes,
   processChildren,
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import type { ContextProps } from '../../shared/Context'
 import Context from '../../shared/Context'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import { iconCase } from './IconHelpers'
 import type { SpacingProps } from '../../shared/types'
@@ -372,6 +371,8 @@ function prepareIconParams({
     params.height = parseFloat(String(height))
   }
 
+  validateDOMAttributes({}, params)
+
   return { params, sizeAsString }
 }
 
@@ -399,9 +400,8 @@ export function prepareIcon(
     skeleton,
     className,
     transitionState: _transitionState,
-    attributes: attributesProp,
-    ...restAttributes
-  } = props as IconAllProps & { attributes?: Record<string, unknown> }
+    ...attributes
+  } = props
 
   const { sizeAsString, iconParams } =
     cachedValues ||
@@ -422,7 +422,8 @@ export function prepareIcon(
   const isFilled = Boolean(fill)
 
   // some wrapper params
-  const wrapperParams: Record<string, any> = {
+  // also used for code markup simulation
+  const wrapperParams = validateDOMAttributes(props, {
     role: alt ? 'img' : 'presentation',
     alt, // in case the image don't shows up (because we define the role to be img)
     'aria-label':
@@ -430,10 +431,8 @@ export function prepareIcon(
         ? label.replace(/_/g, ' ') + ' icon'
         : null, // for screen readers only
     title, // to show on hover, if defined
-    ...removeSpaceProps(restAttributes),
-  }
-  mergeAttributes(wrapperParams, attributesProp)
-  removeNullProps(wrapperParams)
+    ...attributes,
+  })
   if (!alt && typeof wrapperParams['aria-hidden'] === 'undefined') {
     wrapperParams['aria-hidden'] = true
   }

--- a/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
+++ b/packages/dnb-eufemia/src/components/info-card/InfoCard.tsx
@@ -21,7 +21,10 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
 import type { SpacingProps } from '../../shared/types'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type InfoCardProps = {
@@ -162,6 +165,8 @@ const InfoCard = (localProps: InfoCardAllProps) => {
 
   const closeButtonIsHidden = !onClose && !closeButtonText
   const acceptButtonIsHidden = !onAccept && !acceptButtonText
+
+  validateDOMAttributes(allProps, props)
 
   const rootProps = useSpacing(allProps, {
     ...props,

--- a/packages/dnb-eufemia/src/components/input/Input.tsx
+++ b/packages/dnb-eufemia/src/components/input/Input.tsx
@@ -41,7 +41,7 @@ import Suffix from '../../shared/helpers/Suffix'
 import {
   warn,
   removeUndefinedProps,
-  mergeAttributes,
+  validateDOMAttributes,
   processChildren,
   getStatusState,
   combineDescribedBy,
@@ -49,7 +49,7 @@ import {
   convertJsxToString,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -644,7 +644,7 @@ function InputComponent({ ref, ...restProps }: InputProps) {
     'aria-placeholder': placeholder
       ? convertJsxToString(placeholder)
       : undefined,
-    ...removeSpaceProps(attributes),
+    ...attributes,
     ...usedInputAttributes,
     onChange: onChangeHandler,
     onKeyDown: onKeyDownHandler,
@@ -688,9 +688,9 @@ function InputComponent({ ref, ...restProps }: InputProps) {
 
   skeletonDOMAttributes(inputParams, skeleton, context)
 
-  if (inputParams.disabled === true) {
-    inputParams['aria-disabled'] = true
-  }
+  // also used for code markup simulation
+  validateDOMAttributes(restProps, inputParams)
+  validateDOMAttributes(null, shellParams)
 
   if (InputElement && typeof InputElement === 'function') {
     InputElement = (
@@ -917,7 +917,6 @@ function InputSubmitButton({
     statusState,
     statusProps,
     className,
-    attributes,
 
     onSubmitBlur: _onSubmitBlur, //eslint-disable-line
     onSubmitFocus: _onSubmitFocus, //eslint-disable-line
@@ -930,9 +929,7 @@ function InputSubmitButton({
     type: 'submit',
     'aria-label': title,
     disabled,
-    // Strip spacing props (e.g. `top` injected by a Flex parent) so they are
-    // not forwarded to the inner Button, where they would render as margins.
-    ...removeSpaceProps(rest as SpacingProps & typeof rest),
+    ...rest,
   }
 
   skeletonDOMAttributes(
@@ -941,7 +938,8 @@ function InputSubmitButton({
     context
   )
 
-  mergeAttributes(params, attributes)
+  // also used for code markup simulation
+  validateDOMAttributes(ownProps, params)
 
   return (
     <span

--- a/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
+++ b/packages/dnb-eufemia/src/components/input/__tests__/Input.test.tsx
@@ -708,23 +708,6 @@ describe('Input component', () => {
 
     expect(icon).toHaveClass('dnb-icon--medium')
   })
-
-  it('should not forward spacing props to the nested submit button', () => {
-    render(
-      <Input type="search" showSubmitButton value="value" top="large" />
-    )
-
-    // The spacing has to apply to the Input root only
-    expect(document.querySelector('.dnb-input')).toHaveClass(
-      'dnb-space__top--large'
-    )
-
-    // and must not leak onto the nested submit button, where it would
-    // render as a margin and change the layout
-    expect(
-      document.querySelector('.dnb-input__submit-button__button')
-    ).not.toHaveClass('dnb-space__top--large')
-  })
 })
 
 describe('Input with clear button', () => {
@@ -797,19 +780,6 @@ describe('Input with clear button', () => {
     expect(element).toHaveClass(
       'dnb-input dnb-input__border--tokens dnb-form-component dnb-input--text dnb-input--vertical dnb-space__top--large',
       { exact: true }
-    )
-  })
-
-  it('should not forward spacing props to the input element', () => {
-    render(<Input top="large" />)
-
-    const input = document.querySelector('input')
-    expect(input).not.toHaveAttribute('top')
-    expect(input).not.toHaveAttribute('space')
-
-    // spacing is applied to the outer component instead
-    expect(document.querySelector('.dnb-input')).toHaveClass(
-      'dnb-space__top--large'
     )
   })
 

--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -11,7 +11,10 @@ import type {
 } from 'react'
 import { clsx } from 'clsx'
 import Context from '../../shared/Context'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import { useSpacing } from '../space/SpacingUtils'
 import { DnbDefault } from './LogoSvg'
 import type { UseThemeReturn } from '../../shared/useTheme'
@@ -170,8 +173,12 @@ function Logo(localProps: LogoProps) {
     }
   }, [altText, color, height, width])
 
+  const remainingDOMProps = validateDOMAttributes(props, rootParams)
+
   return (
-    <span {...rootParams}>{renderCustomSvg(svg, svgParams, theme)}</span>
+    <span {...remainingDOMProps}>
+      {renderCustomSvg(svg, svgParams, theme)}
+    </span>
   )
 }
 

--- a/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
+++ b/packages/dnb-eufemia/src/components/number-format/NumberFormatBase.tsx
@@ -25,6 +25,7 @@ import Context, { type ContextProps } from '../../shared/Context'
 import useId from '../../shared/helpers/useId'
 import {
   warn,
+  validateDOMAttributes,
   convertJsxToString,
   extendExistingPropsWithContext,
   extendDeep,
@@ -529,6 +530,7 @@ function NumberFormatComponent(ownProps: NumberFormatAllProps) {
     displayParams.onContextMenu = onContextMenuHandler
   }
 
+  validateDOMAttributes(ownProps, attributes)
   skeletonDOMAttributes(attributes, skeleton as boolean, context)
 
   const Element = element as ElementType

--- a/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
+++ b/packages/dnb-eufemia/src/components/pagination/Pagination.tsx
@@ -17,6 +17,7 @@ import { clsx } from 'clsx'
 import PaginationContext from './PaginationContext'
 import PaginationProvider from './PaginationProvider'
 import {
+  validateDOMAttributes,
   extendExistingPropsWithContext,
   removeUndefinedProps,
 } from '../../shared/component-helper'
@@ -366,6 +367,8 @@ const PaginationInstance = memo(function PaginationInstance(
 
   // Pagination mode
   if (ctx.pagination.mode === 'pagination') {
+    validateDOMAttributes(props, mainParams)
+
     const content = items.find(
       ({ pageNumber }) => pageNumber === currentPageInternal
     )?.content

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
@@ -15,6 +15,7 @@ import { clsx } from 'clsx'
 import type { ContextProps } from '../../shared/Context'
 import Context from '../../shared/Context'
 import {
+  validateDOMAttributes,
   dispatchCustomElementEvent,
   extendPropsWithContext,
 } from '../../shared/component-helper'
@@ -53,7 +54,7 @@ function ProgressIndicator(props: ProgressIndicatorAllProps) {
     ...rest
   } = allProps
 
-  const remainingDOMProps = { ...rest }
+  const remainingDOMProps = validateDOMAttributes(allProps, { ...rest })
 
   const [sizeVariant, customSize]: [
     ProgressIndicatorAnimationProps['size'],

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorCircular.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react'
 import type { HTMLProps, RefObject } from 'react'
 import type * as CSS from 'csstype'
 import { clsx } from 'clsx'
+import { validateDOMAttributes } from '../../shared/component-helper'
 import type { ProgressIndicatorCircularAllProps } from './types'
 
 function ProgressIndicatorCircular(
@@ -136,7 +137,7 @@ function ProgressIndicatorCircular(
     rest['aria-busy'] = true
   }
 
-  const remainingDOMAttributes = { ...rest }
+  const remainingDOMAttributes = validateDOMAttributes(props, { ...rest })
 
   return (
     <span

--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicatorLinear.tsx
@@ -5,6 +5,7 @@
 
 import { useRef, useEffect } from 'react'
 import { clsx } from 'clsx'
+import { validateDOMAttributes } from '../../shared/component-helper'
 import type { ProgressIndicatorLinearAllProps } from './types'
 
 function usePrevious<P>(value: P): [P, P] {
@@ -51,7 +52,7 @@ function ProgressIndicatorLine(props: ProgressIndicatorLinearAllProps) {
     rest['aria-busy'] = true
   }
 
-  const remainingDOMAttributes = { ...rest }
+  const remainingDOMAttributes = validateDOMAttributes(props, { ...rest })
 
   return (
     <span

--- a/packages/dnb-eufemia/src/components/radio/Radio.tsx
+++ b/packages/dnb-eufemia/src/components/radio/Radio.tsx
@@ -19,13 +19,14 @@ import useId from '../../shared/helpers/useId'
 import useCombinedRef from '../../shared/helpers/useCombinedRef'
 import {
   extendExistingPropsWithContext,
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
 } from '../../shared/component-helper'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -339,7 +340,6 @@ function RadioComponent({ ref: externalRef, ...ownProps }: RadioProps) {
     label,
     labelSrOnly,
     labelPosition,
-    labelDirection,
     size,
     readOnly,
     skeleton,
@@ -423,11 +423,8 @@ function RadioComponent({ ref: externalRef, ...ownProps }: RadioProps) {
 
   skeletonDOMAttributes(inputParams, skeleton, context)
 
-  if (inputParams.disabled === true) {
-    inputParams['aria-disabled'] = true
-  }
-
-  inputParams = removeSpaceProps(inputParams)
+  // also used for code markup simulation
+  validateDOMAttributes(ownProps, inputParams)
 
   const labelComp = label && (
     <FormLabel

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -8,7 +8,7 @@ import { clsx } from 'clsx'
 import useId from '../../shared/helpers/useId'
 import {
   extendExistingPropsWithContext,
-  mergeAttributes,
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   combineLabelledBy,
@@ -17,7 +17,7 @@ import {
 } from '../../shared/component-helper'
 import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import Space from '../Space'
 import FormLabel from '../FormLabel'
@@ -191,7 +191,6 @@ function RadioGroup(ownProps: RadioGroupProps) {
     children,
     onChange,
 
-    attributes,
     ...rest
   } = props
 
@@ -207,7 +206,7 @@ function RadioGroup(ownProps: RadioGroupProps) {
     ),
   })
 
-  const params = removeSpaceProps(rest)
+  const params = { ...rest }
   const legendId = id + '-label'
 
   if (showStatus || suffix) {
@@ -221,7 +220,8 @@ function RadioGroup(ownProps: RadioGroupProps) {
     params['aria-labelledby'] = combineLabelledBy(params, legendId)
   }
 
-  mergeAttributes(params, attributes)
+  // also used for code markup simulation
+  validateDOMAttributes(ownProps, params)
 
   const groupContext = {
     name: nameRef.current,

--- a/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/Radio.test.tsx
@@ -125,29 +125,6 @@ describe('Radio component', () => {
     })
   })
 
-  it('should not forward spacing props to the input element', () => {
-    render(
-      <Radio
-        top="2rem"
-        right="2rem"
-        bottom="2rem"
-        left="2rem"
-        space="small"
-        innerSpace="small"
-      />
-    )
-
-    const input = document.querySelector('input')
-
-    // Spacing props must become wrapper classes, never DOM attributes on the input
-    expect(input).not.toHaveAttribute('space')
-    expect(input).not.toHaveAttribute('innerSpace')
-    expect(input).not.toHaveAttribute('top')
-    expect(input).not.toHaveAttribute('right')
-    expect(input).not.toHaveAttribute('bottom')
-    expect(input).not.toHaveAttribute('left')
-  })
-
   it('should support inline styling', () => {
     render(<Radio style={{ color: 'red' }} />)
 

--- a/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
@@ -103,18 +103,6 @@ describe('Radio group component', () => {
     )
   })
 
-  it('should forward the attributes prop to the shell element', () => {
-    render(
-      <Radio.Group attributes={{ 'data-foo': 'bar' }}>
-        <Radio id="radio-1" label="Radio 1" value="first" />
-      </Radio.Group>
-    )
-
-    const shell = document.querySelector('.dnb-radio-group__shell')
-
-    expect(shell).toHaveAttribute('data-foo', 'bar')
-  })
-
   it('should inherit formElement vertical label', () => {
     render(
       <Provider formElement={{ labelDirection: 'vertical' }}>

--- a/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/Skeleton.tsx
@@ -14,6 +14,7 @@ import { clsx } from 'clsx'
 import {
   extendExistingPropsWithContext,
   removeUndefinedProps,
+  validateDOMAttributes,
 } from '../../shared/component-helper'
 import { LOCALE } from '../../shared/defaults'
 import Space from '../space/Space'
@@ -146,7 +147,6 @@ function Skeleton(props: SkeletonProps) {
     skeleton,
     ariaBusy,
     ariaReady,
-    element,
     className,
     children,
 
@@ -167,9 +167,10 @@ function Skeleton(props: SkeletonProps) {
     'aria-busy': showSkeleton,
     'aria-label': showSkeleton ? ariaBusy : undefined,
     lang: context.locale || LOCALE,
-    ...(element ? { element } : undefined),
     ...attributes,
   })
+
+  validateDOMAttributes(props, params)
 
   return (
     <Space {...params}>

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -3,14 +3,13 @@ import type { CSSProperties } from 'react'
 import {
   combineDescribedBy,
   combineLabelledBy,
+  validateDOMAttributes,
 } from '../../shared/component-helper'
 import Button from '../button/Button'
 import Tooltip from '../tooltip/Tooltip'
 import { useSliderEvents } from './hooks/useSliderEvents'
 import { useSliderProps } from './hooks/useSliderProps'
 import { clamp, getFormattedNumber } from './SliderHelpers'
-import { removeSpaceProps } from '../space/SpacingUtils'
-import type { SpacingProps } from '../../shared/types'
 
 export function SliderThumb() {
   const { values } = useSliderProps()
@@ -92,11 +91,10 @@ function Thumb({ value, currentIndex }: ThumbProps) {
     )
   }
 
-  const thumbParams = removeSpaceProps(
-    attributes as SpacingProps & Record<string, unknown>
-  )
+  const thumbParams = attributes as Record<string, unknown>
   const elemRef = useRef<HTMLElement>(undefined)
   const [forceActive, setForceActive] = useState(false)
+  validateDOMAttributes(allProps, thumbParams) // because we send along rest attributes
 
   return (
     <span className="dnb-slider__thumb" style={style}>

--- a/packages/dnb-eufemia/src/components/space/Space.tsx
+++ b/packages/dnb-eufemia/src/components/space/Space.tsx
@@ -6,7 +6,10 @@
 import { useContext } from 'react'
 import type { HTMLProps, Ref } from 'react'
 import { clsx } from 'clsx'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import type { ContextProps } from '../../shared/Context'
 import Context from '../../shared/Context'
 import { useSpacing, isInline } from './SpacingUtils'
@@ -152,6 +155,10 @@ function SpaceElement({
 }: SpaceAllProps) {
   const ElementDynamic = element
 
+  if (typeof element === 'string') {
+    // also used for code markup simulation
+    validateDOMAttributes({}, props)
+  }
   props['ref'] = ref
 
   const component = (

--- a/packages/dnb-eufemia/src/components/stat/Content.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Content.tsx
@@ -3,7 +3,7 @@ import type { ElementType, HTMLProps } from 'react'
 import { clsx } from 'clsx'
 import { useSpacing } from '../space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
-import { warn } from '../../shared/component-helper'
+import { validateDOMAttributes, warn } from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatRootContext from './StatRootContext'
 import useStatSkeleton from './useStatSkeleton'
@@ -44,17 +44,20 @@ function Content(props: ContentProps) {
     warn('Stat.Content should be used inside Stat.Root')
   }
 
-  const attributes = useSpacing(props, {
-    ...rest,
-    style,
-    className: clsx(
-      'dnb-stat',
-      'dnb-stat__content-item',
-      `dnb-stat__content-item--${direction}`,
-      skeletonClass,
-      className
-    ),
-  })
+  const attributes = validateDOMAttributes(
+    props,
+    useSpacing(props, {
+      ...rest,
+      style,
+      className: clsx(
+        'dnb-stat',
+        'dnb-stat__content-item',
+        `dnb-stat__content-item--${direction}`,
+        skeletonClass,
+        className
+      ),
+    })
+  )
 
   applySkeletonAttributes(attributes)
 

--- a/packages/dnb-eufemia/src/components/stat/Label.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Label.tsx
@@ -8,7 +8,7 @@ import type {
   TypographyWeight,
 } from '../../elements/typography/Typography'
 import { getHeadingLineHeightSize } from '../../elements/typography/Typography'
-import { warn } from '../../shared/component-helper'
+import { validateDOMAttributes, warn } from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatRootContext from './StatRootContext'
 import useStatSkeleton from './useStatSkeleton'
@@ -63,21 +63,24 @@ function Label(props: LabelProps) {
     warn('Stat.Label should be used inside Stat.Root')
   }
 
-  const attributes = useSpacing(props, {
-    ...rest,
-    style,
-    className: clsx(
-      'dnb-stat',
-      'dnb-stat__label',
-      `dnb-stat__label--${variant}`,
-      srOnly && 'dnb-sr-only',
-      `dnb-t__size--${fontSize}`,
-      `dnb-t__line-height--${resolvedLineHeight}`,
-      `dnb-t__weight--${fontWeight}`,
-      skeletonClass,
-      className
-    ),
-  })
+  const attributes = validateDOMAttributes(
+    props,
+    useSpacing(props, {
+      ...rest,
+      style,
+      className: clsx(
+        'dnb-stat',
+        'dnb-stat__label',
+        `dnb-stat__label--${variant}`,
+        srOnly && 'dnb-sr-only',
+        `dnb-t__size--${fontSize}`,
+        `dnb-t__line-height--${resolvedLineHeight}`,
+        `dnb-t__weight--${fontWeight}`,
+        skeletonClass,
+        className
+      ),
+    })
+  )
 
   applySkeletonAttributes(attributes)
 

--- a/packages/dnb-eufemia/src/components/stat/Text.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Text.tsx
@@ -7,7 +7,10 @@ import type {
 } from '../../elements/typography/Typography'
 import { getHeadingLineHeightSize } from '../../elements/typography/Typography'
 import type { SpacingProps } from '../../shared/types'
-import { convertJsxToString } from '../../shared/component-helper'
+import {
+  convertJsxToString,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import useStatSkeleton from './useStatSkeleton'
 import type { SkeletonMethods } from '../skeleton/SkeletonHelper'
@@ -63,22 +66,25 @@ function TextInternal(props: TextInternalProps) {
     : textValue
   const ariaLabel = srLabel ? srText : rest['aria-label']
 
-  const attributes = useSpacing(props, {
-    ...rest,
-    'aria-label': ariaLabel,
-    style,
-    className: clsx(
-      textClassName,
-      textClassName && fontSize && `dnb-t__size--${fontSize}`,
-      textClassName &&
-        fontSize &&
-        `dnb-t__line-height--${getHeadingLineHeightSize(fontSize)}`,
-      textClassName && fontWeight && `dnb-t__weight--${fontWeight}`,
-      resolvedSignTone && `dnb-stat--tone-${resolvedSignTone}`,
-      skeletonClass,
-      className
-    ),
-  })
+  const attributes = validateDOMAttributes(
+    props,
+    useSpacing(props, {
+      ...rest,
+      'aria-label': ariaLabel,
+      style,
+      className: clsx(
+        textClassName,
+        textClassName && fontSize && `dnb-t__size--${fontSize}`,
+        textClassName &&
+          fontSize &&
+          `dnb-t__line-height--${getHeadingLineHeightSize(fontSize)}`,
+        textClassName && fontWeight && `dnb-t__weight--${fontWeight}`,
+        resolvedSignTone && `dnb-stat--tone-${resolvedSignTone}`,
+        skeletonClass,
+        className
+      ),
+    })
+  )
 
   applySkeletonAttributes(attributes)
 

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorTriggerButton.tsx
@@ -13,7 +13,10 @@ import HeightAnimation from '../height-animation/HeightAnimation'
 import { chevron_down, chevron_up } from '../../icons'
 import Icon from '../icon/Icon'
 import IconPrimary from '../icon-primary/IconPrimary'
-import { combineDescribedBy } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  combineDescribedBy,
+} from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import FormLabel from '../form-label/FormLabel'
 import StepIndicatorContext from './StepIndicatorContext'
@@ -21,8 +24,6 @@ import {
   skeletonDOMAttributes,
   createSkeletonClass,
 } from '../skeleton/SkeletonHelper'
-import { removeSpaceProps } from '../space/SpacingUtils'
-import type { SpacingProps } from '../../shared/types'
 
 const chevronIcon = Icon.transition({
   collapsed: chevron_down,
@@ -58,17 +59,14 @@ function StepIndicatorTriggerButton({
   const label = stepsLabel
   const id = useId()
 
-  const triggerParams = removeSpaceProps({
+  const triggerParams = {
     ...contextWithoutDataRest,
     className: clsx(
       'dnb-step-indicator__trigger',
       createSkeletonClass('font', skeleton)
     ),
     'aria-live': 'polite',
-  } as SpacingProps & Record<string, unknown>) as Omit<
-    HTMLProps<HTMLElement>,
-    'onChange' | 'onClick'
-  >
+  } as Omit<HTMLProps<HTMLElement>, 'onChange' | 'onClick'>
 
   const buttonParams = {
     ...rest,
@@ -95,6 +93,9 @@ function StepIndicatorTriggerButton({
   })
 
   skeletonDOMAttributes(triggerParams, skeleton)
+
+  // also used for code markup simulation
+  validateDOMAttributes(contextWithoutDataRest, triggerParams)
 
   return (
     <Section

--- a/packages/dnb-eufemia/src/components/switch/Switch.tsx
+++ b/packages/dnb-eufemia/src/components/switch/Switch.tsx
@@ -17,14 +17,14 @@ import type {
 } from 'react'
 import { clsx } from 'clsx'
 import {
-  mergeAttributes,
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   extendPropsWithContext,
 } from '../../shared/component-helper'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -147,12 +147,8 @@ function Switch(props: SwitchProps) {
     onChangeEnd,
     onClick,
     ref: refProp,
-    attributes,
-    labelDirection,
     ...rest
-  } = allProps as typeof allProps & {
-    labelDirection?: 'vertical' | 'horizontal'
-  }
+  } = allProps
 
   const [, forceUpdate] = useReducer(() => ({}), {})
   const id = useId(idProp)
@@ -271,7 +267,7 @@ function Switch(props: SwitchProps) {
   const inputParams = {
     disabled,
     checked: isCheckedRef.current,
-    ...removeSpaceProps(rest),
+    ...rest,
   }
 
   if (showStatus || suffix) {
@@ -286,12 +282,7 @@ function Switch(props: SwitchProps) {
   }
 
   skeletonDOMAttributes(inputParams, skeleton, context)
-
-  if (inputParams.disabled === true) {
-    inputParams['aria-disabled'] = true
-  }
-
-  mergeAttributes(inputParams, attributes)
+  validateDOMAttributes(props, inputParams)
 
   const helperParams = useMemo(
     () => ({

--- a/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/Switch.test.tsx
@@ -130,37 +130,6 @@ describe('Switch component', () => {
     )
   })
 
-  it('should not forward spacing props to the input element', () => {
-    render(
-      <Switch
-        top="2rem"
-        right="2rem"
-        bottom="2rem"
-        left="2rem"
-        space="small"
-        innerSpace="small"
-      />
-    )
-
-    const input = document.querySelector('input')
-
-    // Spacing props must become wrapper classes, never DOM attributes on the input
-    expect(input).not.toHaveAttribute('space')
-    expect(input).not.toHaveAttribute('innerSpace')
-    expect(input).not.toHaveAttribute('top')
-    expect(input).not.toHaveAttribute('right')
-    expect(input).not.toHaveAttribute('bottom')
-    expect(input).not.toHaveAttribute('left')
-  })
-
-  it('should forward the attributes prop to the input element', () => {
-    render(<Switch attributes={{ 'data-foo': 'bar' }} />)
-
-    const input = document.querySelector('input')
-
-    expect(input).toHaveAttribute('data-foo', 'bar')
-  })
-
   it('should inherit formElement vertical label', () => {
     render(
       <Provider formElement={{ labelDirection: 'vertical' }}>

--- a/packages/dnb-eufemia/src/components/table/Table.tsx
+++ b/packages/dnb-eufemia/src/components/table/Table.tsx
@@ -5,7 +5,10 @@ import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
 import { useSpacing } from '../space/SpacingUtils'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import ScrollView from './TableScrollView'
 import { TableContext } from './TableContext'
 import { useStickyHeader } from './TableStickyHeader'
@@ -157,6 +160,8 @@ const Table = (componentProps: TableAllProps) => {
   }, [collapseAllHandleRef])
 
   const skeletonClasses = createSkeletonClass('font', skeleton, context)
+
+  validateDOMAttributes(allProps, props)
 
   const tableProps = useSpacing(allProps, {
     ...props,

--- a/packages/dnb-eufemia/src/components/table/TableContainer.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableContainer.tsx
@@ -12,6 +12,7 @@ import { useSpacing } from '../space/SpacingUtils'
 
 import type { TableProps } from './Table'
 import type { SpacingProps } from '../../shared/types'
+import { validateDOMAttributes } from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type TableContainerProps = {
@@ -40,6 +41,8 @@ type InternalTableContainerTableScrollView = Omit<
 
 export default function TableContainer(props: TableContainerAllProps) {
   const { children, className, ...rest } = props
+
+  validateDOMAttributes(props, rest)
 
   const sectionProps = useSpacing(props, {
     className: clsx('dnb-table__container', className),

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -30,6 +30,7 @@ import Context from '../../shared/Context'
 import {
   warn,
   slugify,
+  validateDOMAttributes,
   dispatchCustomElementEvent,
   getClosestParent,
   filterProps,
@@ -1134,6 +1135,8 @@ function TabsComponent(ownProps: TabsProps) {
     ...rest
   }: PropsWithChildren<Record<string, unknown>>) => {
     const params = { ...wrapperSpacingParams }
+
+    validateDOMAttributes(ownProps, params)
 
     delete params.contentInnerSpace
     delete params.tabsInnerSpace

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 import type { HTMLProps, ReactNode, RefObject } from 'react'
 import { clsx } from 'clsx'
-import type {
-  DynamicElement,
-  InnerSpaceType,
-  SpacingProps,
-} from '../../shared/types'
-import { combineLabelledBy } from '../../shared/component-helper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import type { DynamicElement, InnerSpaceType } from '../../shared/types'
+import {
+  validateDOMAttributes,
+  combineLabelledBy,
+} from '../../shared/component-helper'
+import { useSpacing } from '../space/SpacingUtils'
 import Section from '../section/Section'
 import {
   createSharedState,
@@ -95,9 +94,7 @@ export default function ContentWrapper({
     return null
   }
 
-  const params: Record<string, unknown> = {
-    ...removeSpaceProps(rest as SpacingProps & Record<string, unknown>),
-  }
+  const params = { ...rest }
 
   // Use state.key if available (when linked with shared state),
   // otherwise fall back to selectedKey prop
@@ -109,6 +106,19 @@ export default function ContentWrapper({
       `${id}-tab-${activeKey}`
     )
   }
+
+  validateDOMAttributes(
+    {
+      id,
+      children,
+      selectedKey,
+      contentStyle,
+      animate,
+      contentInnerSpace,
+      ...rest,
+    },
+    params
+  )
 
   let content: ReactNode = children as ReactNode
   if (typeof children === 'function') {

--- a/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
+++ b/packages/dnb-eufemia/src/components/tag/TagGroup.tsx
@@ -3,10 +3,13 @@ import type { HTMLAttributes, HTMLProps, ReactNode } from 'react'
 import { clsx } from 'clsx'
 
 // Components
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 // Shared
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import Context from '../../shared/Context'
 import type { SpacingProps } from '../../shared/types'
 import { TagGroupContext } from './TagContext'
@@ -76,10 +79,10 @@ const TagGroup = (
   const spacingProps = useSpacing(props, {
     className: clsx('dnb-tag__group', className),
   })
-  const { skeleton, ...attributes } = removeSpaceProps({
+  const { skeleton, ...attributes } = validateDOMAttributes({}, {
     ...props,
     ...spacingProps,
-  } as SpacingProps & Record<string, unknown>)
+  } as Record<string, unknown>)
 
   return (
     <TagGroupContext value={props}>

--- a/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/Textarea.tsx
@@ -26,6 +26,7 @@ import useId from '../../shared/helpers/useId'
 import {
   extendPropsWithContext,
   removeUndefinedProps,
+  validateDOMAttributes,
   processChildren,
   getStatusState,
   combineDescribedBy,
@@ -36,7 +37,7 @@ import {
 import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
 import AlignmentHelper from '../../shared/AlignmentHelper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import {
   skeletonDOMAttributes,
   createSkeletonClass,
@@ -480,9 +481,7 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
     'aria-placeholder': placeholder
       ? convertJsxToString(placeholder)
       : undefined,
-    ...(removeSpaceProps(
-      attributes
-    ) as unknown as TextareaHTMLAttributes<HTMLTextAreaElement>),
+    ...(attributes as unknown as TextareaHTMLAttributes<HTMLTextAreaElement>),
     ...(typeof size === 'number' ? { size } : {}),
     onChange: onChangeHandler,
     onFocus: onFocusHandler,
@@ -544,9 +543,9 @@ export function TextareaComponent({ ref, ...ownProps }: TextareaProps) {
 
   skeletonDOMAttributes(innerParams, skeleton, context)
 
-  if (textareaParams.disabled === true) {
-    textareaParams['aria-disabled'] = true
-  }
+  validateDOMAttributes(ownProps, textareaParams)
+  validateDOMAttributes(null, innerParams)
+  validateDOMAttributes(null, shellParams)
 
   if (TextareaElement && typeof TextareaElement === 'function') {
     TextareaElement = TextareaElement(textareaParams, textareaRef)

--- a/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
+++ b/packages/dnb-eufemia/src/components/textarea/__tests__/Textarea.test.tsx
@@ -238,19 +238,6 @@ describe('Textarea component', () => {
     )
   })
 
-  it('should not forward spacing props to the textarea element', () => {
-    render(<Textarea top="large" />)
-
-    const textarea = document.querySelector('textarea')
-    expect(textarea).not.toHaveAttribute('top')
-    expect(textarea).not.toHaveAttribute('space')
-
-    // spacing is applied to the outer component instead
-    expect(document.querySelector('.dnb-textarea')).toHaveClass(
-      'dnb-space__top--large'
-    )
-  })
-
   it('should accept props like autoResize via provider', () => {
     render(
       <Provider Textarea={{ autoResize: true }}>

--- a/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
+++ b/packages/dnb-eufemia/src/components/timeline/Timeline.tsx
@@ -14,7 +14,10 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import type { TimelineItemProps } from './TimelineItem'
 import TimelineItem from './TimelineItem'
 import TimelineContext from './TimelineContext'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../../shared/component-helper'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type TimelineProps = {
@@ -66,6 +69,8 @@ const Timeline = (localProps: TimelineAllProps) => {
     children: childrenProp,
     ...props
   } = allProps
+
+  validateDOMAttributes(allProps, props)
 
   const olProps = useSpacing(allProps, {
     ...props,

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButton.tsx
@@ -23,6 +23,7 @@ import useId from '../../shared/helpers/useId'
 import {
   warn,
   extendExistingPropsWithContext,
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   dispatchCustomElementEvent,
@@ -31,7 +32,7 @@ import {
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import type { FormElementProps } from '../../shared/helpers/filterValidProps'
 import { pickFormElementProps } from '../../shared/helpers/filterValidProps'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 
 import Radio from '../radio/Radio'
 import Checkbox from '../checkbox/Checkbox'
@@ -326,6 +327,9 @@ function ToggleButton(ownProps: ToggleButtonProps) {
     ),
   })
 
+  // to remove spacing props
+  validateDOMAttributes(ownProps, rest)
+
   const buttonParams: Record<string, unknown> = {
     id,
     disabled,
@@ -339,7 +343,7 @@ function ToggleButton(ownProps: ToggleButtonProps) {
       role === 'radio' || role === 'checkbox' ? 'checked' : 'pressed'
     }`]: String(resolvedChecked || false),
     role,
-    ...removeSpaceProps(rest),
+    ...rest,
   }
 
   const componentParams: Record<string, unknown> = {

--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -9,13 +9,14 @@ import { clsx } from 'clsx'
 import useId from '../../shared/helpers/useId'
 import {
   extendExistingPropsWithContext,
+  validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
   combineLabelledBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
 } from '../../shared/component-helper'
-import { useSpacing, removeSpaceProps } from '../space/SpacingUtils'
+import { useSpacing } from '../space/SpacingUtils'
 import AlignmentHelper from '../../shared/AlignmentHelper'
 import FormLabel from '../FormLabel'
 import FormStatus from '../FormStatus'
@@ -201,8 +202,8 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
     ),
   })
 
-  const params: Record<string, unknown> = {
-    ...removeSpaceProps(rest),
+  const params = {
+    ...rest,
   }
 
   if (showStatus || suffix) {
@@ -215,6 +216,9 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
   if (label) {
     params['aria-labelledby'] = combineLabelledBy(params, id + '-label')
   }
+
+  // also used for code markup simulation
+  validateDOMAttributes(ownProps, params)
 
   const setContext = useCallback(
     (

--- a/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import type { HTMLAttributes, ReactElement, RefObject } from 'react'
 import { clsx } from 'clsx'
 import Context from '../../shared/Context'
 import type { ContextProps } from '../../shared/Context'
+import { validateDOMAttributes } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import { useSpacing } from '../space/SpacingUtils'
 import TooltipWithEvents from './TooltipWithEvents'
@@ -61,6 +62,9 @@ function Tooltip(localProps: TooltipAllProps) {
       className
     ),
   }) as HTMLAttributes<HTMLElement>
+
+  // also used for code markup simulation
+  validateDOMAttributes(localProps, attributes)
 
   if (targetSource && !target) {
     return null

--- a/packages/dnb-eufemia/src/elements/Element.tsx
+++ b/packages/dnb-eufemia/src/elements/Element.tsx
@@ -7,7 +7,10 @@ import { Fragment, useContext } from 'react'
 import type { HTMLProps, ReactNode, Ref, RefObject } from 'react'
 import { clsx } from 'clsx'
 import Context from '../shared/Context'
-import { extendPropsWithContext } from '../shared/component-helper'
+import {
+  validateDOMAttributes,
+  extendPropsWithContext,
+} from '../shared/component-helper'
 import { useSpacing } from '../components/space/SpacingUtils'
 import type { SkeletonMethods } from '../components/skeleton/SkeletonHelper'
 import {
@@ -81,13 +84,15 @@ function Element(localProps: ElementAllProps) {
     createSkeletonClass(skeletonMethod, skeleton, context)
   )
 
-  // useSpacing must be called before spreading onto the DOM element,
-  // because it strips non-DOM attributes like spacing props from the result
+  // useSpacing must be called before validateDOMAttributes
+  // because the validator removes non-DOM attributes like spacing props
   const params = useSpacing(
     attributes,
     { ...attributes, className: internalClassName },
     typeof Tag === 'string' ? `dnb-${Tag}` : null
   )
+
+  validateDOMAttributes(null, params)
 
   skeletonDOMAttributes(params, skeleton, context)
 

--- a/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
+++ b/packages/dnb-eufemia/src/extensions/payment-card/PaymentCard.tsx
@@ -7,6 +7,7 @@ import { clsx } from 'clsx'
 import Context from '../../shared/Context'
 import Provider from '../../shared/Provider'
 import {
+  validateDOMAttributes,
   extendExistingPropsWithContext,
   removeUndefinedProps,
 } from '../../shared/component-helper'
@@ -172,6 +173,9 @@ function PaymentCard(props: PaymentCardProps) {
   })
 
   skeletonDOMAttributes(params, skeleton, context)
+
+  // also used for code markup simulation
+  validateDOMAttributes(props, params)
 
   return (
     <Provider locale={locale}>

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -17,17 +17,14 @@ import type {
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import { clsx } from 'clsx'
 import {
+  validateDOMAttributes,
   removeUndefinedProps,
-  removeNullProps,
   warn,
 } from '../../shared/component-helper'
 import type { SpacingProps } from '../../shared/types'
 import type { Translation } from '../../shared/Context'
 
-import {
-  useSpacing,
-  removeSpaceProps,
-} from '../../components/space/SpacingUtils'
+import { useSpacing } from '../../components/space/SpacingUtils'
 
 import E from '../../elements/Element'
 import type { DrawerListContextValue } from './DrawerListContext'
@@ -554,9 +551,14 @@ const DrawerListComponent = memo(function DrawerListComponent(
     ulParams.tabIndex = 0
   }
 
+  // also used for code markup simulation
+  validateDOMAttributes(ownProps, mainParams)
+  validateDOMAttributes(null, listParams)
+  validateDOMAttributes(null, ulParams)
+
   Object.assign(
     context.drawerList.attributes,
-    removeNullProps(removeSpaceProps(attributes))
+    validateDOMAttributes(null, attributes)
   )
 
   const ignoreEventsBoolean = ignoreEvents

--- a/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/fragments/scroll-view/ScrollView.tsx
@@ -6,7 +6,10 @@
 import { useContext, useRef, useState } from 'react'
 import type { DetailedHTMLProps, HTMLAttributes, Ref } from 'react'
 import { clsx } from 'clsx'
-import { extendPropsWithContext } from '../../shared/component-helper'
+import {
+  extendPropsWithContext,
+  validateDOMAttributes,
+} from '../../shared/component-helper'
 import Context from '../../shared/Context'
 import { useSpacing } from '../../components/space/SpacingUtils'
 import type { SpacingProps } from '../../shared/types'
@@ -70,6 +73,8 @@ function ScrollView(localProps: ScrollViewAllProps) {
     children,
     ref: localRef,
   })
+
+  validateDOMAttributes(props, mainParams)
 
   return <div {...mainParams}>{children}</div>
 }

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -9,7 +9,7 @@ import { render } from '@testing-library/react'
 import {
   extendDeep,
   defineNavigator,
-  mergeAttributes,
+  validateDOMAttributes,
   processChildren,
   dispatchCustomElementEvent,
   toPascalCase,
@@ -25,7 +25,6 @@ import {
   convertJsxToString,
   escapeRegexChars,
   removeUndefinedProps,
-  removeNullProps,
 } from '../component-helper'
 import userEvent from '@testing-library/user-event'
 
@@ -260,57 +259,110 @@ describe('"checkIfHasScrollbar" should', () => {
   })
 })
 
-describe('"mergeAttributes" should', () => {
-  it('merge attribute contents onto the target and return it', () => {
-    const params = { id: 'x' }
-    const res = mergeAttributes(params, {
-      'data-foo': 'bar',
-      role: 'note',
-    })
-    expect(res).toBe(params)
-    expect(res).toEqual({ id: 'x', 'data-foo': 'bar', role: 'note' })
+describe('"validateDOMAttributes" should', () => {
+  it('work fine', () => {
+    const props = {}
+    const params = {}
+    const res = validateDOMAttributes(props, params)
+    expect(params).toEqual(res)
   })
 
-  it('ignore nullish or non-object attributes', () => {
-    expect(mergeAttributes({ id: 'x' }, undefined)).toEqual({ id: 'x' })
-    expect(mergeAttributes({ id: 'x' }, null)).toEqual({ id: 'x' })
-    expect(mergeAttributes({ id: 'x' }, 'nope')).toEqual({ id: 'x' })
+  it('has equal object after sending an object as prop.attributes', () => {
+    const attr = { foo: 'bar' }
+    const props = { attributes: attr }
+    const params = {}
+    const res = validateDOMAttributes(props, params)
+    expect(res).toEqual(attr)
   })
 
-  it('prevent prototype pollution', () => {
-    const params: Record<string, unknown> = {}
-    const res = mergeAttributes(params, {
-      constructor: { polluted: 'value' },
-      prototype: { polluted: 'value' },
-      safeKey: 'safeValue',
-    })
+  it('"disabled" property should be removed once its value is null', () => {
+    const props = {}
+    const res1 = validateDOMAttributes(
+      props,
+      Object.assign({}, { disabled: null })
+    )
+    expect(res1).not.toHaveProperty('disabled')
+    const res2 = validateDOMAttributes(
+      props,
+      Object.assign({}, { disabled: 'disabled' })
+    )
+    expect(res2).toHaveProperty('disabled')
+  })
 
+  it('pass thru rest attributes', () => {
+    const props = {}
+    const params = { 'aria-hidden': true }
+    const res = validateDOMAttributes(props, params)
+    expect(res).toHaveProperty('aria-hidden')
+  })
+
+  it('remove values with null', () => {
+    const props = {}
+    const params = { 'aria-hidden': null }
+    const res = validateDOMAttributes(props, params)
+    expect(res).not.toHaveProperty('aria-hidden')
+  })
+
+  it('remove attributes with invalid names', () => {
+    const props = {}
+    const params = { aria_hidden: 'true' }
+    const res = validateDOMAttributes(props, params)
+    expect(res).not.toHaveProperty('aria_hidden')
+  })
+
+  it('function props should not be returned as long as they don\'t are "onClick"', () => {
+    const props = {
+      onClick: () => {},
+    }
+    const params = {
+      onChange: () => {},
+      something: () => {},
+    }
+    const res = validateDOMAttributes(props, params)
+    expect(res).toHaveProperty('onChange')
+    expect(res).not.toHaveProperty('something')
+  })
+
+  it('should preserve function ref props', () => {
+    const props = {}
+    const refFn = () => {}
+    const params = { ref: refFn }
+    const res = validateDOMAttributes(props, params)
+    expect(res).toHaveProperty('ref')
+    expect(res.ref).toBe(refFn)
+  })
+
+  it('should prevent prototype pollution via attributes', () => {
+    const props = {
+      attributes: {
+        __proto__: { polluted: 'value' },
+        constructor: { polluted: 'value' },
+        prototype: { polluted: 'value' },
+        safeKey: 'safeValue',
+      },
+    }
+    const params = {}
+    const res = validateDOMAttributes(props, params)
+
+    // Should include safe attributes
     expect(res).toHaveProperty('safeKey', 'safeValue')
+
+    // Should not include dangerous prototype-polluting keys as own properties
+    expect(Object.prototype.hasOwnProperty.call(res, '__proto__')).toBe(
+      false
+    )
     expect(Object.prototype.hasOwnProperty.call(res, 'constructor')).toBe(
       false
     )
     expect(Object.prototype.hasOwnProperty.call(res, 'prototype')).toBe(
       false
     )
+
+    // Verify that Object.prototype was not polluted
     expect(({} as Record<string, unknown>).polluted).toBeUndefined()
-  })
 
-  it('prevent prototype pollution via a JSON-sourced "__proto__" key', () => {
-    // A literal `{ __proto__: ... }` sets the prototype rather than creating
-    // an own key, so it never reaches the guard. `JSON.parse` creates a real,
-    // enumerable `__proto__` key — the actual attack vector. Without the
-    // guard, `params['__proto__'] = value` reassigns the target's prototype
-    // (so `params.polluted` would resolve through it).
-    const attributes = JSON.parse(
-      '{"__proto__":{"polluted":"yes"},"safeKey":"safeValue"}'
-    )
-    const params: Record<string, unknown> = {}
-    const res = mergeAttributes(params, attributes)
-
-    expect(res).toHaveProperty('safeKey', 'safeValue')
-    expect(Object.getPrototypeOf(res)).toBe(Object.prototype)
+    // Verify that the result object itself was not polluted
     expect(res.polluted).toBeUndefined()
-    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
   })
 })
 
@@ -611,27 +663,5 @@ describe('"removeUndefinedProps" should', () => {
 
   it('remove support undefined as data', () => {
     expect(removeUndefinedProps(undefined)).toBeUndefined()
-  })
-})
-
-describe('"removeNullProps" should', () => {
-  it('remove null props', () => {
-    const object = {
-      foo: undefined,
-      bar: null,
-      baz: 'value',
-      qux: null,
-      quux: 0,
-    }
-
-    expect(removeNullProps(object)).toEqual({
-      foo: undefined,
-      baz: 'value',
-      quux: 0,
-    })
-  })
-
-  it('support an empty object', () => {
-    expect(removeNullProps({})).toEqual({})
   })
 })

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -29,31 +29,100 @@ init()
 whatInput.specificKeys([])
 defineNavigator()
 
+/** @private */
+const startsWithCamelCaseRegex = /(^[a-z]{1,}[A-Z]{1})/
+/** @private */
+const notOnlyAZOrHyphenRegex = /[^a-z-]/i
+
 /**
- * Merges a user-provided `attributes` prop object onto a target params object,
- * skipping prototype-polluting keys (`__proto__`, `constructor`, `prototype`).
- *
- * This supports the public `attributes` prop on components.
- *
- * @param params target object that receives the attributes (mutated and returned)
- * @param attributes the user-provided `attributes` prop, if any
+ * @deprecated stop using this function as it only removes things that should be handled in the component any documented prop should be explicitly removed, and props should not have default value `null`
+ * @description Removes invalid DOM attributes from `params`.
+ * @param props properties from `props.attributes` are added to `params`
+ * @param params object with DOM attributes
+ * @returns `params` cleaned from invalid DOM attributes
  */
-export function mergeAttributes<T extends Record<string, unknown>>(
-  params: T,
-  attributes?: unknown
-): T {
-  if (attributes && typeof attributes === 'object') {
-    for (const key of Object.keys(attributes)) {
+export const validateDOMAttributes = (
+  /** `null` or an object with property `attributes` that is merged with `params` */
+  props: Record<string, any>,
+  /** object with DOM attributes */
+  params: Record<string, any>
+) => {
+  // if there is an "attributes" prop, prepare these
+  // mostly used for prop example usage
+  if (props && props.attributes) {
+    const attr = props.attributes
+    if (attr && typeof attr === 'object') {
+      Object.entries(attr).forEach(([key, value]) => {
+        // Prevent prototype pollution
+        if (
+          key === '__proto__' ||
+          key === 'constructor' ||
+          key === 'prototype'
+        ) {
+          return
+        }
+        Object.assign(params, { [key]: value })
+      })
+    }
+    delete params.attributes
+  }
+
+  if (params.disabled === null) {
+    delete params.disabled
+  }
+  if (typeof params.space !== 'undefined') {
+    delete params.space
+  }
+  if (typeof params.top !== 'undefined') {
+    delete params.top
+  }
+  if (typeof params.right !== 'undefined') {
+    delete params.right
+  }
+  if (typeof params.bottom !== 'undefined') {
+    delete params.bottom
+  }
+  if (typeof params.left !== 'undefined') {
+    delete params.left
+  }
+  if (typeof params.noCollapse !== 'undefined') {
+    delete params.noCollapse
+  }
+  if (typeof params.innerSpace !== 'undefined') {
+    delete params.innerSpace
+  }
+  if (typeof params.labelDirection !== 'undefined') {
+    delete params.labelDirection
+  }
+
+  if (params.disabled === true) {
+    params['aria-disabled'] = true
+  }
+
+  // make sure we don't return a render prop as a DOM attribute
+  if (params && typeof params === 'object') {
+    for (const i in params) {
       if (
-        key === '__proto__' ||
-        key === 'constructor' ||
-        key === 'prototype'
+        // is React
+        typeof params[i] === 'function' &&
+        // "ref" is a valid React prop (callback ref)
+        i !== 'ref' &&
+        // only React Style props, like "onClick" are allowed
+        // (starts with lowercase letters followed by at least on uppercase letter)
+        !startsWithCamelCaseRegex.test(i)
       ) {
-        continue
+        delete params[i]
+
+        // filter out invalid attributes
+      } else if (
+        // we don't want NULL values
+        params[i] === null ||
+        // we don't want if there are any characters except "a-z", "A-Z" or "-"
+        // Removes non-standard DOM attribute names (e.g. containing underscores)
+        notOnlyAZOrHyphenRegex.test(i)
+      ) {
+        delete params[i]
       }
-      params[key as keyof T] = (attributes as Record<string, unknown>)[
-        key
-      ] as T[keyof T]
     }
   }
 
@@ -327,17 +396,6 @@ export function escapeRegexChars(str) {
 export function removeUndefinedProps(object) {
   Object.keys(object || {}).forEach((key) => {
     if (object[key] === undefined) {
-      delete object[key]
-    }
-  })
-  return object
-}
-
-export function removeNullProps<T extends Record<string, unknown>>(
-  object: T
-): T {
-  Object.keys(object || {}).forEach((key) => {
-    if (object[key] === null) {
       delete object[key]
     }
   })


### PR DESCRIPTION
Reverts the changes from #8759 (`chore: remove deprecated validateDOMAttributes helper`).

## Why

#8759 removed the shared `validateDOMAttributes` helper and migrated ~52 components to explicit helpers. The migration did not fully reconstruct one of the helper's jobs — merging the public `attributes` prop — on the main input elements of **Input**, **Checkbox**, **Radio** and **Textarea**.

As a result, passing `attributes={{ 'data-foo': 'bar' }}` to those components:

- **silently dropped** the intended attribute, and
- **leaked the raw object** onto the DOM as `attributes="[object Object]"`.

React emits no warning for this, so the existing test suite did not catch it (the guard tests added in #8759 only asserted spacing-prop non-leakage). For Radio, `labelDirection` could also leak onto the `<input>`.

## Why revert (vs. a targeted fix)

Reverting restores the full `validateDOMAttributes` safety net in one step — this covers the `attributes` merge, the `labelDirection` leak, and any other invalid-attribute scrubbing gaps that the migration may have left in components not individually audited. It returns these files to the known-good v11.8.1 behavior.

A **targeted alternative** exists in **#8823**, which keeps the #8759 refactor and only re-adds the `attributes` merge (+ Radio `labelDirection`) on the four affected components, with regression tests. **These two PRs are mutually exclusive — pick one:**

- This revert: safest/most complete, but undoes the deliberate refactor and reinstates the deprecated helper.
- #8823: minimal/surgical, preserves the refactor, but only fixes the components that were audited.

## Verification

- Revert applies cleanly onto latest `main` (git 3-way auto-merge; no conflicts).
- `yarn test:types` — 0 errors.
- Component suites green (Input, Checkbox, Radio, Textarea, Switch, Autocomplete, Button, Dropdown).

## Notes

- 64 files changed (restores the helper, its call sites, and its unit tests; removes the #8759 guard tests).
- Later type-only commits that touched these files were auto-merged on top and still type-check.
