### PR TITLE
chore: add accessible names to icon-only buttons and inputs in examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/button/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/button/Examples.tsx
@@ -498,6 +498,7 @@ export const ButtonOnDarkSurface = () => (
         data-visual-test="button-tertiary-icon-on-dark"
         variant="tertiary"
         icon="bell"
+        title="Notifications"
       />
     </Section>
   </ComponentBox>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -987,7 +987,7 @@ export const KeyboardNavigation = () => (
             <tbody>
               <tr>
                 <Td>
-                  <Field.Name labelSrOnly value="Ola" />
+                  <Field.Name label="Name" labelSrOnly value="Ola" />
                 </Td>
                 <Td>
                   <Field.Email labelSrOnly value="ola@example.no" />
@@ -996,13 +996,19 @@ export const KeyboardNavigation = () => (
                   <Button
                     variant="tertiary"
                     icon={trashIcon}
+                    aria-label="Delete row"
                     tooltip="Delete row"
                   />
                 </Td>
               </tr>
               <tr>
                 <Td>
-                  <Field.Name labelSrOnly value="Kari" multiline />
+                  <Field.Name
+                    label="Name"
+                    labelSrOnly
+                    value="Kari"
+                    multiline
+                  />
                 </Td>
                 <Td>
                   <Field.Email
@@ -1015,6 +1021,7 @@ export const KeyboardNavigation = () => (
                   <Button
                     variant="tertiary"
                     icon={trashIcon}
+                    aria-label="Delete row"
                     tooltip="Delete row"
                   />
                 </Td>
@@ -1042,6 +1049,7 @@ export const KeyboardNavigation = () => (
                   <Button
                     variant="tertiary"
                     icon={trashIcon}
+                    aria-label="Delete row"
                     tooltip="Delete row"
                   />
                 </Td>
@@ -1053,6 +1061,7 @@ export const KeyboardNavigation = () => (
                   <Button
                     variant="tertiary"
                     icon={trashIcon}
+                    aria-label="Delete row"
                     tooltip="Delete row"
                   />
                 </Td>
@@ -1923,6 +1932,7 @@ export const InCard = () => (
                     <Td align="right">
                       <Button
                         icon={trashIcon}
+                        aria-label="Remove from list"
                         tooltip="Remove from list"
                         variant="tertiary"
                         bounding

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/toggle-button/Examples.tsx
@@ -157,9 +157,14 @@ export const ToggleButtonSuffix = () => (
 export const ToggleButtonIconOnly = () => (
   <ComponentBox>
     <ToggleButton.Group label="Icons only">
-      <ToggleButton icon="bell" value="first" checked />
-      <ToggleButton icon="loupe" value="second" />
-      <ToggleButton icon="calendar" value="third" />
+      <ToggleButton
+        icon="bell"
+        title="Notifications"
+        value="first"
+        checked
+      />
+      <ToggleButton icon="loupe" title="Search" value="second" />
+      <ToggleButton icon="calendar" title="Calendar" value="third" />
     </ToggleButton.Group>
   </ComponentBox>
 )


### PR DESCRIPTION
## Description

Several component documentation examples rendered icon-only buttons (and `Field.Name` inputs) without an accessible name. This produced Eufemia dev-mode console warnings and, more importantly, real accessibility failures — confirmed with axe-core on the live site as `button-name` (critical) and `label` (critical) violations (WCAG 4.1.2 Name, Role, Value).

`tooltip` only adds `aria-describedby` on hover; it never provides an accessible *name*, so screen readers announced these buttons as unlabeled.

## Changes

- **Table** (`table/Examples.tsx`): add `aria-label` to the tooltip-only delete/remove buttons and `label` to the `Field.Name` inputs in the "keyboard navigation" and "Watchlist" examples.
- **ToggleButton** (`toggle-button/Examples.tsx`): add `title` to the icon-only toggle buttons in the "Icons only" example.
- **Button** (`button/Examples.tsx`): add `title` to the icon-only button in the "on dark surface" example.

## Verification

Re-ran axe-core (`button-name`, `label`) on all three pages after the change: **0 violations** (previously 8 + 3 + 1 `button-name` and 2 `label`). The Eufemia icon-only-button console warnings are also gone.

Documentation-only changes (portal examples); no `@dnb/eufemia` runtime code is affected.
