### PR TITLE
chore: stub jsdom window scroll methods to silence "Not implemented" warnings

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest/setupVitest.ts
+++ b/packages/dnb-eufemia/src/core/vitest/setupVitest.ts
@@ -66,6 +66,16 @@ if (typeof window !== 'undefined') {
   if (matchMediaDesc && !window.matchMedia) {
     delete (window as unknown as Record<string, unknown>).matchMedia
   }
+
+  // jsdom does not implement the Window scroll methods and logs a noisy
+  // "Not implemented: Window's scrollTo() method" error through its virtual
+  // console whenever a component calls them during a test. Provide no-op
+  // stubs so the methods behave like a real browser (a silent no-op) while
+  // remaining plain data properties that individual tests can still spy on
+  // or override.
+  window.scrollTo = () => undefined
+  window.scroll = () => undefined
+  window.scrollBy = () => undefined
 }
 
 // Silence known noisy console output globally


### PR DESCRIPTION
## Description

Running `yarn workspace @dnb/eufemia test:ci` (and `yarn test`) printed the noisy jsdom warning repeatedly:

```
Not implemented: Window's scrollTo() method
```

jsdom does not implement the Window scroll methods (`window.scrollTo`, `window.scroll`, `window.scrollBy`). Whenever a component calls one during a test — e.g. `shared/helpers` `scrollToLocationHashId`, `GlobalStatus`, Eufemia Forms `Provider` (`scrollTopOnSubmit`), or `Anchor` `scrollToHash` — jsdom emits a "Not implemented" error through its virtual console, cluttering the test output.

## Fix

Add no-op stubs for the three Window scroll methods in the Vitest setup (`setupVitest.ts`), next to the existing jsdom `matchMedia` workaround. This mirrors real browser behaviour (a silent no-op) and prevents jsdom's not-implemented path from ever running.

The stubs are plain data-property functions, so tests that `vi.spyOn(window, 'scrollTo')` or reassign `window.scrollTo = vi.fn()` continue to work and their call assertions still pass.

`Element.prototype.scrollIntoView` is a jsdom no-op already (it does not warn), so it is intentionally left untouched.

## Verification

- Full unit suite (`yarn test`): **0** `Not implemented: Window's scrollTo` warnings (previously emitted many times).
- All scroll-related tests pass unchanged: `helpers`, `GlobalStatus`, `AnchorScroll`, `Dropdown`, Forms `Provider` and `String` (396 tests).
- The pre-existing timing/flaky test failures under the threads pool are unrelated to this change (confirmed identical on clean `main`).
