### PR TITLE
fix(Autocomplete): prevent drawer reopening when data prop changes after selection

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -701,6 +701,11 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
   const modeRef = useRef(mode)
   const hasFocusRef = useRef(hasFocus)
 
+  // Set when a selection closes the drawer, so a data-prop change caused by
+  // that selection (e.g. a fetch in the parent) does not immediately reopen it.
+  // Cleared when the user types or genuinely focuses the input again.
+  const preventReopenRef = useRef(false)
+
   // Keep refs in sync with state for use in callbacks
   searchIndexRef.current = searchIndex
   inputValueRef.current = inputValue
@@ -1692,11 +1697,19 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
               const typed = typedInputValueRef.current
 
               if (typed?.length > 0) {
-                const filteredData: DrawerListInternalData =
-                  runFilterWithSideEffects(typed)
-                if (countData(filteredData) === 0) {
-                  if (modeRef.current !== 'async') {
-                    showNoOptionsItem()
+                // Skip re-running the visible filter (which can reopen the
+                // drawer) when the drawer is closed because of a just-made
+                // selection. It still runs while typing or when already open.
+                if (
+                  drawerListRef.current.open ||
+                  !preventReopenRef.current
+                ) {
+                  const filteredData: DrawerListInternalData =
+                    runFilterWithSideEffects(typed)
+                  if (countData(filteredData) === 0) {
+                    if (modeRef.current !== 'async') {
+                      showNoOptionsItem()
+                    }
                   }
                 }
               } else {
@@ -1810,6 +1823,9 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       setTypedInputValue(val)
       setInputValueState(val)
 
+      // Typing is a clear intent to (re)open and filter the list.
+      preventReopenRef.current = false
+
       dispatchCustomElementEvent(propsRef.current, 'onType', {
         value: val,
         event,
@@ -1921,6 +1937,10 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       if (suppressFocusHandlerRef.current) {
         return undefined // stop here
       }
+
+      // A genuine focus (not the programmatic refocus after a selection, which
+      // is suppressed above) should allow focus-driven data fill to open again.
+      preventReopenRef.current = false
 
       if (!hasFocusRef.current) {
         if (openOnFocus && hasValidData()) {
@@ -2159,6 +2179,10 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
           closingFromChangeRef.current = true
           setHidden()
 
+          // Prevent a data-prop change triggered by this selection (e.g. a
+          // fetch in the parent) from reopening the just-closed drawer.
+          preventReopenRef.current = true
+
           // Do this, so screen readers get a NEW focus later on
           // So we first need a blur of the input basically
           focusDrawerList()
@@ -2286,7 +2310,12 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       lastUpdateDataRef.current = null
 
       updateData(props.data)
-      if (drawerList.open || hasFocus) {
+
+      // Refresh the visible list when the drawer is open, or when the input is
+      // focused and the data change is not the result of a just-made selection
+      // (e.g. focus-driven data fill should open the list, but a fetch caused
+      // by a selection should not reopen the just-closed drawer).
+      if (drawerList.open || (hasFocus && !preventReopenRef.current)) {
         // Re-run filter after updating the search index so highlight
         // and visibility are handled consistently.
         setSearchIndex({ overwriteSearchIndex: true }, () => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -4526,6 +4526,173 @@ describe('Autocomplete component', () => {
     expect(options[0].textContent).toBe('BB')
   })
 
+  it('should not reopen the drawer when the data prop changes (new reference) after a selection', async () => {
+    const onChange = vi.fn()
+
+    function Parent() {
+      const [data, setData] = useState(['AA', 'AB', 'BB'])
+
+      return (
+        <Autocomplete
+          {...mockProps}
+          data={data}
+          onChange={(...args) => {
+            onChange(...args)
+            // Simulate an async data fetch triggered by the selection that
+            // returns a new array reference after the input regains focus.
+            setTimeout(() => {
+              setData(['AA', 'AB', 'BB'])
+            }, 10)
+          }}
+        />
+      )
+    }
+
+    render(<Parent />)
+
+    const input = document.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    keyDownOnInput('ArrowDown')
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+
+    fireEvent.click(document.querySelector('li.dnb-drawer-list__option'))
+
+    // Let the deferred refocus (0ms) and the simulated fetch (10ms) settle.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(input.value).toBe('AA')
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not reopen the drawer when the parent passes a new data reference on every render after a selection', async () => {
+    function Parent() {
+      const [, forceRender] = useState(0)
+
+      // New array reference on every render, mimicking Field.Selection.
+      const data = ['AA', 'AB', 'BB'].map((item) => item)
+
+      return (
+        <Autocomplete
+          {...mockProps}
+          data={data}
+          onChange={() => {
+            setTimeout(() => forceRender((n) => n + 1), 10)
+          }}
+        />
+      )
+    }
+
+    render(<Parent />)
+
+    keyDownOnInput('ArrowDown')
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+
+    fireEvent.click(document.querySelector('li.dnb-drawer-list__option'))
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not reopen the drawer when the data prop changes after typing and selecting with the keyboard', async () => {
+    function Parent() {
+      const [data, setData] = useState(['AA', 'AB', 'BB'])
+
+      return (
+        <Autocomplete
+          {...mockProps}
+          data={data}
+          onChange={() => {
+            // Simulate an async data fetch triggered by the selection.
+            setTimeout(() => {
+              setData(['AA', 'AB', 'BB'])
+            }, 10)
+          }}
+        />
+      )
+    }
+
+    render(<Parent />)
+
+    const input = document.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    // Type to filter, then select the highlighted item with the keyboard.
+    // The typed value persists (no blur), which is what previously caused
+    // the reopen via the updateData filter path.
+    await userEvent.type(input, 'A')
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+
+    keyDownOnInput('ArrowDown')
+    keyDownOnInput('Enter')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
+    expect(input.value).toBe('AA')
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should open the drawer when the data prop fills on focus (no prior selection)', async () => {
+    // Mirrors SelectCountry/SelectCurrency, which fill the data on focus and
+    // rely on the drawer opening from that data change while focused.
+    function Parent() {
+      const [data, setData] = useState<string[]>([])
+
+      return (
+        <Autocomplete
+          {...mockProps}
+          data={data}
+          onFocus={() => {
+            setData(['AA', 'AB', 'BB'])
+          }}
+        />
+      )
+    }
+
+    render(<Parent />)
+
+    const input = document.querySelector(
+      '.dnb-input__input'
+    ) as HTMLInputElement
+
+    fireEvent.focus(input)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
+    expect(
+      document.querySelector('.dnb-drawer-list__options')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelectorAll(
+        '.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+    ).toHaveLength(3)
+  })
+
   it('should open and search after clearing input following keyboard selection', async () => {
     const movies = [
       'The Shawshank Redemption',


### PR DESCRIPTION
Motivation: request by @karini6 🫶 

## Summary

Fixes an issue where the **Autocomplete** drawer reopens by itself right after the user makes a selection, when the parent supplies a new `data` prop as a consequence of that selection (for example, fetching data in response to `onChange`).

This is most easily hit through `Field.Selection` with the `autocomplete` variant, because that field rebuilds its `data` array on every render (`renderDropdownItems(...).concat(makeOptions(...)).filter(Boolean)`), so the `data` reference is new on every render.

## Steps to reproduce (before this fix)

1. Render a `Field.Selection` with `variant="autocomplete"` (or a plain `Autocomplete`).
2. In `onChange`, fetch data in the parent and store it in state (async), passing it back as the `data` prop.
3. Open the dropdown and select an item (by mouse **or** keyboard).
4. The dropdown closes on selection, then **reopens on its own** once the fetched data arrives.

## Root cause

After a selection, the drawer is closed (`setHidden()`) but the input is deliberately refocused so typing can reopen the list. A subsequent `data`-prop change (detected via a referential check) then re-ran the filter **side effects** while the input still had focus, which called `setVisible()` again. There are two such data-driven reopen paths:

- The `useEffect([props.data])` data-change handler (`drawerList.open || hasFocus` branch).
- `updateData()`'s internal typed-filter branch (hit when the typed value persists, e.g. after a keyboard **Enter** selection — a mouse selection blurs and clears it).

## The fix

Introduce a `preventReopenRef` that is set when a selection closes the drawer, and cleared on the next user action that should open it (typing, arrow keys, input click, genuine focus). Both data-driven reopen paths consult it:

- Data-change effect: `drawerList.open || (hasFocus && !preventReopenRef.current)`
- `updateData` typed branch: only re-runs the visible filter when `drawerListRef.current.open || !preventReopenRef.current`

A `data`-prop change still refreshes the list contents, and **focus-driven data fill still opens the drawer** (this is how `SelectCountry`/`SelectCurrency` open on focus), and async typing still opens/refreshes — but a data change caused by a selection no longer reopens the just-closed drawer.

> Note: an earlier, simpler version of this fix (gating only on `drawerList.open`) was rejected because it broke `SelectCountry`/`SelectCurrency`, which rely on the `hasFocus` branch to open the list when their data fills on focus.

## Tests

Added regression tests in `Autocomplete.test.tsx`:

- `should not reopen the drawer when the data prop changes (new reference) after a selection` — async fetch.
- `should not reopen the drawer when the parent passes a new data reference on every render after a selection` — the `Field.Selection`-like case.
- `should not reopen the drawer when the data prop changes after typing and selecting with the keyboard` — the persisted-typed-value / Enter case.
- `should open the drawer when the data prop fills on focus (no prior selection)` — guards the `SelectCountry`/`SelectCurrency` focus-fill behaviour.

The first three fail on `main` and pass with this change; the last one fails under the naive `drawerList.open`-only variant, locking in the preserved behaviour.

## Verification

- `Autocomplete` — 128 tests pass (incl. the 4 above).
- `Field.Selection`, `SelectCountry`, `SelectCurrency`, `Field.Address`, `PhoneNumber` (async consumers), `Dropdown`, `DrawerList` — all pass.
- Prettier: no changes. ESLint: no new warnings/errors.
