### PR TITLE
fix(List.Item.Accordion): add region role so aria-labelledby is valid on content

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -258,6 +258,7 @@ function AccordionContent(props: ItemContentProps) {
         className
       )}
       id={`${accordionId}-content`}
+      role="region" // a role is required for aria-labelledby to be valid on this element
       aria-labelledby={`${accordionId}-header`}
       aria-hidden={!openState}
       {...omitSpacingProps(rest)}

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
@@ -221,7 +221,7 @@ describe('ItemAccordion', () => {
     expect(header.getAttribute('tabindex')).toBe('-1')
   })
 
-  it('content region has id, aria-labelledby and aria-hidden', () => {
+  it('content region has id, role, aria-labelledby and aria-hidden', () => {
     render(
       <ItemAccordion>
         <ItemAccordion.Header>Title</ItemAccordion.Header>
@@ -238,9 +238,36 @@ describe('ItemAccordion', () => {
 
     expect(contentRegion).toBeInTheDocument()
     expect(contentRegion.getAttribute('id')).toBe(contentId)
+    expect(contentRegion.getAttribute('role')).toBe('region')
     expect(contentRegion.getAttribute('aria-labelledby')).toBe(headerId)
     expect(contentRegion.getAttribute('aria-hidden')).toBe('true')
     expect(contentRegion).not.toHaveAttribute('aria-expanded')
+  })
+
+  it('content region is a labelled region (aria-labelledby is valid, not on a role-less element)', () => {
+    render(
+      <ItemAccordion open>
+        <ItemAccordion.Header>Title</ItemAccordion.Header>
+        <ItemAccordion.Content>Content</ItemAccordion.Content>
+      </ItemAccordion>
+    )
+
+    const header = document.querySelector(
+      '.dnb-list__item__accordion__header'
+    )
+    const contentId = header.getAttribute('aria-controls')
+    const contentRegion = document.getElementById(contentId)
+
+    // A naming attribute (aria-labelledby) is prohibited on a role-less
+    // generic element, so the content region carries role="region" to make
+    // the labelled association valid.
+    expect(contentRegion.getAttribute('role')).toBe('region')
+    expect(contentRegion.getAttribute('aria-labelledby')).toBe(
+      header.getAttribute('id')
+    )
+
+    // the referenced header provides the region's accessible name
+    expect(header).toHaveTextContent('Title')
   })
 
   it('content region has aria-hidden false when open and no aria-expanded', () => {
@@ -258,6 +285,7 @@ describe('ItemAccordion', () => {
     const contentRegion = document.getElementById(contentId)
 
     expect(contentRegion).toBeInTheDocument()
+    expect(contentRegion.getAttribute('role')).toBe('region')
     expect(contentRegion.getAttribute('aria-hidden')).toBe('false')
     expect(contentRegion).not.toHaveAttribute('aria-expanded')
   })


### PR DESCRIPTION
## Summary

`List.Item.Accordion`'s content region rendered a **role-less generic element** (a `<div>` via `Flex.Item`) that carried `aria-labelledby` pointing to its header. A naming attribute (`aria-label`/`aria-labelledby`) is prohibited on a generic element (implicit role `generic`), which axe flags as `aria-prohibited-attr` (serious).

This is the same class of issue as #8878 (`ToggleButton.Group`) and #8892 (`Radio.Group`), found while auditing the code base for that pattern.

## Root cause

The content region set `aria-labelledby` on a `Flex.Item`, which renders a `<div>` with no role.

## Fix

Add `role="region"` to the content region so the labelled association becomes valid. Unlike the group shells in #8878/#8892 (where the label was redundant and simply removed), the accordion content *should* be associated with its header, so a labelled `region` is the correct, meaningful role. This mirrors the standalone `Accordion` component, whose content uses a labelled `<section>` (which resolves to `region`).

## Tests

- Assert the content region exposes `role="region"` in both the collapsed and expanded states.
- Add a test documenting the accessibility contract (the region is labelled by an existing header element).

## Note

Eufemia's jsdom-based axe unit tests (jest-axe → axe-core) do not fire `aria-prohibited-attr` for this pattern, so a direct attribute assertion is used as the regression guard rather than an axe assertion.
