### PR TITLE
chore: fix spelling and grammar inconsistencies in MDX files

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution.mdx
@@ -40,7 +40,7 @@ More information in [Style guides - Issue reporting](/contribute/style-guides/is
 
 ## How to submit a Pull Request
 
-After you have committed your changes in a branch, you can go to [Github Pull Requests](https://github.com/dnbexperience/eufemia/pulls) and open a new pull request.
+After you have committed your changes in a branch, you can go to [GitHub Pull Requests](https://github.com/dnbexperience/eufemia/pulls) and open a new pull request.
 In the pull request message, there will be a template that you fill out (including a summary of your changes and of the run tests). Request one of the maintainers as reviewers and submit your request.
 
 More information in [Style guides - Git convention](/contribute/style-guides/git#pull-requests).

--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -116,7 +116,7 @@ How to add support for each of these is explained in [Additional support - Getti
 
 Every component and extension should have a similar structure, as described here.
 
-As an example, we show the folder structure of component Breadcrumb. You can also check out the [source on Github](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/breadcrumb).
+As an example, we show the folder structure of component Breadcrumb. You can also check out the [source on GitHub](https://github.com/dnbexperience/eufemia/tree/main/packages/dnb-eufemia/src/components/breadcrumb).
 
 <InlineImg
   src="/images/folder-structure.png"

--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
@@ -98,12 +98,12 @@ git fetch origin && git rebase origin/main
 
 ## Pull Requests
 
-When you have committed changes to your branch, go to [Github Pull Requests](https://github.com/dnbexperience/eufemia/pulls) and open a `New pull request`.
+When you have committed changes to your branch, go to [GitHub Pull Requests](https://github.com/dnbexperience/eufemia/pulls) and open a `New pull request`.
 
 <InlineImg
   src="/images/pull-request.png"
   width="900"
-  alt="Screenshot of the location of new pull request button on Github"
+  alt="Screenshot of the location of new pull request button on GitHub"
   top
   bottom
 />
@@ -113,7 +113,7 @@ You will most likely get the yellow notification bar mentioning that a branch ha
 <InlineImg
   src="/images/pull-request-part-2.png"
   width="900"
-  alt="Screenshot of opening a new pull request on Github"
+  alt="Screenshot of opening a new pull request on GitHub"
   top
   bottom
 />

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/living-system.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/living-system.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Living system'
-description: "Eufemia is DNB's design system. It is constantly evolving and improving and is our single source of truth for UI design and front-end code."
+description: "Eufemia is DNB's design system. It is constantly evolving and improving and is our single source of truth for UI design and frontend code."
 order: 2
 ---
 
@@ -8,7 +8,7 @@ order: 2
 
 ## What is a living design system?
 
-Eufemia, DNB's design system, is a UI collection of components, rules, principles, constraints, and best practices for UI design and front-end code, and is subject to continuous improvement over time.
+Eufemia, DNB's design system, is a UI collection of components, rules, principles, constraints, and best practices for UI design and frontend code, and is subject to continuous improvement over time.
 
 ### In a practical manner
 
@@ -25,7 +25,7 @@ A design system like Eufemia is the single source of truth for UI assets and com
 
 ## Knowledge pool
 
-We at DNB UX embrace the DNB core vision and main goals: _Do less, do better_ and _Increase user experience_. To meet these goals, Eufemia has as a core value to increase knowledge of front-end development, UX design, and accessibility. This means that Eufemia will always be under continuous improvement and QA.
+We at DNB UX embrace the DNB core vision and main goals: _Do less, do better_ and _Increase user experience_. To meet these goals, Eufemia has as a core value to increase knowledge of frontend development, UX design, and accessibility. This means that Eufemia will always be under continuous improvement and QA.
 
 ## Maintainability
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge/demos.mdx
@@ -34,7 +34,7 @@ The default variant. Equivalent to `variant='information'`.
 
 <BadgeNotificationInline />
 
-### Overlayed badge
+### Overlaid badge
 
 You can overlay the badge on top of an element by wrapping the `<Badge>` component around it.
 
@@ -57,7 +57,7 @@ The default state is equivalent to `status='default'` and `subtle={false}`.
 
 ### Hiding Badge with `hideBadge`
 
-Sometimes you need to hide the badge without hiding the overlayed element. To make this less complicated you can use the `hideBadge` property.
+Sometimes you need to hide the badge without hiding the overlaid element. To make this less complicated you can use the `hideBadge` property.
 
 The example below hides the badge when there are no notifications. You can add or remove notifications with the "+" and "-" buttons.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/badge/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/badge/info.mdx
@@ -10,7 +10,7 @@ import { Badge } from '@dnb/eufemia'
 
 ## Description
 
-Badge can be overlayed on another element by wrapping it, or can be a standalone badge.
+Badge can be overlaid on another element by wrapping it, or can be a standalone badge.
 
 ## Relevant links
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/about-fields.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/about-fields.mdx
@@ -54,7 +54,7 @@ These components are data-driven React components—named and structured—accor
 - **toggle category**—which consists of field types that allow the user to toggle between two values, such as `true` and `false`:
   <ListBaseToggleComponents />
 
-On top of these, a number of [feature fields](#feature-fields) have been built that have special functionality based on given types of data, such as bank account numbers, e-mails and social security numbers.
+On top of these, a number of [feature fields](#feature-fields) have been built that have special functionality based on given types of data, such as bank account numbers, emails and social security numbers.
 
 ## Feature fields
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/best-practices/for-testing.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/best-practices/for-testing.mdx
@@ -23,7 +23,7 @@ Frontend code is changing and moving fast. So 100% code coverage should never be
 
 ### Integration tests
 
-Do not write unit tests in frontend code. But make integration tests. Avoid testing implementation details, but rather treat front-end related components as an independent, changeable and maintainable individuals.
+Do not write unit tests in frontend code. But make integration tests. Avoid testing implementation details, but rather treat frontend-related components as independent, changeable and maintainable individuals.
 
 Think as a user. Think how the user will interact with your application. Do not shallow test, but test components like a user would interact (use mount or render to also test their children).
 


### PR DESCRIPTION
## Summary

Fixes minor spelling and grammar inconsistencies found across the documentation `.mdx` files. Changes align prose with the docs' dominant American-English conventions and correct a few nonstandard spellings and one grammar error. No links, routes, code identifiers, CSS token names, or external URLs were changed.

## Changes

- **`Github` → `GitHub`** (proper-noun capitalization) in the contribution guide and Git style guide (link text and image `alt` text). The `github.com` URLs are unchanged.
- **`front-end` → `frontend`** to match the dominant spelling (18 vs 4 occurrences). In `for-testing.mdx` this also fixes an article/plural agreement error ("treat … components as an … individuals" → "as … individuals").
- **`overlayed` → `overlaid`** (standard past participle of "overlay") in the Badge docs.
- **`e-mails` → `emails`** to match the dominant spelling (`email` is used 33× vs 4× for the hyphenated form).

## Scope / intentionally left unchanged

These look like inconsistencies but are correct as-is:

- `customisation` — a real docs folder/route name used in links and imports (e.g. `/uilib/usage/customisation/...`).
- British spellings inside external URLs (e.g. `colour_contrast`, brreg.no `organisasjonsnummeret`), the EU "Data Visualisation Guide" proper noun, CSS token names (`--dnb-greyscale-*`), and an asset filename (`icon-nearest-neighbour.svg`).
- `EUFEMIA_CHANGELOG.mdx` and version release-note files were not edited.

Verified with `cspell` (no genuine prose typos remain) and a duplicate-word / article scan (clean). Prettier reports all files unchanged.
