### PR TITLE
chore(tools): add explicit Vitest config to mcp-lambda

### DIFF
--- a/tools/mcp-lambda/vitest.config.ts
+++ b/tools/mcp-lambda/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    reporters: ['default'],
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx,js,jsx}'],
+  },
+})


### PR DESCRIPTION
## Description

Follow-up to #8910 / #8912. While auditing config consistency across the `tools/` workspaces, `mcp-lambda` was the only Vitest-based tool without an explicit `vitest.config.ts` — it relied on Vitest defaults, while `eufemia-llm-metadata` and `markdown-tables-utils` both define one.

## Changes

- Add `tools/mcp-lambda/vitest.config.ts` mirroring the sibling tools: `node` environment, default reporter, and an explicit `src/**/*.test.*` include.

The tests already import `describe`/`it`/`expect` from `vitest` and use the Node environment, so this only makes the existing behaviour explicit.

## Verification

- `yarn workspace @dnb/eufemia-mcp test` — 5 files, 53 tests passing (unchanged from before).

## Intentionally out of scope

To keep this to a safe, no-churn consistency fix, the following config gaps were evaluated and deliberately left alone:

- **`tsconfig.json` for `repo-utils` / `markdown-tables-utils`** — their sources are intentionally loosely typed (implicit `any`); adding a `tsconfig` extending the shared config would surface type errors and require unrelated typing work.
- **`eslint` / `tsconfig` for `react-live-ssr`** — this is a vendored, temporary copy of `react-live` (ships a pre-built `dist/`); it shouldn't be linted/type-checked as first-party code.
- **SCSS partial naming in `components/grid/style/`** (`grid-container.scss`, `grid-item.scss`) — these are `@use`-only partials and already follow the existing "no `dnb-` prefix on sub-partials" convention (e.g. `button--tertiary.scss`), so they are not an inconsistency.
