### PR TITLE
fix(ToggleButton.Group): remove invalid aria-labelledby from role-less shell

### DIFF
--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -12,7 +12,6 @@ import {
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
-  combineLabelledBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
 } from '../../shared/component-helper'
@@ -212,9 +211,6 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
       showStatus ? id + '-status' : null,
       suffix ? id + '-suffix' : null
     )
-  }
-  if (label) {
-    params['aria-labelledby'] = combineLabelledBy(params, id + '-label')
   }
 
   // also used for code markup simulation

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
@@ -222,6 +222,35 @@ describe('ToggleButton group component', () => {
       )
       expect(shell).not.toHaveAttribute('role')
     })
+
+    it('should not have aria-labelledby on inner shell element', () => {
+      render(
+        <ToggleButton.Group label="Legend">
+          <ToggleButton text="First" value="first" />
+          <ToggleButton text="Second" value="second" />
+        </ToggleButton.Group>
+      )
+
+      const shell = document.querySelector(
+        '.dnb-toggle-button-group__shell'
+      )
+      expect(shell).not.toHaveAttribute('aria-labelledby')
+
+      // the group is still labelled via the fieldset + legend
+      const fieldset = document.querySelector('fieldset')
+      const legend = document.querySelector('legend')
+      expect(fieldset).toHaveAttribute('aria-labelledby', legend.id)
+    })
+
+    it('should validate with ARIA rules when a label is given', async () => {
+      const result = render(
+        <ToggleButton.Group label="Legend">
+          <ToggleButton text="First" value="first" />
+          <ToggleButton text="Second" value="second" />
+        </ToggleButton.Group>
+      )
+      expect(await axeComponent(result)).toHaveNoViolations()
+    })
   })
 
   it('has multiselect "onChange" event which will trigger on a button click', () => {


### PR DESCRIPTION
## Summary

Every `ToggleButton.Group` **with a `label`** rendered its inner shell `<span class="dnb-toggle-button-group__shell" aria-labelledby="…">` **without a role**. A generic element (implicit role `generic`) is prohibited from having a naming attribute such as `aria-labelledby`, so axe flagged `aria-prohibited-attr` (serious) on the ToggleButton documentation page.

## Root cause

`aria-labelledby` was added to the spread `params` object and applied to the role-less shell `<span>`. The group is **already** correctly labelled on the `<fieldset role="group|radiogroup">` (with its `<legend>`), so the copy on the shell was both redundant and invalid.

## Fix

Removed the `aria-labelledby` assignment from `params` (and the now-unused `combineLabelledBy` import). The group keeps its accessible name via the `<fieldset>` + `<legend>`; the shell no longer carries an invalid naming attribute.

## Tests

- Added a test asserting the shell has no `aria-labelledby` while the `<fieldset>` is still labelled by the `<legend>`.
- Added an axe assertion for a labelled group.
- Existing tests for the fieldset's `aria-labelledby`/`role` and the role-less shell continue to pass.

## How to verify

- **Before:** on https://eufemia.dnb.no/uilib/components/toggle-button the group shells expose `aria-labelledby` with no role.
- **After:** the shell has no `aria-labelledby`; the group is still announced with its label via the fieldset/legend, and axe reports no `aria-prohibited-attr` violation.
