### PR TITLE
chore(forms): remove redundant conditionals flagged by CodeQL

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx
@@ -332,7 +332,7 @@ function FieldBlock<Value = unknown>(props: FieldBlockProps<Value>) {
   )
 
   const statusContent = useMemo(() => {
-    if (typeof error !== 'undefined' || (errorRef.current && !error)) {
+    if (typeof error !== 'undefined' || errorRef.current) {
       errorRef.current = error
       setInternalRecord({
         identifier: blockId,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
@@ -164,13 +164,8 @@ function PrerenderPortal({
 function PrerenderFieldPropsProvider({ showAllErrorsNow, children }) {
   const dataContext = useContext(DataContext)
 
-  const {
-    data,
-    internalDataRef,
-    setFieldInternals,
-    updateDataValue,
-    showAllErrors,
-  } = dataContext || {}
+  const { data, internalDataRef, setFieldInternals, updateDataValue } =
+    dataContext || {}
 
   // Run validation of all fields
   if (showAllErrorsNow) {
@@ -180,7 +175,7 @@ function PrerenderFieldPropsProvider({ showAllErrorsNow, children }) {
           ...dataContext,
           hasContext: true,
           prerenderFieldProps: true,
-          showAllErrors: showAllErrorsNow ? true : showAllErrors,
+          showAllErrors: true,
         }}
       >
         {children}

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
@@ -334,7 +334,7 @@ export default function useFieldError<Value>({
       errorMessages &&
       cache.extendedErrorMessages &&
       Object.values(cache.errorMessages || {}).join('') ===
-        Object.values(errorMessages || {}).join('')
+        Object.values(errorMessages).join('')
     ) {
       return cache.extendedErrorMessages
     }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1827,7 +1827,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   }, [props])
 
   if (bufferedError) {
-    htmlAttributes['aria-invalid'] = bufferedError ? 'true' : 'false'
+    htmlAttributes['aria-invalid'] = 'true'
   }
   if (required) {
     htmlAttributes['aria-required'] = 'true'


### PR DESCRIPTION
Removes redundant conditionals flagged by CodeQL in forms hooks/components.

- **useFieldError**: `errorMessages || {}` is redundant (guarded by an earlier `errorMessages &&`).
- **useFieldProps**: `bufferedError ? 'true' : 'false'` inside `if (bufferedError)` is always `'true'`.
- **Wizard/PrerenderFieldPropsOfOtherSteps**: inside `if (showAllErrorsNow)` the ternary is always `true`; removed the now-unused `showAllErrors` destructure.
- **FieldBlock**: `(errorRef.current && !error)` reduces to `errorRef.current`.

Behavior-preserving. useFieldProps (197), FieldBlock (90), WizardContainer (81) tests pass.

---
_Part of a 7-PR series resolving CodeQL **code quality** findings (46/51 fixed; the 5 remaining `FieldBlock.test.tsx` "missing space" items are false positives to dismiss):_
- #8882 · fix: genuine bugs (regex, Dialog, makePropertiesFile)
- #8883 · refactor(DatePicker)
- #8884 · refactor(forms)
- #8885 · refactor: components
- #8886 · refactor: shared helpers & tools
- #8887 · refactor(portal)
- #8888 · test: dnb-eufemia tests
