### PR TITLE
chore: silence jsdom "Not implemented: navigation" warning in Vitest output

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest/setupVitest.ts
+++ b/packages/dnb-eufemia/src/core/vitest/setupVitest.ts
@@ -82,6 +82,7 @@ if (typeof window !== 'undefined') {
 const originalError = console.error
 const originalLog = console.log
 const originalWarn = console.warn
+const originalStderrWrite = process.stderr.write.bind(process.stderr)
 
 // ANSI escape prefix used by Eufemia's warn() helper
 const eufemiaAnsiPrefix =
@@ -93,13 +94,28 @@ beforeAll(() => {
     if (
       /not wrapped in act/.test(msg) ||
       /not configured to support act/.test(msg) ||
-      /component suspended inside an `act` scope/.test(msg) ||
-      /Not implemented: navigation/.test(msg)
+      /component suspended inside an `act` scope/.test(msg)
     ) {
       return
     }
     originalError.call(console, ...args)
   }
+
+  // jsdom does not implement cross-document navigation and reports it as
+  // "Not implemented: navigation to another Document" through its default
+  // virtual console, which writes straight to process.stderr — bypassing the
+  // console.error override above. This fires whenever a test clicks an
+  // <a href> or submits a form without preventing the default action. Filter
+  // out just that noise while forwarding everything else untouched.
+  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
+    if (String(chunk).includes('Not implemented: navigation')) {
+      return true
+    }
+    return (originalStderrWrite as (...a: unknown[]) => boolean)(
+      chunk,
+      ...args
+    )
+  }) as typeof process.stderr.write
 
   console.log = (...args) => {
     const first = String(args[0] ?? '')
@@ -122,4 +138,5 @@ afterAll(() => {
   console.error = originalError
   console.log = originalLog
   console.warn = originalWarn
+  process.stderr.write = originalStderrWrite
 })


### PR DESCRIPTION
## Description

Running `yarn workspace @dnb/eufemia test:ci` (and `yarn test`) printed the
noisy jsdom warning:

```
Not implemented: navigation to another Document
```

jsdom does not implement cross-document navigation. Whenever a test clicks an
`<a href>` or submits a form without preventing the default action (e.g.
`Card.Action`, `List.Item` action links), jsdom's navigation path reaches
`navigateFetch()` and emits a "Not implemented" error, cluttering the test
output.

## Root cause

`setupVitest.ts` already tried to suppress this on `console.error`, but the
filter never matched. jsdom routes the message through its **default virtual
console** straight to `process.stderr`, bypassing the `console.error` override:

- Vitest constructs the jsdom environment with `virtualConsole: undefined`
  (its `console` option defaults to `false`).
- jsdom then builds its own `(new VirtualConsole()).forwardTo(console)`, whose
  `jsdomError` handler calls `console.error(e.message)` on the **original**
  console reference, which writes to the real stderr stream.

Verified empirically: with the `console.error` override in place, the
navigation warning was still emitted (`consoleErrorCaught=false`,
`stderrCaught=true`).

## Fix

Filter the navigation noise at the `process.stderr.write` level instead — the
channel jsdom actually uses — while forwarding everything else untouched, and
restore the original writer in `afterAll`. The dead `console.error` navigation
filter is removed. This mirrors the pattern already used in the portal's Vitest
setup (`packages/dnb-design-system-portal/vite/__tests__/setup.ts`).

## Verification

- `Not implemented: navigation` warnings: **0** across 408 tests / 13 files
  (previously emitted by `Card.Action`, `List.Item`, etc.), including
  `card`, `list/ItemAction`, `Form/SubmitButton`, `anchor`, `breadcrumb`,
  `pagination`, `tabs`, `button`.
- Non-navigation stderr output still passes through untouched (confirmed with a
  throwaway test writing both a navigation line and a normal line).
- ESLint: no new issues (only pre-existing `no-console` warnings inherent to
  this file). Prettier: unchanged. Type-check: clean.
