### PR TITLE
chore(deps): force @hono/node-server 2.0.5 to fix path-traversal advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/core": "7.29.7",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "@babel/runtime": "7.26.10",
+    "@hono/node-server": "2.0.5",
     "@tootallnate/once": "2.0.1",
     "@xmldom/xmldom": "0.8.13",
     "defu": "6.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,12 +3118,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:^1.19.9":
-  version: 1.19.14
-  resolution: "@hono/node-server@npm:1.19.14"
+"@hono/node-server@npm:2.0.5":
+  version: 2.0.5
+  resolution: "@hono/node-server@npm:2.0.5"
   peerDependencies:
     hono: ^4
-  checksum: 10/618dd95feeb3fd11ec8502e088879cd86529523788de19602edebd16892dd61899e73564d6e3d00875cc5a49488a908ddb2aa425d28f9cdeb7f22cfecabf022c
+  checksum: 10/6931114aaa35a9a6d9b80e5ab2f6c5122b822733cbf6d0572c6e0aa28805fb92ba8013fb64b7da9da54c2e65a0a09ae8e83857792396250724d7a75e3cbc5c35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a `"@hono/node-server": "2.0.5"` [resolution](package.json) to clear one **medium**-severity Dependabot advisory. This is a **major** bump (`1.19.14` → `2.0.5`): the package is pulled in transitively by `@modelcontextprotocol/sdk@1.29.0` (which requests `^1.19.9`), so a resolution is required to force v2.

**Not shipped to consumers.** `@hono/node-server` is only reached via the MCP SDK in the `tools/mcp-lambda` server. That workspace does not import `@hono/node-server` directly and uses the lambda/stdio transports (not the Hono Node HTTP server), so the v1→v2 `serve()` API change is not exercised.

## Advisory fixed

| Alert | Severity | Advisory |
| --- | --- | --- |
| 492 | medium | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) — path traversal in `serve-static` on Windows via encoded backslash (`%5C`) |

## QA (major bump — verified)

- `yarn why @hono/node-server` → single `2.0.5`
- `yarn workspace @dnb/eufemia-mcp typecheck` → passes (exit 0)
- `yarn workspace @dnb/eufemia-mcp test` → **5 files, 53 tests passed**

`2.0.5` is past the repo's `npmMinimalAgeGate: 3d`.
