### PR TITLE
chore(portal): lazy-load non-default brand themes

### DIFF
--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -514,6 +514,46 @@ describe('prerender-utils', () => {
       expect(cssPos).toBeLessThan(headClosePos)
     })
 
+    const themeCssPaths = {
+      ui: '/assets/eufemia-theme-ui.css',
+      sbanken: '/assets/eufemia-theme-sbanken.css',
+      eiendom: '/assets/eufemia-theme-eiendom.css',
+      carnegie: '/assets/eufemia-theme-carnegie.css',
+    }
+
+    it('emits only the default theme as an enabled stylesheet', () => {
+      const result = injectHtml(
+        template,
+        '<h1>Hello</h1>',
+        { js: [], css: [] },
+        '',
+        undefined,
+        themeCssPaths
+      )
+
+      // Default theme (ui) is render-blocking: no `disabled` attribute.
+      expect(result).toContain(
+        '<link rel="stylesheet" crossorigin href="/assets/eufemia-theme-ui.css" data-eufemia-theme="ui">'
+      )
+      expect(result).not.toContain('data-eufemia-theme="ui" disabled')
+    })
+
+    it('emits non-default themes with the disabled attribute', () => {
+      const result = injectHtml(
+        template,
+        '<h1>Hello</h1>',
+        { js: [], css: [] },
+        '',
+        undefined,
+        themeCssPaths
+      )
+
+      // Non-default brand themes are not fetched until a theme switch.
+      expect(result).toContain('data-eufemia-theme="sbanken" disabled>')
+      expect(result).toContain('data-eufemia-theme="eiendom" disabled>')
+      expect(result).toContain('data-eufemia-theme="carnegie" disabled>')
+    })
+
     it('injects SEO meta tags when meta is provided', () => {
       const result = injectHtml(
         template,

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -341,23 +341,28 @@ export function injectHtml(
     `<div id="root">${appHtml}</div>\n\t<script>${contentScript};${scrollRestoreScript}</script>`
   )
 
-  // Inject <link> tags for ALL brand theme CSS chunks.
-  // All links are enabled (render-blocking) so the browser fetches them
-  // before the first paint. A head script disables inactive themes
-  // before the browser paints, and a body-opening script adds the
-  // active brand class to <body> so token selectors match immediately.
+  // Inject <link> tags for the brand theme CSS chunks.
+  // Only the default theme is enabled (render-blocking) so the browser
+  // fetches just that one before the first paint. Every other brand
+  // theme is emitted with the `disabled` attribute, which keeps the
+  // browser from fetching it until the user switches themes — removing
+  // the other themes from the render-blocking critical path and from
+  // the initial byte weight. A body-opening script adds the active
+  // brand class to <body> so token selectors match immediately.
   if (themeCssPaths && Object.keys(themeCssPaths).length > 0) {
     const defaultTheme = 'ui'
     const linkTags = Object.entries(themeCssPaths)
       .map(([name, href]) => {
-        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}">`
+        const disabled = name === defaultTheme ? '' : ' disabled'
+        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}"${disabled}>`
       })
       .join('\n')
 
-    // Head script: determine active theme, disable inactive theme
-    // links, and store the name on globalThis for the body script.
-    // Runs in <head> after the render-blocking links have loaded,
-    // so the disable is instant — no network delay.
+    // Head script: determine the active theme, enable its link (which
+    // starts the fetch when it was emitted disabled) and disable the
+    // rest, then store the name on globalThis for the body script. For
+    // the common case (default theme) this is a no-op — no extra
+    // request is made because only the default stylesheet is enabled.
     const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -90,10 +90,11 @@ async function prerender() {
   let urls = collectUrls(routes)
   console.log(`  ${urls.length} pages to prerender`)
 
-  // Find CSS chunks for ALL themes so we can inject render-blocking
-  // <link> tags. The default theme (ui) is enabled; others are disabled
-  // but present so an early inline script can swap them before first
-  // paint — avoiding a flash of the wrong brand theme.
+  // Find CSS chunks for ALL themes so we can inject <link> tags.
+  // The default theme (ui) is injected enabled (render-blocking); the
+  // other brand themes are injected disabled, so the browser skips them
+  // until the user switches themes. An early inline script enables a
+  // stored non-default theme when needed.
   const assetsDir = path.resolve(outDir, 'assets')
   const themeNames = ['ui', 'sbanken', 'eiendom', 'carnegie']
   const themeCssPaths = {}
@@ -498,23 +499,28 @@ function injectHtml(
     `<div id="root">${appHtml}</div>\n\t<script>${contentScript};${scrollRestoreScript}</script>`
   )
 
-  // Inject <link> tags for ALL brand theme CSS chunks.
-  // All links are enabled (render-blocking) so the browser fetches them
-  // before the first paint. A head script disables inactive themes
-  // before the browser paints, and a body-opening script adds the
-  // active brand class to <body> so token selectors match immediately.
+  // Inject <link> tags for the brand theme CSS chunks.
+  // Only the default theme is enabled (render-blocking) so the browser
+  // fetches just that one before the first paint. Every other brand
+  // theme is emitted with the `disabled` attribute, which keeps the
+  // browser from fetching it until the user switches themes — removing
+  // the other themes from the render-blocking critical path and from
+  // the initial byte weight. A body-opening script adds the active
+  // brand class to <body> so token selectors match immediately.
   if (themeCssPaths && Object.keys(themeCssPaths).length > 0) {
     const defaultTheme = 'ui'
     const linkTags = Object.entries(themeCssPaths)
       .map(([name, href]) => {
-        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}">`
+        const disabled = name === defaultTheme ? '' : ' disabled'
+        return `    <link rel="stylesheet" crossorigin href="${href}" data-eufemia-theme="${name}"${disabled}>`
       })
       .join('\n')
 
-    // Head script: determine active theme, disable inactive theme
-    // links, and store the name on globalThis for the body script.
-    // Runs in <head> after the render-blocking links have loaded,
-    // so the disable is instant — no network delay.
+    // Head script: determine the active theme, enable its link (which
+    // starts the fetch when it was emitted disabled) and disable the
+    // rest, then store the name on globalThis for the body script. For
+    // the common case (default theme) this is a no-op — no extra
+    // request is made because only the default stylesheet is enabled.
     const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after


### PR DESCRIPTION
Only the default (ui) theme is emitted as an enabled, render-blocking stylesheet during prerender. The other brand themes (sbanken, eiendom, carnegie) are now emitted with the `disabled` attribute, so the browser does not fetch them until a user switches themes.

Previously all four themes were downloaded at VeryHigh priority on every first paint (~370 KB extra transfer / ~2.8 MB uncompressed), placing unused theme CSS on the render-blocking critical path. Lighthouse flagged this via render-blocking-requests (~480 ms) and unused-css-rules (carnegie 93.6% unused). The existing head script already enables a stored non-default theme on demand, so theme switching is unaffected.

The change is applied to both injectHtml implementations: the tested prerender-utils.ts copy and the prerender.mjs copy used by the actual production build.

