### PR TITLE
fix(Table): prevent infinite re-render loop when Table content re-renders on its own

### DIFF
--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -262,9 +262,14 @@ export function useHandleOddEven({ children }) {
   }, [children, forceRerender])
 
   // Runs after all child (Tr) effects, so trCountRef.current.count is final.
+  // The dependency array is required: without it the effect runs after every
+  // commit and would loop indefinitely when the Table lives inside content
+  // that re-renders on its own (e.g. an infinity-scrolled Pagination), since
+  // each re-render mutates trCountRef.current.count and setTotalCount would
+  // trigger yet another render.
   useEffect(() => {
     setTotalCount(trCountRef.current.count)
-  })
+  }, [children, rerenderAlias])
 
   return { trCountRef, rerenderAlias, totalCount, setRerenderAlias }
 }

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableTr.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableTr.test.tsx
@@ -1,6 +1,7 @@
-import { StrictMode, useState } from 'react'
+import { StrictMode, useContext, useRef, useState } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import Table from '../Table'
+import { TableContext } from '../TableContext'
 import type { TableTrProps } from '../TableTr'
 import TableTr from '../TableTr'
 
@@ -469,5 +470,51 @@ describe('TableTr', () => {
       expect(rows[1].classList.contains('dnb-table__tr--last')).toBe(false)
       expect(rows[2].classList.contains('dnb-table__tr--last')).toBe(true)
     })
+  })
+
+  describe('re-render loop', () => {
+    it(
+      'should not cause "Maximum update depth exceeded" when the Table content re-renders and remounts rows on its own',
+      { timeout: 5000 },
+      () => {
+        const errorSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => undefined)
+
+        // Reproduces the infinity-scroll scenario: the content consumes the
+        // TableContext, so it re-renders whenever the internal totalCount state
+        // changes, and it remounts its Tr on every render (fresh key). This
+        // mirrors an observer-driven Pagination that mounts/unmounts marker
+        // rows and mutates the shared row count on each render.
+        const InfinityContent = () => {
+          useContext(TableContext)
+          const renderCountRef = useRef(0)
+          renderCountRef.current++
+
+          return (
+            <tbody>
+              <TableTr key={renderCountRef.current}>
+                <td>content</td>
+              </TableTr>
+            </tbody>
+          )
+        }
+
+        render(
+          <Table>
+            <InfinityContent />
+          </Table>
+        )
+
+        const maxDepthErrors = errorSpy.mock.calls.filter((call) =>
+          String(call[0]).includes('Maximum update depth exceeded')
+        )
+
+        expect(maxDepthErrors).toHaveLength(0)
+        expect(document.querySelector('tbody tr')).toBeInTheDocument()
+
+        errorSpy.mockRestore()
+      }
+    )
   })
 })


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1784666210512149

## Description
Fixes an infinite re-render loop (`Maximum update depth exceeded`) in `Table`
that surfaces after upgrading from 11.3 to 11.8, reported with infinity scroll.

### Root cause
`useHandleOddEven` in `TableTr.tsx` had a dependency-free `useEffect` calling
`setTotalCount(trCountRef.current.count)` after every commit. Under React 19
this loops indefinitely when the Table lives inside content that re-renders on
its own (e.g. an infinity-scrolled `Pagination`): each re-render mutates
`trCountRef.current.count`, the effect fires, `setTotalCount` triggers another
render. React 18 masked this via scheduler bailout.

### Fix
Add a `[children, rerenderAlias]` dependency array so the effect only runs when
the row content changes or after an explicit `forceRerender`.

## Test
Adds a regression test under `re-render loop` reproducing the infinity-scroll
scenario. It loops without the fix and passes with it. All table suites pass.