### PR TITLE
chore(deps): bump fast-uri to 3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "ttf2woff2@npm:^6.0.1": "npm:8.0.1",
-    "fast-uri@npm:^3.0.1": "npm:3.1.4",
+    "fast-uri@npm:^3.0.1": "npm:3.1.5",
     "@babel/core": "7.29.7",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "@babel/runtime": "7.26.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9341,10 +9341,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.4":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
+"fast-uri@npm:3.1.5":
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the fast-uri resolution 3.1.4 -> **3.1.5** to clear a newly-published Dependabot advisory (vulnerable < 3.1.5).

fast-uri is pulled in by `ajv`, a **runtime dependency** of @dnb/eufemia, so it reaches published consumers — highest priority of this batch. Rebuilt on latest main; `yarn dedupe --check` passes; only 3.1.5 remains.

Fixes Dependabot alert 537.
