### PR TITLE
chore(Portal): keep decorative heading anchor out of the keyboard tab order

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -69,9 +69,7 @@ const AutoLinkHeader = ({
             href={`#${id}`}
             onClick={clickHandler}
             aria-hidden
-            // Decorative mouse-only affordance: keep it out of the keyboard
-            // tab order (it is aria-hidden, and a focusable aria-hidden
-            // element would let Tab land on it instead of the next element).
+            // aria-hidden decorative affordance: keep out of the tab order
             tabIndex={-1}
           >
             #

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -69,6 +69,10 @@ const AutoLinkHeader = ({
             href={`#${id}`}
             onClick={clickHandler}
             aria-hidden
+            // Decorative mouse-only affordance: keep it out of the keyboard
+            // tab order (it is aria-hidden, and a focusable aria-hidden
+            // element would let Tab land on it instead of the next element).
+            tabIndex={-1}
           >
             #
           </Anchor>

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+
+vi.mock('../AutoLinkHeader.module.scss', () => ({
+  anchorLinkStyle: 'anchorLinkStyle',
+}))
+
+import AutoLinkHeader from '../AutoLinkHeader'
+
+afterEach(cleanup)
+
+function renderHeader(props = {}) {
+  return render(
+    <MemoryRouter>
+      <AutoLinkHeader level={1} {...props}>
+        My Heading
+      </AutoLinkHeader>
+    </MemoryRouter>
+  )
+}
+
+describe('AutoLinkHeader', () => {
+  it('renders the decorative "#" anchor inside the heading', () => {
+    renderHeader()
+
+    const anchor = document.querySelector('.anchor-hash')
+
+    expect(anchor).toBeTruthy()
+    expect(anchor?.getAttribute('href')).toBe('#my-heading')
+  })
+
+  it('keeps the decorative "#" anchor out of the keyboard tab order', () => {
+    // Regression: the anchor is only revealed on :hover, so a leftover
+    // pointer hover after a click-navigation could make it tabbable and let
+    // Tab land on it instead of the next element (e.g. the page tablist).
+    renderHeader()
+
+    const anchor = document.querySelector('.anchor-hash')
+
+    expect(anchor?.getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('hides the decorative "#" anchor from assistive technology', () => {
+    renderHeader()
+
+    const anchor = document.querySelector('.anchor-hash')
+
+    expect(anchor?.getAttribute('aria-hidden')).toBe('true')
+  })
+})


### PR DESCRIPTION
## Summary

Reduces the flakiness of `yarn workspace dnb-design-system-portal test:e2e:portal:ci`, specifically `src/e2e/routeFocus.spec.ts` › **"should focus content when navigating to a route without hash"**, which fails intermittently (e.g. [this run](https://github.com/dnbexperience/eufemia/actions/runs/31161203599/job/92811723319)).

## Root cause

`AutoLinkHeader` renders a decorative `#` anchor as the first child of every heading:

```tsx
<Anchor className="anchor-hash" href={`#${id}`} aria-hidden>#</Anchor>
```

It is `aria-hidden` and hidden with `visibility: hidden` (so normally not tabbable), and only revealed on `:hover`. But it is a **real focusable `<a href>`**.

The flaky test navigates by **clicking** a link. Playwright leaves the mouse pointer where it clicked, and after the client-side navigation that pointer can end up hovering the new page's heading. In Firefox, `:hover` recomputation for a stationary pointer over swapped DOM is inconsistent — when it does apply, the `anchor-hash` becomes `visibility: visible` and therefore **tabbable**. So `Tab` from the focused page `h1` lands on the in-heading `#` anchor instead of the page tablist, and the assertion:

```ts
await expect
  .poll(() => tabList.evaluate((el) => el.contains(document.activeElement)))
  .toBe(true)
```

never becomes true (times out). This matches the observed pattern: fails deterministically for a whole run (stable hover state) but only "every now and then" across runs (layout/timing dependent). The sibling test that navigates via `page.goto(...)` is unaffected because the pointer stays neutral.

## Fix

Add `tabIndex={-1}` to the decorative anchor so it is **never** a keyboard tab stop. `Tab` from the heading now deterministically moves to the next real element (the tablist), regardless of hover state.

This also fixes a genuine accessibility issue: a focusable `aria-hidden="true"` element (flagged by axe rule `aria-hidden-focus`). Mouse users can still hover and click the `#` to set the URL hash.

## Testing

- Added `src/shared/tags/__tests__/AutoLinkHeader.test.tsx` asserting the decorative anchor renders with `tabindex="-1"` and `aria-hidden="true"`.
- `AutoLinkHeader.test.tsx` and the existing `vite/__tests__/route-focus.test.ts` pass.
- Prettier + ESLint clean on the changed files.
