### PR TITLE
fix(Tabs): omit aria-controls on the selected tab when no tabpanel exists

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -56,6 +56,7 @@ import CustomContent from './TabsCustomContent'
 import ContentWrapper from './TabsContentWrapper'
 import {
   createSharedState,
+  useSharedState,
   type SharedStateReturn,
 } from '../../shared/helpers/useSharedState'
 import type { ButtonProps } from '../Button'
@@ -410,8 +411,13 @@ function TabsComponent(ownProps: TabsProps) {
   const [isFirst, setIsFirst] = useState<boolean | undefined>(undefined)
   const [isLast, setIsLast] = useState<boolean | undefined>(undefined)
 
-  // True once an external <Tabs.Content> tabpanel is detected in the DOM.
-  const [hasTabPanel, setHasTabPanel] = useState(false)
+  // Reactively reflects whether an external <Tabs.Content> tabpanel is mounted.
+  // ContentWrapper registers/unregisters its presence in this shared state, so
+  // the selected tab links to it only while it actually exists.
+  const { data: tabPanelPresence } = useSharedState<{ count?: number }>(
+    `${_id}-tabpanel-presence`
+  )
+  const hasTabPanel = Boolean(tabPanelPresence?.count)
 
   // Track previous props for getDerivedStateFromProps equivalent
   const [prevDataSource, setPrevDataSource] = useState(
@@ -947,11 +953,6 @@ function TabsComponent(ownProps: TabsProps) {
     }
   }, [selectedKey, data])
 
-  // Detect an external <Tabs.Content> tabpanel so the selected tab can link to it.
-  useIsomorphicLayoutEffect(() => {
-    setHasTabPanel(Boolean(document.getElementById(`${_id}-content`)))
-  }, [_id, selectedKey, data])
-
   // Navigation handlers
   const focusFirstTab = (e: KeyboardEvent) => {
     const key = dataRef.current[0].key
@@ -1106,6 +1107,11 @@ function TabsComponent(ownProps: TabsProps) {
     return content
   }
 
+  // Resolve the selected tab's content once per render, so the tabpanel and the
+  // aria-controls decision reuse the same result instead of evaluating
+  // (potentially function-based) content twice.
+  const selectedContent = getContent(selectedKeyRef.current)
+
   // Store render functions in refs for stable sub-component wrappers
   const renderWrapperRef =
     useRef<
@@ -1240,7 +1246,10 @@ function TabsComponent(ownProps: TabsProps) {
           (acc, [_idx, cur]) => {
             acc[cur.key] = {
               ...cur,
-              content: getContent(cur.key),
+              content:
+                cur.key == currentSelectedKey
+                  ? selectedContent
+                  : getContent(cur.key),
             }
             return acc
           },
@@ -1250,7 +1259,7 @@ function TabsComponent(ownProps: TabsProps) {
         cacheRef.current = {
           ...(cacheRef.current || {}),
           [currentSelectedKey]: {
-            content: getContent(currentSelectedKey),
+            content: selectedContent,
           },
         }
       }
@@ -1273,7 +1282,7 @@ function TabsComponent(ownProps: TabsProps) {
         }
       )
     } else {
-      content = getContent(currentSelectedKey)
+      content = selectedContent
     }
 
     if (!sharedStateRef.current && !content) {
@@ -1285,6 +1294,7 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
     return (
       <ContentWrapper
         id={_id}
+        nested
         selectedKey={currentSelectedKey}
         contentStyle={propsRef.current.contentStyle}
         contentInnerSpace={propsRef.current.contentInnerSpace}
@@ -1314,10 +1324,7 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
         const isFocus = currentFocusKey == key
         const isSelected = currentSelectedKey == key
         // Only reference a tabpanel that actually exists.
-        if (
-          isSelected &&
-          (hasTabPanel || Boolean(getContent(currentSelectedKey)))
-        ) {
+        if (isSelected && (Boolean(selectedContent) || hasTabPanel)) {
           itemParams['aria-controls'] = `${_id}-content`
         }
 

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -410,6 +410,9 @@ function TabsComponent(ownProps: TabsProps) {
   const [isFirst, setIsFirst] = useState<boolean | undefined>(undefined)
   const [isLast, setIsLast] = useState<boolean | undefined>(undefined)
 
+  // True once an external <Tabs.Content> tabpanel is detected in the DOM.
+  const [hasTabPanel, setHasTabPanel] = useState(false)
+
   // Track previous props for getDerivedStateFromProps equivalent
   const [prevDataSource, setPrevDataSource] = useState(
     ownProps.data || ownProps.children
@@ -944,6 +947,11 @@ function TabsComponent(ownProps: TabsProps) {
     }
   }, [selectedKey, data])
 
+  // Detect an external <Tabs.Content> tabpanel so the selected tab can link to it.
+  useIsomorphicLayoutEffect(() => {
+    setHasTabPanel(Boolean(document.getElementById(`${_id}-content`)))
+  }, [_id, selectedKey, data])
+
   // Navigation handlers
   const focusFirstTab = (e: KeyboardEvent) => {
     const key = dataRef.current[0].key
@@ -1305,7 +1313,11 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
         const itemParams: Record<string, unknown> = { to, href }
         const isFocus = currentFocusKey == key
         const isSelected = currentSelectedKey == key
-        if (isSelected) {
+        // Only reference a tabpanel that actually exists.
+        if (
+          isSelected &&
+          (hasTabPanel || Boolean(getContent(currentSelectedKey)))
+        ) {
           itemParams['aria-controls'] = `${_id}-content`
         }
 

--- a/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/TabsContentWrapper.tsx
@@ -30,6 +30,7 @@ export default function ContentWrapper({
   contentStyle = null,
   animate = null,
   contentInnerSpace = { top: 'large' } as InnerSpaceType | boolean,
+  nested = false,
   ...rest
 }: TabsContentWrapperProps) {
   const sharedStateRef = useRef<SharedState | null>(null)
@@ -69,6 +70,28 @@ export default function ContentWrapper({
       sharedStateRef.current = null
     }
   }, [id])
+
+  // Register this tabpanel's presence in a shared state so a separately
+  // rendered <Tabs> (linked via <Tabs.Content>) can set aria-controls on the
+  // selected tab only while the panel is mounted. Skipped for the internal
+  // panel, which <Tabs> already tracks synchronously.
+  const hasPanel = Boolean(children)
+  useEffect(() => {
+    if (nested || !id || !hasPanel) {
+      return undefined // stop here
+    }
+
+    const presence = createSharedState<{ count: number }>(
+      `${id}-tabpanel-presence`
+    )
+    presence.set({ count: (presence.get()?.count || 0) + 1 })
+
+    return () => {
+      presence.set({
+        count: Math.max(0, (presence.get()?.count || 1) - 1),
+      })
+    }
+  }, [id, nested, hasPanel])
 
   const resolvedInnerSpace =
     contentInnerSpace === true ? 'large' : contentInnerSpace
@@ -178,6 +201,8 @@ export type TabsContentWrapperProps = {
   animate?: boolean
   contentInnerSpace?: InnerSpaceType | boolean
   children?: TabsContentWrapperChildren
+  /** Internal: set by <Tabs> for its own tabpanel so it does not self-register presence. */
+  nested?: boolean
 } & Omit<
   HTMLProps<HTMLElement>,
   'children' | 'ref' | 'onAnimationStart' | 'onAnimationEnd'

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -453,6 +453,84 @@ describe('Tabs aria-controls', () => {
     expect(document.getElementById('no-content-content')).toBeNull()
     expect(selectedTab.getAttribute('aria-controls')).toBeNull()
   })
+
+  it('adds and removes aria-controls as an external Tabs.Content mounts and unmounts', () => {
+    const Wrapper = ({ showContent }: { showContent: boolean }) => (
+      <>
+        <Tabs
+          id="toggle"
+          data={tablistData}
+          selectedKey={startupSelectedKey}
+        />
+        {showContent && (
+          <Tabs.Content id="toggle">
+            {({ key }) => <h2>{key}</h2>}
+          </Tabs.Content>
+        )}
+      </>
+    )
+
+    const selectedTab = () =>
+      document.querySelector(
+        `button[data-tab-key="${startupSelectedKey}"]`
+      )
+
+    const { rerender } = render(<Wrapper showContent={false} />)
+
+    // No external tabpanel yet
+    expect(document.getElementById('toggle-content')).toBeNull()
+    expect(selectedTab().getAttribute('aria-controls')).toBeNull()
+
+    // Mounting the external tabpanel links it from the selected tab
+    rerender(<Wrapper showContent />)
+    expect(document.getElementById('toggle-content')).toBeTruthy()
+    expect(selectedTab().getAttribute('aria-controls')).toBe(
+      'toggle-content'
+    )
+
+    // Removing it again must not leave a dangling reference
+    rerender(<Wrapper showContent={false} />)
+    expect(document.getElementById('toggle-content')).toBeNull()
+    expect(selectedTab().getAttribute('aria-controls')).toBeNull()
+  })
+
+  it('resolves render-prop content once per render (no double evaluation)', () => {
+    const contentFn = vi.fn((key: string | number) => (
+      <h2>content-{key}</h2>
+    ))
+
+    // The render callback runs exactly once per Tabs render, so it is an
+    // accurate counter of render passes regardless of how many times Tabs
+    // re-renders internally.
+    let renderPasses = 0
+
+    render(
+      <Tabs
+        id="single-eval"
+        data={tablistData}
+        selectedKey="second"
+        render={({ Wrapper, TabsList, Tabs: TabItems, Content }) => {
+          renderPasses++
+          return (
+            <Wrapper>
+              <TabsList>
+                <TabItems />
+              </TabsList>
+              <Content />
+            </Wrapper>
+          )
+        }}
+      >
+        {(key) => contentFn(key)}
+      </Tabs>
+    )
+
+    // The selected content is resolved once per render and reused by both the
+    // tabpanel rendering and the aria-controls decision. Before the fix it was
+    // resolved twice per render (2 * renderPasses).
+    expect(renderPasses).toBeGreaterThan(0)
+    expect(contentFn).toHaveBeenCalledTimes(renderPasses)
+  })
 })
 
 describe('TabList component', () => {

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -494,6 +494,44 @@ describe('Tabs aria-controls', () => {
     expect(selectedTab().getAttribute('aria-controls')).toBeNull()
   })
 
+  it('keeps aria-controls correct across an external Tabs.Content toggle in StrictMode', () => {
+    const Wrapper = ({ showContent }: { showContent: boolean }) => (
+      <StrictMode>
+        <Tabs
+          id="toggle-strict"
+          data={tablistData}
+          selectedKey={startupSelectedKey}
+        />
+        {showContent && (
+          <Tabs.Content id="toggle-strict">
+            {({ key }) => <h2>{key}</h2>}
+          </Tabs.Content>
+        )}
+      </StrictMode>
+    )
+
+    const selectedTab = () =>
+      document.querySelector(
+        `button[data-tab-key="${startupSelectedKey}"]`
+      )
+
+    const { rerender } = render(<Wrapper showContent={false} />)
+    expect(selectedTab().getAttribute('aria-controls')).toBeNull()
+
+    // StrictMode double-invokes the presence effect (mount/cleanup/mount);
+    // the ref-count must still resolve to "present".
+    rerender(<Wrapper showContent />)
+    expect(document.getElementById('toggle-strict-content')).toBeTruthy()
+    expect(selectedTab().getAttribute('aria-controls')).toBe(
+      'toggle-strict-content'
+    )
+
+    // Back to absent after unmount — the count must return to 0, not drift.
+    rerender(<Wrapper showContent={false} />)
+    expect(document.getElementById('toggle-strict-content')).toBeNull()
+    expect(selectedTab().getAttribute('aria-controls')).toBeNull()
+  })
+
   it('resolves render-prop content once per render (no double evaluation)', () => {
     const contentFn = vi.fn((key: string | number) => (
       <h2>content-{key}</h2>

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -389,6 +389,72 @@ Tip: Check out other solutions like <Tabs.Content id="unique">Your content, outs
   })
 })
 
+describe('Tabs aria-controls', () => {
+  it('references the tabpanel from the selected tab when internal content is provided', () => {
+    render(
+      <Tabs
+        id="internal"
+        data={tablistData}
+        selectedKey={startupSelectedKey}
+      >
+        {contentWrapperData}
+      </Tabs>
+    )
+
+    const selectedTab = document.querySelector(
+      `button[data-tab-key="${startupSelectedKey}"]`
+    )
+
+    expect(selectedTab.getAttribute('aria-controls')).toBe(
+      'internal-content'
+    )
+    expect(document.getElementById('internal-content')).toBeTruthy()
+  })
+
+  it('references the tabpanel provided by an external Tabs.Content', () => {
+    render(
+      <>
+        <Tabs
+          id="linked"
+          data={tablistData}
+          selectedKey={startupSelectedKey}
+        />
+        <Tabs.Content id="linked">
+          {({ key }) => <h2>{key}</h2>}
+        </Tabs.Content>
+      </>
+    )
+
+    const selectedTab = document.querySelector(
+      `button[data-tab-key="${startupSelectedKey}"]`
+    )
+
+    expect(selectedTab.getAttribute('aria-controls')).toBe(
+      'linked-content'
+    )
+    expect(document.getElementById('linked-content')).toBeTruthy()
+  })
+
+  it('does not set a dangling aria-controls when no tabpanel is rendered', () => {
+    render(
+      <Tabs
+        id="no-content"
+        data={tablistData}
+        selectedKey={startupSelectedKey}
+      />
+    )
+
+    const selectedTab = document.querySelector(
+      `button[data-tab-key="${startupSelectedKey}"]`
+    )
+
+    // Without content, no tabpanel exists, so aria-controls must be omitted
+    // to avoid referencing a non-existent element (WCAG 4.1.2).
+    expect(document.getElementById('no-content-content')).toBeNull()
+    expect(selectedTab.getAttribute('aria-controls')).toBeNull()
+  })
+})
+
 describe('TabList component', () => {
   it('has to have the right amount of rendered components', () => {
     render(


### PR DESCRIPTION
## Description

The selected tab always set `aria-controls="{id}-content"`, even when the `Tabs` component rendered no tabpanel — e.g. when it is used for layout only (with `data` for the tab strip but no content, and no external `<Tabs.Content>`). Since `ContentWrapper` returns `null` when it has no children, no panel with that id exists, leaving a **dangling `aria-controls` reference**.

Confirmed on the live docs with axe-core as `aria-valid-attr-value` (critical, WCAG 4.1.2) on three examples (`unique-tabs-row`, `unique-tabs-max-width`, and a content-less `Tabs`).

## Fix

Set `aria-controls` on the selected tab only when a tabpanel actually exists:

- **Internal content** (`data[].content` / `children`) — known synchronously via `getContent`, so `aria-controls` is present in the prerendered/SSR output too.
- **External `<Tabs.Content id="...">`** — detected in the DOM after render (layout effect).
- **No content** (layout-only tabs) — no panel, so `aria-controls` is omitted.

## Tests

Added a `Tabs aria-controls` describe block:

- keeps `aria-controls` when internal content is provided (regression guard),
- keeps `aria-controls` when content is provided by an external `Tabs.Content` (regression guard),
- omits `aria-controls` when no tabpanel is rendered (the bug — this test fails before the change).

All 38 Tabs tests pass (including the existing ARIA-rules and snapshot tests). Verified live: axe `aria-valid-attr-value` went from 3 → 0, content-ful tabs (including the external-content example) keep a valid `aria-controls`, and layout-only tabs no longer emit one.
