### PR TITLE
chore(deps): bump postcss devDep to 8.5.23 to close alert #531

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -207,7 +207,7 @@
     "ora": "5.4.1",
     "playwright": "1.60.0",
     "pngjs": "7.0.0",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "postcss-preset-env": "9.6.0",
     "prettier": "3.8.1",
     "prettier-package-json": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,7 +2378,7 @@ __metadata:
     ora: "npm:5.4.1"
     playwright: "npm:1.60.0"
     pngjs: "npm:7.0.0"
-    postcss: "npm:8.5.18"
+    postcss: "npm:8.5.23"
     postcss-preset-env: "npm:9.6.0"
     postcss-selector-parser: "npm:7.1.0"
     prettier: "npm:3.8.1"


### PR DESCRIPTION
The root `postcss` resolution is already at 8.5.23 (merged in #8865), and the transitive alert #536 is fixed. But the **direct devDep** in `packages/dnb-eufemia/package.json` still declared `8.5.18`, which keeps Dependabot's direct-manifest alert **#531** (GHSA-fxqj-rqcc-2cmp) open.

This bumps the declaration to **8.5.23** to match the resolution. Installed version is unchanged (already 8.5.23 via the resolution); `yarn dedupe --check` passes.

Fixes Dependabot alert 531.
