### PR TITLE
chore(component-helper): deduplicate ids in combineLabelledBy/combineDescribedBy

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -605,6 +605,13 @@ describe('"combineLabelledBy"/"combineDescribedBy" should', () => {
     expect(combineDescribedBy(['a', 'a'], 'a')).toBe('a')
   })
 
+  it('deduplicate ids within space-separated strings', () => {
+    expect(combineDescribedBy({ 'aria-describedby': 'a b' }, 'a')).toBe(
+      'a b'
+    )
+    expect(combineLabelledBy('a b c', 'b', 'd')).toBe('a b c d')
+  })
+
   it('ignore nullish and non-string values', () => {
     expect(combineLabelledBy('a', null, undefined, false, 'b')).toBe('a b')
     expect(combineLabelledBy({ 'aria-labelledby': undefined }, 'b')).toBe(

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -25,6 +25,8 @@ import {
   convertJsxToString,
   escapeRegexChars,
   removeUndefinedProps,
+  combineLabelledBy,
+  combineDescribedBy,
 } from '../component-helper'
 import userEvent from '@testing-library/user-event'
 
@@ -570,6 +572,52 @@ describe('"makeUniqueId" should', () => {
     expect(makeUniqueId('string-', 10)).toEqual(
       expect.stringMatching(/^string-[a-z0-9]{10}/g)
     )
+  })
+})
+
+describe('"combineLabelledBy"/"combineDescribedBy" should', () => {
+  it('combine string ids into a space-separated string', () => {
+    expect(combineLabelledBy('a', 'b', 'c')).toBe('a b c')
+    expect(combineDescribedBy('a', 'b')).toBe('a b')
+  })
+
+  it('extract the id from objects using the aria key', () => {
+    expect(
+      combineLabelledBy({ 'aria-labelledby': 'from-object' }, 'extra')
+    ).toBe('from-object extra')
+    expect(
+      combineDescribedBy({ 'aria-describedby': 'from-object' }, 'extra')
+    ).toBe('from-object extra')
+  })
+
+  it('flatten arrays of ids', () => {
+    expect(combineLabelledBy(['a', 'b'], 'c')).toBe('a b c')
+  })
+
+  it('deduplicate repeated ids', () => {
+    expect(combineLabelledBy('a', 'a', 'b')).toBe('a b')
+    expect(
+      combineLabelledBy(
+        { 'aria-labelledby': 'shared' },
+        { 'aria-labelledby': 'shared' }
+      )
+    ).toBe('shared')
+    expect(combineDescribedBy(['a', 'a'], 'a')).toBe('a')
+  })
+
+  it('ignore nullish and non-string values', () => {
+    expect(combineLabelledBy('a', null, undefined, false, 'b')).toBe('a b')
+    expect(combineLabelledBy({ 'aria-labelledby': undefined }, 'b')).toBe(
+      'b'
+    )
+  })
+
+  it('return undefined when nothing resolves to a string', () => {
+    expect(combineLabelledBy()).toBeUndefined()
+    expect(combineLabelledBy(null, undefined)).toBeUndefined()
+    expect(
+      combineDescribedBy({ 'aria-describedby': undefined })
+    ).toBeUndefined()
   })
 })
 

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -345,26 +345,23 @@ export function combineDescribedBy(...params) {
   return combineAriaBy('aria-describedby', params)
 }
 function combineAriaBy(type, params) {
-  params = params.map((cur) => {
-    if (Array.isArray(cur)) {
-      return cur.join(' ')
-    }
-    if (cur && params.includes(cur[type])) {
-      return null
-    }
-    if (cur && typeof cur[type] !== 'undefined') {
-      cur = cur[type]
-    }
-    if (typeof cur !== 'string') {
-      cur = null
-    }
-    return cur
-  })
-  params = params.filter(Boolean).join(' ')
-  if (params === '') {
-    params = undefined
+  const resolved = params
+    .flatMap((cur) => {
+      if (Array.isArray(cur)) {
+        return cur
+      }
+      if (cur && typeof cur[type] !== 'undefined') {
+        return cur[type]
+      }
+      return cur
+    })
+    .filter((cur) => typeof cur === 'string')
+
+  const uniqueParams = Array.from(new Set(resolved)).join(' ')
+  if (uniqueParams === '') {
+    return undefined
   }
-  return params
+  return uniqueParams
 }
 
 export function findElementInChildren(children, find) {

--- a/packages/dnb-eufemia/src/shared/component-helper.ts
+++ b/packages/dnb-eufemia/src/shared/component-helper.ts
@@ -345,7 +345,7 @@ export function combineDescribedBy(...params) {
   return combineAriaBy('aria-describedby', params)
 }
 function combineAriaBy(type, params) {
-  const resolved = params
+  const ids = params
     .flatMap((cur) => {
       if (Array.isArray(cur)) {
         return cur
@@ -356,8 +356,12 @@ function combineAriaBy(type, params) {
       return cur
     })
     .filter((cur) => typeof cur === 'string')
+    // aria-labelledby/-describedby are space-separated id lists, so split and
+    // dedupe on individual ids
+    .flatMap((cur) => cur.split(/\s+/))
+    .filter(Boolean)
 
-  const uniqueParams = Array.from(new Set(resolved)).join(' ')
+  const uniqueParams = Array.from(new Set(ids)).join(' ')
   if (uniqueParams === '') {
     return undefined
   }


### PR DESCRIPTION
## Problem

`combineAriaBy`'s dedup check `params.includes(cur[type])` compared a resolved **string** id against the original **mixed-type** `params` array (objects/arrays/strings). It almost never matched, so the deduplication was effectively dead and duplicate ids could end up in `aria-labelledby`/`aria-describedby`.

## Fix

1. Resolve each argument to its string id(s) first — flattening arrays and reading the aria key from objects — then dedupe via a `Set`. All other behavior (object extraction, nullish/non-string filtering, empty → `undefined`) is preserved.

2. **Follow-up (review round): token-level dedup.** `aria-labelledby`/`aria-describedby` are space-separated id lists, so each resolved value is split on whitespace before de-duplicating. Duplicate ids are now removed even when they appear inside a multi-id string (e.g. combining an existing `'a b'` with `'a'` yields `'a b'`, not `'a b a'`).

## Verification

- Added direct unit tests (combining, object/array resolution, deduplication, token-level dedup, nullish handling, empty → undefined). Confirmed the dedup tests fail against the previous implementation and all pass with the fix.
- Because this helper is used by 28 files, ran the full consumer test suites — **1,395 tests pass** with no regressions: checkbox, radio, switch, textarea, toggle-button(+group), input, button, tabs, tooltip, popover, modal, dialog, card, slider, step-indicator, autocomplete, dropdown, date-picker, Field.MultiSelection, useFieldProps, and Form.Element.
