### PR TITLE
fix(scripts): use stylelint result.code instead of deprecated output

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
@@ -676,10 +676,13 @@ const makeDesignTokenSCSS = async ({
       fix: true,
     })
 
+    // `code` holds the autofixed output; `output` is deprecated in stylelint 16
+    const fixedContent = stylelintResult.code ?? outputScssContent
+
     if (appendToFile) {
-      await promises.appendFile(outputPath, stylelintResult.output)
+      await promises.appendFile(outputPath, fixedContent)
     } else {
-      await promises.writeFile(outputPath, stylelintResult.output)
+      await promises.writeFile(outputPath, fixedContent)
     }
 
     log.info(`Generated SCSS file: ${outputPath}`)


### PR DESCRIPTION
## Summary

Removes the `[stylelint:003] DeprecationWarning: `output` is deprecated.` warning that appears during builds and tests (e.g. `yarn workspace @dnb/eufemia test:ci`).

The warning originates from `makePropertiesFile.ts`, which generates the Figma SCSS token files. It called `stylelint.lint({ code, fix: true })` and then read the deprecated `LinterResult.output` property.

## Details

In stylelint 16, `LinterResult.output` is deprecated:

> `@deprecated` Use `report` for the formatted problems, or use `code` for the autofixed code instead. This will be removed in the next major version.

Since this call passes `code` + `fix: true`, the autofixed CSS is now exposed via `LinterResult.code`. The property is optional in the types (it is only populated when autofix runs and the input is not ignored), so a fallback to the original content is used for type-safety and to preserve behavior in edge cases.

```diff
-    if (appendToFile) {
-      await promises.appendFile(outputPath, stylelintResult.output)
-    } else {
-      await promises.writeFile(outputPath, stylelintResult.output)
-    }
+    const fixedContent = stylelintResult.code ?? outputScssContent
+
+    if (appendToFile) {
+      await promises.appendFile(outputPath, fixedContent)
+    } else {
+      await promises.writeFile(outputPath, fixedContent)
+    }
```

## Verification

- Ran the `makePropertiesFile` test suite (which exercises this SCSS-generation path): 49/49 passing, and **no** `DeprecationWarning`/`stylelint:003` is emitted.
- The regenerated SCSS token files are **byte-identical** to what is committed (empty `git diff`), confirming `code` produces the same output as the previous `output`.
- Prettier and ESLint pass on the changed file.
