### PR TITLE
chore(deps): bump js-yaml to 3.15.1 / 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,10 @@
     "picomatch@npm:4.0.3": "4.0.4",
     "node-gyp@npm:latest": "12.4.0",
     "axios@npm:^0.31.1": "0.33.0",
-    "js-yaml@npm:^3.10.0": "3.15.0",
-    "js-yaml@npm:^3.13.1": "3.15.0",
-    "js-yaml@npm:^4.1.0": "4.3.0",
-    "js-yaml@npm:^4.1.1": "4.3.0"
+    "js-yaml@npm:^3.10.0": "3.15.1",
+    "js-yaml@npm:^3.13.1": "3.15.1",
+    "js-yaml@npm:^4.1.0": "4.3.1",
+    "js-yaml@npm:^4.1.1": "4.3.1"
   },
   "engines": {
     "node": ">=24.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11328,26 +11328,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:3.15.0":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+"js-yaml@npm:3.15.1":
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2fdf3a1453ed93a8e06d6ca8054c0bec145cf40ab51f305d1071736a03668b95e40f47cfd0239d7d50019b4780a18cdaca3c935def935594c9876964c49f1185
+  checksum: 10/905842ce08c18b154ff2c187ff81bb41294cc5dda214331b5d9b8bcf395894e48b00fa37b9d4dd4c3ffec672b7496a94558e3876d3a8ad4d12b06248112e6d92
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:4.3.1":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
+  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes two open Dependabot alerts (**#549**, **#550**) for **js-yaml** — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (high severity). `resolveYamlOmap()` enforces key uniqueness for `!!omap` sequences with a linear `indexOf` scan inside the per-element loop, making resolution **O(n²)**. Parsing a modestly sized untrusted YAML document therefore consumes disproportionate CPU, enabling a denial of service. This is the same weakness as CVE-2026-59870, whose fix was not backported to the 3.x / 4.x lines until these releases.

Both versions currently pinned via `resolutions` were still in the vulnerable range:

| Line | Vulnerable range | Was pinned | Now pinned (first patched) |
|---|---|---|---|
| 3.x | `>= 3.0.0, < 3.15.1` | `3.15.0` | **`3.15.1`** |
| 4.x | `>= 4.0.0, < 4.3.1` | `4.3.0` | **`4.3.1`** |

## Changes

- Bumped the four existing `js-yaml` `resolutions` values in the root `package.json` (both `^3.x` keys → `3.15.1`, both `^4.x` keys → `4.3.1`).
- Regenerated `yarn.lock` (only the two `js-yaml` blocks changed).

## Verification

- The four resolution keys (`^3.10.0`, `^3.13.1`, `^4.1.0`, `^4.1.1`) exactly match every parent range requesting `js-yaml`, so all copies move.
- `yarn.lock` now contains only `js-yaml` `3.15.1` and `4.3.1` — no `3.15.0` / `4.3.0` remain.
- `yarn dedupe --check` passes (exit 0).
- Smoke test: `js-yaml` loads and parses YAML correctly.
- Consumers are all dev/build/docs tooling (`@eslint/eslintrc`, `@yarnpkg/parsers`, `cosmiconfig`, `front-matter`, `gray-matter`) — none ship in the `@dnb/eufemia` runtime bundle.
