### PR TITLE
fix(Portal): defer Icon transition support notice to avoid hydration mismatch

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -3,6 +3,7 @@
  *
  */
 
+import { useEffect, useState } from 'react'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
 import {
   bell_medium as BellMedium,
@@ -236,7 +237,15 @@ export function AllIconsTest() {
 }
 
 export function IconTransitionExample() {
-  const notSupported = !Icon.transition.isSupported && (
+  // Rendered after mount only: `Icon.transition.isSupported` relies on a
+  // browser-only CSS feature check, so evaluating it during SSR/first render
+  // would cause a hydration mismatch.
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  const notSupported = isMounted && !Icon.transition.isSupported && (
     <FormStatus state="warning" top>
       Your browser does not support CSS <code>d</code> path interpolation,
       so the icon transition will fall back to a simple crossfade.


### PR DESCRIPTION
## Summary

The Icon "transition" example rendered a `FormStatus` warning gated on `Icon.transition.isSupported`. That flag comes from a **browser-only CSS feature check** (`CSS.supports('d: path("M0 0")')`), so it is `false` during SSR/build and `true` in supporting browsers.

As a result the warning box was present in the pre-rendered HTML but absent after hydration, producing a React hydration mismatch (**error #418**) on the `/uilib/components/icon` page.

## Fix

Gate the notice behind a mounted flag (`useState` + `useEffect`) so that SSR and the first client render agree (both render nothing). The warning still appears after mount for browsers that don't support the feature.

## Notes

- No visual change in supporting browsers (the notice was already hidden there), so the `icon-transition` visual test is unaffected.
- Found during a console/hydration audit of the docs portal.
