### PR TITLE
docs: add edit on GitHub links

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,6 +44,9 @@ jobs:
         run: yarn workspace dnb-design-system-portal build
         env:
           VITE_EUFEMIA_STACKBLITZ_VERSION: 'https://pkg.pr.new/@dnb/eufemia@${{ github.event.pull_request.head.sha }}'
+          VITE_GITHUB_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          VITE_GITHUB_EDIT_REF: ${{ github.event.pull_request.head.ref }}
+          VITE_GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy to Cloudflare Pages (branch preview)
         id: pages_deploy

--- a/packages/dnb-design-system-portal/src/core/PortalLayout.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalLayout.tsx
@@ -17,6 +17,7 @@ import { setPortalHeadData, usePortalHead } from './PortalHead'
 import { Breadcrumb, Button } from '@dnb/eufemia/src'
 import GithubLogo from '../docs/contribute/assets/github-logo'
 import { resolveEditSourcePath } from './editSourcePath'
+import { getGitHubEditTitle, getGitHubEditUrl } from './githubSource'
 
 const ContentWrapper = TabBar.ContentWrapper
 
@@ -220,9 +221,10 @@ function Content({ showTabs, sourcePath, showEditLink, children }) {
         <Button
           variant="secondary"
           text="Edit on GitHub"
+          title={getGitHubEditTitle()}
           icon={GithubLogo}
           iconPosition="left"
-          href={`https://github.com/dnbexperience/eufemia/edit/main/${sourcePath}`}
+          href={getGitHubEditUrl(sourcePath)}
           target="_blank"
           rel="noopener noreferrer"
           top="large"

--- a/packages/dnb-design-system-portal/src/core/PortalLayout.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalLayout.tsx
@@ -14,7 +14,9 @@ import { Link } from '../shared/tags/Anchor'
 import tags from '../shared/tags'
 import { resetLevels } from '@dnb/eufemia/src/components/Heading'
 import { setPortalHeadData, usePortalHead } from './PortalHead'
-import { Breadcrumb } from '@dnb/eufemia/src'
+import { Breadcrumb, Button } from '@dnb/eufemia/src'
+import GithubLogo from '../docs/contribute/assets/github-logo'
+import { resolveEditSourcePath } from './editSourcePath'
 
 const ContentWrapper = TabBar.ContentWrapper
 
@@ -25,6 +27,7 @@ type Frontmatter = {
 }
 type Fields = {
   slug: string
+  sourcePath: string
 }
 type PortalLayoutNode = {
   frontmatter: Frontmatter
@@ -46,6 +49,7 @@ export default function PortalLayout(props: PortalLayoutProps) {
           node {
             fields {
               slug
+              sourcePath
             }
             frontmatter {
               title
@@ -95,12 +99,13 @@ export default function PortalLayout(props: PortalLayoutProps) {
   `)
 
   const slug = location.pathname.replace(/^\/|\/$/g, '')
+  const mdxEdges = data.allMdx.edges
   const mdx =
     useMemo(() => {
-      return data.allMdx.edges.find(({ node }) => {
+      return mdxEdges.find(({ node }) => {
         return slug === node.fields.slug
       })
-    }, [data, slug])?.node || {}
+    }, [mdxEdges, slug])?.node || {}
 
   const { siblings } = mdx
   const category = siblings?.[0] as PortalLayoutNode
@@ -146,6 +151,11 @@ export default function PortalLayout(props: PortalLayoutProps) {
     return <>{children}</> // looks like it was not a MDX, so we just return children
   }
 
+  const editSourcePath = resolveEditSourcePath(
+    mdx,
+    mdxEdges.map(({ node }) => node)
+  )
+
   // Share frontmatter in pageContext during SSR/SSG
   if (pageContext?.frontmatter) {
     setPortalHeadData(pageContext, headData)
@@ -186,12 +196,18 @@ export default function PortalLayout(props: PortalLayoutProps) {
         />
       )}
 
-      <Content showTabs={currentFm.showTabs}>{children}</Content>
+      <Content
+        showTabs={currentFm.showTabs}
+        sourcePath={editSourcePath}
+        showEditLink={!codeFocusMode}
+      >
+        {children}
+      </Content>
     </Layout>
   )
 }
 
-function Content({ showTabs, children }) {
+function Content({ showTabs, sourcePath, showEditLink, children }) {
   if (showTabs) {
     resetLevels(2)
   }
@@ -199,6 +215,20 @@ function Content({ showTabs, children }) {
   return (
     <ContentWrapper>
       <MDXProvider components={tags}>{children}</MDXProvider>
+
+      {showEditLink && (
+        <Button
+          variant="secondary"
+          text="Edit on GitHub"
+          icon={GithubLogo}
+          iconPosition="left"
+          href={`https://github.com/dnbexperience/eufemia/edit/main/${sourcePath}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          top="large"
+          bottom="large"
+        />
+      )}
     </ContentWrapper>
   )
 }

--- a/packages/dnb-design-system-portal/src/core/__tests__/editSourcePath.test.ts
+++ b/packages/dnb-design-system-portal/src/core/__tests__/editSourcePath.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { resolveEditSourcePath } from '../editSourcePath'
+
+type Node = Parameters<typeof resolveEditSourcePath>[0]
+
+const sourceRoot = 'packages/dnb-design-system-portal/src/docs'
+
+function createNode(
+  slug: string,
+  frontmatter: Node['frontmatter'] = {}
+): Node {
+  return {
+    fields: {
+      slug,
+      sourcePath: `${sourceRoot}/${slug}.mdx`,
+    },
+    frontmatter,
+  }
+}
+
+describe('resolveEditSourcePath', () => {
+  it('uses the first tab source for a tabbed parent page', () => {
+    const parent = createNode('uilib/components/button', {
+      title: 'Button',
+      showTabs: true,
+    })
+    const info = createNode('uilib/components/button/info')
+
+    expect(resolveEditSourcePath(parent, [parent, info])).toBe(
+      `${sourceRoot}/uilib/components/button/info.mdx`
+    )
+  })
+
+  it('uses the current source for a tab subpage', () => {
+    const demos = createNode('uilib/components/button/demos', {
+      showTabs: true,
+    })
+
+    expect(resolveEditSourcePath(demos, [demos])).toBe(
+      `${sourceRoot}/uilib/components/button/demos.mdx`
+    )
+  })
+
+  it('supports absolute tab keys', () => {
+    const parent = createNode('uilib/components/date-format', {
+      title: 'DateFormat',
+      showTabs: true,
+      tabs: [
+        {
+          title: 'Info',
+          key: '/uilib/components/date-format/info',
+        },
+      ],
+    })
+    const info = createNode('uilib/components/date-format/info')
+
+    expect(resolveEditSourcePath(parent, [parent, info])).toBe(
+      `${sourceRoot}/uilib/components/date-format/info.mdx`
+    )
+  })
+
+  it('skips hidden tabs', () => {
+    const parent = createNode('uilib/components/example', {
+      title: 'Example',
+      showTabs: true,
+      tabs: [
+        { title: 'Info', key: '/info' },
+        { title: 'Demos', key: '/demos' },
+      ],
+      hideTabs: [{ title: 'Info' }],
+    })
+    const demos = createNode('uilib/components/example/demos')
+
+    expect(resolveEditSourcePath(parent, [parent, demos])).toBe(
+      `${sourceRoot}/uilib/components/example/demos.mdx`
+    )
+  })
+
+  it('keeps the parent source when the first tab points to the parent', () => {
+    const parent = createNode('uilib/usage/customisation/theming', {
+      title: 'Theming',
+      showTabs: true,
+      tabs: [
+        {
+          title: 'Overview',
+          key: '/uilib/usage/customisation/theming',
+        },
+      ],
+    })
+
+    expect(resolveEditSourcePath(parent, [parent])).toBe(
+      `${sourceRoot}/uilib/usage/customisation/theming.mdx`
+    )
+  })
+
+  it('falls back to the parent source when no tab source exists', () => {
+    const parent = createNode('uilib/components/example', {
+      title: 'Example',
+      showTabs: true,
+    })
+
+    expect(resolveEditSourcePath(parent, [parent])).toBe(
+      `${sourceRoot}/uilib/components/example.mdx`
+    )
+  })
+})

--- a/packages/dnb-design-system-portal/src/core/__tests__/githubSource.test.ts
+++ b/packages/dnb-design-system-portal/src/core/__tests__/githubSource.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { getGitHubEditTitle, getGitHubEditUrl } from '../githubSource'
+
+const sourcePath =
+  'packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx'
+
+describe('getGitHubEditUrl', () => {
+  it('uses the provided pull request source repository and branch', () => {
+    const source = {
+      repository: 'contributor/eufemia',
+      editRef: 'fix/button-docs',
+      commitSha: 'abc123456789',
+    }
+
+    expect(getGitHubEditUrl(sourcePath, source)).toBe(
+      `https://github.com/contributor/eufemia/edit/fix/button-docs/${sourcePath}`
+    )
+    expect(getGitHubEditTitle(source)).toBe(
+      'Edit source from preview commit abc1234 on GitHub'
+    )
+  })
+
+  it('omits the preview title without a commit', () => {
+    expect(
+      getGitHubEditTitle({
+        repository: 'dnbexperience/eufemia',
+        editRef: 'main',
+        commitSha: '',
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/dnb-design-system-portal/src/core/editSourcePath.ts
+++ b/packages/dnb-design-system-portal/src/core/editSourcePath.ts
@@ -1,0 +1,48 @@
+import { defaultTabsValue } from '../shared/tags/defaultValues'
+
+type Tab = {
+  title: string
+  key: string
+}
+
+type EditSourceNode = {
+  fields: {
+    slug: string
+    sourcePath: string
+  }
+  frontmatter: {
+    title?: string
+    showTabs?: boolean
+    tabs?: Tab[]
+    hideTabs?: Array<{ title: string }>
+  }
+}
+
+export function resolveEditSourcePath(
+  currentNode: EditSourceNode,
+  allNodes: EditSourceNode[]
+): string {
+  const { fields, frontmatter } = currentNode
+
+  if (!frontmatter.title || !frontmatter.showTabs) {
+    return fields.sourcePath
+  }
+
+  const firstVisibleTab = (frontmatter.tabs || defaultTabsValue).find(
+    ({ title }) =>
+      !frontmatter.hideTabs?.some((hiddenTab) => hiddenTab.title === title)
+  )
+
+  if (!firstVisibleTab) {
+    return fields.sourcePath
+  }
+
+  const tabKey = firstVisibleTab.key.replace(/^\/+|\/+$/g, '')
+  const tabSlug =
+    tabKey === fields.slug || tabKey.startsWith(`${fields.slug}/`)
+      ? tabKey
+      : `${fields.slug}/${tabKey}`
+  const tabNode = allNodes.find(({ fields }) => fields.slug === tabSlug)
+
+  return tabNode?.fields.sourcePath || fields.sourcePath
+}

--- a/packages/dnb-design-system-portal/src/core/githubSource.ts
+++ b/packages/dnb-design-system-portal/src/core/githubSource.ts
@@ -1,0 +1,29 @@
+export type GitHubSource = {
+  repository: string
+  editRef: string
+  commitSha: string
+}
+
+export const githubSource: GitHubSource = {
+  repository:
+    import.meta.env.VITE_GITHUB_REPOSITORY || 'dnbexperience/eufemia',
+  editRef: import.meta.env.VITE_GITHUB_EDIT_REF || 'main',
+  commitSha: import.meta.env.VITE_GITHUB_COMMIT_SHA || '',
+}
+
+export function getGitHubEditUrl(
+  sourcePath: string,
+  source = githubSource
+): string {
+  return `https://github.com/${source.repository}/edit/${source.editRef}/${sourcePath}`
+}
+
+export function getGitHubEditTitle(
+  source = githubSource
+): string | undefined {
+  if (!source.commitSha) {
+    return undefined
+  }
+
+  return `Edit source from preview commit ${source.commitSha.slice(0, 7)} on GitHub`
+}

--- a/packages/dnb-design-system-portal/src/declaration.d.ts
+++ b/packages/dnb-design-system-portal/src/declaration.d.ts
@@ -20,7 +20,7 @@ declare module 'virtual:portal-pages' {
     lazy: () => Promise<{ Component: React.ComponentType }>
   }>
   export const allMdxNodes: Array<{
-    fields: { slug: string }
+    fields: { slug: string; sourcePath: string }
     frontmatter: Record<string, unknown>
   }>
 }

--- a/packages/dnb-design-system-portal/src/declaration.d.ts
+++ b/packages/dnb-design-system-portal/src/declaration.d.ts
@@ -2,6 +2,9 @@ declare module '*.scss'
 
 type ImportMetaEnv = {
   readonly VITE_EUFEMIA_STACKBLITZ_VERSION?: string
+  readonly VITE_GITHUB_REPOSITORY?: string
+  readonly VITE_GITHUB_EDIT_REF?: string
+  readonly VITE_GITHUB_COMMIT_SHA?: string
 }
 
 type ImportMeta = {

--- a/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
@@ -136,12 +136,24 @@ test.describe('Page Navigation', () => {
       await page.goto('/uilib/components/button/')
       await waitForApp(page)
 
+      const repository =
+        process.env.VITE_GITHUB_REPOSITORY || 'dnbexperience/eufemia'
+      const editRef = process.env.VITE_GITHUB_EDIT_REF || 'main'
+      const commitSha = process.env.VITE_GITHUB_COMMIT_SHA
       const editLink = page.getByRole('link', { name: 'Edit on GitHub' })
+
       await expect(editLink).toHaveAttribute(
         'href',
-        'https://github.com/dnbexperience/eufemia/edit/main/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx'
+        `https://github.com/${repository}/edit/${editRef}/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx`
       )
       await expect(editLink).toHaveAttribute('target', '_blank')
+
+      if (commitSha) {
+        await expect(editLink).toHaveAttribute(
+          'title',
+          `Edit source from preview commit ${commitSha.slice(0, 7)} on GitHub`
+        )
+      }
     })
 
     test('click on first main menu card should open /design-system', async ({

--- a/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
@@ -132,6 +132,18 @@ test.describe('Page Navigation', () => {
       expect(title).toContain('Button | Eufemia')
     })
 
+    test('should contain an Edit on GitHub link', async ({ page }) => {
+      await page.goto('/uilib/components/button/')
+      await waitForApp(page)
+
+      const editLink = page.getByRole('link', { name: 'Edit on GitHub' })
+      await expect(editLink).toHaveAttribute(
+        'href',
+        'https://github.com/dnbexperience/eufemia/edit/main/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx'
+      )
+      await expect(editLink).toHaveAttribute('target', '_blank')
+    })
+
     test('click on first main menu card should open /design-system', async ({
       page,
     }) => {

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/portal-pages.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/portal-pages.test.ts
@@ -87,6 +87,9 @@ describe('portal-pages plugin', () => {
       const mdxFile = files.find((f) => f.type === 'mdx')
       expect(mdxFile).toBeDefined()
       expect(mdxFile!.slug).toBe('button/info')
+      expect(mdxFile!.sourcePath).toBe(
+        'packages/dnb-design-system-portal/src/docs/button/info.mdx'
+      )
       expect(mdxFile!.frontmatter).toEqual({ title: 'Button' })
 
       const tsxFile = files.find((f) => f.type === 'tsx')
@@ -112,11 +115,17 @@ describe('portal-pages plugin', () => {
       expect(files[0].slug).toBe('public')
     })
 
-    it('strips index from slug', () => {
-      createFile('uilib/index.mdx', '---\ntitle: UILib\n---')
+    it('strips index from slug while preserving the case-sensitive source filename', () => {
+      createFile(
+        'uilib/extensions/forms/Form/Section/index.mdx',
+        '---\ntitle: Form.Section\n---'
+      )
 
       const files = scanPageFiles(tmpDir)
-      expect(files[0].slug).toBe('uilib')
+      expect(files[0].slug).toBe('uilib/extensions/forms/Form/Section')
+      expect(files[0].sourcePath).toBe(
+        'packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/index.mdx'
+      )
     })
 
     it('extracts frontmatter from MDX files', () => {

--- a/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
@@ -14,6 +14,8 @@ import matter from 'gray-matter'
 
 const VIRTUAL_MODULE_ID = 'virtual:portal-pages'
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
+const PORTAL_DOCS_SOURCE_PATH =
+  'packages/dnb-design-system-portal/src/docs'
 
 // Patterns to ignore when scanning for page files.
 const IGNORE_PATTERNS = [
@@ -34,6 +36,7 @@ export type TableOfContentsItem = {
 
 export type PageFileInfo = {
   filePath: string
+  sourcePath: string
   slug: string
   frontmatter: Record<string, unknown>
   tableOfContents?: { items: TableOfContentsItem[] }
@@ -119,7 +122,8 @@ export function scanPageFiles(docsDir: string): PageFileInfo[] {
       }
 
       const relativePath = path.relative(docsDir, fullPath)
-      const slug = relativePath
+      const normalizedRelativePath = relativePath.replace(/\\/g, '/')
+      const slug = normalizedRelativePath
         .replace(/\.(mdx|tsx)$/, '')
         .replace(/(^|\/)index$/, '$1')
         .replace(/\/$/, '')
@@ -139,6 +143,7 @@ export function scanPageFiles(docsDir: string): PageFileInfo[] {
 
       results.push({
         filePath: fullPath,
+        sourcePath: `${PORTAL_DOCS_SOURCE_PATH}/${normalizedRelativePath}`,
         slug,
         frontmatter,
         tableOfContents,
@@ -175,7 +180,8 @@ export function readPageFileInfo(
   }
 
   const relativePath = path.relative(docsDir, filePath)
-  const slug = relativePath
+  const normalizedRelativePath = relativePath.replace(/\\/g, '/')
+  const slug = normalizedRelativePath
     .replace(/\.(mdx|tsx)$/, '')
     .replace(/(^|\/)index$/, '$1')
     .replace(/\/$/, '')
@@ -196,6 +202,7 @@ export function readPageFileInfo(
 
   return {
     filePath,
+    sourcePath: `${PORTAL_DOCS_SOURCE_PATH}/${normalizedRelativePath}`,
     slug,
     frontmatter,
     tableOfContents,
@@ -294,7 +301,7 @@ export default function portalPagesPlugin(
           // (TSX pages like index.tsx, 404.tsx don't have frontmatter for the sidebar)
           if (file.type === 'mdx') {
             const nodeData: Record<string, unknown> = {
-              fields: { slug: file.slug },
+              fields: { slug: file.slug, sourcePath: file.sourcePath },
               frontmatter: file.frontmatter,
             }
             if (file.tableOfContents) {

--- a/packages/dnb-design-system-portal/vite/vite-env.d.ts
+++ b/packages/dnb-design-system-portal/vite/vite-env.d.ts
@@ -12,7 +12,7 @@ declare module 'virtual:portal-pages' {
     lazy: () => Promise<{ Component: React.ComponentType }>
   }>
   export const allMdxNodes: Array<{
-    fields: { slug: string }
+    fields: { slug: string; sourcePath: string }
     frontmatter: Record<string, unknown>
   }>
 }


### PR DESCRIPTION
Adds an Edit on GitHub button to documentation pages and resolves tabbed pages to the correct MDX source. PR previews target the source repository and branch, with main as the production fallback.

Tests cover source resolution and preview-aware links.