### PR TITLE
chore(deps): bump immutable resolution to 5.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "follow-redirects": "1.16.0",
     "form-data": "4.0.6",
     "hono": "4.12.27",
-    "immutable": "5.1.5",
+    "immutable": "5.1.8",
     "ip-address": "10.2.2",
     "joi": "17.13.4",
     "lodash": "4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10498,10 +10498,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:5.1.5":
-  version: 5.1.5
-  resolution: "immutable@npm:5.1.5"
-  checksum: 10/7aec2740239772ec8e92e793c991bd809203a97694f4ff3a18e50e28f9a6b02393ad033d87b458037bdf8c0ea37d4446d640e825f6171df3405cf6cf300ce028
+"immutable@npm:5.1.8":
+  version: 5.1.8
+  resolution: "immutable@npm:5.1.8"
+  checksum: 10/f6907f3cf932860bf609c635283e3073ba5c978fcdd63e365fe4daa43c34ffef0037db0d3009d8803d9ebc2f1e2a00f06c8cac738250fbe715fb1484c7132f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `immutable` [`resolutions`](package.json) pin `5.1.5` → `5.1.8` to clear two **high**-severity Dependabot advisories.

**Not shipped to consumers.** `immutable` is only pulled in by `sass` (build tooling).

## Advisories fixed

| Alert | Severity | Advisory |
| --- | --- | --- |
| 498 | high | [GHSA-v56q-mh7h-f735](https://github.com/advisories/GHSA-v56q-mh7h-f735) / CVE-2026-59879 — `List` 32-bit trie overflow → unrecoverable DoS |
| 499 | high | [GHSA-xvcm-6775-5m9r](https://github.com/advisories/GHSA-xvcm-6775-5m9r) / CVE-2026-59880 — hash-collision algorithmic complexity DoS in Map/Set |

## Change

- `package.json`: `"immutable": "5.1.5"` → `"5.1.8"`
- `yarn.lock`: regenerated

## Verification

`yarn why immutable` shows `5.1.8`. `5.1.8` is past the repo's `npmMinimalAgeGate: 3d`.
