### PR TITLE
chore: remove redundant conditionals and unused vars in components (CodeQL)

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionHeader.tsx
@@ -237,7 +237,7 @@ export const AccordionHeader = ({
 
   function canClick() {
     const { expanded, allowCloseAll, group } = context
-    return !group || (group && !expanded) || allowCloseAll
+    return !group || !expanded || allowCloseAll
   }
 
   const extendedProps = extendPropsWithContext(
@@ -251,7 +251,6 @@ export const AccordionHeader = ({
 
     // 1. these props should be the same as ...
     leftComponent,
-    expanded, // eslint-disable-line
     title,
     description,
     element,

--- a/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
+++ b/packages/dnb-eufemia/src/components/modal/ModalContent.tsx
@@ -499,7 +499,7 @@ export default function ModalContent(props: ModalContentProps) {
         ? 'dnb-modal__content--fullscreen'
         : fullscreen === 'auto' && 'dnb-modal__content--auto-fullscreen',
       containerPlacement
-        ? `dnb-modal__content--${containerPlacement || 'right'}`
+        ? `dnb-modal__content--${containerPlacement}`
         : null,
       `dnb-modal__vertical-alignment--${verticalAlignment}`,
       contentClass

--- a/packages/dnb-eufemia/src/components/slider/SliderHelpers.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderHelpers.tsx
@@ -109,7 +109,7 @@ export const getFormattedNumber = (
     }
 
     const options = {
-      ...(numberFormat || {}),
+      ...numberFormat,
       returnAria: true as const,
     }
     const formatter =

--- a/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
+++ b/packages/dnb-eufemia/src/components/slider/SliderThumb.tsx
@@ -79,7 +79,7 @@ function Thumb({ value, currentIndex }: ThumbProps) {
   if (label) {
     helperParams['aria-labelledby'] = combineLabelledBy(
       helperParams,
-      label ? id + '-label' : null
+      id + '-label'
     )
   }
 

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorItem.tsx
@@ -140,13 +140,10 @@ function StepIndicatorItem({
     currentItemNum,
 
     title,
-    isCurrent, // eslint-disable-line
     inactive,
     disabled,
     status,
     statusState = 'warning',
-
-    onClick, // eslint-disable-line
   } = props
 
   const hasPassedAndIsCurrent =

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -88,7 +88,7 @@ export function parseContentTitle(
   let ret: string
   const onlyNumericRegex = /[0-9.,-\s]+/
 
-  const hasValue = dataItem && dataItem.selectedValue
+  const hasValue = dataItem.selectedValue
 
   if (
     !(preferSelectedValue && hasValue) &&


### PR DESCRIPTION
Resolves CodeQL findings across several components.

- **SliderThumb**: `label ? id+'-label' : null` inside `if (label)` → `id + '-label'`.
- **SliderHelpers**: `...(numberFormat || {})` inside `if (numberFormat)` → `...numberFormat`.
- **ModalContent**: `containerPlacement || 'right'` inside a `containerPlacement ?` ternary is redundant.
- **DrawerListHelpers**: `dataItem && dataItem.selectedValue` after a `!dataItem` return guard.
- **Accordion**: `!group || (group && !expanded)` → `!group || !expanded`; removed unused `expanded` destructure.
- **StepIndicator**: removed unused `isCurrent`/`onClick` destructures.

Behavior-preserving. Slider, Modal, Accordion, StepIndicator, DrawerList suites pass (270 tests).

---
_Part of a 7-PR series resolving CodeQL **code quality** findings (46/51 fixed; the 5 remaining `FieldBlock.test.tsx` "missing space" items are false positives to dismiss):_
- #8882 · fix: genuine bugs (regex, Dialog, makePropertiesFile)
- #8883 · refactor(DatePicker)
- #8884 · refactor(forms)
- #8885 · refactor: components
- #8886 · refactor: shared helpers & tools
- #8887 · refactor(portal)
- #8888 · test: dnb-eufemia tests
