### PR TITLE
chore(deps): bump postcss to 8.5.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
     "path-to-regexp": "8.4.0",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "qs": "6.15.2",
     "sharp": "0.35.0",
     "svgo": "3.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13228,12 +13228,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/6eec280694e2088d18fb802b1e3bfc4578e27b665b7ecfbe36c7356612fea2f814277056e671e2a1529dff551588a652efdc0bfa39f8a3185bc2247be311872e
+  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
   languageName: node
   linkType: hard
 
@@ -15165,14 +15165,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.18":
-  version: 8.5.18
-  resolution: "postcss@npm:8.5.18"
+"postcss@npm:8.5.23":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/b43f2d2493d82dc43fa50d21cf184bf3b66229e7f53fa1dedc7b8a7c4cecd7ac8ee18fad099f47570da7f78bbf46997a4c6e6c87d8d8ece683dc1f32cda6db3b
+  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the postcss resolution 8.5.18 -> **8.5.23** to clear two newly-published Dependabot advisories (vulnerable <= 8.5.22).

postcss is a build/lint-time dependency, not in the published @dnb/eufemia runtime deps. Rebuilt on latest main; `yarn dedupe --check` passes; only 8.5.23 remains.

Fixes Dependabot alerts 531, 536.
