### PR TITLE
chore(portal): resolve CodeQL code-quality findings

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/Examples.tsx
@@ -124,7 +124,7 @@ export const InfinityPaginationTable = ({ tableItems, ...props }) => {
   ] = useState(createPagination)
   const [orderDirection, setOrderDirection] = useState('asc')
   const [currentPage, setLocalPage] = useState(null)
-  const [cacheHash, forceRerender] = useState(null) // eslint-disable-line
+  const [, forceRerender] = useState(null)
 
   useEffect(() => {
     // Could also be set as "startupPage" in <Pagination startupPage={startupPage} ...>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/pagination/infinity-scroller/Examples.tsx
@@ -189,7 +189,7 @@ export const InfinityPaginationTable = ({ tableItems, ...props }) => {
   ] = useState<PaginationCreateReturn>(createPagination)
   const [orderDirection, setOrderDirection] = useState('asc')
   const [currentPage, setLocalPage] = useState(null)
-  const [cacheHash, forceRerender] = useState(null) // eslint-disable-line
+  const [, forceRerender] = useState(null)
 
   useEffect(() => {
     // Could also be set as "startupPage" in <Pagination startupPage={startupPage} ...>

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -703,7 +703,9 @@ const prepareNav = ({
       )
 
       const level = slug.split('/').filter(Boolean).length
-      level > countLevels ? (countLevels = level) : countLevels
+      if (level > countLevels) {
+        countLevels = level
+      }
 
       return {
         title,
@@ -869,27 +871,22 @@ function checkIfActiveItem(
     return true
   }
 
-  if (showTabs) {
-    // If a page exposes tabs, the last slug segment is usually the active tab.
-    // Remove it from currentPath to determine the active parent item.
-    const slugs = currentPath.split('/').filter(Boolean)
-    const lastSlug = slugs[slugs.length - 1]
-    const currentPathWithoutTabSlug = currentPath.replace(
-      `/${lastSlug}`,
-      ''
-    )
+  // If a page exposes tabs, the last slug segment is usually the active tab.
+  // Remove it from currentPath to determine the active parent item.
+  const slugs = currentPath.split('/').filter(Boolean)
+  const lastSlug = slugs[slugs.length - 1]
+  const currentPathWithoutTabSlug = currentPath.replace(`/${lastSlug}`, '')
 
-    if (itemPath === currentPathWithoutTabSlug) {
-      // In addition, because we show the info.mdx without /info
-      // we don't want the "parent" to be marked as active as well.
-      // So we get tabs and check for that state as well
-      const found = (tabs || defaultTabsValue).some(({ key }) => {
-        return '/' + lastSlug === key
-      })
+  if (itemPath === currentPathWithoutTabSlug) {
+    // In addition, because we show the info.mdx without /info
+    // we don't want the "parent" to be marked as active as well.
+    // So we get tabs and check for that state as well
+    const found = (tabs || defaultTabsValue).some(({ key }) => {
+      return '/' + lastSlug === key
+    })
 
-      if (found) {
-        return true
-      }
+    if (found) {
+      return true
     }
   }
 

--- a/packages/dnb-design-system-portal/vite/__tests__/color-scheme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/color-scheme.test.ts
@@ -44,10 +44,7 @@ describe('color scheme FOUC prevention', () => {
               : 'light'
           }
           document.documentElement.classList.add('eufemia-scope--portal')
-          if (s) {
-            ;(globalThis as Record<string, unknown>).__eufemiaColorScheme =
-              s
-          }
+          ;(globalThis as Record<string, unknown>).__eufemiaColorScheme = s
         } catch (e) {
           // ignore
         }
@@ -81,10 +78,7 @@ describe('color scheme FOUC prevention', () => {
               : 'light'
           }
           document.documentElement.classList.add('eufemia-scope--portal')
-          if (s) {
-            ;(globalThis as Record<string, unknown>).__eufemiaColorScheme =
-              s
-          }
+          ;(globalThis as Record<string, unknown>).__eufemiaColorScheme = s
         } catch (e) {
           // ignore
         }
@@ -112,10 +106,7 @@ describe('color scheme FOUC prevention', () => {
               : 'light'
           }
           document.documentElement.classList.add('eufemia-scope--portal')
-          if (s) {
-            ;(globalThis as Record<string, unknown>).__eufemiaColorScheme =
-              s
-          }
+          ;(globalThis as Record<string, unknown>).__eufemiaColorScheme = s
         } catch (e) {
           // ignore
         }
@@ -143,10 +134,7 @@ describe('color scheme FOUC prevention', () => {
               : 'light'
           }
           document.documentElement.classList.add('eufemia-scope--portal')
-          if (s) {
-            ;(globalThis as Record<string, unknown>).__eufemiaColorScheme =
-              s
-          }
+          ;(globalThis as Record<string, unknown>).__eufemiaColorScheme = s
         } catch (e) {
           // ignore
         }

--- a/packages/dnb-design-system-portal/vite/client/chunk-load-error-handler.ts
+++ b/packages/dnb-design-system-portal/vite/client/chunk-load-error-handler.ts
@@ -36,7 +36,7 @@ export function isChunkLoadError(reason: unknown): boolean {
   }
 
   const errorName =
-    typeof reason === 'object' && reason !== null && 'name' in reason
+    typeof reason === 'object' && 'name' in reason
       ? String((reason as { name?: unknown }).name ?? '')
       : ''
 
@@ -47,9 +47,7 @@ export function isChunkLoadError(reason: unknown): boolean {
   const message =
     typeof reason === 'string'
       ? reason
-      : typeof reason === 'object' &&
-          reason !== null &&
-          'message' in reason
+      : typeof reason === 'object' && 'message' in reason
         ? String((reason as { message?: unknown }).message ?? '')
         : ''
 


### PR DESCRIPTION
Resolves CodeQL code-quality findings in the portal.

- **SidebarMenu**: `level > countLevels ? (countLevels = level) : countLevels` → `if` statement; `if (showTabs)` is always true (the earlier `!showTabs` branch returns).
- **chunk-load-error-handler**: dropped redundant `reason !== null` (early `if (!reason) return false` guarantees non-null).
- **Pagination examples**: `[cacheHash, forceRerender]` → `[, forceRerender]` (unused binding).
- **color-scheme.test**: removed always-true `if (s)` guards in the head-script simulations.

Behavior-preserving. color-scheme (8) and chunk-load-error-handler (15) tests pass.

---
_Part of a 7-PR series resolving CodeQL **code quality** findings (46/51 fixed; the 5 remaining `FieldBlock.test.tsx` "missing space" items are false positives to dismiss):_
- #8882 · fix: genuine bugs (regex, Dialog, makePropertiesFile)
- #8883 · refactor(DatePicker)
- #8884 · refactor(forms)
- #8885 · refactor: components
- #8886 · refactor: shared helpers & tools
- #8887 · refactor(portal)
- #8888 · test: dnb-eufemia tests
