### PR TITLE
chore(FieldBlock): use variables in error summary assertions

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/FieldBlock/__tests__/FieldBlock.test.tsx
@@ -1161,11 +1161,10 @@ describe('FieldBlock', () => {
       })
 
       it('should summarize errors when returned in onChangeValidator', () => {
+        const firstError = 'Error message one'
+        const secondError = 'Error message two'
         const onChangeValidator: Validator<string> = vi.fn(() => {
-          return [
-            new Error('Error message one'),
-            new Error('Error message two'),
-          ]
+          return [new Error(firstError), new Error(secondError)]
         })
 
         render(
@@ -1178,17 +1177,14 @@ describe('FieldBlock', () => {
 
         expect(
           document.querySelector('.dnb-form-status').textContent
-        ).toBe(
-          nb.Field.errorSummary + 'Error message one' + 'Error message two'
-        )
+        ).toBe(nb.Field.errorSummary + firstError + secondError)
       })
 
       it('should summarize errors when returned in onBlurValidator', () => {
+        const firstError = 'Error message one'
+        const secondError = 'Error message two'
         const onBlurValidator: Validator<string> = vi.fn(() => {
-          return [
-            new Error('Error message one'),
-            new Error('Error message two'),
-          ]
+          return [new Error(firstError), new Error(secondError)]
         })
 
         render(
@@ -1201,17 +1197,14 @@ describe('FieldBlock', () => {
 
         expect(
           document.querySelector('.dnb-form-status').textContent
-        ).toBe(
-          nb.Field.errorSummary + 'Error message one' + 'Error message two'
-        )
+        ).toBe(nb.Field.errorSummary + firstError + secondError)
       })
 
       it('should summarize errors when returned in async onChangeValidator', async () => {
+        const firstError = 'Error message one'
+        const secondError = 'Error message two'
         const onChangeValidator: Validator<string> = vi.fn(async () => {
-          return [
-            new Error('Error message one'),
-            new Error('Error message two'),
-          ]
+          return [new Error(firstError), new Error(secondError)]
         })
 
         render(
@@ -1225,20 +1218,15 @@ describe('FieldBlock', () => {
         await waitFor(() => {
           expect(
             document.querySelector('.dnb-form-status').textContent
-          ).toBe(
-            nb.Field.errorSummary +
-              'Error message one' +
-              'Error message two'
-          )
+          ).toBe(nb.Field.errorSummary + firstError + secondError)
         })
       })
 
       it('should summarize errors when returned in async onBlurValidator', async () => {
+        const firstError = 'Error message one'
+        const secondError = 'Error message two'
         const onBlurValidator: Validator<string> = vi.fn(async () => {
-          return [
-            new Error('Error message one'),
-            new Error('Error message two'),
-          ]
+          return [new Error(firstError), new Error(secondError)]
         })
 
         render(
@@ -1252,19 +1240,17 @@ describe('FieldBlock', () => {
         await waitFor(() => {
           expect(
             document.querySelector('.dnb-form-status').textContent
-          ).toBe(
-            nb.Field.errorSummary +
-              'Error message one' +
-              'Error message two'
-          )
+          ).toBe(nb.Field.errorSummary + firstError + secondError)
         })
       })
 
       it('should update error message when onBlurValidator returns array with different errors', async () => {
-        const firstReturn = [new Error('first error')]
+        const firstError = 'first error'
+        const secondError = 'second error'
+        const firstReturn = [new Error(firstError)]
         const secondReturn = [
-          new Error('first error'),
-          new Error('second error'),
+          new Error(firstError),
+          new Error(secondError),
         ]
 
         let count = 0
@@ -1287,7 +1273,7 @@ describe('FieldBlock', () => {
         await waitFor(() => {
           expect(
             document.querySelector('.dnb-form-status').textContent
-          ).toBe('first error')
+          ).toBe(firstError)
         })
 
         fireEvent.blur(input)
@@ -1298,7 +1284,7 @@ describe('FieldBlock', () => {
         await waitFor(() => {
           expect(
             document.querySelector('.dnb-form-status').textContent
-          ).toBe(nb.Field.errorSummary + 'first error' + 'second error')
+          ).toBe(nb.Field.errorSummary + firstError + secondError)
         })
       })
     })


### PR DESCRIPTION
## Summary

Resolves 5 CodeQL **"Missing space in string concatenation"** findings (`js/missing-space-in-concatenation`, Maintainability / Warning) in `FieldBlock.test.tsx`.

These are **false positives**. The error summary renders a title followed by a `<ul>` of `<li>` messages ([FieldBlock.tsx](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/extensions/forms/FieldBlock/FieldBlock.tsx#L753-L762)), so the element's `.textContent` concatenates the parts with **no** separators. The assertions correctly mirror that DOM output — CodeQL only flags them because they concatenate string *literals* (`'Error message one' + 'Error message two'`).

## Changes

Extract the error messages into `firstError` / `secondError` variables and reuse them in both the `new Error(...)` calls and the assertions. This:

- Keeps the asserted strings **byte-for-byte identical** (no behavior change).
- Removes the literal-string concatenation that triggers CodeQL.
- Matches the pattern already used in sibling tests (`Composition.test.tsx`, `String.test.tsx`, `useFieldProps.test.tsx`), which use `firstError`/`secondError` and are therefore not flagged.

## Verification

All 5 affected tests pass:

```
✓ should summarize errors when returned in onChangeValidator
✓ should summarize errors when returned in onBlurValidator
✓ should summarize errors when returned in async onChangeValidator
✓ should summarize errors when returned in async onBlurValidator
✓ should update error message when onBlurValidator returns array with different errors
```

## CodeQL findings addressed

- `FieldBlock.test.tsx:1182`
- `FieldBlock.test.tsx:1205`
- `FieldBlock.test.tsx:1230`
- `FieldBlock.test.tsx:1257`
- `FieldBlock.test.tsx:1301`
