### PR TITLE
chore(deps): bump ip-address to 10.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "form-data": "4.0.6",
     "hono": "4.12.27",
     "immutable": "5.1.8",
-    "ip-address": "10.2.2",
+    "ip-address": "10.3.1",
     "joi": "17.13.4",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10681,10 +10681,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.2.2":
-  version: 10.2.2
-  resolution: "ip-address@npm:10.2.2"
-  checksum: 10/351c470d323d874b79c5525d1701a4a4d1d41eb77806702a64d328100903b6a949ed2d31b833f54ec8068deff408142e2a5823f0c9a142d26f8f1da0117de773
+"ip-address@npm:10.3.1":
+  version: 10.3.1
+  resolution: "ip-address@npm:10.3.1"
+  checksum: 10/cc0d5b9953acb4114990a3887e0701f8fe843903811f982cf2856cd307c5fb6cdca426ad16c39a1f4950091935c8be4d42631a443f797a96626cce161fffed41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the ip-address resolution 10.2.2 -> **10.3.1** to clear a newly-published Dependabot advisory (vulnerable <= 10.3.0).

ip-address is only reached via socks/express-rate-limit (tooling). Rebuilt on latest main; `yarn dedupe --check` passes; only 10.3.1 remains.

Fixes Dependabot alert 546.
