### PR TITLE
fix(List): disabled List.Item border color to match neighbouring items

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
@@ -374,6 +374,44 @@ export const PendingState = () => {
   )
 }
 
+export const DisabledState = () => {
+  return (
+    <ComponentBox data-visual-test="list-disabled" scope={{ fish_medium }}>
+      <List.Container>
+        <List.Item.Action
+          icon={fish_medium}
+          title="Navigate to details 1"
+          onClick={() => console.log('Clicked')}
+        >
+          <List.Cell.End>
+            <NumberFormat.Currency value={1234} />
+          </List.Cell.End>
+        </List.Item.Action>
+
+        <List.Item.Action
+          icon={fish_medium}
+          title="Navigate to details 2"
+          disabled
+        >
+          <List.Cell.End>
+            <NumberFormat.Currency value={1234} />
+          </List.Cell.End>
+        </List.Item.Action>
+
+        <List.Item.Action
+          icon={fish_medium}
+          title="Navigate to details 3"
+          onClick={() => console.log('Clicked')}
+        >
+          <List.Cell.End>
+            <NumberFormat.Currency value={1234} />
+          </List.Cell.End>
+        </List.Item.Action>
+      </List.Container>
+    </ComponentBox>
+  )
+}
+
 export const ProgressIndicatorRow = () => {
   return (
     <ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/demos.mdx
@@ -110,6 +110,12 @@ Use the `pending` property on `List.Item.Basic` or `List.Item.Action` to show a 
 
 <Examples.PendingState />
 
+### Disabled state
+
+Use the `disabled` property on `List.Item.Action` to dim the row and prevent interaction. Set it on `List.Container` to disable every item at once.
+
+<Examples.DisabledState />
+
 ### Progress indicator
 
 A single list item with a circular progress indicator in `List.Cell.Start`.

--- a/packages/dnb-eufemia/src/components/list/__tests__/List.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/list/__tests__/List.screenshot.test.ts
@@ -63,6 +63,13 @@ describe.each(['ui', 'sbanken'])(`List for %s`, (themeName) => {
     })
   })
 
+  it('have to match disabled list', async () => {
+    await makeScreenshot({
+      style: { width: '30rem' },
+      selector: '[data-visual-test="list-disabled"]',
+    })
+  })
+
   it('have to match footer list with buttons', async () => {
     await makeScreenshot({
       style: { width: '30rem' },

--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -425,7 +425,6 @@
         --token-color-icon-action-disabled
       );
       --list-item-icon-color: var(--token-color-icon-action-disabled);
-      --list-item-outline-color: var(--token-color-stroke-action-disabled);
 
       .dnb-list__item__accordion__header {
         cursor: not-allowed;


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1785146071521309

## Problem

Reported by a user: when a `List.Item` is disabled in a list with several items, the border looks off — the disabled row appears "boxed in" with a border in a different colour than the surrounding dividers.

## Cause

Each list item draws a full border via an `::after` overlay; adjacent items overlap so their borders collapse into shared 1px dividers (the outer edges form the container frame). The `.dnb-list__item--disabled` style overrode the *resting* border colour with `--token-color-stroke-action-disabled`, so a disabled item drew its border in the disabled action-stroke colour instead of the neutral divider colour.

Because of paint order (later item on top for equal `z-index`), the disabled item's top/left/right edges showed the disabled colour while its bottom edge was overpainted by the next item's neutral border — producing the inconsistent boxed look. It only appears when the disabled item has neighbours.

## Fix

Remove the resting `--list-item-outline-color` override from the `.dnb-list__item--disabled` block so the border falls back to the neutral subtle colour, matching neighbouring items and the shared dividers. The disabled state is still conveyed by the dimmed text/icon colours, and interaction colours are untouched (disabled rows never trigger hover/focus/active).

## Changes

- `dnb-list.scss` — remove the resting outline-color override on disabled items.
- `Examples.tsx` + `demos.mdx` — add a `DisabledState` demo (middle item disabled, matching the report) and document the `disabled` prop on `List.Item.Action`.
- `List.screenshot.test.ts` — add a `have to match disabled list` screenshot test.

## Testing

- Existing list unit tests pass (105/105).
- Prettier clean.
- New screenshot test needs a baseline generated via the standard screenshot workflow (`yarn workspace @dnb/eufemia test:screenshots:update`) — please run/regenerate in CI.