### PR TITLE
chore: resolve CodeQL code-quality findings in tests

### DIFF
--- a/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
+++ b/packages/dnb-eufemia/src/components/slider/__tests__/Slider.test.tsx
@@ -610,8 +610,8 @@ describe('Slider component', () => {
 
     it('will not need on external prop changes', () => {
       const WrongUsage = () => {
-        const [min, setMinVal] = useState(0) //eslint-disable-line
-        const [max, setMaxVal] = useState(200) //eslint-disable-line
+        const [, setMinVal] = useState(0)
+        const [, setMaxVal] = useState(200)
 
         return (
           <Slider

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -747,7 +747,7 @@ describe('DrawerList component', () => {
           .querySelector('.dnb-drawer-list')
           .getAttribute('id')
 
-        expect(domId).not.toBe(`${undefined}-drawer-list`)
+        expect(domId).not.toBe('undefined-drawer-list')
 
         const id = domId.replace('-drawer-list', '')
 
@@ -795,7 +795,7 @@ describe('DrawerList component', () => {
           .querySelector('.dnb-drawer-list')
           .getAttribute('id')
 
-        expect(domId).not.toBe(`${undefined}-drawer-list`)
+        expect(domId).not.toBe('undefined-drawer-list')
 
         const id = domId.replace('-drawer-list', '')
 

--- a/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useMedia.test.tsx
@@ -254,8 +254,6 @@ describe('useMedia', () => {
       await act(async () => {
         setMedia({ width: BELOW })
 
-        result.current
-
         /**
          * Keep the same state as before
          */
@@ -272,8 +270,6 @@ describe('useMedia', () => {
 
       await act(async () => {
         setMedia({ width: SMALL })
-
-        result.current
 
         expect(result.current).toEqual({
           isSmall: true,
@@ -293,8 +289,6 @@ describe('useMedia', () => {
 
       await act(async () => {
         setMedia({ width: BELOW })
-
-        result.current
 
         /**
          * Keep the same state as before

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/getClosest.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/getClosest.test.tsx
@@ -5,7 +5,7 @@ const Body = () => {
   return (
     <div className="one more classes">
       <div className="some two more classes">
-        <div id="some three more classes">
+        <div className="some three more classes">
           <div id="four">
             <button>
               <span className="five">content</span>


### PR DESCRIPTION
Resolves CodeQL code-quality findings in dnb-eufemia test files.

- **useMedia.test**: removed no-effect `result.current` statements.
- **DrawerList.test**: `` `${undefined}-drawer-list` `` → `'undefined-drawer-list'` (implicit conversion).
- **getClosest.test**: `id="some three more classes"` (invalid — ids can't contain spaces) → `className` (unused by tests).
- **Slider.test**: `[min, setMinVal]` / `[max, setMaxVal]` → `[, setMinVal]` / `[, setMaxVal]` in the `WrongUsage` demo.

Behavior-preserving. useMedia, DrawerList, getClosest, Slider suites pass (123 tests).

> Note: the 5 `FieldBlock.test.tsx` "missing space in concatenation" findings were intentionally left unchanged — they are false positives (the tests correctly assert `.textContent`, where sibling elements join without spaces) and should be dismissed on GitHub.

---
_Part of a 7-PR series resolving CodeQL **code quality** findings (46/51 fixed; the 5 remaining `FieldBlock.test.tsx` "missing space" items are false positives to dismiss):_
- #8882 · fix: genuine bugs (regex, Dialog, makePropertiesFile)
- #8883 · refactor(DatePicker)
- #8884 · refactor(forms)
- #8885 · refactor: components
- #8886 · refactor: shared helpers & tools
- #8887 · refactor(portal)
- #8888 · test: dnb-eufemia tests
