### PR TITLE
docs(Portal): add command+k support for search

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -1,6 +1,6 @@
 @use '@dnb/eufemia/src/style/core/utilities.scss' as utilities;
 
-.autocompleteStyle {
+.headerAutocompleteStyle {
   :global {
     margin-right: 1rem;
 
@@ -23,6 +23,29 @@
 
 .portalClassStyle {
   z-index: 6000;
+}
+
+.dialogAutocompleteStyle {
+  :global {
+    .dnb-autocomplete__shell {
+      &,
+      input {
+        width: 100%;
+      }
+    }
+  }
+}
+
+.dialogClassStyle {
+  :global {
+    // Render the search results inline so the top-aligned dialog expands
+    // downwards as results appear, instead of overlaying in a portal.
+    .dnb-drawer-list__list {
+      position: relative;
+      top: auto;
+      bottom: auto;
+    }
+  }
 }
 
 .drawerClassStyle {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -1,28 +1,44 @@
 @use '@dnb/eufemia/src/style/core/utilities.scss' as utilities;
 
-.headerAutocompleteStyle {
-  :global {
-    margin-right: 1rem;
+.searchButtonStyle {
+  margin-right: 1rem;
 
-    @include utilities.allBelow(small) {
-      margin-right: 0.5rem;
-    }
+  @include utilities.allBelow(small) {
+    margin-right: 0.5rem;
 
-    .dnb-autocomplete__shell {
-      &,
-      input {
-        width: 40vw;
-
-        @include utilities.allBelow(small) {
-          width: 50vw;
-        }
+    :global {
+      // Compact to an icon-only button on small screens.
+      .dnb-button__text,
+      .search-shortcut {
+        display: none;
       }
     }
   }
 }
 
-.portalClassStyle {
-  z-index: 6000;
+.searchButtonContentStyle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  // Match the regular button height, which the default content layout
+  // normally provides via its alignment helper (skipped by customContent).
+  min-height: var(--button-height);
+}
+
+.searchButtonShortcutStyle {
+  display: inline-flex;
+  align-items: center;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+
+  border: 0.0625rem solid currentColor;
+  border-radius: 0.25rem;
+
+  font-family: inherit;
+  font-size: var(--font-size-x-small);
+
+  opacity: 0.6;
 }
 
 .dialogAutocompleteStyle {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -1,17 +1,5 @@
 @use '@dnb/eufemia/src/style/core/utilities.scss' as utilities;
 
-.searchWrapperStyle {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-
-  margin-right: 1rem;
-
-  @include utilities.allBelow(small) {
-    margin-right: 0.5rem;
-  }
-}
-
 .autocompleteStyle {
   :global {
     .dnb-autocomplete__shell {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -52,18 +52,6 @@
   }
 }
 
-.dialogClassStyle {
-  :global {
-    // Render the search results inline so the top-aligned dialog expands
-    // downwards as results appear, instead of overlaying in a portal.
-    .dnb-drawer-list__list {
-      position: relative;
-      top: auto;
-      bottom: auto;
-    }
-  }
-}
-
 .drawerClassStyle {
   :global {
     .search-logo {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -1,13 +1,19 @@
 @use '@dnb/eufemia/src/style/core/utilities.scss' as utilities;
 
+.searchWrapperStyle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+
+  margin-right: 1rem;
+
+  @include utilities.allBelow(small) {
+    margin-right: 0.5rem;
+  }
+}
+
 .autocompleteStyle {
   :global {
-    margin-right: 1rem;
-
-    @include utilities.allBelow(small) {
-      margin-right: 0.5rem;
-    }
-
     .dnb-autocomplete__shell {
       &,
       input {
@@ -19,6 +25,27 @@
       }
     }
   }
+}
+
+.shortcutHintStyle {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+
+  display: inline-flex;
+  align-items: center;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+
+  border: 0.0625rem solid currentcolor;
+  border-radius: 0.25rem;
+
+  font-family: inherit;
+  font-size: var(--font-size-x-small);
+
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .portalClassStyle {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -32,7 +32,7 @@
   height: 1.5rem;
   padding: 0 0.375rem;
 
-  border: 0.0625rem solid currentColor;
+  border: 0.0625rem solid currentcolor;
   border-radius: 0.25rem;
 
   font-family: inherit;

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.module.scss
@@ -1,55 +1,28 @@
 @use '@dnb/eufemia/src/style/core/utilities.scss' as utilities;
 
-.searchButtonStyle {
-  margin-right: 1rem;
-
-  @include utilities.allBelow(small) {
-    margin-right: 0.5rem;
-
-    :global {
-      // Compact to an icon-only button on small screens.
-      .dnb-button__text,
-      .search-shortcut {
-        display: none;
-      }
-    }
-  }
-}
-
-.searchButtonContentStyle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-
-  // Match the regular button height, which the default content layout
-  // normally provides via its alignment helper (skipped by customContent).
-  min-height: var(--button-height);
-}
-
-.searchButtonShortcutStyle {
-  display: inline-flex;
-  align-items: center;
-  height: 1.5rem;
-  padding: 0 0.375rem;
-
-  border: 0.0625rem solid currentcolor;
-  border-radius: 0.25rem;
-
-  font-family: inherit;
-  font-size: var(--font-size-x-small);
-
-  opacity: 0.6;
-}
-
-.dialogAutocompleteStyle {
+.autocompleteStyle {
   :global {
+    margin-right: 1rem;
+
+    @include utilities.allBelow(small) {
+      margin-right: 0.5rem;
+    }
+
     .dnb-autocomplete__shell {
       &,
       input {
-        width: 100%;
+        width: 40vw;
+
+        @include utilities.allBelow(small) {
+          width: 50vw;
+        }
       }
     }
   }
+}
+
+.portalClassStyle {
+  z-index: 6000;
 }
 
 .drawerClassStyle {

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -17,7 +17,6 @@ import {
   searchButtonContentStyle,
   searchButtonShortcutStyle,
   dialogAutocompleteStyle,
-  dialogClassStyle,
   drawerClassStyle,
 } from './SearchBar.module.scss'
 import { scrollToAnimation } from '../parts/layout-utils'
@@ -166,7 +165,6 @@ export const SearchBarInput = () => {
         open={openState}
         onClose={closeDialog}
         focusSelector=".dnb-input__input"
-        className={dialogClassStyle}
       >
         <Autocomplete
           id="portal-search-dialog"
@@ -176,8 +174,7 @@ export const SearchBarInput = () => {
           noScrollAnimation
           preventSelection
           disableFilter
-          skipPortal
-          keepOpen
+          fixedPosition
           stretch
           size="medium"
           placeholder="Search ..."

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -7,50 +7,36 @@ import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent, MouseEvent, SVGProps } from 'react'
 import { clsx } from 'clsx'
 import algoliasearch from 'algoliasearch/lite'
-import { Autocomplete, Button, Dialog, Icon } from '@dnb/eufemia/src'
-import { loupe as loupeIcon } from '@dnb/eufemia/src/icons'
+import { Autocomplete } from '@dnb/eufemia/src/components'
 import type { AutocompleteOnChangeParams } from '@dnb/eufemia/src/components/autocomplete/Autocomplete'
 import { navigate } from 'portal-query'
 import Anchor from '../tags/Anchor'
 import {
-  searchButtonStyle,
-  searchButtonContentStyle,
-  searchButtonShortcutStyle,
-  dialogAutocompleteStyle,
+  autocompleteStyle,
+  portalClassStyle,
   drawerClassStyle,
 } from './SearchBar.module.scss'
 import { scrollToAnimation } from '../parts/layout-utils'
 import {
   applyPageFocus,
-  isMac as isMacHelper,
   isModifiedClickEvent,
 } from '@dnb/eufemia/src/shared/helpers'
 import { formatSearchResultMarkdown } from './SearchBarMarkdown'
 
+const searchInputId = 'portal-search'
+
 export const SearchBarInput = () => {
   const searchIndex = useRef(null)
   const [status, setStatus] = useState(null)
-  const [openState, setOpenState] = useState(false)
-  const [isMac, setIsMac] = useState(false)
-
-  const openDialog = () => {
-    setOpenState(true)
-  }
-
-  const closeDialog = () => {
-    setOpenState(false)
-  }
 
   useEffect(() => {
-    setIsMac(isMacHelper())
-
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (
         (event.metaKey || event.ctrlKey) &&
         (event.key === 'k' || event.key === 'K')
       ) {
         event.preventDefault()
-        openDialog()
+        document.getElementById(searchInputId)?.focus()
       }
     }
 
@@ -75,9 +61,7 @@ export const SearchBarInput = () => {
         searchIndex.current
           ?.search(value)
           .then(({ hits }) => {
-            updateData(
-              makeHitsHumanFriendly({ hits, setHidden, closeDialog })
-            )
+            updateData(makeHitsHumanFriendly({ hits, setHidden }))
             hideIndicator()
             if (hits?.length === 0) {
               showNoOptionsItem()
@@ -111,7 +95,6 @@ export const SearchBarInput = () => {
         setHidden,
         emptyData,
       })
-      closeDialog()
     } catch (e) {
       setStatus(e.message)
     }
@@ -128,81 +111,45 @@ export const SearchBarInput = () => {
   }
 
   return (
-    <>
-      <Button
-        id="portal-search"
-        className={clsx(searchButtonStyle, 'portal-search')}
-        variant="secondary"
-        aria-haspopup="dialog"
-        aria-keyshortcuts="Meta+K Control+K"
-        title="Search the Eufemia documentation"
-        onClick={openDialog}
-        customContent={
-          <span className={searchButtonContentStyle}>
-            <Icon icon={loupeIcon} aria-hidden />
-            <span className="dnb-button__text">Search</span>
-            <kbd
-              className={clsx(
-                searchButtonShortcutStyle,
-                'search-shortcut'
-              )}
-              aria-hidden
-            >
-              {isMac ? '⌘ K' : 'Ctrl K'}
-            </kbd>
-          </span>
-        }
-      />
-
-      <Dialog
-        title="Search the Eufemia documentation"
-        verticalAlignment="top"
-        maxWidth="40rem"
-        omitTriggerButton
-        open={openState}
-        onClose={closeDialog}
-        focusSelector=".dnb-input__input"
-      >
-        <Autocomplete
-          id="portal-search-dialog"
-          className={clsx(dialogAutocompleteStyle, 'portal-search')}
-          mode="async"
-          showClearButton
-          noScrollAnimation
-          preventSelection
-          disableFilter
-          fixedPosition
-          stretch
-          size="medium"
-          placeholder="Search ..."
-          label="Search the Eufemia documentation"
-          labelSrOnly
-          status={status}
-          drawerClass={drawerClassStyle}
-          onType={onTypeHandler}
-          onChange={onChangeHandler}
-          onFocus={onFocusHandler}
-          optionsRender={renderSearchOptions}
-        />
-      </Dialog>
-    </>
+    <Autocomplete
+      id={searchInputId}
+      className={clsx(autocompleteStyle, 'portal-search')}
+      mode="async"
+      showClearButton
+      noScrollAnimation
+      preventSelection
+      disableFilter
+      fixedPosition
+      size="medium"
+      align="right"
+      placeholder="Search ..."
+      label="Search the Eufemia documentation"
+      labelSrOnly
+      aria-keyshortcuts="Meta+K Control+K"
+      status={status}
+      portalClass={portalClassStyle}
+      drawerClass={drawerClassStyle}
+      onType={onTypeHandler}
+      onChange={onChangeHandler}
+      onFocus={onFocusHandler}
+      pageOffset={0} // drawer-list property
+      optionsRender={({ Items, data }) => {
+        return (
+          <>
+            <Items />
+            {data.length > 1 && (
+              <li>
+                <SearchLogo />
+              </li>
+            )}
+          </>
+        )
+      }}
+    />
   )
 }
 
-const renderSearchOptions = ({ Items, data }) => {
-  return (
-    <>
-      <Items />
-      {data.length > 1 && (
-        <li>
-          <SearchLogo />
-        </li>
-      )}
-    </>
-  )
-}
-
-const makeHitsHumanFriendly = ({ hits, setHidden, closeDialog }) => {
+const makeHitsHumanFriendly = ({ hits, setHidden }) => {
   const data = []
 
   hits.forEach((hit) => {
@@ -221,7 +168,6 @@ const makeHitsHumanFriendly = ({ hits, setHidden, closeDialog }) => {
         })
       ) {
         event.preventDefault()
-        closeDialog?.()
       }
     }
 
@@ -253,7 +199,6 @@ const makeHitsHumanFriendly = ({ hits, setHidden, closeDialog }) => {
           })
         ) {
           event.preventDefault()
-          closeDialog?.()
         }
       }
 

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import type { KeyboardEvent, MouseEvent, SVGProps } from 'react'
 import { clsx } from 'clsx'
 import algoliasearch from 'algoliasearch/lite'
@@ -12,7 +12,6 @@ import type { AutocompleteOnChangeParams } from '@dnb/eufemia/src/components/aut
 import { navigate } from 'portal-query'
 import Anchor from '../tags/Anchor'
 import {
-  searchWrapperStyle,
   autocompleteStyle,
   shortcutHintStyle,
   portalClassStyle,
@@ -24,24 +23,29 @@ import {
   isMac,
   isModifiedClickEvent,
 } from '@dnb/eufemia/src/shared/helpers'
-import { useIsomorphicLayoutEffect as useLayoutEffect } from '@dnb/eufemia/src/shared/helpers/useIsomorphicLayoutEffect'
 import { formatSearchResultMarkdown } from './SearchBarMarkdown'
 
 const searchInputId = 'portal-search'
+const subscribeToPlatform = () => () => undefined
+const getShortcutHint = (): string | null => (isMac() ? '⌘ K' : 'Ctrl K')
+const getServerShortcutHint = (): string | null => null
+
+// Rendered as a component so Autocomplete's injected trigger props don't reach the <kbd>.
+const ShortcutHint = ({ hint }: { hint: string }) => (
+  <kbd className={shortcutHintStyle} aria-hidden="true">
+    {hint}
+  </kbd>
+)
 
 export const SearchBarInput = () => {
   const searchIndex = useRef(null)
   const [status, setStatus] = useState(null)
   const [hasValue, setHasValue] = useState(false)
-
-  // Render the platform-specific hint only after mount, to avoid a
-  // server/client hydration mismatch (isMac() is always false during SSR).
-  const [isMounted, setIsMounted] = useState(false)
-  const shortcutHint = useMemo(() => (!isMac() ? 'Ctrl K' : '⌘ K'), [])
-
-  useLayoutEffect(() => {
-    setIsMounted(true)
-  }, [])
+  const shortcutHint = useSyncExternalStore(
+    subscribeToPlatform,
+    getShortcutHint,
+    getServerShortcutHint
+  )
 
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -127,50 +131,47 @@ export const SearchBarInput = () => {
   }
 
   return (
-    <span className={searchWrapperStyle}>
-      <Autocomplete
-        id={searchInputId}
-        className={clsx(autocompleteStyle, 'portal-search')}
-        mode="async"
-        showClearButton
-        noScrollAnimation
-        preventSelection
-        disableFilter
-        fixedPosition
-        size="medium"
-        align="right"
-        placeholder="Search ..."
-        label="Search the Eufemia documentation"
-        labelSrOnly
-        aria-keyshortcuts="Meta+K Control+K"
-        status={status}
-        portalClass={portalClassStyle}
-        drawerClass={drawerClassStyle}
-        onType={onTypeHandler}
-        onChange={onChangeHandler}
-        onFocus={onFocusHandler}
-        onClear={() => setHasValue(false)}
-        pageOffset={0} // drawer-list property
-        optionsRender={({ Items, data }) => {
-          return (
-            <>
-              <Items />
-              {data.length > 1 && (
-                <li>
-                  <SearchLogo />
-                </li>
-              )}
-            </>
-          )
-        }}
-      />
-
-      {isMounted && !hasValue && (
-        <kbd className={shortcutHintStyle} aria-hidden="true">
-          {shortcutHint}
-        </kbd>
-      )}
-    </span>
+    <Autocomplete
+      id={searchInputId}
+      className={clsx(autocompleteStyle, 'portal-search')}
+      mode="async"
+      showClearButton
+      noScrollAnimation
+      preventSelection
+      disableFilter
+      fixedPosition
+      size="medium"
+      align="right"
+      placeholder="Search ..."
+      label="Search the Eufemia documentation"
+      labelSrOnly
+      aria-keyshortcuts="Meta+K Control+K"
+      status={status}
+      portalClass={portalClassStyle}
+      drawerClass={drawerClassStyle}
+      onType={onTypeHandler}
+      onChange={onChangeHandler}
+      onFocus={onFocusHandler}
+      onClear={() => setHasValue(false)}
+      submitElement={
+        !hasValue && shortcutHint ? (
+          <ShortcutHint hint={shortcutHint} />
+        ) : undefined
+      }
+      pageOffset={0} // drawer-list property
+      optionsRender={({ Items, data }) => {
+        return (
+          <>
+            <Items />
+            {data.length > 1 && (
+              <li>
+                <SearchLogo />
+              </li>
+            )}
+          </>
+        )
+      }}
+    />
   )
 }
 

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -24,6 +24,7 @@ import {
   isMac,
   isModifiedClickEvent,
 } from '@dnb/eufemia/src/shared/helpers'
+import { useIsomorphicLayoutEffect as useLayoutEffect } from '@dnb/eufemia/src/shared/helpers/useIsomorphicLayoutEffect'
 import { formatSearchResultMarkdown } from './SearchBarMarkdown'
 
 const searchInputId = 'portal-search'
@@ -34,11 +35,13 @@ export const SearchBarInput = () => {
   const [hasValue, setHasValue] = useState(false)
   const [shortcutHint, setShortcutHint] = useState<string | null>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Resolve the hint on the client to keep it in sync with the platform
     // and avoid a server/client hydration mismatch.
     setShortcutHint(isMac() ? '⌘ K' : 'Ctrl K')
+  }, [])
 
+  useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (
         (event.metaKey || event.ctrlKey) &&

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { KeyboardEvent, MouseEvent, SVGProps } from 'react'
 import { clsx } from 'clsx'
 import algoliasearch from 'algoliasearch/lite'
@@ -33,12 +33,14 @@ export const SearchBarInput = () => {
   const searchIndex = useRef(null)
   const [status, setStatus] = useState(null)
   const [hasValue, setHasValue] = useState(false)
-  const [shortcutHint, setShortcutHint] = useState<string | null>(null)
+
+  // Render the platform-specific hint only after mount, to avoid a
+  // server/client hydration mismatch (isMac() is always false during SSR).
+  const [isMounted, setIsMounted] = useState(false)
+  const shortcutHint = useMemo(() => (!isMac() ? 'Ctrl K' : '⌘ K'), [])
 
   useLayoutEffect(() => {
-    // Resolve the hint on the client to keep it in sync with the platform
-    // and avoid a server/client hydration mismatch.
-    setShortcutHint(isMac() ? '⌘ K' : 'Ctrl K')
+    setIsMounted(true)
   }, [])
 
   useEffect(() => {
@@ -163,7 +165,7 @@ export const SearchBarInput = () => {
         }}
       />
 
-      {shortcutHint && !hasValue && (
+      {isMounted && !hasValue && (
         <kbd className={shortcutHintStyle} aria-hidden="true">
           {shortcutHint}
         </kbd>

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -22,6 +22,7 @@ import {
 import { scrollToAnimation } from '../parts/layout-utils'
 import {
   applyPageFocus,
+  isMac as isMacHelper,
   isModifiedClickEvent,
 } from '@dnb/eufemia/src/shared/helpers'
 import { formatSearchResultMarkdown } from './SearchBarMarkdown'
@@ -41,11 +42,7 @@ export const SearchBarInput = () => {
   }
 
   useEffect(() => {
-    setIsMac(
-      /Mac|iPhone|iPad|iPod/i.test(
-        navigator.platform || navigator.userAgent
-      )
-    )
+    setIsMac(isMacHelper())
 
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -7,15 +7,17 @@ import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent, MouseEvent, SVGProps } from 'react'
 import { clsx } from 'clsx'
 import algoliasearch from 'algoliasearch/lite'
-import { Autocomplete, Dialog } from '@dnb/eufemia/src'
+import { Autocomplete, Button, Dialog, Icon } from '@dnb/eufemia/src'
+import { loupe as loupeIcon } from '@dnb/eufemia/src/icons'
 import type { AutocompleteOnChangeParams } from '@dnb/eufemia/src/components/autocomplete/Autocomplete'
 import { navigate } from 'portal-query'
 import Anchor from '../tags/Anchor'
 import {
-  headerAutocompleteStyle,
+  searchButtonStyle,
+  searchButtonContentStyle,
+  searchButtonShortcutStyle,
   dialogAutocompleteStyle,
   dialogClassStyle,
-  portalClassStyle,
   drawerClassStyle,
 } from './SearchBar.module.scss'
 import { scrollToAnimation } from '../parts/layout-utils'
@@ -29,19 +31,30 @@ export const SearchBarInput = () => {
   const searchIndex = useRef(null)
   const [status, setStatus] = useState(null)
   const [openState, setOpenState] = useState(false)
+  const [isMac, setIsMac] = useState(false)
+
+  const openDialog = () => {
+    setOpenState(true)
+  }
 
   const closeDialog = () => {
     setOpenState(false)
   }
 
   useEffect(() => {
+    setIsMac(
+      /Mac|iPhone|iPad|iPod/i.test(
+        navigator.platform || navigator.userAgent
+      )
+    )
+
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (
         (event.metaKey || event.ctrlKey) &&
         (event.key === 'k' || event.key === 'K')
       ) {
         event.preventDefault()
-        setOpenState(true)
+        openDialog()
       }
     }
 
@@ -120,28 +133,29 @@ export const SearchBarInput = () => {
 
   return (
     <>
-      <Autocomplete
+      <Button
         id="portal-search"
-        className={clsx(headerAutocompleteStyle, 'portal-search')}
-        mode="async"
-        showClearButton
-        noScrollAnimation
-        preventSelection
-        disableFilter
-        fixedPosition
-        size="medium"
-        align="right"
-        placeholder="Search ..."
-        label="Search the Eufemia documentation"
-        labelSrOnly
-        status={status}
-        portalClass={portalClassStyle}
-        drawerClass={drawerClassStyle}
-        onType={onTypeHandler}
-        onChange={onChangeHandler}
-        onFocus={onFocusHandler}
-        pageOffset={0} // drawer-list property
-        optionsRender={renderSearchOptions}
+        className={clsx(searchButtonStyle, 'portal-search')}
+        variant="secondary"
+        aria-haspopup="dialog"
+        aria-keyshortcuts="Meta+K Control+K"
+        title="Search the Eufemia documentation"
+        onClick={openDialog}
+        customContent={
+          <span className={searchButtonContentStyle}>
+            <Icon icon={loupeIcon} aria-hidden />
+            <span className="dnb-button__text">Search</span>
+            <kbd
+              className={clsx(
+                searchButtonShortcutStyle,
+                'search-shortcut'
+              )}
+              aria-hidden
+            >
+              {isMac ? '⌘ K' : 'Ctrl K'}
+            </kbd>
+          </span>
+        }
       />
 
       <Dialog

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -12,13 +12,16 @@ import type { AutocompleteOnChangeParams } from '@dnb/eufemia/src/components/aut
 import { navigate } from 'portal-query'
 import Anchor from '../tags/Anchor'
 import {
+  searchWrapperStyle,
   autocompleteStyle,
+  shortcutHintStyle,
   portalClassStyle,
   drawerClassStyle,
 } from './SearchBar.module.scss'
 import { scrollToAnimation } from '../parts/layout-utils'
 import {
   applyPageFocus,
+  isMac,
   isModifiedClickEvent,
 } from '@dnb/eufemia/src/shared/helpers'
 import { formatSearchResultMarkdown } from './SearchBarMarkdown'
@@ -28,8 +31,14 @@ const searchInputId = 'portal-search'
 export const SearchBarInput = () => {
   const searchIndex = useRef(null)
   const [status, setStatus] = useState(null)
+  const [hasValue, setHasValue] = useState(false)
+  const [shortcutHint, setShortcutHint] = useState<string | null>(null)
 
   useEffect(() => {
+    // Resolve the hint on the client to keep it in sync with the platform
+    // and avoid a server/client hydration mismatch.
+    setShortcutHint(isMac() ? '⌘ K' : 'Ctrl K')
+
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (
         (event.metaKey || event.ctrlKey) &&
@@ -56,6 +65,8 @@ export const SearchBarInput = () => {
     updateData,
     debounce,
   }) => {
+    setHasValue(Boolean(value))
+
     debounce(
       ({ value }) => {
         searchIndex.current
@@ -111,41 +122,50 @@ export const SearchBarInput = () => {
   }
 
   return (
-    <Autocomplete
-      id={searchInputId}
-      className={clsx(autocompleteStyle, 'portal-search')}
-      mode="async"
-      showClearButton
-      noScrollAnimation
-      preventSelection
-      disableFilter
-      fixedPosition
-      size="medium"
-      align="right"
-      placeholder="Search ..."
-      label="Search the Eufemia documentation"
-      labelSrOnly
-      aria-keyshortcuts="Meta+K Control+K"
-      status={status}
-      portalClass={portalClassStyle}
-      drawerClass={drawerClassStyle}
-      onType={onTypeHandler}
-      onChange={onChangeHandler}
-      onFocus={onFocusHandler}
-      pageOffset={0} // drawer-list property
-      optionsRender={({ Items, data }) => {
-        return (
-          <>
-            <Items />
-            {data.length > 1 && (
-              <li>
-                <SearchLogo />
-              </li>
-            )}
-          </>
-        )
-      }}
-    />
+    <span className={searchWrapperStyle}>
+      <Autocomplete
+        id={searchInputId}
+        className={clsx(autocompleteStyle, 'portal-search')}
+        mode="async"
+        showClearButton
+        noScrollAnimation
+        preventSelection
+        disableFilter
+        fixedPosition
+        size="medium"
+        align="right"
+        placeholder="Search ..."
+        label="Search the Eufemia documentation"
+        labelSrOnly
+        aria-keyshortcuts="Meta+K Control+K"
+        status={status}
+        portalClass={portalClassStyle}
+        drawerClass={drawerClassStyle}
+        onType={onTypeHandler}
+        onChange={onChangeHandler}
+        onFocus={onFocusHandler}
+        onClear={() => setHasValue(false)}
+        pageOffset={0} // drawer-list property
+        optionsRender={({ Items, data }) => {
+          return (
+            <>
+              <Items />
+              {data.length > 1 && (
+                <li>
+                  <SearchLogo />
+                </li>
+              )}
+            </>
+          )
+        }}
+      />
+
+      {shortcutHint && !hasValue && (
+        <kbd className={shortcutHintStyle} aria-hidden="true">
+          {shortcutHint}
+        </kbd>
+      )}
+    </span>
   )
 }
 

--- a/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SearchBar.tsx
@@ -3,16 +3,18 @@
  *
  */
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent, MouseEvent, SVGProps } from 'react'
 import { clsx } from 'clsx'
 import algoliasearch from 'algoliasearch/lite'
-import { Autocomplete } from '@dnb/eufemia/src/components'
+import { Autocomplete, Dialog } from '@dnb/eufemia/src'
 import type { AutocompleteOnChangeParams } from '@dnb/eufemia/src/components/autocomplete/Autocomplete'
 import { navigate } from 'portal-query'
 import Anchor from '../tags/Anchor'
 import {
-  autocompleteStyle,
+  headerAutocompleteStyle,
+  dialogAutocompleteStyle,
+  dialogClassStyle,
   portalClassStyle,
   drawerClassStyle,
 } from './SearchBar.module.scss'
@@ -26,6 +28,29 @@ import { formatSearchResultMarkdown } from './SearchBarMarkdown'
 export const SearchBarInput = () => {
   const searchIndex = useRef(null)
   const [status, setStatus] = useState(null)
+  const [openState, setOpenState] = useState(false)
+
+  const closeDialog = () => {
+    setOpenState(false)
+  }
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        (event.key === 'k' || event.key === 'K')
+      ) {
+        event.preventDefault()
+        setOpenState(true)
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [])
 
   const onTypeHandler = ({
     value,
@@ -41,7 +66,9 @@ export const SearchBarInput = () => {
         searchIndex.current
           ?.search(value)
           .then(({ hits }) => {
-            updateData(makeHitsHumanFriendly({ hits, setHidden }))
+            updateData(
+              makeHitsHumanFriendly({ hits, setHidden, closeDialog })
+            )
             hideIndicator()
             if (hits?.length === 0) {
               showNoOptionsItem()
@@ -75,6 +102,7 @@ export const SearchBarInput = () => {
         setHidden,
         emptyData,
       })
+      closeDialog()
     } catch (e) {
       setStatus(e.message)
     }
@@ -91,44 +119,82 @@ export const SearchBarInput = () => {
   }
 
   return (
-    <Autocomplete
-      id="portal-search"
-      className={clsx(autocompleteStyle, 'portal-search')}
-      mode="async"
-      showClearButton
-      noScrollAnimation
-      preventSelection
-      disableFilter
-      fixedPosition
-      size="medium"
-      align="right"
-      placeholder="Search ..."
-      label="Search the Eufemia documentation"
-      labelSrOnly
-      status={status}
-      portalClass={portalClassStyle}
-      drawerClass={drawerClassStyle}
-      onType={onTypeHandler}
-      onChange={onChangeHandler}
-      onFocus={onFocusHandler}
-      pageOffset={0} // drawer-list property
-      optionsRender={({ Items, data }) => {
-        return (
-          <>
-            <Items />
-            {data.length > 1 && (
-              <li>
-                <SearchLogo />
-              </li>
-            )}
-          </>
-        )
-      }}
-    />
+    <>
+      <Autocomplete
+        id="portal-search"
+        className={clsx(headerAutocompleteStyle, 'portal-search')}
+        mode="async"
+        showClearButton
+        noScrollAnimation
+        preventSelection
+        disableFilter
+        fixedPosition
+        size="medium"
+        align="right"
+        placeholder="Search ..."
+        label="Search the Eufemia documentation"
+        labelSrOnly
+        status={status}
+        portalClass={portalClassStyle}
+        drawerClass={drawerClassStyle}
+        onType={onTypeHandler}
+        onChange={onChangeHandler}
+        onFocus={onFocusHandler}
+        pageOffset={0} // drawer-list property
+        optionsRender={renderSearchOptions}
+      />
+
+      <Dialog
+        title="Search the Eufemia documentation"
+        verticalAlignment="top"
+        maxWidth="40rem"
+        omitTriggerButton
+        open={openState}
+        onClose={closeDialog}
+        focusSelector=".dnb-input__input"
+        className={dialogClassStyle}
+      >
+        <Autocomplete
+          id="portal-search-dialog"
+          className={clsx(dialogAutocompleteStyle, 'portal-search')}
+          mode="async"
+          showClearButton
+          noScrollAnimation
+          preventSelection
+          disableFilter
+          skipPortal
+          keepOpen
+          stretch
+          size="medium"
+          placeholder="Search ..."
+          label="Search the Eufemia documentation"
+          labelSrOnly
+          status={status}
+          drawerClass={drawerClassStyle}
+          onType={onTypeHandler}
+          onChange={onChangeHandler}
+          onFocus={onFocusHandler}
+          optionsRender={renderSearchOptions}
+        />
+      </Dialog>
+    </>
   )
 }
 
-const makeHitsHumanFriendly = ({ hits, setHidden }) => {
+const renderSearchOptions = ({ Items, data }) => {
+  return (
+    <>
+      <Items />
+      {data.length > 1 && (
+        <li>
+          <SearchLogo />
+        </li>
+      )}
+    </>
+  )
+}
+
+const makeHitsHumanFriendly = ({ hits, setHidden, closeDialog }) => {
   const data = []
 
   hits.forEach((hit) => {
@@ -147,6 +213,7 @@ const makeHitsHumanFriendly = ({ hits, setHidden }) => {
         })
       ) {
         event.preventDefault()
+        closeDialog?.()
       }
     }
 
@@ -178,6 +245,7 @@ const makeHitsHumanFriendly = ({ hits, setHidden }) => {
           })
         ) {
           event.preventDefault()
+          closeDialog?.()
         }
       }
 

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, it, expect, vi } from 'vitest'
 import { cleanup, fireEvent, render } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
 import { Autocomplete } from '@dnb/eufemia/src/components'
 import { formatSearchResultMarkdown } from '../SearchBarMarkdown'
 import { SearchBarInput } from '../SearchBar'
@@ -169,12 +170,27 @@ describe('SearchBarInput', () => {
     expect(document.activeElement).toBe(input)
   })
 
-  it('shows the keyboard shortcut hint', () => {
+  it('does not render a platform-specific hint on the server', () => {
+    const html = renderToString(<SearchBarInput />)
+
+    expect(html).not.toContain('<kbd')
+  })
+
+  it.each([
+    ['MacIntel', '⌘ K'],
+    ['Win32', 'Ctrl K'],
+  ])('shows the %s keyboard shortcut hint', (platform, shortcut) => {
+    const platformSpy = vi
+      .spyOn(navigator, 'platform', 'get')
+      .mockReturnValue(platform)
+
     render(<SearchBarInput />)
 
     const hint = document.querySelector('kbd')
     expect(hint).not.toBeNull()
-    expect(hint?.textContent).toContain('K')
+    expect(hint?.textContent).toBe(shortcut)
+
+    platformSpy.mockRestore()
   })
 
   it('hides the keyboard shortcut hint when the input has a value', () => {

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -168,4 +168,25 @@ describe('SearchBarInput', () => {
 
     expect(document.activeElement).toBe(input)
   })
+
+  it('shows the keyboard shortcut hint', () => {
+    render(<SearchBarInput />)
+
+    const hint = document.querySelector('kbd')
+    expect(hint).not.toBeNull()
+    expect(hint?.textContent).toContain('K')
+  })
+
+  it('hides the keyboard shortcut hint when the input has a value', () => {
+    render(<SearchBarInput />)
+
+    expect(document.querySelector('kbd')).not.toBeNull()
+
+    const input = document.querySelector(
+      '#portal-search'
+    ) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'button' } })
+
+    expect(document.querySelector('kbd')).toBeNull()
+  })
 })

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -198,7 +198,7 @@ describe('SearchBarInput', () => {
     })
   })
 
-  it('renders the search field with results inline in the dialog', async () => {
+  it('renders the search field inside the dialog', async () => {
     render(<SearchBarInput />)
 
     fireEvent.keyDown(document, { key: 'k', metaKey: true })

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -141,11 +141,25 @@ describe('SearchBarInput', () => {
 
   afterEach(cleanup)
 
-  it('renders an inline search field in the header', () => {
+  it('renders a search trigger button in the header', () => {
     render(<SearchBarInput />)
 
-    expect(document.querySelector('#portal-search')).not.toBeNull()
+    const trigger = document.querySelector('#portal-search')
+    expect(trigger).not.toBeNull()
+    expect(trigger?.tagName).toBe('BUTTON')
     expect(document.querySelector('.dnb-dialog')).toBeNull()
+  })
+
+  it('opens the dialog when clicking the trigger button', async () => {
+    render(<SearchBarInput />)
+
+    expect(document.querySelector('.dnb-dialog')).toBeNull()
+
+    fireEvent.click(document.querySelector('#portal-search'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-dialog')).not.toBeNull()
+    })
   })
 
   it('opens the dialog when pressing command+k', async () => {

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -1,10 +1,5 @@
 import { afterEach, beforeAll, describe, it, expect, vi } from 'vitest'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { Autocomplete } from '@dnb/eufemia/src/components'
 import { formatSearchResultMarkdown } from '../SearchBarMarkdown'
 import { SearchBarInput } from '../SearchBar'
@@ -135,79 +130,42 @@ describe('SearchBar', () => {
 })
 
 describe('SearchBarInput', () => {
-  beforeAll(() => {
-    ;(window as unknown as { IS_TEST: boolean }).IS_TEST = true
-  })
-
-  afterEach(cleanup)
-
-  it('renders a search trigger button in the header', () => {
+  it('renders the search input', () => {
     render(<SearchBarInput />)
 
-    const trigger = document.querySelector('#portal-search')
-    expect(trigger).not.toBeNull()
-    expect(trigger?.tagName).toBe('BUTTON')
-    expect(document.querySelector('.dnb-dialog')).toBeNull()
+    const input = document.querySelector('#portal-search')
+    expect(input).not.toBeNull()
+    expect(input?.tagName).toBe('INPUT')
   })
 
-  it('opens the dialog when clicking the trigger button', async () => {
+  it('exposes the keyboard shortcut on the search input', () => {
     render(<SearchBarInput />)
 
-    expect(document.querySelector('.dnb-dialog')).toBeNull()
-
-    fireEvent.click(document.querySelector('#portal-search'))
-
-    await waitFor(() => {
-      expect(document.querySelector('.dnb-dialog')).not.toBeNull()
-    })
+    const input = document.querySelector('#portal-search')
+    expect(input?.getAttribute('aria-keyshortcuts')).toBe(
+      'Meta+K Control+K'
+    )
   })
 
-  it('opens the dialog when pressing command+k', async () => {
+  it('focuses the search input when pressing command+k', () => {
     render(<SearchBarInput />)
 
-    expect(document.querySelector('.dnb-dialog')).toBeNull()
+    const input = document.querySelector('#portal-search')
+    expect(document.activeElement).not.toBe(input)
 
     fireEvent.keyDown(document, { key: 'k', metaKey: true })
 
-    await waitFor(() => {
-      expect(document.querySelector('.dnb-dialog')).not.toBeNull()
-    })
+    expect(document.activeElement).toBe(input)
   })
 
-  it('opens the dialog when pressing ctrl+k', async () => {
+  it('focuses the search input when pressing ctrl+k', () => {
     render(<SearchBarInput />)
+
+    const input = document.querySelector('#portal-search')
+    expect(document.activeElement).not.toBe(input)
 
     fireEvent.keyDown(document, { key: 'k', ctrlKey: true })
 
-    await waitFor(() => {
-      expect(document.querySelector('.dnb-dialog')).not.toBeNull()
-    })
-  })
-
-  it('renders the dialog top aligned so it can expand', async () => {
-    render(<SearchBarInput />)
-
-    fireEvent.keyDown(document, { key: 'k', metaKey: true })
-
-    await waitFor(() => {
-      const content = document.querySelector('.dnb-modal__content')
-      expect(content).not.toBeNull()
-      expect(
-        content.classList.contains('dnb-modal__vertical-alignment--top')
-      ).toBe(true)
-    })
-  })
-
-  it('renders the search field inside the dialog', async () => {
-    render(<SearchBarInput />)
-
-    fireEvent.keyDown(document, { key: 'k', metaKey: true })
-
-    await waitFor(() => {
-      const content = document.querySelector('.dnb-modal__content')
-      expect(content).not.toBeNull()
-      expect(content.querySelector('#portal-search-dialog')).not.toBeNull()
-      expect(content.querySelector('.dnb-input__input')).not.toBeNull()
-    })
+    expect(document.activeElement).toBe(input)
   })
 })

--- a/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/__tests__/SearchBar.test.tsx
@@ -1,7 +1,21 @@
 import { afterEach, beforeAll, describe, it, expect, vi } from 'vitest'
-import { cleanup, render } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react'
 import { Autocomplete } from '@dnb/eufemia/src/components'
 import { formatSearchResultMarkdown } from '../SearchBarMarkdown'
+import { SearchBarInput } from '../SearchBar'
+
+vi.mock('algoliasearch/lite', () => ({
+  default: () => ({
+    initIndex: () => ({
+      search: vi.fn().mockResolvedValue({ hits: [] }),
+    }),
+  }),
+}))
 
 type CustomResizeTo = (opts: { width?: number; height?: number }) => void
 
@@ -117,5 +131,69 @@ describe('SearchBar', () => {
     expect(link).not.toBeNull()
     expect(code?.textContent).toBe('Card')
     expect(highlight?.textContent).toBe('Ca')
+  })
+})
+
+describe('SearchBarInput', () => {
+  beforeAll(() => {
+    ;(window as unknown as { IS_TEST: boolean }).IS_TEST = true
+  })
+
+  afterEach(cleanup)
+
+  it('renders an inline search field in the header', () => {
+    render(<SearchBarInput />)
+
+    expect(document.querySelector('#portal-search')).not.toBeNull()
+    expect(document.querySelector('.dnb-dialog')).toBeNull()
+  })
+
+  it('opens the dialog when pressing command+k', async () => {
+    render(<SearchBarInput />)
+
+    expect(document.querySelector('.dnb-dialog')).toBeNull()
+
+    fireEvent.keyDown(document, { key: 'k', metaKey: true })
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-dialog')).not.toBeNull()
+    })
+  })
+
+  it('opens the dialog when pressing ctrl+k', async () => {
+    render(<SearchBarInput />)
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true })
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-dialog')).not.toBeNull()
+    })
+  })
+
+  it('renders the dialog top aligned so it can expand', async () => {
+    render(<SearchBarInput />)
+
+    fireEvent.keyDown(document, { key: 'k', metaKey: true })
+
+    await waitFor(() => {
+      const content = document.querySelector('.dnb-modal__content')
+      expect(content).not.toBeNull()
+      expect(
+        content.classList.contains('dnb-modal__vertical-alignment--top')
+      ).toBe(true)
+    })
+  })
+
+  it('renders the search field with results inline in the dialog', async () => {
+    render(<SearchBarInput />)
+
+    fireEvent.keyDown(document, { key: 'k', metaKey: true })
+
+    await waitFor(() => {
+      const content = document.querySelector('.dnb-modal__content')
+      expect(content).not.toBeNull()
+      expect(content.querySelector('#portal-search-dialog')).not.toBeNull()
+      expect(content.querySelector('.dnb-input__input')).not.toBeNull()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Adds Cmd/Ctrl+K support to the portal search by focusing the existing header `Autocomplete`. The search input also shows a platform-aware shortcut hint when empty.

## Changes

- Adds a global Cmd/Ctrl+K keyboard listener that prevents the browser default and focuses `#portal-search`.
- Exposes the supported shortcuts through `aria-keyshortcuts="Meta+K Control+K"`.
- Shows `⌘ K` on macOS and `Ctrl K` on other platforms inside the search input.
- Omits the platform-specific hint during server rendering, then resolves it on the client.
- Hides the hint when the search has a value and restores it when the input is cleared.
- Adds styling for the shortcut hint and adjusts the existing autocomplete spacing.
- Adds tests for rendering, shortcut metadata, Cmd/Ctrl+K focus behavior, server rendering, platform-specific labels, and hiding the hint when typing.

## Testing

All PR checks pass, including tests, type checks, lint, build tests, end-to-end tests, and visual regression tests.

## Breaking changes

None. This only changes the portal search behavior and presentation.
