### PR TITLE
chore(deps): bump fast-uri to 3.1.4 to fix host-confusion advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "ttf2woff2@npm:^6.0.1": "npm:8.0.1",
-    "fast-uri@npm:^3.0.1": "npm:3.1.2",
+    "fast-uri@npm:^3.0.1": "npm:3.1.4",
     "@babel/core": "7.29.7",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "@babel/runtime": "7.26.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9307,10 +9307,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.2":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10/1dff04865b2a38d3e0659deadfbf72efdf83a776bfbf9667e4aa9e5a3ec31bc341cda9622136b32b7652a857c8ba11896794186e8f876f8b2b72731fce8622f6
+"fast-uri@npm:3.1.4":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `fast-uri` [`resolutions`](package.json) pin from `3.1.2` → `3.1.4` to clear two **high**-severity Dependabot advisories.

`fast-uri` is pulled in by `ajv@8.18.0`, which is a **runtime `dependency` of `@dnb/eufemia`** — so unlike most of the other Dependabot alerts (dev/build/docs tooling), this one reaches published consumers. That makes it the highest-priority of the batch.

## Advisories fixed

| Dependabot alert | Severity | Advisory |
| --- | --- | --- |
| 502 | high | [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676 — host confusion via failed IDN canonicalization |
| 503 | high | [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / CVE-2026-16221 — host confusion via literal backslash authority delimiter |

## Change

- `package.json`: `"fast-uri@npm:^3.0.1": "npm:3.1.2"` → `"npm:3.1.4"`
- `yarn.lock`: regenerated (single `fast-uri` entry updated)

## Verification

```
$ yarn why fast-uri
└─ ajv@npm:8.18.0
   └─ fast-uri@npm:3.1.4 (via npm:3.1.4)
```

`3.1.4` is well past the repo's `npmMinimalAgeGate: 3d`.
