### PR TITLE
fix(forms): null-safe access of sharedAttachmentsRef.current in useData

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/DataContext/useData.ts
@@ -309,7 +309,7 @@ export function useDataReturn<Data = JsonObject>({
   >(
     (data, options = {}) => {
       if (id) {
-        return sharedAttachmentsRef.current.data?.visibleDataHandler?.(
+        return sharedAttachmentsRef.current?.data?.visibleDataHandler?.(
           data,
           options
         )
@@ -323,7 +323,7 @@ export function useDataReturn<Data = JsonObject>({
   const filterData = useCallback<UseDataReturn<Data>['filterData']>(
     (filter, data = getCurrentData()) => {
       if (id) {
-        return sharedAttachmentsRef.current.data?.filterDataHandler?.(
+        return sharedAttachmentsRef.current?.data?.filterDataHandler?.(
           data,
           filter
         )


### PR DESCRIPTION
## Problem

In `useData`, `reduceToVisibleFields` and `filterData` accessed `sharedAttachmentsRef.current.data?...` without guarding `.current`. The ref is typed as nullable (`ReturnType<typeof createSharedState<...>> | null`), so this access is not null-safe.

## Fix

Add optional chaining on `.current` (`sharedAttachmentsRef.current?.data?....`), consistent with the `?.` already used further along the same chain.

## Scope / honesty note

In practice `.current` is assigned synchronously every render when `id` is truthy (`createSharedState` never returns null), so this is a **defensive / type-safety** improvement rather than a reproduced runtime crash.

## Verification

Full `useData` suite passes (57/57). The modified `id` branch is exercised by the existing `filterData`/`reduceToVisibleFields` tests that render with `<Provider id=...>`, confirming no behavior change.