### PR TITLE
fix(Tabs): avoid dangling aria-controls when no tabpanel exists

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -410,6 +410,9 @@ function TabsComponent(ownProps: TabsProps) {
   const [isFirst, setIsFirst] = useState<boolean | undefined>(undefined)
   const [isLast, setIsLast] = useState<boolean | undefined>(undefined)
 
+  // Only link the selected tab to its panel when the panel actually exists
+  const [hasTabPanel, setHasTabPanel] = useState(false)
+
   // Track previous props for getDerivedStateFromProps equivalent
   const [prevDataSource, setPrevDataSource] = useState(
     ownProps.data || ownProps.children
@@ -442,6 +445,11 @@ function TabsComponent(ownProps: TabsProps) {
   useEffect(() => {
     listenForPropChangesRef.current = true
   })
+
+  // Avoid a dangling aria-controls when there is no tabpanel in the DOM
+  useEffect(() => {
+    setHasTabPanel(Boolean(document.getElementById(`${_id}-content`)))
+  }, [_id, data, selectedKey])
 
   // Store latest state in refs so stable sub-components can access them
   const dataRef = useRef(data)
@@ -1305,7 +1313,7 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
         const itemParams: Record<string, unknown> = { to, href }
         const isFocus = currentFocusKey == key
         const isSelected = currentSelectedKey == key
-        if (isSelected) {
+        if (isSelected && hasTabPanel) {
           itemParams['aria-controls'] = `${_id}-content`
         }
 

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -901,4 +901,51 @@ describe('Tabs ARIA', () => {
     )
     expect(await axeComponent(Comp)).toHaveNoViolations()
   })
+
+  it('should set aria-controls on the selected tab referencing an existing tabpanel', () => {
+    render(<Tabs id="with-panel" data={tablistDataWithContent} />)
+
+    const selectedTab = document.querySelector(
+      'button[role="tab"][aria-selected="true"]'
+    )
+    const controls = selectedTab.getAttribute('aria-controls')
+
+    expect(controls).toBe('with-panel-content')
+    expect(document.getElementById(controls).getAttribute('role')).toBe(
+      'tabpanel'
+    )
+  })
+
+  it('should link aria-controls to an external Tabs.Content panel', () => {
+    render(
+      <>
+        <Tabs id="linked-aria" data={tablistData} selectedKey="second" />
+        <Tabs.Content id="linked-aria">
+          {({ key }) => <h2>{key}</h2>}
+        </Tabs.Content>
+      </>
+    )
+
+    const selectedTab = document.querySelector(
+      'button[role="tab"][aria-selected="true"]'
+    )
+
+    expect(selectedTab.getAttribute('aria-controls')).toBe(
+      'linked-aria-content'
+    )
+    expect(
+      document.getElementById('linked-aria-content').getAttribute('role')
+    ).toBe('tabpanel')
+  })
+
+  it('should not set aria-controls when no tabpanel is rendered', () => {
+    render(<Tabs id="no-panel" data={tablistData} selectedKey="second" />)
+
+    const selectedTab = document.querySelector(
+      'button[role="tab"][aria-selected="true"]'
+    )
+
+    expect(document.querySelector('[role="tabpanel"]')).toBeNull()
+    expect(selectedTab.hasAttribute('aria-controls')).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

The selected tab always rendered `aria-controls="${id}-content"`, even when `Tabs` was used **without any content** (e.g. a data-only tab bar used for layout/navigation, as in the "row" and "max-width" docs demos). This produced an `aria-controls` reference pointing to a **non-existent element** — invalid ARIA (WCAG 4.1.2 _Name, Role, Value_), flagged by axe as `aria-valid-attr-value` (critical) on the Tabs documentation page.

## Root cause

`aria-controls` was assigned unconditionally to the selected tab, but the `${id}-content` tabpanel is only rendered when the component actually has content — `TabsContentWrapper` returns `null` when it has no children. Both the "own content" and the "linked" (`<Tabs id="x" /><Tabs.Content id="x">`) patterns produce a panel, while a content-less `<Tabs data={...} />` does not.

## Fix

`aria-controls` is now only set on the selected tab when a matching `${id}-content` tabpanel is present in the DOM. Existence is detected in an effect (the component already uses the same `getElementById(`${id}-content`)` check elsewhere), so all usages behave correctly:

- own content → panel exists → `aria-controls` set
- linked `Tabs.Content` → external panel exists → `aria-controls` set
- content-less tab bar → no panel → `aria-controls` omitted (no dangling reference)

## Tests

Added tests under `Tabs ARIA` covering all three cases.

## How to verify

- **Before:** on https://eufemia.dnb.no/uilib/components/tabs the "row" and "max-width" demos have a selected tab with `aria-controls` pointing to a missing element.
- **After:** no `aria-controls` is emitted for those content-less tab bars, and axe reports no `aria-valid-attr-value` violation.
