### PR TITLE
chore(deps): bump hono to 4.12.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "flatted": "3.4.2",
     "follow-redirects": "1.16.0",
     "form-data": "4.0.6",
-    "hono": "4.12.27",
+    "hono": "4.12.34",
     "immutable": "5.1.8",
     "ip-address": "10.3.1",
     "joi": "17.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10298,10 +10298,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:4.12.27":
-  version: 4.12.27
-  resolution: "hono@npm:4.12.27"
-  checksum: 10/f1bb52f3871093fae5b5bc40fb179ff2e6d43c6dab8d7065ef182d8ff6cdc1c41dc1124b07f2f02e0fe36ec1e39e72300ed3447f64391e39d71978616d4f5a07
+"hono@npm:4.12.34":
+  version: 4.12.34
+  resolution: "hono@npm:4.12.34"
+  checksum: 10/c33104233b751c50e1821382eefad5584823ff2b635af261eb1e85c17bab706f73f3c1e5ace4d2f4c23a7fdced24e4e4de9cc5a32404b134ac93b66ff0e81a0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the hono resolution 4.12.27 -> **4.12.34** to clear Dependabot **alert 547** (vulnerable < 4.12.34).

hono is a transitive dependency of `@modelcontextprotocol/sdk`, which is a **devDependency** of `@dnb/eufemia` and a runtime dependency of the `tools/mcp-lambda` tooling. It is **not** part of the shipped `@dnb/eufemia` runtime.

### Age gate cleared
`4.12.34` was published 2026-08-03, so the repo's `npmMinimalAgeGate: 3d` no longer quarantines it. `yarn install --immutable` now passes (no `YN0016`). Verified locally on latest `main`: only `4.12.34` resolves (`yarn why hono`) and `yarn dedupe --check` is clean.

Fixes Dependabot alert 547.
