### PR TITLE
fix(Portal): defer client-only media query examples to avoid hydration mismatch

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/Examples.tsx
@@ -187,8 +187,20 @@ export const MediaQueryUseMedia = () => (
   <ComponentBox scope={{ useMedia, useWindowWidth }} hideCode>
     {() => {
       const Playground = () => {
+        // `useMedia` and `window.innerWidth` are client-only, so their values
+        // differ between SSR and the first client render. Render after mount to
+        // avoid a hydration mismatch.
+        const [isMounted, setIsMounted] = useState(false)
+        useEffect(() => {
+          setIsMounted(true)
+        }, [])
+
         const { isSmall, isMedium, isLarge, isSSR } = useMedia()
         const { innerWidth } = useWindowWidth()
+
+        if (!isMounted) {
+          return null
+        }
 
         return (
           <Code>
@@ -211,6 +223,13 @@ export const MediaQueryLiveExample = () => (
   <ComponentBox scope={{ MediaQuery, useMediaQuery }} hideCode>
     {() => {
       const Playground = () => {
+        // `useMediaQuery`/`MediaQuery` are client-only, so render after mount to
+        // avoid a hydration mismatch.
+        const [isMounted, setIsMounted] = useState(false)
+        useEffect(() => {
+          setIsMounted(true)
+        }, [])
+
         const [query, updateQuery] = useState({
           screen: true,
           not: true,
@@ -231,6 +250,10 @@ export const MediaQueryLiveExample = () => (
         useEffect(() => {
           console.log('mediaQuery:', match1, match2)
         }, [match1, match2])
+
+        if (!isMounted) {
+          return null
+        }
 
         return (
           <>


### PR DESCRIPTION
## Summary

The live examples on the **Media Queries** page (`/uilib/layout/media-queries`) render values that only exist on the client:

- `MediaQueryUseMedia` prints `useMedia()`'s `isSSR` flag and `window.innerWidth`.
- `MediaQueryLiveExample` renders `<MediaQuery>` / `useMediaQuery` results driven by `matchMedia`.

`useMedia()` returns `isSSR: true` during SSR but `false` on the first client render, and `window.innerWidth` is `0` during SSR — so the pre-rendered HTML doesn't match the first client render, producing a React hydration mismatch (**error #418**).

## Fix

Gate both example playgrounds behind a mounted flag (`useState` + `useEffect`) so SSR and the first client render agree (both render nothing), and the reactive values render right after mount. `ComponentBox` already injects `useState`/`useEffect` into the live-example scope, so no scope changes are needed.

## Notes

- User-visible behavior after mount is unchanged (the values shown post-hydration are the same as before).
- Found during a console/hydration audit of the docs portal.
