### PR TITLE
fix(Forms): handle pending state consistently during async validation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
@@ -40,11 +40,11 @@ export const PostalCode = () => {
           },
         })
 
-        const onBlurValidator = withConfig(
+        const onChangeValidator = withConfig(
           Connectors.Bring.postalCode.validator
         )
 
-        const onBlur = withConfig(Connectors.Bring.postalCode.autofill, {
+        const onChange = withConfig(Connectors.Bring.postalCode.autofill, {
           cityPath: '/city',
         })
 
@@ -55,8 +55,8 @@ export const PostalCode = () => {
                 countryCode="/countryCode"
                 postalCode={{
                   path: '/postalCode',
-                  onBlurValidator,
-                  onBlur,
+                  onChangeValidator,
+                  onChange,
                   required: true,
                 }}
                 city={{

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/Examples.tsx
@@ -3,25 +3,50 @@ import { getMockData as getMockDataPostalCode } from '@dnb/eufemia/src/extension
 import { getMockData as getMockDataAddress } from '@dnb/eufemia/src/extensions/forms/Connectors/Bring/address'
 import { Form, Field, Connectors } from '@dnb/eufemia/src/extensions/forms'
 
-let mockFetchTimeout = null
-async function mockFetch(countryCode: string, data) {
-  const originalFetch = globalThis.fetch
+const mockResponses = new Map<string, unknown>()
+let originalFetch: typeof globalThis.fetch | undefined
+let mockFetchImplementation: typeof globalThis.fetch | undefined
 
-  globalThis.fetch = () => {
-    return Promise.resolve({
-      ok: true,
-      json: () => {
-        return Promise.resolve(data)
-      },
-    }) as Promise<Response>
+export function resetMockFetch() {
+  mockResponses.clear()
+
+  if (originalFetch) {
+    globalThis.fetch = originalFetch
+  }
+
+  originalFetch = undefined
+  mockFetchImplementation = undefined
+}
+
+export async function mockFetch(url: string, data: unknown) {
+  mockResponses.set(url, data)
+
+  if (globalThis.fetch !== mockFetchImplementation) {
+    originalFetch = globalThis.fetch
+    const fallbackFetch = originalFetch
+    mockFetchImplementation = (input, init) => {
+      const requestUrl =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url
+
+      if (mockResponses.has(requestUrl)) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockResponses.get(requestUrl)), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      }
+
+      return fallbackFetch(input, init)
+    }
+    globalThis.fetch = mockFetchImplementation
   }
 
   await new Promise((resolve) => setTimeout(resolve, 1000))
-
-  clearTimeout(mockFetchTimeout)
-  mockFetchTimeout = setTimeout(() => {
-    globalThis.fetch = originalFetch
-  }, 1100)
 }
 
 export const PostalCode = () => {
@@ -31,11 +56,9 @@ export const PostalCode = () => {
         const { withConfig } = Connectors.createContext({
           fetchConfig: {
             url: async (value, { countryCode }) => {
-              await mockFetch(
-                countryCode,
-                getMockDataPostalCode(countryCode)
-              )
-              return `[YOUR-API-URL]/${value}`
+              const url = `[YOUR-API-URL]/postal-code/${value}`
+              await mockFetch(url, getMockDataPostalCode(countryCode))
+              return url
             },
           },
         })
@@ -85,8 +108,9 @@ export const Address = () => {
         const { withConfig } = Connectors.createContext({
           fetchConfig: {
             url: async (value, { countryCode }) => {
-              await mockFetch(countryCode, getMockDataAddress(countryCode))
-              return `[YOUR-API-URL]/${value}`
+              const url = `[YOUR-API-URL]/address/${value}`
+              await mockFetch(url, getMockDataAddress(countryCode))
+              return url
             },
           },
         })

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/__tests__/Examples.test.ts
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Connectors/Bring/__tests__/Examples.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mockFetch, resetMockFetch } from '../Examples'
+
+describe('Connector.Bring example mock', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    vi.useRealTimers()
+    resetMockFetch()
+    globalThis.fetch = originalFetch
+  })
+
+  it('keeps the latest mocked response while requests overlap', async () => {
+    vi.useFakeTimers()
+    const fallbackFetch = vi.fn(async () => {
+      return new Response('Not mocked')
+    })
+    globalThis.fetch = fallbackFetch
+
+    const firstRequest = mockFetch('/first', { value: 'first' })
+    await vi.advanceTimersByTimeAsync(1000)
+    await firstRequest
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    const secondData = { value: 'second' }
+    const secondRequest = mockFetch('/second', secondData)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await secondRequest
+
+    const response = await globalThis.fetch('/second')
+
+    expect(await response.json()).toEqual(secondData)
+
+    const fallbackResponse = await globalThis.fetch('/not-mocked', {
+      headers: { Accept: 'application/json' },
+    })
+
+    expect(await fallbackResponse.text()).toBe('Not mocked')
+    expect(fallbackFetch).toHaveBeenCalledWith('/not-mocked', {
+      headers: { Accept: 'application/json' },
+    })
+
+    resetMockFetch()
+    expect(globalThis.fetch).toBe(fallbackFetch)
+  })
+})

--- a/packages/dnb-design-system-portal/src/e2e/bring-connector.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/bring-connector.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import waitForApp from './shared/waitForApp'
+
+test.describe('Connector.Bring', () => {
+  test('keeps an invalid Swedish postal code error after change, blur, and submit', async ({
+    page,
+  }) => {
+    await page.goto('/uilib/extensions/forms/Connectors/Bring/')
+    await waitForApp(page)
+
+    const form = page
+      .locator('form')
+      .filter({
+        has: page.locator('.dnb-forms-field-postal-code-and-city'),
+      })
+      .first()
+    const countryInput = form.locator(
+      '.dnb-forms-field-select-country input'
+    )
+    const postalCodeInput = form.locator(
+      '.dnb-forms-field-postal-code-and-city__postal-code input'
+    )
+    const postalCodeIndicator = form.locator(
+      '.dnb-forms-field-postal-code-and-city__postal-code .dnb-forms-submit-indicator'
+    )
+
+    await countryInput.click()
+    await countryInput.fill('sver')
+    await page
+      .locator('.dnb-drawer-list__option')
+      .filter({ hasText: 'Sverige' })
+      .first()
+      .click()
+
+    await expect(countryInput).toHaveValue('Sverige')
+
+    await postalCodeInput.fill('12345')
+    await expect(form.getByRole('alert')).toHaveText('Ugyldig postnummer.')
+    await expect(postalCodeIndicator).not.toHaveClass(
+      /dnb-forms-submit-indicator--state-pending/
+    )
+
+    await postalCodeInput.press('Backspace')
+    await postalCodeInput.press('4')
+    await expect(postalCodeIndicator).toHaveClass(
+      /dnb-forms-submit-indicator--state-pending/
+    )
+    await postalCodeInput.blur()
+    await expect(postalCodeIndicator).not.toHaveClass(
+      /dnb-forms-submit-indicator--state-pending/
+    )
+    await expect(form.getByRole('alert')).toHaveText('Ugyldig postnummer.')
+
+    await form.locator('button[type="submit"]').click()
+    await expect(form.locator('.dnb-form-status')).toContainText(
+      'Ugyldig postnummer.'
+    )
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
@@ -1001,6 +1001,47 @@ describe('postalCode', () => {
       expect(cityInput).toHaveValue('Vollen')
     })
 
+    it('should not fill city from a stale request', async () => {
+      let resolveFetch: () => void = () => undefined
+      const fetchPromise = new Promise<void>((resolve) => {
+        resolveFetch = resolve
+      })
+      globalThis.fetch = createFetchMock(null, () => fetchPromise)
+
+      render(
+        <Form.Handler>
+          <Field.PostalCodeAndCity
+            postalCode={{
+              path: '/postalCode',
+              onChange,
+            }}
+            city={{ path: '/city' }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
+      )
+      const cityInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__city .dnb-input__input'
+      )
+
+      fireEvent.change(postalCodeInput, { target: { value: '1391' } })
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+      })
+
+      fireEvent.change(postalCodeInput, { target: { value: '139' } })
+      resolveFetch()
+
+      await waitFor(() => {
+        expect(postalCodeInput).toHaveValue('139')
+        expect(cityInput).toHaveValue('')
+      })
+    })
+
     it('should not fill city when invalid postal code is given', async () => {
       render(
         <Form.Handler>

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
@@ -349,34 +349,11 @@ describe('postalCode', () => {
     })
 
     it('should use AbortController to cancel request while typing', async () => {
-      const mockAbort = vi.fn()
-
-      const mockSignal = {
-        aborted: false,
-        onabort: null,
-        reason: undefined,
-        throwIfAborted: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      }
-
-      globalThis.AbortController = vi.fn(function () {
-        return {
-          signal: mockSignal,
-          abort: mockAbort,
-        }
-      })
-
-      // With delay so we can abort
-      globalThis.fetch = createFetchMock(null, async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10))
-      })
+      const signals = mockPendingFetch()
 
       render(
         <Form.Handler>
           <Field.PostalCodeAndCity
-            // Use SE ini order to call "fetch" twice.
             countryCode="SE"
             postalCode={{
               path: '/postalCode',
@@ -390,17 +367,84 @@ describe('postalCode', () => {
         '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
       )
 
-      await userEvent.type(postalCodeInput, '00000')
-
-      expect(mockAbort).toHaveBeenCalledTimes(1)
+      fireEvent.change(postalCodeInput, { target: { value: '0000' } })
 
       await waitFor(() => {
-        expect(
-          document.querySelector('.dnb-form-status')
-        ).toBeInTheDocument()
-        expect(
-          document.querySelector('.dnb-form-status')
-        ).toHaveTextContent(nb.PostalCodeAndCity.invalidCode)
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+      })
+
+      fireEvent.change(postalCodeInput, { target: { value: '00000' } })
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+        expect(signals[0].aborted).toBe(true)
+      })
+    })
+
+    it('should cancel autofill when the input becomes too short', async () => {
+      const signals = mockPendingFetch()
+      const onChange = withConfig(Connectors.Bring.postalCode.autofill, {
+        cityPath: '/city',
+      })
+
+      render(
+        <Form.Handler>
+          <Field.PostalCodeAndCity
+            postalCode={{ path: '/postalCode', onBlur: onChange }}
+            city={{ path: '/city' }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
+      )
+
+      fireEvent.change(postalCodeInput, { target: { value: '1391' } })
+      fireEvent.blur(postalCodeInput)
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+      })
+
+      fireEvent.change(postalCodeInput, { target: { value: '139' } })
+      fireEvent.blur(postalCodeInput)
+
+      await waitFor(() => {
+        expect(signals[0].aborted).toBe(true)
+      })
+    })
+
+    it('should cancel validation when the country becomes unsupported', async () => {
+      const signals = mockPendingFetch()
+
+      render(
+        <Form.Handler
+          defaultData={{ postalCode: '1391', countryCode: 'NO' }}
+        >
+          <Field.String path="/countryCode" className="country" />
+          <Field.PostalCodeAndCity
+            countryCode="/countryCode"
+            postalCode={{ path: '/postalCode', onChangeValidator }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
+      )
+      const countryInput = document.querySelector('.country input')
+
+      fireEvent.change(postalCodeInput, { target: { value: '1392' } })
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+      })
+
+      fireEvent.change(countryInput, { target: { value: 'CH' } })
+
+      await waitFor(() => {
+        expect(signals[0].aborted).toBe(true)
       })
     })
 
@@ -1109,6 +1153,23 @@ describe('postalCode', () => {
     })
   })
 })
+
+function mockPendingFetch() {
+  const signals: AbortSignal[] = []
+  globalThis.fetch = vi.fn((_, { signal }: RequestInit) => {
+    signals.push(signal)
+
+    return new Promise<Response>((resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        reject(
+          new DOMException('The operation was aborted.', 'AbortError')
+        )
+      })
+    })
+  })
+
+  return signals
+}
 
 function createFetchMock(overwrite = null, delay = null) {
   return vi.fn(async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
@@ -147,6 +147,131 @@ describe('postalCode', () => {
       })
     })
 
+    it('should keep pending indicator while autofill is fetching', async () => {
+      let resolveValidation: () => void = () => undefined
+      let resolveAutofill: () => void = () => undefined
+      const validationPromise = new Promise<void>((resolve) => {
+        resolveValidation = resolve
+      })
+      const autofillPromise = new Promise<void>((resolve) => {
+        resolveAutofill = resolve
+      })
+      let requestCount = 0
+      globalThis.fetch = createFetchMock(null, () => {
+        requestCount++
+        return requestCount === 1 ? validationPromise : autofillPromise
+      })
+
+      const onChange = withConfig(Connectors.Bring.postalCode.autofill, {
+        cityPath: '/city',
+      })
+
+      render(
+        <Form.Handler>
+          <Field.PostalCodeAndCity
+            postalCode={{
+              path: '/postalCode',
+              onChangeValidator,
+              onChange,
+            }}
+            city={{ path: '/city' }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeBlock = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code'
+      )
+      const postalCodeInput = postalCodeBlock.querySelector(
+        '.dnb-input__input'
+      )
+      const postalCodeIndicator = postalCodeBlock.querySelector(
+        '.dnb-forms-submit-indicator'
+      )
+      const cityInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__city .dnb-input__input'
+      )
+
+      fireEvent.change(postalCodeInput, { target: { value: '1391' } })
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+        expect(postalCodeIndicator).toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+
+      resolveValidation()
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+      })
+      expect(cityInput).toHaveValue('')
+      expect(postalCodeIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+
+      resolveAutofill()
+
+      await waitFor(() => {
+        expect(cityInput).toHaveValue('Vollen')
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+    })
+
+    it('should clear pending indicator after submitting a valid postal code', async () => {
+      const onSubmit = vi.fn()
+      const onChange = withConfig(Connectors.Bring.postalCode.autofill, {
+        cityPath: '/city',
+      })
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Field.PostalCodeAndCity
+            postalCode={{
+              path: '/postalCode',
+              onChangeValidator,
+              onChange,
+            }}
+            city={{ path: '/city' }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeBlock = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code'
+      )
+      const postalCodeInput = postalCodeBlock.querySelector(
+        '.dnb-input__input'
+      )
+      const postalCodeIndicator = postalCodeBlock.querySelector(
+        '.dnb-forms-submit-indicator'
+      )
+      const cityInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__city .dnb-input__input'
+      )
+
+      await userEvent.type(postalCodeInput, '1391')
+
+      await waitFor(() => {
+        expect(cityInput).toHaveValue('Vollen')
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+
+      fireEvent.submit(document.querySelector('form'))
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+    })
+
     it('should show error when postal code is not valid', async () => {
       render(
         <Form.Handler>

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
@@ -147,6 +147,67 @@ describe('postalCode', () => {
       })
     })
 
+    it('should clear pending indicator when the value becomes synchronously invalid', async () => {
+      let resolveFetch: () => void = () => undefined
+      const fetchPromise = new Promise<void>((resolve) => {
+        resolveFetch = resolve
+      })
+      globalThis.fetch = createFetchMock(null, () => fetchPromise)
+
+      render(
+        <Form.Handler>
+          <Field.PostalCodeAndCity
+            postalCode={{
+              path: '/postalCode',
+              onChangeValidator,
+            }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeBlock = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code'
+      )
+      const postalCodeInput = postalCodeBlock.querySelector(
+        '.dnb-input__input'
+      )
+      const postalCodeIndicator = postalCodeBlock.querySelector(
+        '.dnb-forms-submit-indicator'
+      )
+
+      fireEvent.change(postalCodeInput, { target: { value: '1234' } })
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+        expect(postalCodeIndicator).toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+
+      fireEvent.change(postalCodeInput, { target: { value: '12345' } })
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toHaveTextContent(nb.PostalCode.errorPattern)
+
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+
+      resolveFetch()
+
+      await waitFor(() => {
+        expect(postalCodeIndicator).toHaveClass(
+          'dnb-forms-submit-indicator--state-error'
+        )
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+    })
+
     it('should keep pending indicator while autofill is fetching', async () => {
       let resolveValidation: () => void = () => undefined
       let resolveAutofill: () => void = () => undefined

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/__tests__/postalCode.test.tsx
@@ -30,6 +30,123 @@ describe('postalCode', () => {
       onChangeValidator = withConfig(Connectors.Bring.postalCode.validator)
     })
 
+    it('should not reveal a stale pattern error when blurred while fetching', async () => {
+      let resolveFetch: () => void = () => undefined
+      const fetchPromise = new Promise<void>((resolve) => {
+        resolveFetch = resolve
+      })
+      globalThis.fetch = createFetchMock(null, () => fetchPromise)
+
+      const onChange = withConfig(Connectors.Bring.postalCode.autofill, {
+        cityPath: '/city',
+      })
+
+      render(
+        <Form.Handler>
+          <Field.PostalCodeAndCity
+            postalCode={{
+              path: '/postalCode',
+              onChangeValidator,
+              onChange,
+            }}
+            city={{ path: '/city' }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeInput = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code .dnb-input__input'
+      )
+
+      for (const value of ['1', '11', '111', '1111']) {
+        fireEvent.change(postalCodeInput, { target: { value } })
+      }
+      fireEvent.blur(postalCodeInput)
+
+      expect(
+        document.querySelector('.dnb-form-status')
+      ).not.toBeInTheDocument()
+
+      resolveFetch()
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-form-status')
+        ).toHaveTextContent(nb.PostalCodeAndCity.invalidCode)
+      })
+    })
+
+    it('should show pending indicator only while fetching', async () => {
+      let resolveFetch: () => void = () => undefined
+      const fetchPromise = new Promise<void>((resolve) => {
+        resolveFetch = resolve
+      })
+      globalThis.fetch = createFetchMock(null, () => fetchPromise)
+
+      for (const value of ['1', '13', '139']) {
+        expect(onChangeValidator(value)).not.toBeInstanceOf(Promise)
+      }
+
+      render(
+        <Form.Handler>
+          <Field.PostalCodeAndCity
+            postalCode={{
+              path: '/postalCode',
+              onChangeValidator,
+            }}
+          />
+        </Form.Handler>
+      )
+
+      const postalCodeBlock = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__postal-code'
+      )
+      const cityBlock = document.querySelector(
+        '.dnb-forms-field-postal-code-and-city__city'
+      )
+      const postalCodeInput = postalCodeBlock.querySelector(
+        '.dnb-input__input'
+      )
+      const postalCodeIndicator = postalCodeBlock.querySelector(
+        '.dnb-forms-submit-indicator'
+      )
+      const cityIndicator = cityBlock.querySelector(
+        '.dnb-forms-submit-indicator'
+      )
+
+      for (const value of ['1', '13', '139']) {
+        fireEvent.change(postalCodeInput, { target: { value } })
+
+        expect(globalThis.fetch).not.toHaveBeenCalled()
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+        expect(cityIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      }
+
+      fireEvent.change(postalCodeInput, { target: { value: '1391' } })
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+        expect(postalCodeIndicator).toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+      expect(cityIndicator).not.toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+
+      resolveFetch()
+
+      await waitFor(() => {
+        expect(postalCodeIndicator).not.toHaveClass(
+          'dnb-forms-submit-indicator--state-pending'
+        )
+      })
+    })
+
     it('should show error when postal code is not valid', async () => {
       render(
         <Form.Handler>

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/address.tsx
@@ -145,13 +145,20 @@ export function suggestions(
       const parameters = {
         countryCode: String(countryCode).toLowerCase(),
       }
-      const { data } = await fetchData<AddressResolverData>(value, {
+      const result = await fetchData<AddressResolverData>(value, {
         generalConfig,
         parameters,
         abortControllerRef,
         preResponseResolver:
           handlerConfig?.preResponseResolver ?? preResponseResolver,
       })
+
+      if (!result) {
+        additionalArgs.hideIndicator()
+        return undefined // stop here
+      }
+
+      const { data } = result
 
       const { payload } = responseResolver(data, handlerConfig)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -151,7 +151,7 @@ export function validator(
   | UseFieldProps<string>['onBlurValidator'] {
   const abortControllerRef = { current: null }
 
-  return async function validatorHandler(value, additionalArgs?) {
+  return function validatorHandler(value, additionalArgs?) {
     if (!(typeof value === 'string' && value.length >= 4)) {
       return undefined // stop here
     }
@@ -165,41 +165,48 @@ export function validator(
     })
 
     if (!isSupportedCountryCode(countryCode, supportedCountryCodes)) {
-      return new Error(
-        unsupportedCountryCodeMessage.replace('{countryCode}', countryCode)
+      return Promise.resolve(
+        new Error(
+          unsupportedCountryCodeMessage.replace(
+            '{countryCode}',
+            countryCode
+          )
+        )
       )
     }
 
-    try {
-      const parameters = {
-        countryCode: String(countryCode).toLowerCase(),
-      }
-      const { data, status } = await fetchData<PostalCodeResolverData>(
-        value,
-        {
-          generalConfig,
-          parameters,
-          abortControllerRef,
-          preResponseResolver:
-            handlerConfig?.preResponseResolver ?? preResponseResolver,
+    return (async () => {
+      try {
+        const parameters = {
+          countryCode: String(countryCode).toLowerCase(),
         }
-      )
+        const { data, status } = await fetchData<PostalCodeResolverData>(
+          value,
+          {
+            generalConfig,
+            parameters,
+            abortControllerRef,
+            preResponseResolver:
+              handlerConfig?.preResponseResolver ?? preResponseResolver,
+          }
+        )
 
-      const onMatch = () => {
-        return new FormError('PostalCodeAndCity.invalidCode')
+        const onMatch = () => {
+          return new FormError('PostalCodeAndCity.invalidCode')
+        }
+
+        const { matcher } = responseResolver(data, handlerConfig)
+        const match = matcher(value)
+
+        if (status !== 400 && !match) {
+          return onMatch()
+        }
+      } catch (error) {
+        return error as Error
       }
 
-      const { matcher } = responseResolver(data, handlerConfig)
-      const match = matcher(value)
-
-      if (status !== 400 && !match) {
-        return onMatch()
-      }
-    } catch (error) {
-      return error as Error
-    }
-
-    return undefined
+      return undefined
+    })()
   }
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -112,13 +112,19 @@ export function autofill(
       const parameters = {
         countryCode: String(countryCode).toLowerCase(),
       }
-      const { data } = await fetchData<PostalCodeResolverData>(value, {
+      const result = await fetchData<PostalCodeResolverData>(value, {
         generalConfig,
         parameters,
         abortControllerRef,
         preResponseResolver:
           handlerConfig?.preResponseResolver ?? preResponseResolver,
       })
+
+      if (!result || currentRequestId !== requestId) {
+        return undefined // stop here
+      }
+
+      const { data } = result
 
       const onMatch = (payload: PostalCodeResolverPayload) => {
         const { cityPath } = handlerConfig || {}
@@ -131,9 +137,10 @@ export function autofill(
           const { dataContext } = additionalArgs
           const internalData = dataContext.internalDataRef.current
           const postalCodePath = additionalArgs.props?.path
-          const postalCodeValue = postalCodePath
-            ? pointer.get(internalData, postalCodePath)
-            : value
+          const postalCodeValue =
+            postalCodePath && pointer.has(internalData, postalCodePath)
+              ? pointer.get(internalData, postalCodePath)
+              : value
           const cityValue = pointer.has(internalData, cityPath)
             ? pointer.get(internalData, cityPath)
             : undefined
@@ -166,10 +173,15 @@ export function validator(
   | UseFieldProps<string>['onChangeValidator']
   | UseFieldProps<string>['onBlurValidator'] {
   const abortControllerRef = { current: null }
+  let requestId = 0
 
   return setAsyncValidatorBehavior(
     function validatorHandler(value, additionalArgs?) {
+      const currentRequestId = ++requestId
+
       if (!(typeof value === 'string' && value.length >= 4)) {
+        abortControllerRef.current?.abort()
+        abortControllerRef.current = null
         return undefined // stop here
       }
 
@@ -182,6 +194,8 @@ export function validator(
       })
 
       if (!isSupportedCountryCode(countryCode, supportedCountryCodes)) {
+        abortControllerRef.current?.abort()
+        abortControllerRef.current = null
         return Promise.resolve(
           new Error(
             unsupportedCountryCodeMessage.replace(
@@ -197,16 +211,19 @@ export function validator(
           const parameters = {
             countryCode: String(countryCode).toLowerCase(),
           }
-          const { data, status } = await fetchData<PostalCodeResolverData>(
-            value,
-            {
-              generalConfig,
-              parameters,
-              abortControllerRef,
-              preResponseResolver:
-                handlerConfig?.preResponseResolver ?? preResponseResolver,
-            }
-          )
+          const result = await fetchData<PostalCodeResolverData>(value, {
+            generalConfig,
+            parameters,
+            abortControllerRef,
+            preResponseResolver:
+              handlerConfig?.preResponseResolver ?? preResponseResolver,
+          })
+
+          if (!result || currentRequestId !== requestId) {
+            return undefined // stop here
+          }
+
+          const { data, status } = result
 
           const onMatch = () => {
             return new FormError('PostalCodeAndCity.invalidCode')

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -1,5 +1,5 @@
 import type { Path, PathStrict, UseFieldProps } from '../../types'
-import { FormError } from '../../utils'
+import { FormError, setAsyncValidatorBehavior } from '../../utils'
 import pointer from '../../utils/json-pointer'
 import type {
   GeneralConfig,
@@ -151,63 +151,65 @@ export function validator(
   | UseFieldProps<string>['onBlurValidator'] {
   const abortControllerRef = { current: null }
 
-  return function validatorHandler(value, additionalArgs?) {
-    if (!(typeof value === 'string' && value.length >= 4)) {
-      return undefined // stop here
-    }
-
-    // Get country code from path or use given countryCode value, and re-validate on path changes
-    const { countryCode } = handleCountryPath({
-      value,
-      countryCode: handlerConfig?.countryCode,
-      additionalArgs,
-      handler: validatorHandler,
-    })
-
-    if (!isSupportedCountryCode(countryCode, supportedCountryCodes)) {
-      return Promise.resolve(
-        new Error(
-          unsupportedCountryCodeMessage.replace(
-            '{countryCode}',
-            countryCode
-          )
-        )
-      )
-    }
-
-    return (async () => {
-      try {
-        const parameters = {
-          countryCode: String(countryCode).toLowerCase(),
-        }
-        const { data, status } = await fetchData<PostalCodeResolverData>(
-          value,
-          {
-            generalConfig,
-            parameters,
-            abortControllerRef,
-            preResponseResolver:
-              handlerConfig?.preResponseResolver ?? preResponseResolver,
-          }
-        )
-
-        const onMatch = () => {
-          return new FormError('PostalCodeAndCity.invalidCode')
-        }
-
-        const { matcher } = responseResolver(data, handlerConfig)
-        const match = matcher(value)
-
-        if (status !== 400 && !match) {
-          return onMatch()
-        }
-      } catch (error) {
-        return error as Error
+  return setAsyncValidatorBehavior(
+    function validatorHandler(value, additionalArgs?) {
+      if (!(typeof value === 'string' && value.length >= 4)) {
+        return undefined // stop here
       }
 
-      return undefined
-    })()
-  }
+      // Get country code from path or use given countryCode value, and re-validate on path changes
+      const { countryCode } = handleCountryPath({
+        value,
+        countryCode: handlerConfig?.countryCode,
+        additionalArgs,
+        handler: validatorHandler,
+      })
+
+      if (!isSupportedCountryCode(countryCode, supportedCountryCodes)) {
+        return Promise.resolve(
+          new Error(
+            unsupportedCountryCodeMessage.replace(
+              '{countryCode}',
+              countryCode
+            )
+          )
+        )
+      }
+
+      return (async () => {
+        try {
+          const parameters = {
+            countryCode: String(countryCode).toLowerCase(),
+          }
+          const { data, status } = await fetchData<PostalCodeResolverData>(
+            value,
+            {
+              generalConfig,
+              parameters,
+              abortControllerRef,
+              preResponseResolver:
+                handlerConfig?.preResponseResolver ?? preResponseResolver,
+            }
+          )
+
+          const onMatch = () => {
+            return new FormError('PostalCodeAndCity.invalidCode')
+          }
+
+          const { matcher } = responseResolver(data, handlerConfig)
+          const match = matcher(value)
+
+          if (status !== 400 && !match) {
+            return onMatch()
+          }
+        } catch (error) {
+          return error as Error
+        }
+
+        return undefined
+      })()
+    }
+  )
 }
 
 export function getMockData(countryCode?: string) {

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/Bring/postalCode.ts
@@ -1,5 +1,6 @@
 import type { Path, PathStrict, UseFieldProps } from '../../types'
-import { FormError, setAsyncValidatorBehavior } from '../../utils'
+import { FormError } from '../../utils'
+import { setAsyncValidatorBehavior } from '../../utils/validatorOptions'
 import pointer from '../../utils/json-pointer'
 import type {
   GeneralConfig,
@@ -82,9 +83,14 @@ export function autofill(
   handlerConfig?: AutofillHandlerConfig & { cityPath: Path }
 ): UseFieldProps<string>['onChange'] {
   const abortControllerRef = { current: null }
+  let requestId = 0
 
   return async function autofillHandler(value, additionalArgs?) {
+    const currentRequestId = ++requestId
+
     if (!(typeof value === 'string' && value.length >= 4)) {
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
       return undefined // stop here
     }
 
@@ -97,6 +103,8 @@ export function autofill(
     })
 
     if (!isSupportedCountryCode(countryCode, supportedCountryCodes)) {
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
       return undefined // stop here
     }
 
@@ -122,10 +130,18 @@ export function autofill(
           }
           const { dataContext } = additionalArgs
           const internalData = dataContext.internalDataRef.current
-          const value = pointer.has(internalData, cityPath)
+          const postalCodePath = additionalArgs.props?.path
+          const postalCodeValue = postalCodePath
+            ? pointer.get(internalData, postalCodePath)
+            : value
+          const cityValue = pointer.has(internalData, cityPath)
             ? pointer.get(internalData, cityPath)
             : undefined
-          if (!value) {
+          if (
+            currentRequestId === requestId &&
+            postalCodeValue === value &&
+            !cityValue
+          ) {
             dataContext.handlePathChangeUnvalidated(cityPath, payload.city)
           }
         }

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/__tests__/createContext.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/__tests__/createContext.test.ts
@@ -169,6 +169,24 @@ describe('additional tests', () => {
     global.fetch = originalFetch
   })
 
+  it('should handle an aborted fetch without destructuring undefined', async () => {
+    const originalFetch = global.fetch
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException('The operation was aborted.', 'AbortError')
+      )
+
+    await expect(
+      fetchData('testValue', {
+        generalConfig: { fetchConfig: { url: 'https://example.com' } },
+        abortControllerRef: { current: null },
+      })
+    ).resolves.toBeUndefined()
+
+    global.fetch = originalFetch
+  })
+
   it('should handle default country code in getCountryCodeValue', () => {
     const mockAdditionalArgs = {
       props: {},

--- a/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Connectors/createContext.ts
@@ -68,23 +68,23 @@ export type FetchDataFromAPIOptions = {
 async function fetchDataFromAPI<Data = unknown>(
   generalConfig: GeneralConfig & { fetchConfig: { url: string } },
   options?: FetchDataFromAPIOptions
-): Promise<{
-  data: Data
-  response: Response
-}> {
+): Promise<
+  | {
+      data: Data
+      response: Response
+    }
+  | undefined
+> {
   const { fetchConfig } = generalConfig
 
   const controller = options?.abortControllerRef
+  controller?.current?.abort()
+
+  const abortController = controller ? new AbortController() : null
   if (controller) {
-    if (controller.current) {
-      controller.current.abort()
-      controller.current = null
-    }
-    if (!controller.current) {
-      controller.current = new AbortController()
-    }
+    controller.current = abortController
   }
-  const { signal } = controller?.current || {}
+  const signal = abortController?.signal
 
   const fetchOptions = {
     method: 'GET',
@@ -98,8 +98,8 @@ async function fetchDataFromAPI<Data = unknown>(
   try {
     const response = await fetch(fetchConfig.url, fetchOptions)
 
-    if (controller) {
-      controller.current = null
+    if (!response) {
+      throw new Error('Please try again!')
     }
 
     return {
@@ -108,7 +108,11 @@ async function fetchDataFromAPI<Data = unknown>(
     }
   } catch (error) {
     if (!(error instanceof DOMException && error.name === 'AbortError')) {
-      return error as never
+      throw error
+    }
+  } finally {
+    if (controller?.current === abortController) {
+      controller.current = null
     }
   }
   return undefined
@@ -122,7 +126,7 @@ export type FetchDataReturnValue<Data = unknown> = {
 export async function fetchData<Data = unknown>(
   value: string,
   options: FetchDataFromAPIOptions
-): Promise<FetchDataReturnValue<Data>> {
+): Promise<FetchDataReturnValue<Data> | undefined> {
   const { generalConfig, parameters } = options || {}
 
   const result = options?.preResponseResolver?.({ value })
@@ -133,7 +137,7 @@ export async function fetchData<Data = unknown>(
   const u = generalConfig.fetchConfig.url
   const url = typeof u === 'function' ? await u(value, parameters) : u
 
-  const { data, response } = await fetchDataFromAPI<Data>(
+  const resultFromAPI = await fetchDataFromAPI<Data>(
     {
       ...generalConfig,
       fetchConfig: {
@@ -144,9 +148,11 @@ export async function fetchData<Data = unknown>(
     options
   )
 
-  if (!response) {
-    throw new Error('Please try again!')
+  if (!resultFromAPI?.response) {
+    return undefined
   }
+
+  const { data, response } = resultFromAPI
 
   // Check if the response status is in the range of 200-299
   if (!response.ok) {

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -15,6 +15,7 @@ import {
   isZodSchema,
   createZodValidator,
   zodErrorsToFormErrors,
+  hasAsyncValidatorBehavior,
 } from '../../utils'
 import type {
   GlobalErrorMessagesWithPaths,
@@ -937,8 +938,8 @@ export default function Provider<Data extends JsonObject>(
       const { enableAsyncMode, props } = fieldInternals
       if (
         enableAsyncMode ||
-        isAsync(props?.onChangeValidator) ||
-        isAsync(props?.onBlurValidator)
+        hasAsyncValidatorBehavior(props?.onChangeValidator) ||
+        hasAsyncValidatorBehavior(props?.onBlurValidator)
       ) {
         return true
       }

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -15,8 +15,8 @@ import {
   isZodSchema,
   createZodValidator,
   zodErrorsToFormErrors,
-  hasAsyncValidatorBehavior,
 } from '../../utils'
+import { hasAsyncValidatorBehavior } from '../../utils/validatorOptions'
 import type {
   GlobalErrorMessagesWithPaths,
   SubmitState,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
@@ -786,37 +786,73 @@ describe('Field.Composition', () => {
     })
   })
 
-  it('should forward field state through nested compositions', async () => {
-    const onChangeValidator = vi.fn(async () => {
-      await wait(50)
+  it('should aggregate state from simultaneous child validations', async () => {
+    const firstValidator = vi.fn(async () => {
+      await wait(100)
+      return undefined
+    })
+    const secondValidator = vi.fn(async () => {
+      await wait(20)
       return undefined
     })
 
     render(
       <FieldBlock label="Outer field block">
         <Field.Composition>
-          <Field.String onChangeValidator={onChangeValidator} />
+          <Field.String onChangeValidator={firstValidator} />
+          <Field.String onChangeValidator={secondValidator} />
         </Field.Composition>
       </FieldBlock>
     )
 
-    const [fieldIndicator, compositionIndicator, outerIndicator] =
-      Array.from(document.querySelectorAll('.dnb-forms-submit-indicator'))
-    const input = document.querySelector('input')
+    const inputs = Array.from(document.querySelectorAll('input'))
+    const indicators = Array.from(
+      document.querySelectorAll('.dnb-forms-submit-indicator')
+    )
+    const firstIndicator = indicators[0]
+    const secondIndicator = indicators[1]
+    const compositionIndicator = indicators[2]
+    const outerIndicator = indicators[3]
 
-    fireEvent.change(input, { target: { value: 'value' } })
+    fireEvent.change(inputs[0], { target: { value: 'first' } })
+    fireEvent.change(inputs[1], { target: { value: 'second' } })
 
     await waitFor(() => {
+      expect(firstIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+      expect(secondIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
       expect(outerIndicator).toHaveClass(
         'dnb-forms-submit-indicator--state-pending'
       )
-      expect(fieldIndicator).toHaveClass(
-        'dnb-forms-submit-indicator--state-pending'
-      )
     })
+    expect(
+      document.querySelectorAll(
+        '.dnb-forms-submit-indicator--state-pending'
+      )
+    ).toHaveLength(3)
     expect(compositionIndicator).not.toHaveClass(
       'dnb-forms-submit-indicator--state-pending'
     )
+
+    await waitFor(() => {
+      expect(firstIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+      expect(secondIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-complete'
+      )
+      expect(outerIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+      expect(
+        document.querySelectorAll(
+          '.dnb-forms-submit-indicator--state-pending'
+        )
+      ).toHaveLength(2)
+    })
   })
 
   it('should show submit indicator on Form.SubmitButton inside Field.Composition', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Composition/__tests__/Composition.test.tsx
@@ -1,7 +1,7 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { JSONSchema } from '../../..'
-import { Field, Form, makeAjvInstance } from '../../..'
+import { Field, FieldBlock, Form, makeAjvInstance } from '../../..'
 import {
   axeComponent,
   wait,
@@ -784,6 +784,39 @@ describe('Field.Composition', () => {
 
       expect(await axeComponent(result)).toHaveNoViolations()
     })
+  })
+
+  it('should forward field state through nested compositions', async () => {
+    const onChangeValidator = vi.fn(async () => {
+      await wait(50)
+      return undefined
+    })
+
+    render(
+      <FieldBlock label="Outer field block">
+        <Field.Composition>
+          <Field.String onChangeValidator={onChangeValidator} />
+        </Field.Composition>
+      </FieldBlock>
+    )
+
+    const [fieldIndicator, compositionIndicator, outerIndicator] =
+      Array.from(document.querySelectorAll('.dnb-forms-submit-indicator'))
+    const input = document.querySelector('input')
+
+    fireEvent.change(input, { target: { value: 'value' } })
+
+    await waitFor(() => {
+      expect(outerIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+      expect(fieldIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+    })
+    expect(compositionIndicator).not.toHaveClass(
+      'dnb-forms-submit-indicator--state-pending'
+    )
   })
 
   it('should show submit indicator on Form.SubmitButton inside Field.Composition', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -175,13 +175,7 @@ describe('Field.PostalCodeAndCity', () => {
     const postalCodeBlock = document.querySelector(
       '.dnb-forms-field-postal-code-and-city__postal-code'
     )
-    const cityBlock = document.querySelector(
-      '.dnb-forms-field-postal-code-and-city__city'
-    )
     const postalCodeIndicator = postalCodeBlock.querySelector(
-      '.dnb-forms-submit-indicator'
-    )
-    const cityIndicator = cityBlock.querySelector(
       '.dnb-forms-submit-indicator'
     )
     const postalCodeInput = postalCodeBlock.querySelector(
@@ -196,9 +190,11 @@ describe('Field.PostalCodeAndCity', () => {
       )
     })
 
-    expect(cityIndicator).not.toHaveClass(
-      'dnb-forms-submit-indicator--state-pending'
-    )
+    expect(
+      document.querySelectorAll(
+        '.dnb-forms-submit-indicator--state-pending'
+      )
+    ).toHaveLength(1)
   })
 
   it('should show error message when postal code is 0000', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PostalCodeAndCity/__tests__/PostalCodeAndCity.test.tsx
@@ -158,6 +158,49 @@ describe('Field.PostalCodeAndCity', () => {
     expect(city).toHaveValue('æ - ø - å')
   })
 
+  it('should only show pending indicator on postal code during async validator', async () => {
+    const onChangeValidator = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      return undefined
+    })
+
+    render(
+      <Field.PostalCodeAndCity
+        postalCode={{
+          onChangeValidator,
+        }}
+      />
+    )
+
+    const postalCodeBlock = document.querySelector(
+      '.dnb-forms-field-postal-code-and-city__postal-code'
+    )
+    const cityBlock = document.querySelector(
+      '.dnb-forms-field-postal-code-and-city__city'
+    )
+    const postalCodeIndicator = postalCodeBlock.querySelector(
+      '.dnb-forms-submit-indicator'
+    )
+    const cityIndicator = cityBlock.querySelector(
+      '.dnb-forms-submit-indicator'
+    )
+    const postalCodeInput = postalCodeBlock.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    fireEvent.change(postalCodeInput, { target: { value: '1234' } })
+
+    await waitFor(() => {
+      expect(postalCodeIndicator).toHaveClass(
+        'dnb-forms-submit-indicator--state-pending'
+      )
+    })
+
+    expect(cityIndicator).not.toHaveClass(
+      'dnb-forms-submit-indicator--state-pending'
+    )
+  })
+
   it('should show error message when postal code is 0000', async () => {
     render(
       <Field.PostalCodeAndCity

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -235,7 +235,7 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
   const blockId = useId(props.id)
   const [salt, forceUpdate] = useReducer(() => ({}), {})
   const mountedFieldsRef = useRef<MountedFieldsRef>(new Map())
-  const fieldStateRef = useRef<SubmitState | null>(null)
+  const fieldStatesRef = useRef<Map<Identifier, SubmitState>>(new Map())
   const stateRecordRef = useRef<StateRecord>({})
   const fieldStateIdsRef = useRef<FieldErrorIdsRef | null>(null)
   const contentsRef = useRef<HTMLDivElement>(null)
@@ -299,8 +299,12 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
         return undefined
       }
 
-      if (fieldState !== fieldStateRef.current) {
-        fieldStateRef.current = fieldState
+      if (fieldState !== fieldStatesRef.current.get(identifier)) {
+        if (fieldState) {
+          fieldStatesRef.current.set(identifier, fieldState)
+        } else {
+          fieldStatesRef.current.delete(identifier)
+        }
 
         forceUpdate()
       }
@@ -493,6 +497,7 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
   useEffect(
     () => () => {
       mountedFieldsRef.current = new Map()
+      fieldStatesRef.current = new Map()
       stateRecordRef.current = {}
     },
     []
@@ -694,13 +699,40 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
           </div>
 
           <SubmitIndicator
-            state={fieldState ?? fieldStateRef.current}
+            state={
+              fieldState ?? getAggregateFieldState(fieldStatesRef.current)
+            }
             className="dnb-forms-field-block__indicator dnb-forms-submit-indicator--inline-wrap"
           />
         </div>
       </Space>
     </FieldBlockContext>
   )
+}
+
+const fieldStatePriority: Record<SubmitState, number> = {
+  abort: 0,
+  complete: 1,
+  success: 2,
+  error: 3,
+  pending: 4,
+}
+
+function getAggregateFieldState(
+  fieldStates: Map<Identifier, SubmitState>
+): SubmitState | undefined {
+  let aggregateState: SubmitState
+
+  fieldStates.forEach((state) => {
+    if (
+      !aggregateState ||
+      fieldStatePriority[state] > fieldStatePriority[aggregateState]
+    ) {
+      aggregateState = state
+    }
+  })
+
+  return aggregateState
 }
 
 function useEnableFieldset({

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -294,13 +294,17 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
 
   const setFieldState = useCallback(
     (identifier: Identifier, fieldState: SubmitState) => {
+      if (composition) {
+        return undefined
+      }
+
       if (fieldState !== fieldStateRef.current) {
         fieldStateRef.current = fieldState
 
         forceUpdate()
       }
     },
-    []
+    [composition]
   )
 
   const showFieldError = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -295,6 +295,7 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
   const setFieldState = useCallback(
     (identifier: Identifier, fieldState: SubmitState) => {
       if (composition) {
+        nestedFieldBlockContext?.setFieldState?.(identifier, fieldState)
         return undefined
       }
 
@@ -304,7 +305,7 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
         forceUpdate()
       }
     },
-    [composition]
+    [composition, nestedFieldBlockContext]
   )
 
   const showFieldError = useCallback(

--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/style/dnb-field-block.scss
@@ -301,21 +301,8 @@ fieldset.dnb-forms-field-block {
     }
   }
 
-  // Because we want to hide / show the indicator responsively,
-  // we render both, but hide the one we don't want to show.
-  // Use the specific __indicator class to avoid hiding the
-  // SubmitIndicator inside Form.SubmitButton.
-  @include utilities.allBelow(x-small) {
-    &__composition > &__grid > .dnb-forms-field-block__indicator {
-      display: none;
-    }
-  }
-  @include utilities.allAbove(x-small) {
-    &__composition
-      > &__grid
-      > &__contents
-      .dnb-forms-field-block__indicator {
-      display: none;
-    }
+  // Composition wrappers delegate async indicators to their fields.
+  &__composition > &__grid > .dnb-forms-field-block__indicator {
+    display: none;
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -38,6 +38,7 @@ import {
   wait,
 } from '../../../../core/test-utils/testSetup'
 import { useSharedState } from '../../../../shared/helpers/useSharedState'
+import { setAsyncValidatorBehavior } from '../../utils/validatorOptions'
 
 import nbNO from '../../constants/locales/nb-NO'
 import enGB from '../../constants/locales/en-GB'
@@ -4194,6 +4195,146 @@ describe('useFieldProps', () => {
         })
 
         window.requestAnimationFrame = original
+      })
+
+      it('should clear pending state when a marked async validator returns synchronously', async () => {
+        let resolveValidation: (error?: Error) => void = () => undefined
+        const onChangeValidator = setAsyncValidatorBehavior(
+          (value: string) => {
+            if (value.length < 4) {
+              return undefined
+            }
+
+            return new Promise<Error | undefined>((resolve) => {
+              resolveValidation = resolve
+            })
+          }
+        )
+
+        const { result } = renderHook(
+          (props: any) => useFieldProps(props),
+          {
+            initialProps: { onChangeValidator },
+          }
+        )
+
+        act(() => {
+          result.current.handleChange('1234')
+        })
+
+        expect(result.current.fieldState).toBe('pending')
+
+        act(() => {
+          result.current.handleChange('123')
+        })
+
+        await waitFor(() => {
+          expect(result.current.fieldState).toBe('complete')
+          expect(result.current.error).toBeUndefined()
+        })
+
+        resolveValidation(new Error('Stale error'))
+
+        await waitFor(() => {
+          expect(result.current.fieldState).toBe('complete')
+          expect(result.current.error).toBeUndefined()
+        })
+      })
+
+      it('should ignore an older async validator result', async () => {
+        const validations: Array<(error?: Error) => void> = []
+        const onChangeValidator = vi.fn(
+          () =>
+            new Promise<Error | undefined>((resolve) => {
+              validations.push(resolve)
+            })
+        )
+
+        const { result } = renderHook(
+          (props: any) => useFieldProps(props),
+          {
+            initialProps: { onChangeValidator },
+          }
+        )
+
+        act(() => {
+          result.current.handleChange('first')
+          result.current.handleChange('second')
+        })
+
+        expect(result.current.fieldState).toBe('pending')
+        expect(validations).toHaveLength(2)
+
+        validations[1]()
+
+        await waitFor(() => {
+          expect(result.current.fieldState).toBe('complete')
+          expect(result.current.error).toBeUndefined()
+        })
+
+        validations[0](new Error('Stale error'))
+
+        await waitFor(() => {
+          expect(result.current.fieldState).toBe('complete')
+          expect(result.current.error).toBeUndefined()
+        })
+      })
+
+      it('should show pending state for marked async path validation', async () => {
+        const validations: Array<(error?: Error) => void> = []
+        const onChangeValidator = setAsyncValidatorBehavior(
+          (value: string, { connectWithPath }) => {
+            connectWithPath('/dependency').getValue()
+
+            return new Promise<Error | undefined>((resolve) => {
+              validations.push(resolve)
+            })
+          }
+        )
+
+        render(
+          <Form.Handler>
+            <Field.String path="/dependency" className="dependency" />
+            <Field.String
+              path="/value"
+              className="value"
+              defaultValue="value"
+              onChangeValidator={onChangeValidator}
+              validateInitially
+            />
+          </Form.Handler>
+        )
+
+        const valueIndicator = document.querySelector(
+          '.value .dnb-forms-submit-indicator'
+        )
+
+        await waitFor(() => {
+          expect(valueIndicator).toHaveClass(
+            'dnb-forms-submit-indicator--state-pending'
+          )
+        })
+
+        validations[0]()
+
+        await waitFor(() => {
+          expect(valueIndicator).toHaveClass(
+            'dnb-forms-submit-indicator--state-complete'
+          )
+        })
+
+        const validationCount = validations.length
+        const dependencyInput = document.querySelector('.dependency input')
+        fireEvent.change(dependencyInput, { target: { value: 'changed' } })
+
+        await waitFor(() => {
+          expect(validations.length).toBeGreaterThan(validationCount)
+          expect(valueIndicator).toHaveClass(
+            'dnb-forms-submit-indicator--state-pending'
+          )
+        })
+
+        validations.slice(validationCount).forEach((resolve) => resolve())
       })
     })
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -256,6 +256,8 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     showFieldError: showFieldErrorFieldBlock,
     mountedFieldsRef: mountedFieldsRefFieldBlock,
   } = (inFieldBlock ? fieldBlockContext : {}) as FieldBlockContextProps
+  const setFieldStateFieldBlockRef = useRef(setFieldStateFieldBlock)
+  setFieldStateFieldBlockRef.current = setFieldStateFieldBlock
   const {
     activeIndex,
     activeIndexRef,
@@ -1126,6 +1128,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         isMounted: false,
         isPreMounted: false,
       })
+      setFieldStateFieldBlockRef.current?.(identifier, undefined)
       setMountedFieldSnapshot?.(identifier, { isMounted: false })
     }
   }, [

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -9,11 +9,8 @@ import {
 import type { AriaAttributes, ReactNode, RefObject } from 'react'
 import pointer from '../utils/json-pointer'
 import type { ValidateFunction } from 'ajv/dist/2020.js'
-import {
-  getValidatorOptions,
-  hasAsyncValidatorBehavior,
-  isZodSchema,
-} from '../utils'
+import { getValidatorOptions, isZodSchema } from '../utils'
+import { hasAsyncValidatorBehavior } from '../utils/validatorOptions'
 import type * as z from 'zod'
 import type {
   FieldPropsGeneric,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -9,7 +9,11 @@ import {
 import type { AriaAttributes, ReactNode, RefObject } from 'react'
 import pointer from '../utils/json-pointer'
 import type { ValidateFunction } from 'ajv/dist/2020.js'
-import { getValidatorOptions, isZodSchema } from '../utils'
+import {
+  getValidatorOptions,
+  hasAsyncValidatorBehavior,
+  isZodSchema,
+} from '../utils'
 import type * as z from 'zod'
 import type {
   FieldPropsGeneric,
@@ -801,7 +805,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
             return startOnBlurValidatorProcess({ overrideValue })
           },
-          isAsync(onBlurValidatorRef.current)
+          hasAsyncValidatorBehavior(onBlurValidatorRef.current)
         )
 
         await runPool(() => {
@@ -876,9 +880,9 @@ export default function useFieldProps<Value, EmptyValue, Props>(
         () => {
           setValidatedValidatorValue('onChangeValidator')
 
-          return validateValue()
+          return validateValue({ keepPendingForAsyncBehavior: true })
         },
-        isAsync(onChangeValidatorRef.current)
+        hasAsyncValidatorBehavior(onChangeValidatorRef.current)
       )
 
       addToPool(
@@ -1253,7 +1257,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
             return startOnBlurValidatorProcess()
           },
-          isAsync(onBlurValidatorRef.current)
+          hasAsyncValidatorBehavior(onBlurValidatorRef.current)
         )
 
         runPool(() => {
@@ -1662,7 +1666,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
           return startOnChangeValidatorValidation()
         },
-        isAsync(onChangeValidatorRef.current)
+        hasAsyncValidatorBehavior(onChangeValidatorRef.current)
       )
     }
 
@@ -1679,7 +1683,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
           return startOnBlurValidatorProcess()
         },
-        isAsync(onBlurValidatorRef.current)
+        hasAsyncValidatorBehavior(onBlurValidatorRef.current)
       )
     }
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -274,18 +274,23 @@ export default function useFieldValidation<Value>({
   const callValidatorFnAsync = useCallback(
     async (
       validator: Validator<Value>,
-      value: Value = valueRef.current
-    ): Promise<ReturnType<Validator<Value>>> => {
+      value: Value = valueRef.current,
+      result?: ReturnType<Validator<Value>>
+    ): Promise<Awaited<ReturnType<Validator<Value>>>> => {
       if (typeof validator !== 'function') {
         return undefined
       }
 
-      const result = await validator(value, additionalArgs)
+      let validationResult = result
+      if (typeof validationResult === 'undefined') {
+        validationResult = validator(value, additionalArgs)
+      }
+      validationResult = await validationResult
 
-      if (Array.isArray(result)) {
+      if (Array.isArray(validationResult)) {
         const errors = []
 
-        for (const validatorOrError of result) {
+        for (const validatorOrError of validationResult) {
           if (validatorOrError instanceof Error) {
             errors.push(validatorOrError)
           } else if (!hasBeenCalledRef(validatorOrError)) {
@@ -308,7 +313,7 @@ export default function useFieldValidation<Value>({
 
         callStackRef.current = []
       } else {
-        return ensureErrorMessageObject(result)
+        return ensureErrorMessageObject(validationResult)
       }
     },
     [additionalArgs, hasBeenCalledRef, ensureErrorMessageObject, valueRef]
@@ -325,15 +330,21 @@ export default function useFieldValidation<Value>({
 
       const result = validator(value, additionalArgs)
 
+      if (result instanceof Promise) {
+        return callValidatorFnAsync(validator, value, result)
+      }
+
       if (Array.isArray(result)) {
         const hasAsyncValidator = result.some((validator) =>
           isAsync(validator)
         )
         if (hasAsyncValidator) {
           return new Promise((resolve) => {
-            callValidatorFnAsync(validator, value).then((result) => {
-              resolve(result)
-            })
+            callValidatorFnAsync(validator, value, result).then(
+              (result) => {
+                resolve(result)
+              }
+            )
           })
         }
 
@@ -381,9 +392,7 @@ export default function useFieldValidation<Value>({
   // -- onChange validator orchestration --
 
   const revealOnChangeValidatorResult = useCallback(
-    ({ result, unchangedValue }) => {
-      const runAsync = isAsync(onChangeValidatorRef.current)
-
+    ({ result, unchangedValue, runAsync }) => {
       if (unchangedValue) {
         persistErrorState(
           runAsync ? 'gracefully' : 'weak',
@@ -435,16 +444,14 @@ export default function useFieldValidation<Value>({
     }
 
     const tmpValue = valueRef.current
-
-    let result = isAsync(onChangeValidatorRef.current)
-      ? await callValidatorFnAsync(onChangeValidatorRef.current)
+    const validationResult = isAsync(onChangeValidatorRef.current)
+      ? callValidatorFnAsync(onChangeValidatorRef.current)
       : callValidatorFnSync(onChangeValidatorRef.current)
-    if (result instanceof Promise) {
-      result = await result
-    }
+    const runAsync = validationResult instanceof Promise
+    const result = runAsync ? await validationResult : validationResult
 
     const unchangedValue = tmpValue === valueRef.current
-    return { result, unchangedValue }
+    return { result, unchangedValue, runAsync }
   }, [callValidatorFnAsync, callValidatorFnSync, valueRef])
 
   const startOnChangeValidatorValidation = useCallback(async () => {
@@ -452,22 +459,22 @@ export default function useFieldValidation<Value>({
       return undefined
     }
 
-    if (isAsync(onChangeValidatorRef.current)) {
+    const tmpValue = valueRef.current
+    const validationResult = isAsync(onChangeValidatorRef.current)
+      ? callValidatorFnAsync(onChangeValidatorRef.current)
+      : callValidatorFnSync(onChangeValidatorRef.current)
+    const runAsync = validationResult instanceof Promise
+
+    if (runAsync) {
       defineAsyncProcess('onChangeValidator')
       setFieldState('validating')
       hideError()
     }
 
-    const tmpValue = valueRef.current
-    let result = isAsync(onChangeValidatorRef.current)
-      ? await callValidatorFnAsync(onChangeValidatorRef.current)
-      : callValidatorFnSync(onChangeValidatorRef.current)
-    if (result instanceof Promise) {
-      result = await result
-    }
+    const result = runAsync ? await validationResult : validationResult
     const unchangedValue = tmpValue === valueRef.current
 
-    revealOnChangeValidatorResult({ result, unchangedValue })
+    revealOnChangeValidatorResult({ result, unchangedValue, runAsync })
 
     return { result }
   }, [
@@ -485,14 +492,19 @@ export default function useFieldValidation<Value>({
       return undefined // stop here
     }
 
-    const { result, unchangedValue } = await callOnChangeValidator()
+    const { result, unchangedValue, runAsync } =
+      await callOnChangeValidator()
 
     if (
       String(result) !==
       String(validatorCacheRef.current.onChangeValidator)
     ) {
       if (result) {
-        revealOnChangeValidatorResult({ result, unchangedValue })
+        revealOnChangeValidatorResult({
+          result,
+          unchangedValue,
+          runAsync,
+        })
       } else {
         hideError()
         clearErrorState()
@@ -524,23 +536,22 @@ export default function useFieldValidation<Value>({
         'onBlurValidator'
       )
 
-      let result = isAsync(onBlurValidatorRef.current)
-        ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
+      const validationResult = isAsync(onBlurValidatorRef.current)
+        ? callValidatorFnAsync(onBlurValidatorRef.current, value)
         : callValidatorFnSync(onBlurValidatorRef.current, value)
-      if (result instanceof Promise) {
-        result = await result
-      }
+      const runAsync = validationResult instanceof Promise
+      const result = runAsync ? await validationResult : validationResult
 
-      return { result }
+      return { result, runAsync }
     },
     [callValidatorFnAsync, callValidatorFnSync, transformers, valueRef]
   )
 
   const revealOnBlurValidatorResult = useCallback(
-    ({ result }) => {
+    ({ result, runAsync }) => {
       persistErrorState('gracefully', 'onBlurValidator', result)
 
-      if (isAsync(onBlurValidatorRef.current)) {
+      if (runAsync) {
         defineAsyncProcess(undefined)
         setFieldState(result instanceof Error ? 'error' : 'complete')
       }
@@ -569,24 +580,23 @@ export default function useFieldValidation<Value>({
         return undefined // stop here
       }
 
-      if (isAsync(onBlurValidatorRef.current)) {
-        defineAsyncProcess('onBlurValidator')
-        setFieldState('validating')
-      }
-
       const value = transformers.current.toEvent(
         overrideValue ?? valueRef.current,
         'onBlurValidator'
       )
-
-      let result = isAsync(onBlurValidatorRef.current)
-        ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
+      const validationResult = isAsync(onBlurValidatorRef.current)
+        ? callValidatorFnAsync(onBlurValidatorRef.current, value)
         : callValidatorFnSync(onBlurValidatorRef.current, value)
-      if (result instanceof Promise) {
-        result = await result
+      const runAsync = validationResult instanceof Promise
+
+      if (runAsync) {
+        defineAsyncProcess('onBlurValidator')
+        setFieldState('validating')
       }
 
-      revealOnBlurValidatorResult({ result })
+      const result = runAsync ? await validationResult : validationResult
+
+      revealOnBlurValidatorResult({ result, runAsync })
 
       return { result }
     },
@@ -608,7 +618,7 @@ export default function useFieldValidation<Value>({
       return undefined // stop here
     }
 
-    const { result } = await callOnBlurValidator()
+    const { result, runAsync } = await callOnBlurValidator()
 
     if (
       String(result) !==
@@ -616,7 +626,7 @@ export default function useFieldValidation<Value>({
       revealErrorRef.current
     ) {
       if (result) {
-        revealOnBlurValidatorResult({ result })
+        revealOnBlurValidatorResult({ result, runAsync })
       } else {
         hideError()
         clearErrorState()
@@ -727,6 +737,10 @@ export default function useFieldValidation<Value>({
         onChangeValidatorRef.current &&
         (changedRef.current || validateInitially || validateUnchanged)
       ) {
+        if (isProcessActive()) {
+          clearErrorState()
+        }
+
         const { result } = await startOnChangeValidatorValidation()
 
         if (result instanceof Error) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -923,6 +923,17 @@ export default function useFieldValidation<Value>({
         validatedValueRef.current = value
       } catch (error) {
         if (isProcessActive()) {
+          if (
+            asyncProcessRef.current ||
+            hasAsyncValidatorBehavior(onChangeValidatorRef.current) ||
+            hasAsyncValidatorBehavior(onBlurValidatorRef.current)
+          ) {
+            onChangeValidationIdRef.current++
+            onBlurPathValidationIdRef.current++
+            defineAsyncProcess(undefined)
+            setFieldState('error')
+          }
+
           persistErrorState('weak', initiator, error as Error | FormError)
 
           if (validateContinuously && changedRef.current) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -391,6 +391,9 @@ export default function useFieldValidation<Value>({
 
   // -- onChange validator orchestration --
 
+  const onChangeValidationIdRef = useRef(0)
+  const onBlurPathValidationIdRef = useRef(0)
+
   const revealOnChangeValidatorResult = useCallback(
     ({
       result,
@@ -455,16 +458,44 @@ export default function useFieldValidation<Value>({
       return {}
     }
 
+    const validationId = ++onChangeValidationIdRef.current
     const tmpValue = valueRef.current
     const validationResult = isAsync(onChangeValidatorRef.current)
       ? callValidatorFnAsync(onChangeValidatorRef.current)
       : callValidatorFnSync(onChangeValidatorRef.current)
     const runAsync = validationResult instanceof Promise
-    const result = runAsync ? await validationResult : validationResult
+
+    if (runAsync) {
+      defineAsyncProcess('onChangeValidator')
+      setFieldState('validating')
+      hideError()
+    }
+
+    const result = ensureErrorMessageObject(
+      runAsync ? await validationResult : validationResult
+    )
+    const isCurrent = validationId === onChangeValidationIdRef.current
+
+    if (
+      isCurrent &&
+      (runAsync || hasAsyncValidatorBehavior(onChangeValidatorRef.current))
+    ) {
+      defineAsyncProcess(undefined)
+      setFieldState(result instanceof Error ? 'error' : 'complete')
+    }
 
     const unchangedValue = tmpValue === valueRef.current
-    return { result, unchangedValue, runAsync }
-  }, [callValidatorFnAsync, callValidatorFnSync, valueRef])
+
+    return { result, unchangedValue, runAsync, isCurrent }
+  }, [
+    callValidatorFnAsync,
+    callValidatorFnSync,
+    defineAsyncProcess,
+    ensureErrorMessageObject,
+    hideError,
+    setFieldState,
+    valueRef,
+  ])
 
   const startOnChangeValidatorValidation = useCallback(
     async ({
@@ -476,6 +507,7 @@ export default function useFieldValidation<Value>({
         return undefined
       }
 
+      const validationId = ++onChangeValidationIdRef.current
       const tmpValue = valueRef.current
       const validationResult = isAsync(onChangeValidatorRef.current)
         ? callValidatorFnAsync(onChangeValidatorRef.current)
@@ -491,7 +523,23 @@ export default function useFieldValidation<Value>({
         hideError()
       }
 
-      const result = runAsync ? await validationResult : validationResult
+      const result = ensureErrorMessageObject(
+        runAsync ? await validationResult : validationResult
+      )
+      const isCurrent = validationId === onChangeValidationIdRef.current
+
+      if (!isCurrent) {
+        return { result: undefined, isCurrent }
+      }
+
+      if (
+        !runAsync &&
+        hasAsyncValidatorBehavior(onChangeValidatorRef.current)
+      ) {
+        defineAsyncProcess(undefined)
+        setFieldState(result instanceof Error ? 'error' : 'complete')
+      }
+
       const unchangedValue = tmpValue === valueRef.current
 
       revealOnChangeValidatorResult({
@@ -508,6 +556,7 @@ export default function useFieldValidation<Value>({
       callValidatorFnSync,
       clearErrorState,
       defineAsyncProcess,
+      ensureErrorMessageObject,
       hideError,
       revealOnChangeValidatorResult,
       setFieldState,
@@ -520,8 +569,12 @@ export default function useFieldValidation<Value>({
       return undefined // stop here
     }
 
-    const { result, unchangedValue, runAsync } =
+    const { result, unchangedValue, runAsync, isCurrent } =
       await callOnChangeValidator()
+
+    if (!isCurrent) {
+      return undefined // stop here
+    }
 
     if (
       String(result) !==
@@ -559,21 +612,46 @@ export default function useFieldValidation<Value>({
         return {}
       }
 
+      const validationId = ++onBlurPathValidationIdRef.current
       const value = transformers.current.toEvent(
         overrideValue ?? valueRef.current,
         'onBlurValidator'
       )
-
-      let result = isAsync(onBlurValidatorRef.current)
-        ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
+      const validationResult = isAsync(onBlurValidatorRef.current)
+        ? callValidatorFnAsync(onBlurValidatorRef.current, value)
         : callValidatorFnSync(onBlurValidatorRef.current, value)
-      if (result instanceof Promise) {
-        result = await result
+      const runAsync = validationResult instanceof Promise
+
+      if (runAsync) {
+        defineAsyncProcess('onBlurValidator')
+        setFieldState('validating')
       }
 
-      return { result }
+      const result = ensureErrorMessageObject(
+        runAsync ? await validationResult : validationResult
+      )
+      const isCurrent = validationId === onBlurPathValidationIdRef.current
+
+      if (
+        isCurrent &&
+        !runAsync &&
+        hasAsyncValidatorBehavior(onBlurValidatorRef.current)
+      ) {
+        defineAsyncProcess(undefined)
+        setFieldState(result instanceof Error ? 'error' : 'complete')
+      }
+
+      return { result, runAsync, isCurrent }
     },
-    [callValidatorFnAsync, callValidatorFnSync, transformers, valueRef]
+    [
+      callValidatorFnAsync,
+      callValidatorFnSync,
+      defineAsyncProcess,
+      ensureErrorMessageObject,
+      setFieldState,
+      transformers,
+      valueRef,
+    ]
   )
 
   const revealOnBlurValidatorResult = useCallback(
@@ -629,9 +707,14 @@ export default function useFieldValidation<Value>({
           setFieldState('validating')
         }
 
-        const result = runAsync
-          ? ensureErrorMessageObject(await validationResult)
-          : validationResult
+        const result = ensureErrorMessageObject(
+          runAsync ? await validationResult : validationResult
+        )
+
+        if (!runAsync) {
+          defineAsyncProcess(undefined)
+          setFieldState(result instanceof Error ? 'error' : 'complete')
+        }
 
         revealOnBlurValidatorResult({ result, runAsync })
 
@@ -673,7 +756,11 @@ export default function useFieldValidation<Value>({
       return undefined // stop here
     }
 
-    const { result } = await callOnBlurValidator()
+    const { result, runAsync, isCurrent } = await callOnBlurValidator()
+
+    if (!isCurrent) {
+      return undefined // stop here
+    }
 
     if (
       String(result) !==
@@ -681,7 +768,7 @@ export default function useFieldValidation<Value>({
       revealErrorRef.current
     ) {
       if (result) {
-        revealOnBlurValidatorResult({ result })
+        revealOnBlurValidatorResult({ result, runAsync })
       } else {
         hideError()
         clearErrorState()
@@ -800,9 +887,14 @@ export default function useFieldValidation<Value>({
           onChangeValidatorRef.current &&
           (changedRef.current || validateInitially || validateUnchanged)
         ) {
-          const { result } = await startOnChangeValidatorValidation({
-            keepPendingForAsyncBehavior,
-          })
+          const { result, isCurrent = true } =
+            await startOnChangeValidatorValidation({
+              keepPendingForAsyncBehavior,
+            })
+
+          if (!isCurrent) {
+            return undefined // stop here
+          }
 
           if (result instanceof Error) {
             initiator = 'onChangeValidator'

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -6,6 +6,7 @@ import {
   isZodSchema,
   createZodValidator,
   zodErrorsToOneFormError,
+  hasAsyncValidatorBehavior,
 } from '../utils'
 import type { AjvInstance } from '../utils/ajv'
 import type * as z from 'zod'
@@ -274,23 +275,18 @@ export default function useFieldValidation<Value>({
   const callValidatorFnAsync = useCallback(
     async (
       validator: Validator<Value>,
-      value: Value = valueRef.current,
-      result?: ReturnType<Validator<Value>>
-    ): Promise<Awaited<ReturnType<Validator<Value>>>> => {
+      value: Value = valueRef.current
+    ): Promise<ReturnType<Validator<Value>>> => {
       if (typeof validator !== 'function') {
         return undefined
       }
 
-      let validationResult = result
-      if (typeof validationResult === 'undefined') {
-        validationResult = validator(value, additionalArgs)
-      }
-      validationResult = await validationResult
+      const result = await validator(value, additionalArgs)
 
-      if (Array.isArray(validationResult)) {
+      if (Array.isArray(result)) {
         const errors = []
 
-        for (const validatorOrError of validationResult) {
+        for (const validatorOrError of result) {
           if (validatorOrError instanceof Error) {
             errors.push(validatorOrError)
           } else if (!hasBeenCalledRef(validatorOrError)) {
@@ -313,7 +309,7 @@ export default function useFieldValidation<Value>({
 
         callStackRef.current = []
       } else {
-        return ensureErrorMessageObject(validationResult)
+        return ensureErrorMessageObject(result)
       }
     },
     [additionalArgs, hasBeenCalledRef, ensureErrorMessageObject, valueRef]
@@ -330,21 +326,15 @@ export default function useFieldValidation<Value>({
 
       const result = validator(value, additionalArgs)
 
-      if (result instanceof Promise) {
-        return callValidatorFnAsync(validator, value, result)
-      }
-
       if (Array.isArray(result)) {
         const hasAsyncValidator = result.some((validator) =>
           isAsync(validator)
         )
         if (hasAsyncValidator) {
           return new Promise((resolve) => {
-            callValidatorFnAsync(validator, value, result).then(
-              (result) => {
-                resolve(result)
-              }
-            )
+            callValidatorFnAsync(validator, value).then((result) => {
+              resolve(result)
+            })
           })
         }
 
@@ -392,7 +382,12 @@ export default function useFieldValidation<Value>({
   // -- onChange validator orchestration --
 
   const revealOnChangeValidatorResult = useCallback(
-    ({ result, unchangedValue, runAsync }) => {
+    ({
+      result,
+      unchangedValue,
+      runAsync,
+      keepPendingForAsyncBehavior = false,
+    }) => {
       if (unchangedValue) {
         persistErrorState(
           runAsync ? 'gracefully' : 'weak',
@@ -419,13 +414,20 @@ export default function useFieldValidation<Value>({
         defineAsyncProcess(undefined)
 
         if (unchangedValue) {
-          setFieldState(result instanceof Error ? 'error' : 'complete')
+          setFieldState(
+            result instanceof Error
+              ? 'error'
+              : keepPendingForAsyncBehavior && asyncBehaviorIsEnabled
+                ? 'pending'
+                : 'complete'
+          )
         } else {
           setFieldState('pending')
         }
       }
     },
     [
+      asyncBehaviorIsEnabled,
       validateContinuously,
       defineAsyncProcess,
       persistErrorState,
@@ -454,38 +456,54 @@ export default function useFieldValidation<Value>({
     return { result, unchangedValue, runAsync }
   }, [callValidatorFnAsync, callValidatorFnSync, valueRef])
 
-  const startOnChangeValidatorValidation = useCallback(async () => {
-    if (typeof onChangeValidatorRef.current !== 'function') {
-      return undefined
-    }
+  const startOnChangeValidatorValidation = useCallback(
+    async ({
+      keepPendingForAsyncBehavior = false,
+    }: {
+      keepPendingForAsyncBehavior?: boolean
+    } = {}) => {
+      if (typeof onChangeValidatorRef.current !== 'function') {
+        return undefined
+      }
 
-    const tmpValue = valueRef.current
-    const validationResult = isAsync(onChangeValidatorRef.current)
-      ? callValidatorFnAsync(onChangeValidatorRef.current)
-      : callValidatorFnSync(onChangeValidatorRef.current)
-    const runAsync = validationResult instanceof Promise
+      const tmpValue = valueRef.current
+      const validationResult = isAsync(onChangeValidatorRef.current)
+        ? callValidatorFnAsync(onChangeValidatorRef.current)
+        : callValidatorFnSync(onChangeValidatorRef.current)
+      const runAsync = validationResult instanceof Promise
 
-    if (runAsync) {
-      defineAsyncProcess('onChangeValidator')
-      setFieldState('validating')
-      hideError()
-    }
+      if (runAsync) {
+        if (!isAsync(onChangeValidatorRef.current)) {
+          clearErrorState()
+        }
+        defineAsyncProcess('onChangeValidator')
+        setFieldState('validating')
+        hideError()
+      }
 
-    const result = runAsync ? await validationResult : validationResult
-    const unchangedValue = tmpValue === valueRef.current
+      const result = runAsync ? await validationResult : validationResult
+      const unchangedValue = tmpValue === valueRef.current
 
-    revealOnChangeValidatorResult({ result, unchangedValue, runAsync })
+      revealOnChangeValidatorResult({
+        result,
+        unchangedValue,
+        runAsync,
+        keepPendingForAsyncBehavior,
+      })
 
-    return { result }
-  }, [
-    callValidatorFnAsync,
-    callValidatorFnSync,
-    defineAsyncProcess,
-    hideError,
-    revealOnChangeValidatorResult,
-    setFieldState,
-    valueRef,
-  ])
+      return { result }
+    },
+    [
+      callValidatorFnAsync,
+      callValidatorFnSync,
+      clearErrorState,
+      defineAsyncProcess,
+      hideError,
+      revealOnChangeValidatorResult,
+      setFieldState,
+      valueRef,
+    ]
+  )
 
   const runOnChangeValidator = useCallback(async () => {
     if (!onChangeValidatorRef.current) {
@@ -536,19 +554,20 @@ export default function useFieldValidation<Value>({
         'onBlurValidator'
       )
 
-      const validationResult = isAsync(onBlurValidatorRef.current)
-        ? callValidatorFnAsync(onBlurValidatorRef.current, value)
+      let result = isAsync(onBlurValidatorRef.current)
+        ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
         : callValidatorFnSync(onBlurValidatorRef.current, value)
-      const runAsync = validationResult instanceof Promise
-      const result = runAsync ? await validationResult : validationResult
+      if (result instanceof Promise) {
+        result = await result
+      }
 
-      return { result, runAsync }
+      return { result }
     },
     [callValidatorFnAsync, callValidatorFnSync, transformers, valueRef]
   )
 
   const revealOnBlurValidatorResult = useCallback(
-    ({ result, runAsync }) => {
+    ({ result, runAsync = isAsync(onBlurValidatorRef.current) }) => {
       persistErrorState('gracefully', 'onBlurValidator', result)
 
       if (runAsync) {
@@ -575,28 +594,29 @@ export default function useFieldValidation<Value>({
         (localErrorInitiatorRef.current === 'required' ||
           localErrorInitiatorRef.current === 'schema') &&
         !asyncBehaviorIsEnabled &&
-        !isAsync(onChangeValidatorRef.current)
+        !hasAsyncValidatorBehavior(onChangeValidatorRef.current)
       ) {
         return undefined // stop here
+      }
+
+      if (isAsync(onBlurValidatorRef.current)) {
+        defineAsyncProcess('onBlurValidator')
+        setFieldState('validating')
       }
 
       const value = transformers.current.toEvent(
         overrideValue ?? valueRef.current,
         'onBlurValidator'
       )
-      const validationResult = isAsync(onBlurValidatorRef.current)
-        ? callValidatorFnAsync(onBlurValidatorRef.current, value)
-        : callValidatorFnSync(onBlurValidatorRef.current, value)
-      const runAsync = validationResult instanceof Promise
 
-      if (runAsync) {
-        defineAsyncProcess('onBlurValidator')
-        setFieldState('validating')
+      let result = isAsync(onBlurValidatorRef.current)
+        ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
+        : callValidatorFnSync(onBlurValidatorRef.current, value)
+      if (result instanceof Promise) {
+        result = await result
       }
 
-      const result = runAsync ? await validationResult : validationResult
-
-      revealOnBlurValidatorResult({ result, runAsync })
+      revealOnBlurValidatorResult({ result })
 
       return { result }
     },
@@ -618,7 +638,7 @@ export default function useFieldValidation<Value>({
       return undefined // stop here
     }
 
-    const { result, runAsync } = await callOnBlurValidator()
+    const { result } = await callOnBlurValidator()
 
     if (
       String(result) !==
@@ -626,7 +646,7 @@ export default function useFieldValidation<Value>({
       revealErrorRef.current
     ) {
       if (result) {
-        revealOnBlurValidatorResult({ result, runAsync })
+        revealOnBlurValidatorResult({ result })
       } else {
         hideError()
         clearErrorState()
@@ -671,138 +691,146 @@ export default function useFieldValidation<Value>({
 
   // -- validateValue --
 
-  const validateValue = useCallback(async () => {
-    const isProcessActive = startProcess()
+  const validateValue = useCallback(
+    async ({
+      keepPendingForAsyncBehavior = false,
+    }: {
+      keepPendingForAsyncBehavior?: boolean
+    } = {}) => {
+      const isProcessActive = startProcess()
 
-    if (disabled) {
-      if (isProcessActive()) {
-        clearErrorState()
-      }
-      hideError()
-      setFieldState(undefined)
-      return undefined // stop here
-    }
-
-    const value = valueRef.current
-    changeEventResultRef.current = null
-    validatedValueRef.current = null
-    let initiator: ErrorInitiator = null
-
-    try {
-      const requiredError = transformers.current.validateRequired(value, {
-        emptyValue,
-        required,
-        isChanged: changedRef.current,
-        error: new FormError('Field.errorRequired'),
-      })
-      if (requiredError instanceof Error) {
-        initiator = 'required'
-        throw requiredError
+      if (disabled) {
+        if (isProcessActive()) {
+          clearErrorState()
+        }
+        hideError()
+        setFieldState(undefined)
+        return undefined // stop here
       }
 
-      if (error instanceof Error) {
-        initiator = 'errorProp'
-        throw error
-      }
+      const value = valueRef.current
+      changeEventResultRef.current = null
+      validatedValueRef.current = null
+      let initiator: ErrorInitiator = null
 
-      // Validate by provided schema (AJV or Zod) for this value
-      const skipLocalSchema =
-        prioritizeContextSchema || prioritizeSectionSchema
-      if (
-        value !== undefined &&
-        !skipLocalSchema &&
-        typeof schemaValidatorRef.current === 'function'
-      ) {
-        const validationResult = schemaValidatorRef.current(value)
-        if (validationResult !== true) {
-          let error: FormError | undefined
-
-          if (hasZodSchema) {
-            const zodError = validationResult as z.ZodError<unknown>
-            error = zodErrorsToOneFormError(zodError.issues)
-          } else {
-            error = getAjvInstance()?.ajvErrorsToOneFormError(
-              (schemaValidatorRef.current as ValidateFunction).errors,
-              value
-            )
+      try {
+        const requiredError = transformers.current.validateRequired(
+          value,
+          {
+            emptyValue,
+            required,
+            isChanged: changedRef.current,
+            error: new FormError('Field.errorRequired'),
           }
+        )
+        if (requiredError instanceof Error) {
+          initiator = 'required'
+          throw requiredError
+        }
 
-          initiator = 'schema'
+        if (error instanceof Error) {
+          initiator = 'errorProp'
           throw error
         }
-      }
 
-      // Validate by provided derivative validator
-      if (
-        onChangeValidatorRef.current &&
-        (changedRef.current || validateInitially || validateUnchanged)
-      ) {
+        // Validate by provided schema (AJV or Zod) for this value
+        const skipLocalSchema =
+          prioritizeContextSchema || prioritizeSectionSchema
+        if (
+          value !== undefined &&
+          !skipLocalSchema &&
+          typeof schemaValidatorRef.current === 'function'
+        ) {
+          const validationResult = schemaValidatorRef.current(value)
+          if (validationResult !== true) {
+            let error: FormError | undefined
+
+            if (hasZodSchema) {
+              const zodError = validationResult as z.ZodError<unknown>
+              error = zodErrorsToOneFormError(zodError.issues)
+            } else {
+              error = getAjvInstance()?.ajvErrorsToOneFormError(
+                (schemaValidatorRef.current as ValidateFunction).errors,
+                value
+              )
+            }
+
+            initiator = 'schema'
+            throw error
+          }
+        }
+
+        // Validate by provided derivative validator
+        if (
+          onChangeValidatorRef.current &&
+          (changedRef.current || validateInitially || validateUnchanged)
+        ) {
+          const { result } = await startOnChangeValidatorValidation({
+            keepPendingForAsyncBehavior,
+          })
+
+          if (result instanceof Error) {
+            initiator = 'onChangeValidator'
+            throw result
+          }
+        }
+
+        // Only for when "validateInitially" is set to true
+        if (
+          onBlurValidatorRef.current &&
+          validateInitially &&
+          !changedRef.current
+        ) {
+          const { result } = await startOnBlurValidatorProcess()
+
+          if (result instanceof Error) {
+            initiator = 'onBlurValidator'
+            throw result
+          }
+        }
+
         if (isProcessActive()) {
           clearErrorState()
         }
 
-        const { result } = await startOnChangeValidatorValidation()
+        validatedValueRef.current = value
+      } catch (error) {
+        if (isProcessActive()) {
+          persistErrorState('weak', initiator, error as Error | FormError)
 
-        if (result instanceof Error) {
-          initiator = 'onChangeValidator'
-          throw result
+          if (validateContinuously && changedRef.current) {
+            revealError()
+          }
         }
       }
-
-      // Only for when "validateInitially" is set to true
-      if (
-        onBlurValidatorRef.current &&
-        validateInitially &&
-        !changedRef.current
-      ) {
-        const { result } = await startOnBlurValidatorProcess()
-
-        if (result instanceof Error) {
-          initiator = 'onBlurValidator'
-          throw result
-        }
-      }
-
-      if (isProcessActive()) {
-        clearErrorState()
-      }
-
-      validatedValueRef.current = value
-    } catch (error) {
-      if (isProcessActive()) {
-        persistErrorState('weak', initiator, error as Error | FormError)
-
-        if (validateContinuously && changedRef.current) {
-          revealError()
-        }
-      }
-    }
-  }, [
-    clearErrorState,
-    disabled,
-    emptyValue,
-    error,
-    hasZodSchema,
-    hideError,
-    persistErrorState,
-    prioritizeContextSchema,
-    prioritizeSectionSchema,
-    required,
-    revealError,
-    setFieldState,
-    startOnBlurValidatorProcess,
-    startOnChangeValidatorValidation,
-    startProcess,
-    validateInitially,
-    validateContinuously,
-    validateUnchanged,
-    valueRef,
-    changedRef,
-    changeEventResultRef,
-    validatedValueRef,
-    transformers,
-    schemaValidatorRef,
-  ])
+    },
+    [
+      clearErrorState,
+      disabled,
+      emptyValue,
+      error,
+      hasZodSchema,
+      hideError,
+      persistErrorState,
+      prioritizeContextSchema,
+      prioritizeSectionSchema,
+      required,
+      revealError,
+      setFieldState,
+      startOnBlurValidatorProcess,
+      startOnChangeValidatorValidation,
+      startProcess,
+      validateInitially,
+      validateContinuously,
+      validateUnchanged,
+      valueRef,
+      changedRef,
+      changeEventResultRef,
+      validatedValueRef,
+      transformers,
+      schemaValidatorRef,
+    ]
+  )
 
   // Update connectWithPathListenerRef when validators change
   connectWithPathListenerRef.current = () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -6,8 +6,8 @@ import {
   isZodSchema,
   createZodValidator,
   zodErrorsToOneFormError,
-  hasAsyncValidatorBehavior,
 } from '../utils'
+import { hasAsyncValidatorBehavior } from '../utils/validatorOptions'
 import type { AjvInstance } from '../utils/ajv'
 import type * as z from 'zod'
 import type {
@@ -338,6 +338,16 @@ export default function useFieldValidation<Value>({
           })
         }
 
+        const hasMarkedAsyncValidator = result.some((validator) => {
+          return hasAsyncValidatorBehavior(validator)
+        })
+        if (hasMarkedAsyncValidator) {
+          return callValidatorFnAsync(
+            (() => result) as Validator<Value>,
+            value
+          ) as ReturnType<Validator<Value>>
+        }
+
         const errors = []
 
         for (const validatorOrError of result) {
@@ -599,15 +609,39 @@ export default function useFieldValidation<Value>({
         return undefined // stop here
       }
 
-      if (isAsync(onBlurValidatorRef.current)) {
-        defineAsyncProcess('onBlurValidator')
-        setFieldState('validating')
-      }
-
       const value = transformers.current.toEvent(
         overrideValue ?? valueRef.current,
         'onBlurValidator'
       )
+      const usesMarkedAsyncBehavior =
+        !isAsync(onBlurValidatorRef.current) &&
+        hasAsyncValidatorBehavior(onBlurValidatorRef.current)
+
+      if (usesMarkedAsyncBehavior) {
+        const validationResult = callValidatorFnSync(
+          onBlurValidatorRef.current,
+          value
+        )
+        const runAsync = validationResult instanceof Promise
+
+        if (runAsync) {
+          defineAsyncProcess('onBlurValidator')
+          setFieldState('validating')
+        }
+
+        const result = runAsync
+          ? ensureErrorMessageObject(await validationResult)
+          : validationResult
+
+        revealOnBlurValidatorResult({ result, runAsync })
+
+        return { result }
+      }
+
+      if (isAsync(onBlurValidatorRef.current)) {
+        defineAsyncProcess('onBlurValidator')
+        setFieldState('validating')
+      }
 
       let result = isAsync(onBlurValidatorRef.current)
         ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
@@ -625,6 +659,7 @@ export default function useFieldValidation<Value>({
       callValidatorFnAsync,
       callValidatorFnSync,
       defineAsyncProcess,
+      ensureErrorMessageObject,
       revealOnBlurValidatorResult,
       setFieldState,
       localErrorInitiatorRef,

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/validatorOptions.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/validatorOptions.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+
+import {
+  getValidatorOptions,
+  hasAsyncValidatorBehavior,
+  setAsyncValidatorBehavior,
+  withValidatorOptions,
+} from '../validatorOptions'
+
+describe('validatorOptions', () => {
+  it('detects declared and marked async validators', () => {
+    const unmarkedValidator = () => undefined
+    const asyncValidator = async () => undefined
+    const markedValidator = setAsyncValidatorBehavior(() => undefined)
+
+    expect(hasAsyncValidatorBehavior(unmarkedValidator)).toBe(false)
+    expect(hasAsyncValidatorBehavior(asyncValidator)).toBe(true)
+    expect(hasAsyncValidatorBehavior(markedValidator)).toBe(true)
+    expect(hasAsyncValidatorBehavior(undefined)).toBe(false)
+  })
+
+  it('preserves async behavior when adding submit options', () => {
+    const validator = setAsyncValidatorBehavior(() => undefined)
+    const configured = withValidatorOptions(validator, {
+      runOnSubmit: 'when-changed',
+    })
+
+    expect(hasAsyncValidatorBehavior(configured)).toBe(true)
+    expect(getValidatorOptions(configured)).toEqual({
+      hasAsyncBehavior: true,
+      runOnSubmit: 'when-changed',
+    })
+  })
+
+  it('preserves submit options when marking async behavior', () => {
+    const validator = withValidatorOptions(() => undefined, {
+      runOnSubmit: 'never',
+    })
+    const marked = setAsyncValidatorBehavior(validator)
+
+    expect(hasAsyncValidatorBehavior(marked)).toBe(true)
+    expect(getValidatorOptions(marked)).toEqual({
+      hasAsyncBehavior: true,
+      runOnSubmit: 'never',
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/utils/index.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/index.ts
@@ -1,7 +1,14 @@
 export * from './ajv'
 export * from './errors'
 export * from './json-pointer'
-export * from './validatorOptions'
+export {
+  getValidatorOptions,
+  withValidatorOptions,
+} from './validatorOptions'
+export type {
+  ValidatorOptions,
+  ValidatorRunOnSubmit,
+} from './validatorOptions'
 export * from './zod'
 export { FormError } from './FormError'
 export { default as detectCountryCode } from '../../../shared/detectCountryCode'

--- a/packages/dnb-eufemia/src/extensions/forms/utils/validatorOptions.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/validatorOptions.ts
@@ -6,9 +6,13 @@ export type ValidatorOptions = {
   runOnSubmit?: ValidatorRunOnSubmit
 }
 
+type InternalValidatorOptions = ValidatorOptions & {
+  hasAsyncBehavior?: boolean
+}
+
 type ValidatorFunction = (...args: Array<any>) => unknown
 
-const validatorOptions = new WeakMap<object, ValidatorOptions>()
+const validatorOptions = new WeakMap<object, InternalValidatorOptions>()
 
 export function withValidatorOptions<
   ValidatorFn extends ValidatorFunction,
@@ -31,6 +35,28 @@ export function withValidatorOptions<
   validatorOptions.set(validatorWithOptions, mergedOptions)
 
   return validatorWithOptions
+}
+
+export function hasAsyncValidatorBehavior(validator: unknown): boolean {
+  if (typeof validator !== 'function') {
+    return false
+  }
+
+  return (
+    isAsync(validator) ||
+    validatorOptions.get(validator)?.hasAsyncBehavior === true
+  )
+}
+
+export function setAsyncValidatorBehavior<
+  ValidatorFn extends ValidatorFunction,
+>(validator: ValidatorFn): ValidatorFn {
+  validatorOptions.set(validator, {
+    ...validatorOptions.get(validator),
+    hasAsyncBehavior: true,
+  })
+
+  return validator
 }
 
 export function getValidatorOptions(


### PR DESCRIPTION
## Summary

- keep pending indicators scoped to the active child field in compositions
- preserve pending state for validators with conditional async behavior
- prevent stale validation errors and autofill results from superseded Bring requests
- cancel superseded Bring requests with `AbortController`
- update the Bring example to expose pending behavior during validation
- add regression tests for compositions, async validation, pending indicators, and stale requests