### PR TITLE
chore(deps): add hono 4.12.27 resolution to fix advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "flatted": "3.4.2",
     "follow-redirects": "1.16.0",
     "form-data": "4.0.6",
+    "hono": "4.12.27",
     "immutable": "5.1.5",
     "ip-address": "10.1.1",
     "joi": "17.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10264,10 +10264,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.11.4":
-  version: 4.12.25
-  resolution: "hono@npm:4.12.25"
-  checksum: 10/0cbdcdfdfb45b43cc915beaa44604170bb73b45e647927917714ec222347e7f44c944708471a45b4733cfd20b03c53820593db5b3b19663b935afca9cf984817
+"hono@npm:4.12.27":
+  version: 4.12.27
+  resolution: "hono@npm:4.12.27"
+  checksum: 10/f1bb52f3871093fae5b5bc40fb179ff2e6d43c6dab8d7065ef182d8ff6cdc1c41dc1124b07f2f02e0fe36ec1e39e72300ed3447f64391e39d71978616d4f5a07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a `"hono": "4.12.27"` [resolution](package.json) to clear three **medium**-severity Dependabot advisories. `hono` is pulled in transitively by `@modelcontextprotocol/sdk` (`^4.11.4`), and `4.12.27` satisfies that range — a safe in-range patch bump.

**Not shipped to consumers.** `hono` is only used by the MCP server tooling (`tools/mcp-lambda`).

## Advisories fixed

| Alert | Severity | Advisory |
| --- | --- | --- |
| 495 | medium | [GHSA-hvrm-45r6-mjfj](https://github.com/advisories/GHSA-hvrm-45r6-mjfj) / CVE-2026-59896 — hono/jsx does not isolate context per request (cross-request data disclosure) |
| 496 | medium | [GHSA-xgm2-5f3f-mvvc](https://github.com/advisories/GHSA-xgm2-5f3f-mvvc) / CVE-2026-59897 — API Gateway v1 adapter drops repeated header value during de-duplication |
| 497 | medium | [GHSA-w62v-xxxg-mg59](https://github.com/advisories/GHSA-w62v-xxxg-mg59) / CVE-2026-59895 — server-side XSS via JSX escaping bypass in `cx()` |

## Change

- `package.json`: adds `"hono": "4.12.27"` to `resolutions`
- `yarn.lock`: regenerated

## Verification

`yarn why hono` shows `4.12.27`. `4.12.27` is past the repo's `npmMinimalAgeGate: 3d`.
