### PR TITLE
fix(NumberFormat): normalize whitespace separators for SSR hydration safety

### DIFF
--- a/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
+++ b/packages/dnb-eufemia/src/components/number-format/__tests__/NumberUtils.test.ts
@@ -931,6 +931,48 @@ describe('getThousandsSeparator should', () => {
   it('return space when locale is en-US', () => {
     expect(getThousandsSeparator('en-US')).toBe(',')
   })
+
+  it('never returns a narrow or thin space (ICU-version safe)', () => {
+    expect(getThousandsSeparator('fr-CH')).not.toMatch(
+      /[\u202F\u2009\u2007\u205F]/
+    )
+    expect(getThousandsSeparator('fr-FR')).not.toMatch(
+      /[\u202F\u2009\u2007\u205F]/
+    )
+  })
+})
+
+describe('separator normalization (SSR determinism)', () => {
+  // ICU changed the group/currency separator of several locales from a NO-BREAK
+  // SPACE to a NARROW NO-BREAK SPACE (e.g. `fr` in ICU 72). Node.js (SSR/build)
+  // and browsers can ship different ICU versions, so the separator is
+  // normalized to avoid React hydration mismatches.
+  it('normalizes narrow no-break spaces returned by Intl to a no-break space', () => {
+    const spy = vi
+      .spyOn(Intl.NumberFormat.prototype, 'formatToParts')
+      .mockReturnValue([
+        { type: 'integer', value: '1' },
+        { type: 'group', value: '\u202F' },
+        { type: 'integer', value: '234' },
+        { type: 'group', value: '\u202F' },
+        { type: 'integer', value: '567' },
+      ])
+
+    expect(formatNumber(1234567)).toBe('1\u00A0234\u00A0567')
+
+    spy.mockRestore()
+  })
+
+  it('never outputs narrow or thin space variants across locales', () => {
+    for (const loc of ['fr-FR', 'fr-CH', 'nb-NO', 'de-DE', 'en-GB']) {
+      expect(formatNumber(-12345678.9, { locale: loc })).not.toMatch(
+        /[\u202F\u2009\u2007\u205F]/
+      )
+      expect(
+        formatCurrency(-12345.6, { locale: loc, currency: 'NOK' })
+      ).not.toMatch(/[\u202F\u2009\u2007\u205F]/)
+    }
+  })
 })
 
 describe('getCurrencySymbol should', () => {

--- a/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
+++ b/packages/dnb-eufemia/src/components/number-format/utils/formatNumberCore.ts
@@ -14,6 +14,18 @@ import type {
   InternalNumberFormatOptions,
 } from './types'
 
+// ICU changed the group/currency separator of several locales from NO-BREAK
+// SPACE to NARROW NO-BREAK SPACE (e.g. `fr` in ICU 72). Since Node.js (SSR) and
+// browsers can ship different ICU versions, the same locale may render a
+// different separator on the server and the client, causing hydration
+// mismatches. Normalising these variants to NO-BREAK SPACE keeps the output
+// deterministic across environments.
+const NON_STANDARD_SPACES_REGEX = /[\u202f\u2009\u2007\u205f]/g
+
+function normalizeSeparatorSpaces(value: string): string {
+  return value.replace(NON_STANDARD_SPACES_REGEX, '\u00a0')
+}
+
 /**
  * Strips custom properties (e.g. `decimals`) so the object
  * is compatible with the native `Intl.NumberFormatOptions` type.
@@ -43,9 +55,17 @@ function getFormatParts({
       toIntlOptions(options || {})
     )
     if (typeof inst.formatToParts === 'function') {
-      return inst.formatToParts(Number(number))
+      return inst.formatToParts(Number(number)).map((part) => ({
+        ...part,
+        value: normalizeSeparatorSpaces(part.value),
+      }))
     }
-    return [{ value: inst.format(Number(number)), type: 'unknown' }]
+    return [
+      {
+        value: normalizeSeparatorSpaces(inst.format(Number(number))),
+        type: 'unknown',
+      },
+    ]
   }
 
   return [{ value: String(number), type: 'unknown' }]


### PR DESCRIPTION
## Summary

`NumberFormat` (and everything built on it — `Value.Currency`, `Value.Number`, `Field.Number`, `Slider`, etc.) rendered a locale's group/currency separator straight from `Intl.NumberFormat`. That character is **ICU-version dependent**: several locales switched from NO-BREAK SPACE (`U+00A0`) to NARROW NO-BREAK SPACE (`U+202F`) in ICU 72 (e.g. `fr`).

When the build/SSR environment (Node.js) and the visitor's browser ship different ICU versions, the same locale renders a **different separator on the server than on the client**, which triggers a React hydration mismatch (**error #418**).

This was observed on the docs portal: the `fr-CH`/`fr-FR` examples on the NumberFormat page render `-12<U+00A0>345…` in the pre-rendered HTML but `-12<U+202F>345…` in the browser.

## Fix

Normalize narrow/thin space variants (`U+202F`, `U+2009`, `U+2007`, `U+205F`) to a single NO-BREAK SPACE (`U+00A0`) at the `Intl.formatToParts` chokepoint (`getFormatParts`). This makes the output deterministic across ICU versions, so SSR and client always agree. Non-space separators (comma, dot, apostrophe for `de-CH`, etc.) are left untouched.

Because the normalization happens where every variant formatter (`formatNumber`, `formatCurrency`, `formatPercent`, `useNumberFormat`, `useNumberFormatWithParts`, `getThousandsSeparator`, …) reads its parts, all paths are covered by a single change.

## Tests

- New deterministic test mocking `Intl.NumberFormat.prototype.formatToParts` to return `U+202F` groups and asserting the output uses `U+00A0`.
- Invariant tests asserting the output never contains narrow/thin space variants across `fr-FR`, `fr-CH`, `nb-NO`, `de-DE`, `en-GB`.
- Full existing NumberFormat suite passes (518 tests), plus downstream `Value/Field` Currency+Number and Slider (278 tests).

## Notes

Found during a console/hydration audit of the docs portal. Related follow-ups (docs example hydration fixes) are tracked in separate PRs.
