### PR TITLE
fix(Portal): migrate to react-router v8 (fixes RSC CSRF advisory #517)

### DIFF
--- a/packages/dnb-design-system-portal/package.json
+++ b/packages/dnb-design-system-portal/package.json
@@ -94,7 +94,7 @@
     "prismjs": "1.30.0",
     "react-live-ssr": "workspace:*",
     "react-markdown": "9.1.0",
-    "react-router-dom": "7.16.0",
+    "react-router": "8.3.0",
     "remark-frontmatter": "5.0.0",
     "remark-gfm": "4",
     "remark-gfm-react-markdown": "npm:remark-gfm@4.0.1",

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/info.mdx
@@ -29,7 +29,7 @@ You can combine a meta framework link with the Anchor. This way, all the framewo
 
 ```jsx
 import Anchor from '@dnb/eufemia/components/Anchor'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 render(
   <App>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/anchor/properties.mdx
@@ -15,7 +15,7 @@ import { AnchorProperties } from '@dnb/eufemia/src/components/anchor/AnchorDocs'
 You can make use of the `element` property in combination with the `to` property.
 
 ```jsx
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 render(
   <Anchor to="/url" element={Link}>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/heading/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/heading/info.mdx
@@ -76,7 +76,7 @@ First, warnings will not show up in production builds. And to skip the auto corr
 
 ```jsx
 import { useEffect } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { resetLevels } from '@dnb/eufemia/components/Heading'
 
 function HeadingLevelReset() {

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
@@ -8,7 +8,7 @@ import ComponentBox from '../../../../shared/tags/ComponentBox'
 
 import Input from '@dnb/eufemia/src/components/input/Input'
 import styled from '@emotion/styled'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { navigate } from 'portal-query'
 import {
   Tabs,

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/location-hooks/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/location-hooks/Examples.tsx
@@ -1,5 +1,5 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { navigate } from 'portal-query'
 import { P } from '@dnb/eufemia/src'
 import { Form, Wizard } from '@dnb/eufemia/src/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/location-hooks/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/location-hooks/info.mdx
@@ -23,17 +23,17 @@ The `id` parameter is used to identify the `Wizard.Container` component. But it 
 
 If you use a router, you may connect one of the supported hooks to it. This way your application will not import unnecessary and unused code.
 
-- [react-router-dom](https://reactrouter.com/) via [useReactRouter](#with-react-router-dom)
+- [react-router](https://reactrouter.com/) via [useReactRouter](#with-react-router)
 - [@reach/router](https://reach.tech/router/) via [useReachRouter](#with-reachrouter)
 - [Next.js](https://nextjs.org/) via [useNextRouter](#with-nextnavigation)
 
 If you do not use a router, you can make use of the [useQueryLocator](#without-a-router) hook.
 
-### With `react-router-dom`
+### With `react-router`
 
 ```jsx
 import { Form, Wizard } from '@dnb/eufemia/extensions/forms'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 function MyForm() {
   Wizard.useReactRouter('unique-id', { useSearchParams })

--- a/packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/RelatedComponents.tsx
@@ -1,6 +1,6 @@
 import { useStaticQuery, graphql } from 'portal-query'
 import { Li, P, Ul } from '@dnb/eufemia/src'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import Anchor from '../tags/Anchor'
 import AutoLinkHeader from '../tags/AutoLinkHeader'
 import {

--- a/packages/dnb-design-system-portal/src/shared/parts/__tests__/RelatedComponents.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/__tests__/RelatedComponents.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 
 const mockData = vi.hoisted(() => ({
   components: {

--- a/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/Anchor.tsx
@@ -6,7 +6,7 @@
 import type { AnchorHTMLAttributes, DetailedHTMLProps, Ref } from 'react'
 import { Anchor as EufemiaAnchor } from '@dnb/eufemia/src'
 import type { AnchorAllProps as Props } from '@dnb/eufemia/src/components/Anchor'
-import { Link as RouterLink, type LinkProps } from 'react-router-dom'
+import { Link as RouterLink, type LinkProps } from 'react-router'
 
 export type AnchorProps = Props &
   DetailedHTMLProps<

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -6,7 +6,7 @@ import Heading, {
   type HeadingAllProps,
 } from '@dnb/eufemia/src/components/Heading'
 import { makeSlug } from '../../uilib/utils/slug'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { anchorLinkStyle } from './AutoLinkHeader.module.scss'
 
 type AutoLinkHeaderProps = {

--- a/packages/dnb-design-system-portal/vite.config.ts
+++ b/packages/dnb-design-system-portal/vite.config.ts
@@ -195,7 +195,7 @@ export default defineConfig({
     include: [
       'react',
       'react-dom',
-      'react-router-dom',
+      'react-router',
       '@emotion/react',
       '@emotion/cache',
       '@mdx-js/react',

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/catch-links.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/catch-links.test.ts
@@ -47,12 +47,12 @@ describe('catch-links plugin', () => {
   })
 
   describe('runtime code', () => {
-    it('imports useNavigate from react-router-dom', () => {
+    it('imports useNavigate from react-router', () => {
       const plugin = catchLinksPlugin()
       const load = plugin.load as (id: string) => string | undefined
       const code = load('\0virtual:catch-links')!
 
-      expect(code).toContain("from 'react-router-dom'")
+      expect(code).toContain("from 'react-router'")
       expect(code).toContain('useNavigate')
     })
 

--- a/packages/dnb-design-system-portal/vite/__tests__/shims/portal-query.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/portal-query.test.ts
@@ -50,8 +50,8 @@ vi.mock('virtual:portal-pages', () => ({
   ],
 }))
 
-// Must mock react-router-dom before importing the portal query shim.
-vi.mock('react-router-dom', () => ({
+// Must mock react-router before importing the portal query shim.
+vi.mock('react-router', () => ({
   Link: vi.fn(({ to, children, ...rest }) => null),
   useNavigate: vi.fn(() => vi.fn()),
 }))

--- a/packages/dnb-design-system-portal/vite/client/plugins/catch-links.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/catch-links.ts
@@ -37,7 +37,7 @@ export default function catchLinksPlugin(): Plugin {
  */
 const RUNTIME_CODE = `
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 
 /**
  * React hook that intercepts clicks on internal <a> tags and navigates

--- a/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/portal-pages.ts
@@ -329,7 +329,7 @@ export default function portalPagesPlugin(
 
         return `
 import React from 'react';
-import { redirect, useLocation } from 'react-router-dom';
+import { redirect, useLocation } from 'react-router';
 
 // No-op component for redirect routes so React Router does not warn
 // about a matched leaf route without an element or Component.

--- a/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.runtime.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/scroll-position.runtime.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 
 const SCROLL_ELEMENTS = [
   {

--- a/packages/dnb-design-system-portal/vite/client/portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/portal-app.tsx
@@ -12,7 +12,7 @@ import {
   Outlet,
   useLocation,
   type RouteObject,
-} from 'react-router-dom'
+} from 'react-router'
 import { CacheProvider } from '@emotion/react'
 import createEmotionCache from '@emotion/cache'
 import { Provider, Context, Theme } from '@dnb/eufemia/src/shared'

--- a/packages/dnb-design-system-portal/vite/client/shims/portal-query.tsx
+++ b/packages/dnb-design-system-portal/vite/client/shims/portal-query.tsx
@@ -5,7 +5,7 @@
  * plus navigate for imperative routing outside React components.
  */
 
-import { useNavigate, type To } from 'react-router-dom'
+import { useNavigate, type To } from 'react-router'
 import { allMdxNodes } from 'virtual:portal-pages'
 
 // graphql tag — preserves the query string so useStaticQuery can

--- a/packages/dnb-design-system-portal/vite/prod/entry-server.tsx
+++ b/packages/dnb-design-system-portal/vite/prod/entry-server.tsx
@@ -15,7 +15,7 @@ import {
   StaticRouterProvider,
   Outlet,
   useLocation,
-} from 'react-router-dom'
+} from 'react-router'
 import { Provider, Theme } from '@dnb/eufemia/src/shared'
 import IsolatedStyleScope from '@dnb/eufemia/src/shared/IsolatedStyleScope'
 import { CacheProvider } from '@emotion/react'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7263,6 +7263,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-es@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "cookie-es@npm:3.1.1"
+  checksum: 10/e40083c42d0e3a4b3caa271775858f8e6cdd31f24b9c445ff08d7a8f4dc01069fc82012bdf1602d5a03fa1d75aba51a3dd33cd8a5db639db2ed17bcfd650f4bc
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:^1.2.1":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
@@ -7277,7 +7284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.0.1, cookie@npm:^1.0.2":
+"cookie@npm:^1.0.2":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: 10/85538153054791155cf4d38d2e807e3b9382d71bf71d92fc46fca348515ea574049d0d9ef8eb84d2d54a681ad1d7a7316b1989b901dace50a6c0f4c3858dbdb2
@@ -7873,7 +7880,7 @@ __metadata:
     react-dom: "npm:19.2.5"
     react-live-ssr: "workspace:*"
     react-markdown: "npm:9.1.0"
-    react-router-dom: "npm:7.16.0"
+    react-router: "npm:8.3.0"
     remark-frontmatter: "npm:5.0.0"
     remark-gfm: "npm:4"
     remark-gfm-react-markdown: "npm:remark-gfm@4.0.1"
@@ -15535,31 +15542,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:7.16.0":
-  version: 7.16.0
-  resolution: "react-router-dom@npm:7.16.0"
+"react-router@npm:8.3.0":
+  version: 8.3.0
+  resolution: "react-router@npm:8.3.0"
   dependencies:
-    react-router: "npm:7.16.0"
+    cookie-es: "npm:^3.1.1"
   peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10/f8d7da28bf1276c8a3bd2d85948b104810aa1b08e1ac761fbeccafbeb2f381aeb04c4ff3ec53c43e6a4e96564d1aa571d16b3a07e115f2b3782a16705bfde2c3
-  languageName: node
-  linkType: hard
-
-"react-router@npm:7.16.0":
-  version: 7.16.0
-  resolution: "react-router@npm:7.16.0"
-  dependencies:
-    cookie: "npm:^1.0.1"
-    set-cookie-parser: "npm:^2.6.0"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
+    react: ">=19.2.7"
+    react-dom: ">=19.2.7"
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10/2c77d27170eab1dfa6f0593e846f9d352424cc789a505aaee9bee9c9da1ed9d6a044d0a476e3eaf240e73b09169b4ffb85b5910d026a34abd055aed5b2f5a5cb
+  checksum: 10/6ef9ee17910356e7a7c1d262d3c3a943a25e36bf871a199628438d1436d1a16828091da30a5df7c318030dff434c5b3f003c16f82c7ffca9cf37545316f6525c
   languageName: node
   linkType: hard
 
@@ -16500,13 +16494,6 @@ __metadata:
     parseurl: "npm:^1.3.3"
     send: "npm:^1.2.0"
   checksum: 10/71500fe80cc7163fec04e4297de7591ad1cb682d137fc030e7a53e57040fda5187e8082a9c1b2ef37f1d3f9c27c9a94d4ba61806ebc28938ba4a7c8947c9f71e
-  languageName: node
-  linkType: hard
-
-"set-cookie-parser@npm:^2.6.0":
-  version: 2.7.2
-  resolution: "set-cookie-parser@npm:2.7.2"
-  checksum: 10/4b6f5ec4e3fa1aef471d9207117704d217ba6bb6443400b41f5ea945c4a7f6fc08e405a122c1a32b4ebde41f06dea75e02c2af87cee9abb27f3e3fe911e5839b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Migrates the docs portal from `react-router-dom` to **`react-router` v8 (8.3.0)** to resolve the last open React Router advisory, **#517**, which is only patched in react-router 8.3.0. Because `react-router-dom` was discontinued at `7.18.2` (v8 folds the DOM package into `react-router`), the fix requires importing from `react-router` directly.

react-router 8.3.0 also includes the 7.18.0 fixes, so this PR clears **all five** React Router alerts.

> **Supersedes [#8860](https://github.com/dnbexperience/eufemia/pull/8860)** (which bumped `react-router-dom` to 7.18.2 for the other 4). Merge one or the other, not both — this PR covers all five including #517.

## Advisory fixed (the one #8860 can't)

| Alert | Severity | Advisory |
| --- | --- | --- |
| 517 | high | [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) — RSC Mode CSRF bypass allows action execution before 400 response |

Also clears 515, 518, 519, 520 (all fixed ≥ 7.18.0).

## Changes (portal only — not shipped to consumers)

- `package.json`: `react-router-dom@7.16.0` → `react-router@8.3.0`.
- **15 code/config/test files**: imports changed `'react-router-dom'` → `'react-router'` (incl. SSR entry `entry-server.tsx` using `createStaticHandler`/`createStaticRouter`/`StaticRouterProvider`, `portal-app.tsx`, the `catch-links` virtual module + its test, and the `portal-query` shim mock). All these symbols are exported from `react-router` in v8.
- **4 docs (`.mdx`)**: consumer examples updated to `react-router`; the `location-hooks` "Supported routers" section + its self-anchor renamed `#with-react-router-dom` → `#with-react-router`. The historical note about **react-router-dom v5 `withRouter`** in `heading/info.mdx` is intentionally left unchanged (it is version-specific legacy guidance).

## QA

- `yarn why react-router` → single **8.3.0**; `react-router-dom` fully removed from the tree.
- Portal typecheck (`tsc --noEmit`) → **passes** (validates type-only imports `LinkProps`, `To`, `RouteObject`).
- Affected unit tests (catch-links, portal-query shim, RelatedComponents) → **54 passed**.
- Full prerender build (`vite/prod/prerender.mjs`) → **1059 pages, exit 0** — confirms SSR + live doc examples bundle and render on v8.

`react-router@8.3.0` is past the repo's `npmMinimalAgeGate: 3d`.
