### PR TITLE
fix(Radio.Group): remove invalid aria-labelledby from role-less shell

### DIFF
--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -11,7 +11,6 @@ import {
   validateDOMAttributes,
   getStatusState,
   combineDescribedBy,
-  combineLabelledBy,
   dispatchCustomElementEvent,
   removeUndefinedProps,
 } from '../../shared/component-helper'
@@ -215,9 +214,6 @@ function RadioGroup(ownProps: RadioGroupProps) {
       showStatus ? id + '-status' : null,
       suffix ? id + '-suffix' : null
     )
-  }
-  if (label) {
-    params['aria-labelledby'] = combineLabelledBy(params, legendId)
   }
 
   // also used for code markup simulation

--- a/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
@@ -242,6 +242,23 @@ describe('Radio group component', () => {
       const shell = document.querySelector('.dnb-radio-group__shell')
       expect(shell).not.toHaveAttribute('role')
     })
+
+    it('should not have aria-labelledby on inner shell element', () => {
+      render(
+        <Radio.Group label="Legend">
+          <Radio label="First" value="first" />
+          <Radio label="Second" value="second" />
+        </Radio.Group>
+      )
+
+      const shell = document.querySelector('.dnb-radio-group__shell')
+      expect(shell).not.toHaveAttribute('aria-labelledby')
+
+      // the group is still labelled via the fieldset + legend
+      const fieldset = document.querySelector('fieldset')
+      const legend = document.querySelector('legend')
+      expect(fieldset).toHaveAttribute('aria-labelledby', legend.id)
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Every `Radio.Group` with a `label` rendered its inner shell `<span class="dnb-radio-group__shell" aria-labelledby="…">` without a role. A generic element (implicit role `generic`) is prohibited from having a naming attribute such as `aria-labelledby`, so axe flags `aria-prohibited-attr` (serious).

This is a follow-up to #8878, which fixed the exact same pattern in `ToggleButton.Group` (as suggested in the review there).

## Root cause

`aria-labelledby` was added to the spread `params` object and applied to the role-less shell `<span>`. The group is already correctly labelled on the `<fieldset role="radiogroup">` (with its `<legend>`), so the copy on the shell was both redundant and invalid.

## Fix

Removed the `aria-labelledby` assignment from `params` (and the now-unused `combineLabelledBy` import). The group keeps its accessible name via the `<fieldset>` + `<legend>`; the shell no longer carries an invalid naming attribute.

## Tests

- Added a test asserting the shell has no `aria-labelledby` while the `<fieldset>` is still labelled by the `<legend>`.
- Existing tests for the fieldset's `aria-labelledby`/`role` and the role-less shell continue to pass.

## How to verify

- Before: the group shell exposes `aria-labelledby` with no role.
- After: the shell has no `aria-labelledby`; the group is still announced with its label via the fieldset/legend, and axe reports no `aria-prohibited-attr` violation.
