### PR TITLE
chore(DatePicker): remove redundant conditionals flagged by CodeQL

### DIFF
--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -776,7 +776,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   />
                 )}
                 <DatePickerFooter
-                  isRange={inline ? false : range}
+                  isRange={false}
                   onSubmit={onSubmitHandler}
                   onCancel={onCancelHandler}
                   onReset={onResetHandler}
@@ -872,7 +872,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                       />
                     )}
                     <DatePickerFooter
-                      isRange={inline ? false : range}
+                      isRange={range}
                       onSubmit={onSubmitHandler}
                       onCancel={onCancelHandler}
                       onReset={onResetHandler}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -417,7 +417,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
           const { startDate: currentStart, endDate: currentEnd } =
             currentDatesRef.current
 
-          if (!currentStart || (resetDate && currentStart && currentEnd)) {
+          if (!currentStart || (resetDate && currentEnd)) {
             // First selection: set start date, clear end date
             // Keep focusedDateRef so arrow keys continue from this date
             updateDates(
@@ -864,7 +864,7 @@ function onSelectRange({
   // Set to true to stop calendar views from changing in range mode when clicking a day
   setHasClickedCalendarDay(true)
 
-  if (!startDate || (resetDate && startDate && endDate)) {
+  if (!startDate || (resetDate && endDate)) {
     // set startDate
     // user is selecting startDate
     return onSelect({


### PR DESCRIPTION
Removes always-constant conditional operands flagged by CodeQL in the DatePicker.

- Footer `isRange={inline ? false : range}` is always `false` in the inline branch and always `range` in the popover branch.
- Range-selection guards: `resetDate && startDate && endDate` (and the `currentStart`/`currentEnd` variant) — the start operand is guaranteed truthy by the preceding `!startDate ||` / `!currentStart ||`.

Behavior-preserving. DatePicker suites pass (188 tests).

---
_Part of a 7-PR series resolving CodeQL **code quality** findings (46/51 fixed; the 5 remaining `FieldBlock.test.tsx` "missing space" items are false positives to dismiss):_
- #8882 · fix: genuine bugs (regex, Dialog, makePropertiesFile)
- #8883 · refactor(DatePicker)
- #8884 · refactor(forms)
- #8885 · refactor: components
- #8886 · refactor: shared helpers & tools
- #8887 · refactor(portal)
- #8888 · test: dnb-eufemia tests
