### PR TITLE
chore(Portal): remove always-false conditional in StickyMenuBar

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -120,9 +120,3 @@
   flex-wrap: nowrap;
   align-items: center;
 }
-
-.hideSidebarToggleButtonStyle {
-  #toggle-sidebar-menu {
-    display: none;
-  }
-}

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -18,7 +18,6 @@ import {
   centerWrapperStyle,
   toolsStyle,
   portalHeaderWrapperStyle,
-  hideSidebarToggleButtonStyle,
 } from './StickyMenuBar.module.scss'
 import { Link } from '../tags/Anchor'
 import GithubLogo from '../../docs/contribute/assets/github-logo'
@@ -35,14 +34,7 @@ export default function StickyMenuBar({
   }
 
   return (
-    <header
-      className={clsx(
-        headerStyle,
-        hideSidebarToggleButton && hideSidebarToggleButtonStyle,
-        'sticky-menu',
-        'dev-grid'
-      )}
-    >
+    <header className={clsx(headerStyle, 'sticky-menu', 'dev-grid')}>
       <div className={portalHeaderWrapperStyle}>
         <HomeButton id="toggle-main-menu" text="Home" />
         <HomeButton id="toggle-main-menu-small-screen" size="default" />


### PR DESCRIPTION
## Summary

Fixes a CodeQL **"Useless conditional"** finding (`js/trivial-conditional`, Reliability / Warning) in `StickyMenuBar`.

The component early-returns when `hideSidebarToggleButton` is truthy:

```tsx
if (preventBarVisibility || hideSidebarToggleButton) {
  return null
}
```

By the time the `<header>` renders, `hideSidebarToggleButton` is therefore **always** `false`, so the `clsx` branch below was dead code that could never apply:

```tsx
hideSidebarToggleButton && hideSidebarToggleButtonStyle,
```

## Changes

- Remove the always-false `hideSidebarToggleButton && hideSidebarToggleButtonStyle` entry from the `clsx` call.
- Remove the now-orphaned `hideSidebarToggleButtonStyle` import.
- Remove the unused `.hideSidebarToggleButtonStyle` SCSS rule.

No behavior change: the only caller (`Layout.tsx`) never passes the prop, and the removed branch never executed. The `hideSidebarToggleButton` prop still hides the bar via the early return.

## CodeQL finding

- `packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx:41` — _"This use of variable 'hideSidebarToggleButton' always evaluates to false."_
