### PR TITLE
fix(Form.Outlet): support rendering before handler

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Outlet/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Outlet/Examples.tsx
@@ -54,6 +54,52 @@ export const OutsideTreeFields = () => {
   )
 }
 
+export const OutletBeforeHandler = () => {
+  return (
+    <ComponentBox hideCode scope={{ useId }}>
+      {() => {
+        const Example = () => {
+          const formHandlerId = useId()
+
+          return (
+            <Flex.Stack>
+              <Form.Card>
+                <Flex.Stack>
+                  <Form.SubHeading>
+                    Form.Outlet rendered first
+                  </Form.SubHeading>
+
+                  <Form.Outlet formHandlerId={formHandlerId}>
+                    <Field.Name.First path="/firstName" />
+                    <Field.Name.Last path="/lastName" />
+                  </Form.Outlet>
+                </Flex.Stack>
+              </Form.Card>
+
+              <Form.Handler
+                id={formHandlerId}
+                data={{ firstName: 'Nora', lastName: 'Mork' }}
+              >
+                <Form.Card>
+                  <Form.SubHeading>
+                    Form.Handler rendered afterwards
+                  </Form.SubHeading>
+                  <Value.Composition label="Name">
+                    <Value.String path="/firstName" />
+                    <Value.String path="/lastName" />
+                  </Value.Composition>
+                </Form.Card>
+              </Form.Handler>
+            </Flex.Stack>
+          )
+        }
+
+        return <Example />
+      }}
+    </ComponentBox>
+  )
+}
+
 export const SectionInsideOutlet = () => {
   return (
     <ComponentBox hideCode scope={{ useId }}>

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Outlet/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Outlet/demos.mdx
@@ -10,6 +10,12 @@ import * as Examples from './Examples'
 
 <Examples.OutsideTreeFields />
 
+### Render outlet before handler
+
+`Form.Outlet` can be rendered before its linked `Form.Handler`. It stays empty until the handler context is available and then connects automatically.
+
+<Examples.OutletBeforeHandler />
+
 ### Linked data inside Form.Section in outlet
 
 <Examples.SectionInsideOutlet />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Outlet/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Outlet/info.mdx
@@ -16,7 +16,7 @@ render(<Form.Outlet formHandlerId="my-form-id">...</Form.Outlet>)
 
 This is useful when you need to render parts of a form outside the handler subtree, such as in a side panel, modal footer, or another layout region.
 
-The `formHandlerId` is required and must reference a mounted `Form.Handler`.
+The `formHandlerId` is required. The matching `Form.Handler` can be rendered before or after the outlet. The outlet stays empty until the handler context is available and then connects automatically.
 
 When `Form.Outlet` is placed **outside** a `Form.Handler` subtree it automatically wraps its children in a `<form>` element, so submit buttons work correctly. When placed **inside** an existing `Form.Handler`, no extra `<form>` element is added.
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Outlet/Outlet.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Outlet/Outlet.tsx
@@ -1,8 +1,7 @@
-import { useContext, useMemo, useRef } from 'react'
+import { useContext, useRef } from 'react'
 import type { ReactNode } from 'react'
 import type { SharedStateId } from '../../../../shared/helpers/useSharedState'
 import {
-  createSharedState,
   createReferenceKey,
   useSharedState,
 } from '../../../../shared/helpers/useSharedState'
@@ -12,9 +11,6 @@ import DataContext from '../../DataContext/Context'
 import DataContextRefContext from '../../DataContext/DataContextRefContext'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 import FormElement from '../Element'
-
-const invalidOutletErrorMessage =
-  'Form.Outlet needs a valid formHandlerId that points to a mounted Form.Handler'
 
 export type FormOutletProps = {
   /**
@@ -36,40 +32,19 @@ function Outlet(props: FormOutletProps) {
 
   // Subscribe to reactive attachments updates to trigger re-renders
   // when linked validation/form state changes in the source handler.
-  const { data: linkedAttachments } = useSharedState<
-    SharedAttachments<unknown>
-  >(createReferenceKey(formHandlerId, 'attachments'))
-  const linkedValidationVersion = linkedAttachments?.validationVersion
-  const linkedShowAllErrors = linkedAttachments?.showAllErrors
+  useSharedState<SharedAttachments<unknown>>(
+    createReferenceKey(formHandlerId, 'attachments')
+  )
 
-  // Stable reference to the linked data-context shared store.
-  // createSharedState is idempotent — safe to call in render, but we memoize
-  // the result so useMemo below has a stable dep without an eslint-disable.
-  const dataContextStore = useMemo(
-    () =>
-      createSharedState<ContextState>(
-        createReferenceKey(formHandlerId, 'data-context')
-      ),
-    [formHandlerId]
+  const { data: dataContext } = useSharedState<ContextState>(
+    createReferenceKey(formHandlerId, 'data-context')
   )
 
   const dataContextRef = useRef<ContextState>(undefined)
 
-  const dataContext = useMemo(() => {
-    // Consume the reactive signals so the context is re-read on validation
-    // state changes (e.g. submit-triggered showAllErrors) without a
-    // redundant eslint-disable.
-    void linkedValidationVersion
-    void linkedShowAllErrors
-
-    const context = dataContextStore.get()
-
-    if (!context?.hasContext) {
-      throw new Error(invalidOutletErrorMessage)
-    }
-
-    return context
-  }, [dataContextStore, linkedValidationVersion, linkedShowAllErrors])
+  if (!dataContext?.hasContext) {
+    return null
+  }
 
   // Mirror the linked context into a stable ref so consumers using
   // `useDataValue` (which subscribe through `DataContextRefContext`) can

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Outlet/__tests__/Outlet.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Outlet/__tests__/Outlet.test.tsx
@@ -9,22 +9,90 @@ describe('Form.Outlet', () => {
     )
   })
 
-  it('should throw if no matching Form.Handler exists for formHandlerId', () => {
-    const log = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    const renderFn = () => {
-      render(
-        <Form.Outlet formHandlerId="missing-handler-id">
-          <Field.String path="/name" />
-        </Form.Outlet>
-      )
-    }
-
-    expect(renderFn).toThrow(
-      'Form.Outlet needs a valid formHandlerId that points to a mounted Form.Handler'
+  it('should stay empty while no matching Form.Handler exists', () => {
+    render(
+      <Form.Outlet formHandlerId="missing-handler-id">
+        <Field.String path="/name" />
+      </Form.Outlet>
     )
 
-    log.mockRestore()
+    expect(document.querySelector('input.dnb-input__input')).toBeNull()
+  })
+
+  it('should connect when rendered before Form.Handler in the same tree', async () => {
+    const formId = 'outlet-before-handler'
+
+    render(
+      <>
+        <Form.Outlet formHandlerId={formId}>
+          <Field.String path="/name" />
+        </Form.Outlet>
+        <Form.Handler id={formId} data={{ name: 'Nora' }}>
+          {null}
+        </Form.Handler>
+      </>
+    )
+
+    await waitFor(() => {
+      expect(
+        (
+          document.querySelector(
+            'input.dnb-input__input'
+          ) as HTMLInputElement
+        )?.value
+      ).toBe('Nora')
+    })
+  })
+
+  it('should connect and submit when Form.Handler mounts later', async () => {
+    const formId = 'outlet-before-later-handler'
+    const onSubmit = vi.fn()
+
+    const renderTree = (showHandler: boolean) => (
+      <>
+        <Form.Outlet formHandlerId={formId}>
+          <Field.String path="/name" />
+          <Form.SubmitButton>Submit from outlet</Form.SubmitButton>
+        </Form.Outlet>
+        {showHandler && (
+          <Form.Handler
+            id={formId}
+            data={{ name: 'Nora' }}
+            onSubmit={onSubmit}
+          >
+            {null}
+          </Form.Handler>
+        )}
+      </>
+    )
+
+    const { rerender } = render(renderTree(false))
+
+    expect(document.querySelector('input.dnb-input__input')).toBeNull()
+
+    rerender(renderTree(true))
+
+    const input = await waitFor(() => {
+      const element = document.querySelector(
+        'input.dnb-input__input'
+      ) as HTMLInputElement
+
+      expect(element?.value).toBe('Nora')
+
+      return element
+    })
+
+    fireEvent.change(input, { target: { value: 'Ada' } })
+
+    const outletForm = input.closest('form')
+    fireEvent.submit(outletForm)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        { name: 'Ada' },
+        expect.anything()
+      )
+    })
   })
 
   it('should connect nested fields to linked Form.Handler by formHandlerId', () => {


### PR DESCRIPTION
Supports rendering Form.Outlet before its linked Form.Handler.