### PR TITLE
chore(forms): return FormError from ajvErrorToFormError for errorMessage keyword

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajvErrors.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajvErrors.test.ts
@@ -52,6 +52,16 @@ describe('getInstancePath', () => {
     expect(getInstancePath(error)).toBe('/innerPath')
   })
 
+  it('should not throw for an errorMessage error without wrapped errors', () => {
+    const error: ErrorObject = {
+      schemaPath: '#',
+      keyword: 'errorMessage',
+      instancePath: '/path',
+      params: {},
+    }
+    expect(getInstancePath(error)).toBe('/path')
+  })
+
   it('should return the original instance path for other errors', () => {
     const error: ErrorObject = {
       schemaPath: '#',
@@ -79,6 +89,16 @@ describe('getValidationRule', () => {
     }
     const rule = getValidationRule(ajvError)
     expect(rule).toBe('required')
+  })
+
+  it('should not throw for an errorMessage error without wrapped errors', () => {
+    const ajvError: ErrorObject = {
+      schemaPath: '#',
+      keyword: 'errorMessage',
+      instancePath: '/path',
+      params: {},
+    }
+    expect(getValidationRule(ajvError)).toBe('errorMessage')
   })
 
   it('should return undefined if the keyword is not defined', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajvErrors.test.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/__tests__/ajvErrors.test.ts
@@ -247,6 +247,29 @@ describe('ajvErrorToFormError', () => {
     expect(formError.message).toBe('StringField.errorMinLength')
   })
 
+  it('should return a FormError (not a plain Error) for an errorMessage keyword', () => {
+    const ajvError: ErrorObject = {
+      schemaPath: '#',
+      instancePath: '/path',
+      keyword: 'errorMessage',
+      params: {
+        errors: [
+          {
+            schemaPath: '#',
+            instancePath: '/path',
+            keyword: 'minLength',
+            params: { limit: 5 },
+          },
+        ],
+      },
+      message: 'Custom error message',
+    }
+    const formError = ajvErrorToFormError(ajvError)
+    expect(formError).toBeInstanceOf(FormError)
+    expect(formError.message).toBe('Custom error message')
+    expect(formError.ajvKeyword).toBe('errorMessage')
+  })
+
   it('should return a FormError with "Unknown error" message if no message and undefined keyword is provided', () => {
     const ajvError: ErrorObject = {
       schemaPath: '#',

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajvErrors.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajvErrors.ts
@@ -28,7 +28,7 @@ export function getInstancePath(ajvError: ErrorObject): Path {
     case 'errorMessage': {
       // errorMessage structures (from ajv-errors) wrap the original error. Find instance path from original
       // to avoid issues like required-errors pointing at parent object.
-      if (ajvError.params.errors[0]) {
+      if (ajvError.params.errors?.[0]) {
         return getInstancePath(ajvError.params.errors[0])
       }
     }
@@ -44,7 +44,7 @@ export function getInstancePath(ajvError: ErrorObject): Path {
  * @returns The validation rule.
  */
 export function getValidationRule(ajvError: ErrorObject): string {
-  if (ajvError.keyword === 'errorMessage' && ajvError.params.errors[0]) {
+  if (ajvError.keyword === 'errorMessage' && ajvError.params.errors?.[0]) {
     // errorMessage structures (from ajv-errors) wrap the original error. Find keyword from original
     // to avoid issues like required-errors pointing at parent object.
     return getValidationRule(ajvError.params.errors[0])

--- a/packages/dnb-eufemia/src/extensions/forms/utils/ajvErrors.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/utils/ajvErrors.ts
@@ -94,7 +94,11 @@ export function getMessageValues(
  */
 export function ajvErrorToFormError(ajvError: ErrorObject): FormError {
   if (ajvError.keyword === 'errorMessage') {
-    return new Error(ajvError.message ?? 'Unknown error')
+    // The message is already the final custom message from ajv-errors, so no
+    // messageValues are resolved here (they live on the wrapped params.errors).
+    return new FormError(ajvError.message ?? 'Unknown error', {
+      ajvKeyword: ajvError.keyword,
+    })
   }
 
   return new FormError(


### PR DESCRIPTION
## Problem

When the AJV keyword is `errorMessage`, `ajvErrorToFormError` returned a plain `Error` instead of a `FormError`, which is inconsistent with its `FormError` return type. Callers doing `instanceof FormError` checks or reading `FormError`-specific properties (e.g. `ajvKeyword`) got a plain `Error`.

## Fix

1. Return a `FormError` (with `ajvKeyword`) for the `errorMessage` branch.

   **Note on `messageValues`:** the finding suggested calling `getMessageValues(ajvError)` here, but that is unsafe/incorrect for this branch — the `errorMessage` message is already the final custom message from ajv-errors, and `getMessageValues`→`getValidationRule` would read `limit`/`pattern` from the wrong params level.

2. **Follow-up hardening (review round):** `getInstancePath` and `getValidationRule` unwrapped `ajvError.params.errors[0]` for the `errorMessage` keyword without checking that `params.errors` exists, throwing a `TypeError` for a malformed `errorMessage` error. Added optional chaining so they fall back to the error's own `instancePath`/`keyword` instead of throwing.

## Verification

- Added a test asserting the `errorMessage` branch returns a `FormError` (instance), preserves the custom message, and sets `ajvKeyword`.
- Added tests asserting `getInstancePath`/`getValidationRule` do not throw for an `errorMessage` error without wrapped errors.
- Confirmed each new test fails against the previous implementation and passes with the fix. Full `ajvErrors` suite: 32/32 passing.
