### PR TITLE
chore(mcp): add optional X-Edge-Auth header check

### DIFF
--- a/tools/mcp-lambda/ghe-deploy-workflow.yml
+++ b/tools/mcp-lambda/ghe-deploy-workflow.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Deploy
         env:
           TF_VAR_cost_allocation: ${{ vars.COST_ALLOCATION }}
+          TF_VAR_edge_auth_secret: ${{ secrets.EDGE_AUTH_SECRET }}
         run: |
           set -euo pipefail
           cd infra

--- a/tools/mcp-lambda/infra/main.tf
+++ b/tools/mcp-lambda/infra/main.tf
@@ -18,8 +18,8 @@ resource "aws_lambda_function" "mcp" {
 
   # LLM clients fan out tool calls in parallel, so the cap must absorb
   # bursts well above the previous 10 to avoid Lambda throttling (429 ->
-  # surfaced by the HTTP API as 503). Kept conservative while the endpoint
-  # is unauthenticated; raise once Akamai edge rate-limiting fronts it.
+  # surfaced by the HTTP API as 503). Kept conservative for now; raise as
+  # traffic grows.
   reserved_concurrent_executions = 30
 
   filename         = "${path.module}/../dist/lambda.zip"
@@ -28,6 +28,9 @@ resource "aws_lambda_function" "mcp" {
   environment {
     variables = {
       NODE_OPTIONS = "--enable-source-maps"
+
+      # Optional shared secret sent as the X-Edge-Auth header; empty disables the check.
+      EDGE_AUTH_SECRET = var.edge_auth_secret
     }
   }
 

--- a/tools/mcp-lambda/infra/variables.tf
+++ b/tools/mcp-lambda/infra/variables.tf
@@ -30,3 +30,10 @@ variable "domain_name" {
   description = "Custom domain for the MCP endpoint (no trailing dot)"
   default     = "mcp.dev.eufemia.tech-03.net"
 }
+
+variable "edge_auth_secret" {
+  type        = string
+  description = "Optional shared secret for the X-Edge-Auth header; empty disables the check."
+  default     = ""
+  sensitive   = true
+}

--- a/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
+++ b/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
@@ -182,3 +182,95 @@ describe('lambda-handler error handling', () => {
     }
   })
 })
+
+describe('lambda-handler origin auth (X-Edge-Auth)', () => {
+  const secret = 'edge-shared-secret'
+  let docsRoot: string
+
+  beforeAll(async () => {
+    docsRoot = await createTempDocs()
+    process.env.EUFEMIA_DOCS_ROOT = docsRoot
+  })
+
+  afterAll(async () => {
+    delete process.env.EUFEMIA_DOCS_ROOT
+    delete process.env.EDGE_AUTH_SECRET
+    await fs.rm(docsRoot, { recursive: true, force: true })
+  })
+
+  function mcpEvent(headers: Record<string, string>): unknown {
+    return {
+      rawPath: '/mcp',
+      requestContext: {
+        domainName: 'example.test',
+        http: { method: 'POST' },
+      },
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...headers,
+      },
+      body: JSON.stringify(toolsListRequest),
+    }
+  }
+
+  it('rejects with 403 when the secret is set but the header is missing', async () => {
+    process.env.EDGE_AUTH_SECRET = secret
+    const { handler } = await import('../transports/lambda-handler.js')
+
+    const result = (await handler(
+      mcpEvent({}) as Parameters<typeof handler>[0]
+    )) as { statusCode: number; body: string }
+
+    expect(result.statusCode).toBe(403)
+    expect(JSON.parse(result.body).error.message).toBe('Forbidden')
+  })
+
+  it('rejects with 403 when the header does not match', async () => {
+    process.env.EDGE_AUTH_SECRET = secret
+    const { handler } = await import('../transports/lambda-handler.js')
+
+    const result = (await handler(
+      mcpEvent({ 'x-edge-auth': 'wrong-secret' }) as Parameters<
+        typeof handler
+      >[0]
+    )) as { statusCode: number }
+
+    expect(result.statusCode).toBe(403)
+  })
+
+  it('lets the request through when the header matches', async () => {
+    process.env.EDGE_AUTH_SECRET = secret
+    const { handler } = await import('../transports/lambda-handler.js')
+
+    const result = (await handler(
+      mcpEvent({ 'x-edge-auth': secret }) as Parameters<typeof handler>[0]
+    )) as { statusCode: number }
+
+    expect(result.statusCode).not.toBe(403)
+  })
+
+  it('is a no-op when the secret is unset', async () => {
+    delete process.env.EDGE_AUTH_SECRET
+    const { handler } = await import('../transports/lambda-handler.js')
+
+    const result = (await handler(
+      mcpEvent({}) as Parameters<typeof handler>[0]
+    )) as { statusCode: number }
+
+    expect(result.statusCode).not.toBe(403)
+  })
+
+  it('keeps GET /healthz open even when the secret is set', async () => {
+    process.env.EDGE_AUTH_SECRET = secret
+    const { handler } = await import('../transports/lambda-handler.js')
+
+    const result = (await handler({
+      rawPath: '/healthz',
+      requestContext: { http: { method: 'GET' } },
+      headers: {},
+    } as Parameters<typeof handler>[0])) as { statusCode: number }
+
+    expect(result.statusCode).toBe(200)
+  })
+})

--- a/tools/mcp-lambda/src/transports/lambda-handler.ts
+++ b/tools/mcp-lambda/src/transports/lambda-handler.ts
@@ -2,6 +2,7 @@ import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyResultV2,
 } from 'aws-lambda'
+import { timingSafeEqual } from 'node:crypto'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import server from '../server.js'
 
@@ -29,6 +30,28 @@ function toWebRequest(event: APIGatewayProxyEventV2): Request {
     headers,
     body,
   })
+}
+
+// Verifies the X-Edge-Auth header against the configured secret.
+// No secret set = check disabled (local and pre-edge environments).
+function isEdgeAuthorized(event: APIGatewayProxyEventV2): boolean {
+  const expected = process.env.EDGE_AUTH_SECRET
+  if (!expected) {
+    return true
+  }
+
+  const provided = event.headers['x-edge-auth']
+  if (!provided) {
+    return false
+  }
+
+  const expectedBuf = Buffer.from(expected)
+  const providedBuf = Buffer.from(provided)
+  if (expectedBuf.length !== providedBuf.length) {
+    return false
+  }
+
+  return timingSafeEqual(expectedBuf, providedBuf)
 }
 
 async function toApiGatewayResult(
@@ -59,6 +82,19 @@ export async function handler(
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status: 'ok' }),
+    }
+  }
+
+  // Enforced after /healthz so health probes stay open.
+  if (!isEdgeAuthorized(event)) {
+    return {
+      statusCode: 403,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Forbidden' },
+        id: null,
+      }),
     }
   }
 


### PR DESCRIPTION
## What
Adds an optional shared-secret header check to the MCP Lambda handler.

## Details
- When `EDGE_AUTH_SECRET` is set, the handler verifies a matching `X-Edge-Auth` header using a constant-time `timingSafeEqual` and returns `403` on mismatch.
- Disabled when `EDGE_AUTH_SECRET` is unset (the default), so local runs are unaffected.
- `GET /healthz` remains open.
- Terraform: new sensitive `edge_auth_secret` variable wired to the Lambda's `EDGE_AUTH_SECRET` env var.

## Tests
Added 5 tests covering the header check. Full suite: **9/9 pass**.

## Merge

- [x] Postpone merge until [akamai is setup and merged](https://dnb.ghe.com/akamai-delivery/akamai_delivery_eufemia/pull/5/changes)