### PR TITLE
chore(deps): bump ip-address resolution to 10.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "follow-redirects": "1.16.0",
     "form-data": "4.0.6",
     "immutable": "5.1.5",
-    "ip-address": "10.1.1",
+    "ip-address": "10.2.2",
     "joi": "17.13.4",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10647,10 +10647,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.1.1":
-  version: 10.1.1
-  resolution: "ip-address@npm:10.1.1"
-  checksum: 10/4289c1cd06eed843df627e0b8041f49a76b3683879dd1703aebf72b68071ee51b3e866a6ef5826a78c8222d78d3996d59c6e92ad44f2379660b63a47e8f7782c
+"ip-address@npm:10.2.2":
+  version: 10.2.2
+  resolution: "ip-address@npm:10.2.2"
+  checksum: 10/351c470d323d874b79c5525d1701a4a4d1d41eb77806702a64d328100903b6a949ed2d31b833f54ec8068deff408142e2a5823f0c9a142d26f8f1da0117de773
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `ip-address` [`resolutions`](package.json) pin `10.1.1` → `10.2.2` to clear two **medium**-severity Dependabot advisories.

**Not shipped to consumers.** `ip-address` is only pulled in by `socks` / `express-rate-limit` (proxy/tooling).

## Advisories fixed

| Alert | Severity | Advisory |
| --- | --- | --- |
| 529 | medium | [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) / CVE-2026-54272 — IPv4-mapped/NAT64 misclassification can bypass SSRF/trust-boundary checks |
| 530 | medium | [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh) / CVE-2026-69198 — CIDR suffix suppresses special-use classification, bypassing SSRF checks |

## Change

- `package.json`: `"ip-address": "10.1.1"` → `"10.2.2"`
- `yarn.lock`: regenerated

## Verification

`yarn why ip-address` shows `10.2.2`. `10.2.2` is past the repo's `npmMinimalAgeGate: 3d`.
