### PR TITLE
chore(InteractionInvalidation): rename shadowed selector param for clarity

### DIFF
--- a/packages/dnb-eufemia/src/shared/helpers/InteractionInvalidation.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/InteractionInvalidation.ts
@@ -173,11 +173,11 @@ export class InteractionInvalidation {
         // Check if node should be bypassed by elements or selectors
         const bypassedByElement = this.bypassElements.includes(node)
         const bypassedBySelector = this.bypassSelectors.some(
-          (selector) => {
+          (bypassSelector) => {
             try {
               // Handle wildcard selectors (ending with *)
-              if (selector.endsWith(' *')) {
-                const baseSelector = selector.replace(' *', '')
+              if (bypassSelector.endsWith(' *')) {
+                const baseSelector = bypassSelector.replace(' *', '')
                 const baseElement = (
                   targetElement || document.documentElement
                 ).querySelector(baseSelector)
@@ -186,7 +186,7 @@ export class InteractionInvalidation {
                 // Handle direct selectors
                 const matchingElement = (
                   targetElement || document.documentElement
-                ).querySelector(selector)
+                ).querySelector(bypassSelector)
                 return matchingElement && matchingElement.contains(node)
               }
             } catch (e) {


### PR DESCRIPTION
## Context

A code-quality finding flagged that the `bypassSelectors.some(...)` callback parameter `selector` shadows the outer `selector` variable (the full built CSS selector), suggesting `querySelector` used the wrong value.

## Assessment

This is **not a behavioral bug**: due to shadowing, every `selector` reference inside the callback resolves to the **parameter** (the correct per-iteration value), so `querySelector` already used the right selector. Verified by the existing bypass-selector tests (direct `.bypass-invalid` and wildcard `.bypass *`), which pass unchanged before and after.

## Change

Pure clarity refactor: rename the callback parameter to `bypassSelector` to remove the confusing shadowing. No behavior change.

## Verification

`InteractionInvalidation` suite: 13/13 passing, identical before and after the rename.