### PR TITLE
chore(component-helper): declare idIncrement before makeUniqueId

### DIFF
--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -213,6 +213,7 @@ export function toCapitalized(str) {
     : str
 }
 
+let idIncrement = 0
 export const makeUniqueId = (prefix = 'id-', length = 8) =>
   prefix +
   String(
@@ -220,7 +221,6 @@ export const makeUniqueId = (prefix = 'id-', length = 8) =>
       .toString(36)
       .substring(2, 2 + length) + idIncrement++
   ).slice(-length)
-let idIncrement = 0
 
 export const slugify = (s) =>
   String(s)


### PR DESCRIPTION
## Problem

`makeUniqueId` closes over `idIncrement`, which was declared with `let` **after** the function. Referencing a `let` binding before its declaration line is a temporal dead zone (TDZ) hazard.

## Fix

Move `let idIncrement = 0` above the `makeUniqueId` declaration. No behavior change — `makeUniqueId` is only ever called at runtime (after module evaluation), so this is purely a safety/clarity improvement.

## Verification

Full `component-helper` test suite passes (50/50), including the `makeUniqueId` uniqueness tests.