### PR TITLE
chore(Portal): remove leaked css attribute from code block pre elements

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/CodeBlock.tsx
@@ -124,7 +124,7 @@ const CodeBlock = ({
         theme={prismTheme}
         prism={Prism}
       >
-        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        {({ className, tokens, getLineProps, getTokenProps }) => (
           <div
             className={clsx(
               codeBlockStyle,
@@ -136,7 +136,7 @@ const CodeBlock = ({
               className={copyButtonStyle}
             />
 
-            <Tag as="pre" className={className} css={style}>
+            <Tag as="pre" className={className}>
               {cleanTokens(tokens).map((line, i) => {
                 const { key, ...lineProps } = getLineProps({
                   line,

--- a/packages/dnb-design-system-portal/src/shared/tags/Tag.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/Tag.tsx
@@ -3,13 +3,12 @@
  *
  */
 
-import type { CSSProperties, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { clsx } from 'clsx'
 import type { DynamicElement } from '@dnb/eufemia/src/shared/types'
 
 type Props = {
   as: DynamicElement
-  css?: CSSProperties
   className?: string
   children: ReactNode
 }

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/CodeBlock.test.tsx
@@ -295,6 +295,16 @@ describe('CodeBlock', () => {
     expect(pre.textContent).toContain('Hello')
   })
 
+  it('should not leak a css attribute onto the pre element', () => {
+    const { container } = render(
+      <CodeBlock language="jsx">{'<div>Hello</div>'}</CodeBlock>
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre).toBeTruthy()
+    expect(pre.getAttribute('css')).toBeNull()
+  })
+
   it('should detect language from className', () => {
     const { container } = render(
       <CodeBlock className="language-typescript">


### PR DESCRIPTION
## Summary

Every **static (non-editable) code block** on the portal rendered its `<pre>` with a leaked, invalid attribute: `css="[object Object]"`.

## Root cause

`CodeBlock` passed the `prism-react-renderer` theme object as a **`css` prop** to the internal `Tag` component:

```tsx
<Tag as="pre" className={className} css={style}>
```

`Tag` forwards unknown props to the DOM via `{...rest}`, and there is no Emotion JSX transform in this file, so the object was serialized onto the element as `css="[object Object]"`. The theme's `plain` style (`color` + `transparent` background) was **never actually applied** — the code block's colors and background are controlled by SCSS (as noted in the theme file: _"actual colors are controlled via CSS"_). Verified on the live site: the `<pre>` renders with SCSS-driven colors while carrying the bogus `css` attribute.

## Fix

- Removed the `css={style}` prop (and the now-unused `style` from the render-prop destructure). No visual change — the theme's plain style was inert, and applying it as a real `style` would have overridden the SCSS (e.g. transparent background), which is why it is intentionally omitted.
- Removed the now-unused `css?: CSSProperties` prop from `Tag` to prevent the same mistake recurring.

## Tests

Added a regression test asserting the rendered `<pre>` has no `css` attribute.

## How to verify

- **Before:** on any component page (e.g. https://eufemia.dnb.no/uilib/components/input) inspect a static code example — the `<pre class="dnb-pre prism-code">` has `css="[object Object]"`.
- **After:** the attribute is gone; code blocks render identically.
