### PR TITLE
chore(deps): bump @hono/node-server to 2.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "7.29.7",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "@babel/runtime": "7.26.10",
-    "@hono/node-server": "2.0.5",
+    "@hono/node-server": "2.0.10",
     "@tootallnate/once": "2.0.1",
     "@xmldom/xmldom": "0.8.13",
     "body-parser": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3127,12 +3127,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:2.0.5":
-  version: 2.0.5
-  resolution: "@hono/node-server@npm:2.0.5"
+"@hono/node-server@npm:2.0.10":
+  version: 2.0.10
+  resolution: "@hono/node-server@npm:2.0.10"
   peerDependencies:
     hono: ^4
-  checksum: 10/6931114aaa35a9a6d9b80e5ab2f6c5122b822733cbf6d0572c6e0aa28805fb92ba8013fb64b7da9da54c2e65a0a09ae8e83857792396250724d7a75e3cbc5c35
+  checksum: 10/72f803bec74e47f51cc7e2fe4d97e9265c87fedffa6ae0ff1fd1f2c08447678067b99be13b4619fa4135ad1299cb4cef7b52bd477bd83f5c3b0d816d4ed15808
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the @hono/node-server resolution 2.0.5 -> **2.0.10** to clear a newly-published Dependabot advisory (vulnerable >= 2.0.0, <= 2.0.9) — a patch bump within the v2 line we already adopted.

Only reached via @modelcontextprotocol/sdk in tools/mcp-lambda. QA: `mcp-lambda typecheck` passes; `yarn dedupe --check` passes; only 2.0.10 remains.

Fixes Dependabot alert 548.
