### PR TITLE
chore: remove redundant conditionals in shared helpers and tools (CodeQL)

### DIFF
--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -307,21 +307,19 @@ function createDocsContext(source: DocsSource) {
     }
 
     // links from frontmatter
-    if (!properties || !events) {
-      try {
-        const mdText = await source.read(doc)
-        if (mdText !== null) {
-          const links = extractFrontmatterLinks(mdText)
-          if (links?.properties) {
-            properties = links.properties
-          }
-          if (links?.events) {
-            events = links.events
-          }
+    try {
+      const mdText = await source.read(doc)
+      if (mdText !== null) {
+        const links = extractFrontmatterLinks(mdText)
+        if (links?.properties) {
+          properties = links.properties
         }
-      } catch {
-        // ignore
+        if (links?.events) {
+          events = links.events
+        }
       }
+    } catch {
+      // ignore
     }
 
     if (!properties) {

--- a/packages/dnb-eufemia/src/shared/helpers/filterValidProps.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/filterValidProps.ts
@@ -17,8 +17,8 @@ export function filterValidProps<T extends Record<string, unknown>>(
 
   for (const key in props) {
     if (
-      (!validKeys || (validKeys && o.call(validKeys, key))) &&
-      (!excludeKeys || (excludeKeys && !o.call(excludeKeys, key)))
+      (!validKeys || o.call(validKeys, key)) &&
+      (!excludeKeys || !o.call(excludeKeys, key))
     ) {
       res[key] = props[key]
     }

--- a/tools/eufemia-llm-metadata/src/convertHelpers.ts
+++ b/tools/eufemia-llm-metadata/src/convertHelpers.ts
@@ -1331,7 +1331,7 @@ function addDocsFromExport(
     related: string[]
   }
 ) {
-  for (const [key, entry] of Object.entries(value || {})) {
+  for (const [key, entry] of Object.entries(value)) {
     const relMatch = /^\[([^\]]+)\]/.exec(key)
 
     if (relMatch && relMatch[1]) {


### PR DESCRIPTION
Resolves CodeQL "useless conditional" findings in shared helpers & tooling.

- **filterValidProps**: `!validKeys || (validKeys && …)` → `!validKeys || …` (same for `excludeKeys`).
- **mcp-docs-server**: `if (!properties || !events)` is always true (both init `null`, unset before) — reads frontmatter unconditionally.
- **eufemia-llm-metadata/convertHelpers**: `value || {}` redundant (caller guards `!value || typeof value !== 'object'`).

Behavior-preserving. filterValidProps (5), mcp-docs-server (38), convertHelpers (30) tests pass.

---
_Part of a 7-PR series resolving CodeQL **code quality** findings (46/51 fixed; the 5 remaining `FieldBlock.test.tsx` "missing space" items are false positives to dismiss):_
- #8882 · fix: genuine bugs (regex, Dialog, makePropertiesFile)
- #8883 · refactor(DatePicker)
- #8884 · refactor(forms)
- #8885 · refactor: components
- #8886 · refactor: shared helpers & tools
- #8887 · refactor(portal)
- #8888 · test: dnb-eufemia tests
