### PR TITLE
chore(scripts): stop logging redundant errors in makePropertiesFile transforms

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makePropertiesFile.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makePropertiesFile.test.ts
@@ -326,7 +326,9 @@ describe('makePropertiesFile', () => {
           targetVariableSetName: 'colors',
         }
 
-        expect(() => transformFigmaAlias(val)).toThrow()
+        expect(() => transformFigmaAlias(val)).toThrow(
+          'Unsupported theme prefix: nonsense for variable nonsense/ColdGreen/600'
+        )
       })
     })
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makePropertiesFile.ts
@@ -248,9 +248,9 @@ export const transformFigmaAlias = (
     })
 
     if (newPrefix === undefined) {
-      const errorMessage = `Unsupported theme prefix: ${path[0]} for variable ${figmaVariableName}`
-      log.fail(errorMessage)
-      throw new Error(errorMessage)
+      throw new Error(
+        `Unsupported theme prefix: ${path[0]} for variable ${figmaVariableName}`
+      )
     }
     path[0] = newPrefix
     return `var(${transformNamespace()}${transformFigmaPath(path)})` // Including transform namespace as we might want to be able to apply that in the future
@@ -343,11 +343,11 @@ export const transformFigmaPath = (path: string[]) => {
     .join(TOKEN_GROUP_SEPARATOR)
 
   if (unsupportedCharacters.length > 0) {
-    const errorMessage = `Unsupported characters [ '${unsupportedCharacters.join(
-      "', '"
-    )}' ] in variable: "${cleanPath.join('/')}"`
-    log.fail(errorMessage)
-    throw new Error(errorMessage)
+    throw new Error(
+      `Unsupported characters [ '${unsupportedCharacters.join(
+        "', '"
+      )}' ] in variable: "${cleanPath.join('/')}"`
+    )
   }
   return transformedPath
 }


### PR DESCRIPTION
## Summary

Running `yarn workspace @dnb/eufemia test:ci` on `main` printed two misleading failure lines even though every test passed:

```
✖ Unsupported theme prefix: nonsense for variable nonsense/ColdGreen/600
✖ Unsupported characters [ '*', ' ', '?', '(' ] in variable: "Colo*rs/Pri ma?ry/Da(rk"
```

## Root cause

`transformFigmaAlias` and `transformFigmaPath` in `scripts/prebuild/tasks/makePropertiesFile.ts` both called `log.fail(errorMessage)` **and** `throw new Error(errorMessage)` with the same message. The scripts unit tests deliberately exercise these throwing paths (and assert they throw), so the redundant `log.fail()` (an `ora` spinner) printed the `✖` lines to the CI output — making a green run look like it contained failures.

## Fix

- Remove the redundant `log.fail()` calls so the transform functions only `throw`. Pure transform helpers shouldn't have logging side-effects.
- Production error visibility is unchanged: the thrown error still propagates through `makeDesignTokenSCSS` (which logs the failing file) up to `runPrepublishTasks`, whose `ErrorHandler(e)` prints the message.
- Strengthen the theme-prefix test to assert the exact error message (the sibling character test already did), locking the contract now that the logging is gone.

## Verification

- `yarn test:scripts makePropertiesFile` → 49/49 pass, no more `✖ Unsupported ...` lines in the output.
- `yarn test:types` → passes.
- ESLint + Prettier → clean.
