### PR TITLE
chore(deps): bump react-router-dom to 7.18.2 (clears 4 of 5 advisories)

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -94,7 +94,7 @@
     "prismjs": "1.30.0",
     "react-live-ssr": "workspace:*",
     "react-markdown": "9.1.0",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.2",
     "remark-frontmatter": "5.0.0",
     "remark-gfm": "4",
     "remark-gfm-react-markdown": "npm:remark-gfm@4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7873,7 +7873,7 @@ __metadata:
     react-dom: "npm:19.2.5"
     react-live-ssr: "workspace:*"
     react-markdown: "npm:9.1.0"
-    react-router-dom: "npm:7.16.0"
+    react-router-dom: "npm:7.18.2"
     remark-frontmatter: "npm:5.0.0"
     remark-gfm: "npm:4"
     remark-gfm-react-markdown: "npm:remark-gfm@4.0.1"
@@ -15535,21 +15535,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:7.16.0":
-  version: 7.16.0
-  resolution: "react-router-dom@npm:7.16.0"
+"react-router-dom@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router-dom@npm:7.18.2"
   dependencies:
-    react-router: "npm:7.16.0"
+    react-router: "npm:7.18.2"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 10/f8d7da28bf1276c8a3bd2d85948b104810aa1b08e1ac761fbeccafbeb2f381aeb04c4ff3ec53c43e6a4e96564d1aa571d16b3a07e115f2b3782a16705bfde2c3
+  checksum: 10/354a7af84963fe7acaf32c583f180b636b5071d9cf1f83090dba8ff2616ac65bba82aaf8e3cfa425d2a523a3318df3cfcf526462a154211c8abbf7ee70045a07
   languageName: node
   linkType: hard
 
-"react-router@npm:7.16.0":
-  version: 7.16.0
-  resolution: "react-router@npm:7.16.0"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -15559,7 +15559,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10/2c77d27170eab1dfa6f0593e846f9d352424cc789a505aaee9bee9c9da1ed9d6a044d0a476e3eaf240e73b09169b4ffb85b5910d026a34abd055aed5b2f5a5cb
+  checksum: 10/e68aa655e5ec2d4143f66ab3b745c50b8588152d89e4ec66c099625357c6a16dfaee5a7e963a9f4f9fbe0adaa37cf9731d63a108a2c4abfaa00124a06da16c24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the portal's `react-router-dom` `7.16.0` → `7.18.2` (latest 7.x) to clear four of the five React Router Dependabot advisories — **no code changes**, since `react-router-dom@7.18.2` re-exports `react-router@7.18.2`.

**Not shipped to consumers.** `react-router-dom` is a dependency of the docs portal only.

## Advisories fixed (4 of 5)

| Alert | Severity | Advisory |
| --- | --- | --- |
| 518 | high | [GHSA-chx6-hx7r-mcp5](https://github.com/advisories/GHSA-chx6-hx7r-mcp5) / CVE-2026-55685 — unauthenticated DoS via inefficient route matching |
| 515 | medium | [GHSA-h8fp-f39c-q6mh](https://github.com/advisories/GHSA-h8fp-f39c-q6mh) / CVE-2026-53667 — RSCErrorHandler missing protocol validation (XSS) |
| 519 | medium | [GHSA-337j-9hxr-rhxg](https://github.com/advisories/GHSA-337j-9hxr-rhxg) / CVE-2026-53666 — arbitrary constructor injection via deserializeErrors() |
| 520 | medium | [GHSA-wrjc-x8rr-h8h6](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6) / CVE-2026-53669 — open redirect via backslash in `<Link>`/`useNavigate` |

## Still open after this PR

- **Alert 517** ([GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), high — RSC Mode CSRF bypass) is only patched in **react-router 8.3.0**. Since `react-router-dom` was discontinued at `7.18.2` (v8 dropped the separate DOM package), that fix requires migrating the portal off `react-router-dom` onto `react-router` v8 imports across ~19 files (incl. SSR entry points). Tracked as a separate change.

## Verification

`yarn why react-router-dom` and `yarn why react-router` both show `7.18.2`. Past the repo's `npmMinimalAgeGate: 3d`.
