### PR TITLE
chore(deps): bump axios 0.x resolution to 0.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "undici@npm:7.18.2": "7.28.0",
     "picomatch@npm:4.0.3": "4.0.4",
     "node-gyp@npm:latest": "12.4.0",
-    "axios@npm:^0.31.1": "0.32.0",
+    "axios@npm:^0.31.1": "0.33.0",
     "js-yaml@npm:^3.10.0": "3.15.0",
     "js-yaml@npm:^3.13.1": "3.15.0",
     "js-yaml@npm:^4.1.0": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6256,14 +6256,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.32.0":
-  version: 0.32.0
-  resolution: "axios@npm:0.32.0"
+"axios@npm:0.33.0":
+  version: 0.33.0
+  resolution: "axios@npm:0.33.0"
   dependencies:
     follow-redirects: "npm:^1.15.4"
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10/1e35bb0778507851d32587176f72e9dbd9b091e4e7d59b8b60ce77c78fe1663f2b2e949478db1f71998ce68b3eb94df3031fcce110ce4e1c637474c50119e0a1
+  checksum: 10/36c468997b94f71cda99c8b575fe3fbb75d6dc19242c43546e3a72e703f398df98bff8294c418bccfbc88da67da88cfb94f37c49cb89468c648fe83ec6f3e955
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `axios` (0.x line) [`resolutions`](package.json) pin `0.32.0` → `0.33.0` to clear seven Dependabot advisories.

**Not shipped to consumers.** The vulnerable 0.x axios is only pulled in by the dev tool `bundlewatch`. The `axios@1.18.1` used by `wait-on` (also dev) is outside every vulnerable range and is untouched.

## Advisories fixed

| Alert | Severity | Advisory |
| --- | --- | --- |
| 489 | high | [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9) — inherited proxy after interceptor config cloning |
| 485 | medium | [GHSA-pmv8-rq9r-6j72](https://github.com/advisories/GHSA-pmv8-rq9r-6j72) — deep formToJSON key recursion DoS |
| 486 | medium | [GHSA-42h9-826w-cgv3](https://github.com/advisories/GHSA-42h9-826w-cgv3) — excessive recursion in formDataToJSON DoS |
| 487 | medium | [GHSA-f4gw-2p7v-4548](https://github.com/advisories/GHSA-f4gw-2p7v-4548) — NO_PROXY bypass for 0.0.0.0 |
| 488 | medium | [GHSA-hcpx-6fm6-wx23](https://github.com/advisories/GHSA-hcpx-6fm6-wx23) — form serializer maxDepth bypass |
| 513 | medium | [GHSA-7q8q-rj6j-mhjq](https://github.com/advisories/GHSA-7q8q-rj6j-mhjq) — nested option prototype pollution |
| 514 | medium | [GHSA-mmx7-hfxf-jppx](https://github.com/advisories/GHSA-mmx7-hfxf-jppx) — prototype pollution gadgets |

## Change

- `package.json`: `"axios@npm:^0.31.1": "0.32.0"` → `"0.33.0"`
- `yarn.lock`: regenerated

## Verification

`yarn why axios` shows the 0.x line at `0.33.0` (bundlewatch) and `1.18.1` (wait-on) unchanged. `0.33.0` is past the repo's `npmMinimalAgeGate: 3d`.
