### PR TITLE
chore(analytics): add S3 + Athena analytics storage tool

### DIFF
--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -8,7 +8,7 @@ name: Analytics Lambda
 #
 # Triggers:
 # - `release` branch and `v*` / `v*.*.*` tags — deploys automatically.
-# - Any branch named `**/analytics` (e.g. `feat/analytics`).
+# - Any branch under the `analytics/` prefix (e.g. `analytics/new-field`).
 # - `workflow_dispatch` — manual deploy from the Actions tab.
 #
 # See tools/analytics/README.md for deploy details.
@@ -17,7 +17,7 @@ on:
   push:
     branches:
       - release
-      - '**/analytics'
+      - 'analytics/**'
     tags:
       - 'v*'
       - 'v*.*.*'

--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -1,0 +1,159 @@
+name: Analytics Lambda
+
+# Build, test and deploy the Eufemia analytics service as an AWS Lambda function.
+#
+# This workflow runs tests and builds the Lambda zip on public GitHub,
+# then pushes the built artifact + Terraform config to a GitHub Enterprise
+# repository where OIDC federation handles AWS authentication.
+#
+# Triggers:
+# - `release` branch and `v*` / `v*.*.*` tags — deploys automatically.
+# - Any branch named `**/analytics` (e.g. `feat/analytics`).
+# - `workflow_dispatch` — manual deploy from the Actions tab.
+#
+# Requires the following GitHub secrets:
+# - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
+# - GHE_ANALYTICS_DEPLOY_REPO: The GHE repo (e.g. `eufemia/eufemia-analytics`)
+#
+# See tools/analytics/README.md for manual deploy instructions.
+
+on:
+  push:
+    branches:
+      - release
+      - '**/analytics'
+    tags:
+      - 'v*'
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: 'package.json'
+
+      - name: Use node_modules cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        id: modules-cache
+        with:
+          path: |
+            node_modules
+            tools/analytics/node_modules
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
+
+      - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Typecheck
+        run: cd tools/analytics && yarn test:types
+
+      - name: Lint
+        run: cd tools/analytics && yarn lint
+
+      - name: Run tests
+        run: cd tools/analytics && yarn test
+
+  build-and-push:
+    name: Build & Push to GHE
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: 'package.json'
+
+      - name: Use node_modules cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        id: modules-cache
+        with:
+          path: |
+            node_modules
+            tools/analytics/node_modules
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
+
+      - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Skip if GHE credentials are missing
+        id: gate
+        env:
+          GHE_PAT: ${{ secrets.GHE_DEPLOY_PAT }}
+        run: |
+          if [ -z "${GHE_PAT:-}" ]; then
+            echo "GHE_DEPLOY_PAT is not set; skipping push."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Lambda zip
+        if: steps.gate.outputs.skip != 'true'
+        run: cd tools/analytics && yarn build
+
+      - name: Push to GHE deploy repo
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          GHE_PAT: ${{ secrets.GHE_DEPLOY_PAT }}
+          GHE_REPO: ${{ secrets.GHE_ANALYTICS_DEPLOY_REPO }}
+          SOURCE_REF: ${{ github.ref_name }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          DEPLOY_DIR=$(mktemp -d)
+          cd "$DEPLOY_DIR"
+
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Copy the built zip and Terraform config, preserving the
+          # dist/ + infra/ layout that main.tf expects (../dist/lambda.zip)
+          mkdir -p dist
+          cp "$GITHUB_WORKSPACE/tools/analytics/dist/lambda.zip" dist/
+          cp -R "$GITHUB_WORKSPACE/tools/analytics/infra" .
+
+          # Include the deploy workflow so it lives on (and triggers from) the deploy branch
+          mkdir -p .github/workflows
+          cp "$GITHUB_WORKSPACE/tools/analytics/ghe-deploy-workflow.yml" .github/workflows/deploy.yml
+
+          git add -A
+          git commit -m "Deploy from ${SOURCE_REF} (${SOURCE_SHA:0:7})"
+
+          # Authenticate via a per-invocation http.extraheader instead of
+          # embedding the PAT in the remote URL. This keeps the token out of
+          # .git/config on disk and out of the stored remote URL.
+          AUTH_HEADER=$(printf 'x-access-token:%s' "$GHE_PAT" | base64 | tr -d '\n')
+          git -c http.extraheader="AUTHORIZATION: basic ${AUTH_HEADER}" \
+            push "https://dnb.ghe.com/${GHE_REPO}.git" HEAD:refs/heads/deploy --force

--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -61,6 +61,11 @@ jobs:
         if: steps.modules-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
+      - name: Audit dependencies
+        # Audit the shipped (production) dep tree to catch known advisories,
+        # matching the MCP pipeline and the EDS-823 supply-chain work.
+        run: yarn workspace eufemia-analytics audit:ci
+
       - name: Typecheck
         run: cd tools/analytics && yarn test:types
 

--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -11,10 +11,7 @@ name: Analytics Lambda
 # - Any branch named `**/analytics` (e.g. `feat/analytics`).
 # - `workflow_dispatch` — manual deploy from the Actions tab.
 #
-# Requires the following GitHub secrets:
-# - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
-# - GHE_ANALYTICS_DEPLOY_REPO: The GHE repo (e.g. `eufemia/eufemia-analytics`)
-#
+# See tools/analytics/README.md for deploy details.
 # See tools/analytics/README.md for manual deploy instructions.
 
 on:
@@ -125,11 +122,23 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         env:
           GHE_PAT: ${{ secrets.GHE_DEPLOY_PAT }}
-          GHE_REPO: ${{ secrets.GHE_ANALYTICS_DEPLOY_REPO }}
+          GHE_REPO: ${{ vars.GHE_ANALYTICS_DEPLOY_REPO }}
           SOURCE_REF: ${{ github.ref_name }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+
+          # Fail loudly on a misconfigured GHE_REPO (e.g. a token pasted where
+          # owner/repo belongs) instead of an opaque SSO redirect on push.
+          if [[ ! "$GHE_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+            echo "::error::GHE_ANALYTICS_DEPLOY_REPO must be 'owner/repo' (got ${#GHE_REPO} chars)."
+            exit 1
+          fi
+          case "$GHE_REPO" in
+            github_pat_*|ghp_*|gho_*|ghs_*)
+              echo "::error::GHE_ANALYTICS_DEPLOY_REPO looks like a token, not a repo name."
+              exit 1 ;;
+          esac
 
           DEPLOY_DIR=$(mktemp -d)
           cd "$DEPLOY_DIR"

--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -12,7 +12,6 @@ name: Analytics Lambda
 # - `workflow_dispatch` — manual deploy from the Actions tab.
 #
 # See tools/analytics/README.md for deploy details.
-# See tools/analytics/README.md for manual deploy instructions.
 
 on:
   push:

--- a/tools/analytics/.gitignore
+++ b/tools/analytics/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+
+# Terraform
+infra/.terraform/
+*.tfstate
+*.tfstate.*
+terraform.tfvars

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -73,7 +73,7 @@ public GitHub (.github/workflows/analytics-lambda.yml)
           → OIDC assume role → terraform apply
 ```
 
-- **Triggers** (`analytics-lambda.yml`): the `release` branch, any `**/analytics` branch, `v*` tags, or manual `workflow_dispatch`.
+- **Triggers** (`analytics-lambda.yml`): the `release` branch, any `analytics/**` branch, `v*` tags, or manual `workflow_dispatch`.
 - The public workflow copies `ghe-deploy-workflow.yml` onto the GHE `deploy` branch, so the deploy job is self-installing — no manual workflow setup in the GHE repo.
 - On forks and PRs without deploy credentials, the build-and-push step is skipped (tests still run).
 

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -75,20 +75,11 @@ public GitHub (.github/workflows/analytics-lambda.yml)
 
 - **Triggers** (`analytics-lambda.yml`): the `release` branch, any `**/analytics` branch, `v*` tags, or manual `workflow_dispatch`.
 - The public workflow copies `ghe-deploy-workflow.yml` onto the GHE `deploy` branch, so the deploy job is self-installing — no manual workflow setup in the GHE repo.
-- If `GHE_DEPLOY_PAT` is unset, the build-and-push step is skipped (tests still run), so forks and PRs are safe.
+- On forks and PRs without deploy credentials, the build-and-push step is skipped (tests still run).
 
 ### Required configuration
 
-On the **public repo** (secrets):
-
-- `GHE_DEPLOY_PAT` — GHE PAT with repo + workflow push scope (shared with the MCP pipeline).
-- `GHE_ANALYTICS_DEPLOY_REPO` — the GHE deploy repo, e.g. `eufemia/eufemia-analytics`.
-
-On the **GHE deploy repo** (variables/secrets):
-
-- `AWS_ROLE_ARN` (variable) — the OIDC deploy role to assume.
-- `COST_ALLOCATION` (variable) — passed as `TF_VAR_cost_allocation`.
-- `API_TOKEN` (secret, optional) — passed as `TF_VAR_api_token` to enable bearer auth.
+Deploy credentials and configuration are provided via repository secrets and variables (managed in the repository settings), not stored in this repo.
 
 ### One-time bootstrap (admin, out-of-band)
 

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -1,0 +1,74 @@
+# Eufemia Analytics (AWS Lambda)
+
+Minimal service to store and retrieve analytics records in AWS, deployed as an AWS Lambda function behind API Gateway.
+
+## Architecture
+
+```
+POST /records → API Gateway HTTP API → Lambda (Node.js 22) → S3 (records/dt=YYYY-MM-DD/<id>.json)
+GET  /records → API Gateway HTTP API → Lambda (Node.js 22) → Athena (Glue table w/ partition projection) → S3
+```
+
+Records are written to S3 as one JSON object per record, partitioned by date. A Glue table with partition projection lets Athena query them without `MSCK`/`ADD PARTITION`. The Lambda is stateless.
+
+## HTTP API
+
+| Route           | Auth   | Description                                             |
+| --------------- | ------ | ------------------------------------------------------- |
+| `GET /healthz`  | open   | Liveness probe                                          |
+| `POST /records` | bearer | Store a record: `{ "id", "name", "value" }`             |
+| `GET /records`  | bearer | Retrieve records; optional `?id=` and `?limit=` filters |
+
+Auth is a bearer token compared against the `API_TOKEN` environment variable. When `API_TOKEN` is unset, auth is disabled (local/demo only).
+
+### Record shape
+
+`id`, `name` and `value` are supplied by the caller; `createdAt` is stamped by the service.
+
+```json
+{
+  "id": "abc-1",
+  "name": "Widget",
+  "value": 42,
+  "createdAt": "2026-08-07T09:00:00.000Z"
+}
+```
+
+`id` must match `^[A-Za-z0-9._-]{1,128}$`, `name` is at most 256 characters, and `value` must be a finite number.
+
+## Prerequisites
+
+- Node.js — the repo pins Node via Volta for local development; the deployed Lambda runtime is Node 22
+- Yarn (workspace-aware)
+- AWS CLI configured with appropriate credentials
+- Terraform >= 1.10
+
+## Local development
+
+```bash
+yarn test        # run the unit tests
+yarn test:types  # type-check
+yarn lint        # lint
+```
+
+## Build & deploy
+
+```bash
+yarn build        # bundle src/lambda/index.ts → dist/lambda.zip
+yarn deploy:plan  # build + terraform plan
+yarn deploy       # build + terraform apply
+```
+
+Copy `infra/terraform.tfvars.example` to `infra/terraform.tfvars` and fill in `cost_allocation` (and `api_token` to enable auth). `terraform.tfvars` is gitignored.
+
+## Infrastructure
+
+`infra/` provisions:
+
+- **S3 bucket** (versioned, SSE-S3, public access blocked) holding both records (`records/`) and Athena output (`athena-results/`, expired after 7 days).
+- **Glue database + table** with JSON SerDe and partition projection on `dt`.
+- **Athena workgroup** for the retrieve queries.
+- **Lambda function** (`nodejs22.x`) — its execution role is pre-created out-of-band, because the OIDC deploy role's permissions boundary forbids `iam:CreateRole` (ADR 0004); it is only referenced here.
+- **API Gateway HTTP API** with the two `/records` routes and throttling.
+
+Terraform state reuses the shared `eufemia-mcp-terraform-state` bucket under the `analytics/` key.

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -51,7 +51,7 @@ yarn test:types  # type-check
 yarn lint        # lint
 ```
 
-## Build & deploy
+## Build & deploy (manual)
 
 ```bash
 yarn build        # bundle src/lambda/index.ts → dist/lambda.zip
@@ -60,6 +60,39 @@ yarn deploy       # build + terraform apply
 ```
 
 Copy `infra/terraform.tfvars.example` to `infra/terraform.tfvars` and fill in `cost_allocation` (and `api_token` to enable auth). `terraform.tfvars` is gitignored.
+
+## CI/CD deploy (two-repo flow)
+
+Deployment mirrors the MCP Lambda pattern: public GitHub builds and tests, then hands off to GitHub Enterprise where OIDC federation authenticates to AWS.
+
+```
+public GitHub (.github/workflows/analytics-lambda.yml)
+  → test + build lambda.zip
+  → force-push dist/ + infra/ + deploy workflow to GHE repo `deploy` branch
+      → GHE (ghe-deploy-workflow.yml as .github/workflows/deploy.yml)
+          → OIDC assume role → terraform apply
+```
+
+- **Triggers** (`analytics-lambda.yml`): the `release` branch, any `**/analytics` branch, `v*` tags, or manual `workflow_dispatch`.
+- The public workflow copies `ghe-deploy-workflow.yml` onto the GHE `deploy` branch, so the deploy job is self-installing — no manual workflow setup in the GHE repo.
+- If `GHE_DEPLOY_PAT` is unset, the build-and-push step is skipped (tests still run), so forks and PRs are safe.
+
+### Required configuration
+
+On the **public repo** (secrets):
+
+- `GHE_DEPLOY_PAT` — GHE PAT with repo + workflow push scope (shared with the MCP pipeline).
+- `GHE_ANALYTICS_DEPLOY_REPO` — the GHE deploy repo, e.g. `eufemia/eufemia-analytics`.
+
+On the **GHE deploy repo** (variables/secrets):
+
+- `AWS_ROLE_ARN` (variable) — the OIDC deploy role to assume.
+- `COST_ALLOCATION` (variable) — passed as `TF_VAR_cost_allocation`.
+- `API_TOKEN` (secret, optional) — passed as `TF_VAR_api_token` to enable bearer auth.
+
+### One-time bootstrap (admin, out-of-band)
+
+Because the OIDC deploy role's permissions boundary forbids `iam:CreateRole` (ADR 0004), an admin must pre-create the Lambda execution role `eufemia-<env>-analytics-role` (trust policy for Lambda + `AWSLambdaBasicExecutionRole`) with an attached policy granting: `s3:GetObject`/`PutObject`/`ListBucket` on the data bucket, `athena:StartQueryExecution`/`GetQueryExecution`/`GetQueryResults` on the workgroup, and `glue:GetTable`/`GetDatabase`/`GetPartitions` on the analytics database/table. The GHE deploy repo and its OIDC role/federation entry must also be provisioned, as with the MCP pipeline.
 
 ## Infrastructure
 

--- a/tools/analytics/__tests__/http.test.ts
+++ b/tools/analytics/__tests__/http.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { isAuthorized } from '../src/lambda/http.js'
+
+describe('isAuthorized', () => {
+  const original = process.env.API_TOKEN
+
+  beforeEach(() => {
+    delete process.env.API_TOKEN
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.API_TOKEN
+    } else {
+      process.env.API_TOKEN = original
+    }
+  })
+
+  it('allows any request when API_TOKEN is not set', () => {
+    expect(isAuthorized(undefined)).toBe(true)
+    expect(isAuthorized({})).toBe(true)
+  })
+
+  it('accepts a matching bearer token', () => {
+    process.env.API_TOKEN = 'secret-token'
+
+    expect(isAuthorized({ authorization: 'Bearer secret-token' })).toBe(
+      true
+    )
+    expect(isAuthorized({ Authorization: 'Bearer secret-token' })).toBe(
+      true
+    )
+  })
+
+  it('rejects a wrong token', () => {
+    process.env.API_TOKEN = 'secret-token'
+
+    expect(isAuthorized({ authorization: 'Bearer nope' })).toBe(false)
+  })
+
+  it('rejects a missing or malformed header', () => {
+    process.env.API_TOKEN = 'secret-token'
+
+    expect(isAuthorized(undefined)).toBe(false)
+    expect(isAuthorized({})).toBe(false)
+    expect(isAuthorized({ authorization: 'secret-token' })).toBe(false)
+    expect(isAuthorized({ authorization: 'Basic secret-token' })).toBe(
+      false
+    )
+  })
+})

--- a/tools/analytics/__tests__/index.test.ts
+++ b/tools/analytics/__tests__/index.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { APIGatewayProxyEventV2 } from 'aws-lambda'
+
+const { storeRecord, retrieveRecords } = vi.hoisted(() => ({
+  storeRecord: vi.fn(),
+  retrieveRecords: vi.fn(),
+}))
+
+vi.mock('../src/lambda/store.js', () => ({ storeRecord }))
+vi.mock('../src/lambda/retrieve.js', () => ({
+  retrieveRecords,
+  InvalidQueryError: class InvalidQueryError extends Error {},
+}))
+
+import { handler } from '../src/lambda/index.js'
+import { InvalidQueryError } from '../src/lambda/retrieve.js'
+
+type Response = { statusCode: number; body: string }
+
+function event(
+  method: string,
+  path: string,
+  opts: {
+    body?: string
+    isBase64Encoded?: boolean
+    headers?: Record<string, string | undefined>
+    query?: Record<string, string | undefined>
+  } = {}
+): APIGatewayProxyEventV2 {
+  return {
+    rawPath: path,
+    headers: opts.headers ?? {},
+    queryStringParameters: opts.query,
+    requestContext: { http: { method } },
+    body: opts.body,
+    isBase64Encoded: opts.isBase64Encoded ?? false,
+  } as unknown as APIGatewayProxyEventV2
+}
+
+const auth = { authorization: 'Bearer secret' }
+
+async function invoke(event: APIGatewayProxyEventV2): Promise<Response> {
+  return (await handler(event)) as Response
+}
+
+describe('handler', () => {
+  beforeEach(() => {
+    storeRecord.mockReset()
+    retrieveRecords.mockReset()
+    process.env.API_TOKEN = 'secret'
+  })
+
+  afterEach(() => {
+    delete process.env.API_TOKEN
+  })
+
+  it('serves /healthz without auth', async () => {
+    const res = await invoke(event('GET', '/healthz'))
+
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' })
+  })
+
+  it('rejects unauthenticated requests to /records', async () => {
+    const res = await invoke(event('POST', '/records', { body: '{}' }))
+
+    expect(res.statusCode).toBe(401)
+    expect(storeRecord).not.toHaveBeenCalled()
+  })
+
+  it('stores a valid record and returns 201', async () => {
+    const stored = {
+      id: 'abc',
+      name: 'W',
+      value: 1,
+      createdAt: '2026-08-07T00:00:00.000Z',
+    }
+    storeRecord.mockResolvedValue(stored)
+
+    const res = await invoke(
+      event('POST', '/records', {
+        headers: auth,
+        body: JSON.stringify({ id: 'abc', name: 'W', value: 1 }),
+      })
+    )
+
+    expect(res.statusCode).toBe(201)
+    expect(JSON.parse(res.body)).toEqual(stored)
+    expect(storeRecord).toHaveBeenCalledWith({
+      id: 'abc',
+      name: 'W',
+      value: 1,
+    })
+  })
+
+  it('decodes a base64-encoded body', async () => {
+    storeRecord.mockResolvedValue({})
+
+    await invoke(
+      event('POST', '/records', {
+        headers: auth,
+        body: Buffer.from(
+          JSON.stringify({ id: 'abc', name: 'W', value: 1 })
+        ).toString('base64'),
+        isBase64Encoded: true,
+      })
+    )
+
+    expect(storeRecord).toHaveBeenCalledWith({
+      id: 'abc',
+      name: 'W',
+      value: 1,
+    })
+  })
+
+  it('returns 400 for an invalid JSON body', async () => {
+    const res = await invoke(
+      event('POST', '/records', { headers: auth, body: 'not json' })
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(storeRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 with details when validation fails', async () => {
+    const res = await invoke(
+      event('POST', '/records', {
+        headers: auth,
+        body: JSON.stringify({ id: '', name: '', value: 'nope' }),
+      })
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(JSON.parse(res.body).error).toBe('Validation failed')
+    expect(storeRecord).not.toHaveBeenCalled()
+  })
+
+  it('retrieves records with the id and limit filters', async () => {
+    retrieveRecords.mockResolvedValue([{ id: 'abc' }])
+
+    const res = await invoke(
+      event('GET', '/records', {
+        headers: auth,
+        query: { id: 'abc', limit: '5' },
+      })
+    )
+
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.body)).toEqual({ records: [{ id: 'abc' }] })
+    expect(retrieveRecords).toHaveBeenCalledWith({ id: 'abc', limit: 5 })
+  })
+
+  it('returns 400 for a non-numeric limit', async () => {
+    const res = await invoke(
+      event('GET', '/records', {
+        headers: auth,
+        query: { limit: 'abc' },
+      })
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(retrieveRecords).not.toHaveBeenCalled()
+  })
+
+  it('maps InvalidQueryError to 400', async () => {
+    retrieveRecords.mockRejectedValue(new InvalidQueryError('bad id'))
+
+    const res = await invoke(
+      event('GET', '/records', { headers: auth, query: { id: '!' } })
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(JSON.parse(res.body).error).toBe('bad id')
+  })
+
+  it('returns 404 for an unknown route', async () => {
+    const res = await invoke(event('GET', '/nope', { headers: auth }))
+
+    expect(res.statusCode).toBe(404)
+  })
+})

--- a/tools/analytics/__tests__/retrieve.test.ts
+++ b/tools/analytics/__tests__/retrieve.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  clampLimit,
+  retrieveRecords,
+  InvalidQueryError,
+} from '../src/lambda/retrieve.js'
+
+describe('clampLimit', () => {
+  it('defaults when no limit is given', () => {
+    expect(clampLimit(undefined)).toBe(100)
+  })
+
+  it('defaults for non-finite values', () => {
+    expect(clampLimit(NaN)).toBe(100)
+    expect(clampLimit(Infinity)).toBe(100)
+  })
+
+  it('clamps to at least 1', () => {
+    expect(clampLimit(0)).toBe(1)
+    expect(clampLimit(-5)).toBe(1)
+  })
+
+  it('clamps to at most 1000', () => {
+    expect(clampLimit(5000)).toBe(1000)
+  })
+
+  it('truncates fractional values', () => {
+    expect(clampLimit(3.9)).toBe(3)
+  })
+
+  it('passes through an in-range value', () => {
+    expect(clampLimit(42)).toBe(42)
+  })
+})
+
+describe('retrieveRecords id guard', () => {
+  beforeEach(() => {
+    process.env.GLUE_DATABASE = 'db'
+    process.env.GLUE_TABLE = 'records'
+    process.env.ATHENA_WORKGROUP = 'wg'
+  })
+
+  afterEach(() => {
+    delete process.env.GLUE_DATABASE
+    delete process.env.GLUE_TABLE
+    delete process.env.ATHENA_WORKGROUP
+  })
+
+  it('rejects an injection attempt before any query runs', async () => {
+    await expect(
+      retrieveRecords({ id: "a'; DROP TABLE records;--" })
+    ).rejects.toBeInstanceOf(InvalidQueryError)
+  })
+})

--- a/tools/analytics/__tests__/store.test.ts
+++ b/tools/analytics/__tests__/store.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { send } = vi.hoisted(() => ({ send: vi.fn() }))
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class {
+    send = send
+  },
+  PutObjectCommand: class {
+    input: unknown
+    constructor(input: unknown) {
+      this.input = input
+    }
+  },
+}))
+
+import { storeRecord } from '../src/lambda/store.js'
+
+type PutInput = {
+  Bucket: string
+  Key: string
+  Body: string
+  ContentType: string
+}
+
+describe('storeRecord', () => {
+  beforeEach(() => {
+    send.mockReset()
+    send.mockResolvedValue({})
+    process.env.DATA_BUCKET = 'my-bucket'
+  })
+
+  afterEach(() => {
+    delete process.env.DATA_BUCKET
+  })
+
+  it('writes a date-partitioned key and stamps createdAt', async () => {
+    const record = await storeRecord({
+      id: 'abc-1',
+      name: 'Widget',
+      value: 42,
+    })
+
+    expect(record).toMatchObject({
+      id: 'abc-1',
+      name: 'Widget',
+      value: 42,
+    })
+    expect(record.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+
+    expect(send).toHaveBeenCalledTimes(1)
+
+    const input = send.mock.calls[0][0].input as PutInput
+    const dt = record.createdAt.slice(0, 10)
+
+    expect(input).toMatchObject({
+      Bucket: 'my-bucket',
+      Key: `records/dt=${dt}/abc-1.json`,
+      ContentType: 'application/json',
+    })
+  })
+
+  it('persists lowercase keys matching the Glue columns', async () => {
+    const record = await storeRecord({ id: 'abc', name: 'W', value: 1 })
+
+    const input = send.mock.calls[0][0].input as PutInput
+
+    expect(JSON.parse(input.Body)).toEqual({
+      id: 'abc',
+      name: 'W',
+      value: 1,
+      createdat: record.createdAt,
+    })
+  })
+
+  it('throws when DATA_BUCKET is not set', async () => {
+    delete process.env.DATA_BUCKET
+
+    await expect(
+      storeRecord({ id: 'a', name: 'b', value: 1 })
+    ).rejects.toThrow('DATA_BUCKET')
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/tools/analytics/__tests__/types.test.ts
+++ b/tools/analytics/__tests__/types.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { validateRecordInput } from '../src/types.js'
+
+describe('validateRecordInput', () => {
+  it('accepts a well-formed record', () => {
+    const result = validateRecordInput({
+      id: 'abc-1',
+      name: 'Widget',
+      value: 42,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: { id: 'abc-1', name: 'Widget', value: 42 },
+    })
+  })
+
+  it('rejects a non-object body', () => {
+    for (const input of ['string', 42, null, [], true]) {
+      const result = validateRecordInput(input)
+
+      expect(result.ok).toBe(false)
+    }
+  })
+
+  it('requires a non-empty id', () => {
+    const result = validateRecordInput({
+      id: '  ',
+      name: 'Widget',
+      value: 1,
+    })
+
+    expect(result).toMatchObject({ ok: false })
+    if (!result.ok) {
+      expect(result.errors).toContain('"id" must be a non-empty string')
+    }
+  })
+
+  it('rejects an id with illegal characters', () => {
+    const result = validateRecordInput({
+      id: "a'; DROP TABLE records;--",
+      name: 'Widget',
+      value: 1,
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an id longer than 128 characters', () => {
+    const result = validateRecordInput({
+      id: 'a'.repeat(129),
+      name: 'Widget',
+      value: 1,
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('requires a non-empty name', () => {
+    const result = validateRecordInput({ id: 'abc', name: '', value: 1 })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a name longer than 256 characters', () => {
+    const result = validateRecordInput({
+      id: 'abc',
+      name: 'x'.repeat(257),
+      value: 1,
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('requires value to be a finite number', () => {
+    for (const value of ['1', NaN, Infinity, undefined, null]) {
+      const result = validateRecordInput({
+        id: 'abc',
+        name: 'Widget',
+        value,
+      })
+
+      expect(result.ok).toBe(false)
+    }
+  })
+
+  it('collects multiple errors at once', () => {
+    const result = validateRecordInput({ id: '', name: '', value: 'nope' })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.length).toBeGreaterThanOrEqual(3)
+    }
+  })
+})

--- a/tools/analytics/__tests__/types.test.ts
+++ b/tools/analytics/__tests__/types.test.ts
@@ -46,6 +46,14 @@ describe('validateRecordInput', () => {
     expect(result.ok).toBe(false)
   })
 
+  it('rejects an id without any letter or number', () => {
+    for (const id of ['.', '..', '-', '_', '._-']) {
+      const result = validateRecordInput({ id, name: 'Widget', value: 1 })
+
+      expect(result.ok).toBe(false)
+    }
+  })
+
   it('rejects an id longer than 128 characters', () => {
     const result = validateRecordInput({
       id: 'a'.repeat(129),

--- a/tools/analytics/eslint.config.mjs
+++ b/tools/analytics/eslint.config.mjs
@@ -1,0 +1,2 @@
+import parentConfig from 'dnb-design-system-portal/eslint.config.mjs'
+export default [...parentConfig]

--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -1,0 +1,69 @@
+# This workflow runs in the GitHub Enterprise deploy repo.
+# It is triggered when the public GitHub workflow pushes a built
+# lambda.zip + Terraform config to the `deploy` branch.
+#
+# The public workflow (.github/workflows/analytics-lambda.yml) copies this file
+# to .github/workflows/deploy.yml on the `deploy` branch automatically, so
+# no manual installation in the GHE repo is required.
+
+name: Deploy Analytics Lambda
+
+on:
+  push:
+    branches:
+      - deploy
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+# Never cancel an in-flight deploy: interrupting `terraform apply` can leave
+# the state lock dangling and require a manual force-unlock. Queue concurrent
+# deploys instead so they run one after another.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: eu-north-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: '~> 1.10'
+
+      - name: Deploy
+        env:
+          TF_VAR_cost_allocation: ${{ vars.COST_ALLOCATION }}
+          TF_VAR_api_token: ${{ secrets.API_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd infra
+          terraform init -input=false
+          terraform apply -auto-approve -input=false
+
+      - name: Post deploy summary
+        run: |
+          cd infra
+          ENDPOINT=$(terraform output -raw api_endpoint)
+          BUCKET=$(terraform output -raw data_bucket)
+          echo "## Analytics Lambda deployed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Endpoint:** \`${ENDPOINT}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Data bucket:** \`${BUCKET}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/tools/analytics/infra/.terraform.lock.hcl
+++ b/tools/analytics/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -1,0 +1,263 @@
+locals {
+  function_name = "eufemia-${var.environment}-analytics"
+  database_name = "eufemia_${var.environment}_analytics"
+  table_name    = "records"
+
+  tags = {
+    CostAllocation = var.cost_allocation
+    Environment    = var.environment
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+# Single bucket holds both the stored records (records/) and the Athena query
+# output (athena-results/). Account id keeps the name globally unique.
+resource "aws_s3_bucket" "data" {
+  bucket = "${local.function_name}-${data.aws_caller_identity.current.account_id}"
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Athena scratch output is transient; expire it so it does not accumulate cost.
+resource "aws_s3_bucket_lifecycle_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    id     = "expire-athena-results"
+    status = "Enabled"
+
+    filter {
+      prefix = "athena-results/"
+    }
+
+    expiration {
+      days = 7
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Glue Data Catalog
+# ---------------------------------------------------------------------------
+
+resource "aws_glue_catalog_database" "analytics" {
+  name = local.database_name
+}
+
+resource "aws_glue_catalog_table" "records" {
+  name          = local.table_name
+  database_name = aws_glue_catalog_database.analytics.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    classification     = "json"
+    has_encrypted_data = "true"
+
+    # Partition projection avoids running MSCK / ADD PARTITION as new days
+    # arrive. Athena derives the partitions from the dt range at query time.
+    "projection.enabled"          = "true"
+    "projection.dt.type"          = "date"
+    "projection.dt.range"         = "2024-01-01,NOW"
+    "projection.dt.format"        = "yyyy-MM-dd"
+    "projection.dt.interval"      = "1"
+    "projection.dt.interval.unit" = "DAYS"
+    "storage.location.template"   = "s3://${aws_s3_bucket.data.id}/records/dt=$${dt}/"
+  }
+
+  partition_keys {
+    name = "dt"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.data.id}/records/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+
+      parameters = {
+        "case.insensitive" = "true"
+      }
+    }
+
+    columns {
+      name = "id"
+      type = "string"
+    }
+
+    columns {
+      name = "name"
+      type = "string"
+    }
+
+    columns {
+      name = "value"
+      type = "double"
+    }
+
+    columns {
+      name = "createdat"
+      type = "string"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Athena
+# ---------------------------------------------------------------------------
+
+resource "aws_athena_workgroup" "analytics" {
+  name = local.function_name
+  tags = local.tags
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.data.id}/athena-results/"
+
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Lambda
+# ---------------------------------------------------------------------------
+
+# Pre-created out-of-band: the OIDC deploy role's permissions boundary forbids
+# iam:CreateRole (ADR 0004), so an account admin provisions the execution role
+# (trust policy + AWSLambdaBasicExecutionRole) and it is only referenced here.
+#
+# The role additionally needs an inline/attached policy granting:
+#   - s3:GetObject, s3:PutObject, s3:ListBucket on the data bucket (records/*)
+#   - s3:GetObject, s3:PutObject on the data bucket (athena-results/*)
+#   - athena:StartQueryExecution, athena:GetQueryExecution,
+#     athena:GetQueryResults on the analytics workgroup
+#   - glue:GetTable, glue:GetDatabase, glue:GetPartitions on the analytics db/table
+data "aws_iam_role" "lambda" {
+  name = "${local.function_name}-role"
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${local.function_name}"
+  retention_in_days = 30
+  tags              = local.tags
+}
+
+resource "aws_lambda_function" "analytics" {
+  function_name = local.function_name
+  role          = data.aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "nodejs22.x"
+  timeout       = 30
+  memory_size   = 256
+
+  filename         = "${path.module}/../dist/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/../dist/lambda.zip")
+
+  environment {
+    variables = {
+      NODE_OPTIONS     = "--enable-source-maps"
+      DATA_BUCKET      = aws_s3_bucket.data.id
+      GLUE_DATABASE    = aws_glue_catalog_database.analytics.name
+      GLUE_TABLE       = aws_glue_catalog_table.records.name
+      ATHENA_WORKGROUP = aws_athena_workgroup.analytics.name
+      API_TOKEN        = var.api_token
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
+  tags       = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# API Gateway (HTTP API)
+# ---------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api" "analytics" {
+  name          = local.function_name
+  protocol_type = "HTTP"
+  tags          = local.tags
+}
+
+resource "aws_apigatewayv2_stage" "analytics" {
+  api_id      = aws_apigatewayv2_api.analytics.id
+  name        = "$default"
+  auto_deploy = true
+  tags        = local.tags
+
+  default_route_settings {
+    throttling_burst_limit = 50
+    throttling_rate_limit  = 100
+  }
+}
+
+resource "aws_apigatewayv2_integration" "analytics" {
+  api_id                 = aws_apigatewayv2_api.analytics.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.analytics.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "store" {
+  api_id    = aws_apigatewayv2_api.analytics.id
+  route_key = "POST /records"
+  target    = "integrations/${aws_apigatewayv2_integration.analytics.id}"
+}
+
+resource "aws_apigatewayv2_route" "retrieve" {
+  api_id    = aws_apigatewayv2_api.analytics.id
+  route_key = "GET /records"
+  target    = "integrations/${aws_apigatewayv2_integration.analytics.id}"
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  api_id    = aws_apigatewayv2_api.analytics.id
+  route_key = "GET /healthz"
+  target    = "integrations/${aws_apigatewayv2_integration.analytics.id}"
+}
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.analytics.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.analytics.execution_arn}/*/*"
+}

--- a/tools/analytics/infra/outputs.tf
+++ b/tools/analytics/infra/outputs.tf
@@ -1,0 +1,12 @@
+output "api_endpoint" {
+  description = "Base URL of the HTTP API"
+  value       = aws_apigatewayv2_stage.analytics.invoke_url
+}
+
+output "function_name" {
+  value = aws_lambda_function.analytics.function_name
+}
+
+output "data_bucket" {
+  value = aws_s3_bucket.data.id
+}

--- a/tools/analytics/infra/providers.tf
+++ b/tools/analytics/infra/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = "~> 1.10"
+
+  # Reuses the existing Eufemia Terraform state bucket with a dedicated key so
+  # this stack's state is isolated from the other stacks.
+  backend "s3" {
+    bucket       = "eufemia-mcp-terraform-state"
+    key          = "analytics/terraform.tfstate"
+    region       = "eu-north-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/tools/analytics/infra/terraform.tfvars.example
+++ b/tools/analytics/infra/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+
+# BA number from ServiceNow used for cost allocation tagging.
+cost_allocation = "BSN00000000"
+
+# Bearer token required on /records requests. Leave empty to disable auth
+# (demo only — never do this outside a throwaway environment).
+# api_token = "change-me"
+
+# environment = "dev"

--- a/tools/analytics/infra/terraform.tfvars.example
+++ b/tools/analytics/infra/terraform.tfvars.example
@@ -3,8 +3,7 @@
 # BA number from ServiceNow used for cost allocation tagging.
 cost_allocation = "BSN00000000"
 
-# Bearer token required on /records requests. Leave empty to disable auth
-# (demo only — never do this outside a throwaway environment).
-# api_token = "change-me"
+# Bearer token required on all /records requests (must be non-empty).
+api_token = "change-me"
 
 # environment = "dev"

--- a/tools/analytics/infra/variables.tf
+++ b/tools/analytics/infra/variables.tf
@@ -21,7 +21,11 @@ variable "cost_allocation" {
 
 variable "api_token" {
   type        = string
-  description = "Bearer token required on /records requests. Empty disables auth (demo only)."
-  default     = ""
+  description = "Bearer token required on all /records requests."
   sensitive   = true
+
+  validation {
+    condition     = length(var.api_token) > 0
+    error_message = "api_token must be non-empty; an empty token would leave the HTTP API publicly readable and writable."
+  }
 }

--- a/tools/analytics/infra/variables.tf
+++ b/tools/analytics/infra/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  type    = string
+  default = "eu-north-1"
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment (dev, test, sit, uat, preprod, prod)"
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "test", "sit", "uat", "preprod", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, test, sit, uat, preprod, prod."
+  }
+}
+
+variable "cost_allocation" {
+  type        = string
+  description = "BA number from ServiceNow for cost allocation tagging"
+}
+
+variable "api_token" {
+  type        = string
+  description = "Bearer token required on /records requests. Empty disables auth (demo only)."
+  default     = ""
+  sensitive   = true
+}

--- a/tools/analytics/package.json
+++ b/tools/analytics/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:types": "../../node_modules/.bin/tsc --noEmit",
     "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts'",
+    "audit:ci": "yarn npm audit --recursive --environment production --severity high",
     "build": "rm -rf dist && esbuild src/lambda/index.ts --bundle --platform=node --target=node22 --format=esm --sourcemap --outfile=dist/index.mjs '--external:@aws-sdk/*' && cd dist && zip -rq lambda.zip index.mjs index.mjs.map",
     "deploy": "yarn build && terraform -chdir=infra init && terraform -chdir=infra apply -auto-approve",
     "deploy:plan": "yarn build && terraform -chdir=infra init && terraform -chdir=infra plan"

--- a/tools/analytics/package.json
+++ b/tools/analytics/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "eufemia-analytics",
+  "description": "Store and retrieve records in AWS (S3 + Athena) via an HTTP API",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "author": "DNB Team",
+  "license": "SEE LICENSE IN LICENSE FILE",
+  "scripts": {
+    "test": "vitest run",
+    "test:types": "../../node_modules/.bin/tsc --noEmit",
+    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts'",
+    "build": "rm -rf dist && esbuild src/lambda/index.ts --bundle --platform=node --target=node22 --format=esm --sourcemap --outfile=dist/index.mjs '--external:@aws-sdk/*' && cd dist && zip -rq lambda.zip index.mjs index.mjs.map",
+    "deploy": "yarn build && terraform -chdir=infra init && terraform -chdir=infra apply -auto-approve",
+    "deploy:plan": "yarn build && terraform -chdir=infra init && terraform -chdir=infra plan"
+  },
+  "dependencies": {
+    "@aws-sdk/client-athena": "3.1075.0",
+    "@aws-sdk/client-s3": "3.1075.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "8.10.161",
+    "esbuild": "0.25.5",
+    "vitest": "4.1.8"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/tools/analytics/package.json
+++ b/tools/analytics/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "eufemia-analytics",
+  "description": "Store and retrieve records in AWS (S3 + Athena) via an HTTP API",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "author": "DNB Team",
+  "license": "SEE LICENSE IN LICENSE FILE",
+  "scripts": {
+    "test": "vitest run",
+    "test:types": "../../node_modules/.bin/tsc --noEmit",
+    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts'",
+    "build": "rm -rf dist && esbuild src/lambda/index.ts --bundle --platform=node --target=node22 --format=esm --sourcemap --outfile=dist/index.mjs '--external:@aws-sdk/*' && cd dist && zip -rq lambda.zip index.mjs index.mjs.map",
+    "deploy": "yarn build && terraform -chdir=infra init && terraform -chdir=infra apply -auto-approve",
+    "deploy:plan": "yarn build && terraform -chdir=infra init && terraform -chdir=infra plan"
+  },
+  "dependencies": {
+    "@aws-sdk/client-athena": "3.1075.0",
+    "@aws-sdk/client-s3": "3.1075.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "8.10.161",
+    "esbuild": "0.25.5",
+    "vitest": "4.1.10"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/tools/analytics/src/lambda/http.ts
+++ b/tools/analytics/src/lambda/http.ts
@@ -1,0 +1,52 @@
+import { timingSafeEqual } from 'node:crypto'
+import type { APIGatewayProxyResultV2 } from 'aws-lambda'
+
+/** Constant-time compare for equal-length inputs; unequal lengths short-circuit. */
+function safeEqual(a: string, b: string): boolean {
+  const bufA = new TextEncoder().encode(a)
+  const bufB = new TextEncoder().encode(b)
+
+  if (bufA.length !== bufB.length) {
+    return false
+  }
+
+  return timingSafeEqual(bufA, bufB)
+}
+
+/** Build a JSON HTTP response for API Gateway (HTTP API / payload v2). */
+export function json(
+  statusCode: number,
+  body: unknown
+): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+/**
+ * Simple bearer-token check.
+ *
+ * The expected token is read from the `API_TOKEN` environment variable. When
+ * `API_TOKEN` is not set, auth is disabled (useful for local testing only).
+ * Returns `true` when the request is authorized.
+ */
+export function isAuthorized(
+  headers: Record<string, string | undefined> | undefined
+): boolean {
+  const expected = process.env.API_TOKEN
+
+  if (!expected) {
+    return true
+  }
+
+  const header = headers?.authorization ?? headers?.Authorization ?? ''
+  const [scheme, token] = header.split(' ')
+
+  return (
+    scheme === 'Bearer' &&
+    token !== undefined &&
+    safeEqual(token, expected)
+  )
+}

--- a/tools/analytics/src/lambda/index.ts
+++ b/tools/analytics/src/lambda/index.ts
@@ -1,0 +1,102 @@
+import type {
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+} from 'aws-lambda'
+import { isAuthorized, json } from './http.js'
+import { storeRecord } from './store.js'
+import { InvalidQueryError, retrieveRecords } from './retrieve.js'
+import { validateRecordInput } from '../types.js'
+
+function parseBody(event: APIGatewayProxyEventV2): unknown {
+  if (!event.body) {
+    return undefined
+  }
+
+  const raw = event.isBase64Encoded
+    ? Buffer.from(event.body, 'base64').toString('utf8')
+    : event.body
+
+  return JSON.parse(raw)
+}
+
+async function handleStore(
+  event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyResultV2> {
+  let payload: unknown
+  try {
+    payload = parseBody(event)
+  } catch {
+    return json(400, { error: 'Body must be valid JSON' })
+  }
+
+  const validation = validateRecordInput(payload)
+  if (!validation.ok) {
+    return json(400, {
+      error: 'Validation failed',
+      details: validation.errors,
+    })
+  }
+
+  const record = await storeRecord(validation.value)
+
+  return json(201, record)
+}
+
+async function handleRetrieve(
+  event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyResultV2> {
+  const params = event.queryStringParameters ?? {}
+
+  let limit: number | undefined
+  if (params.limit !== undefined) {
+    limit = Number(params.limit)
+    if (!Number.isFinite(limit)) {
+      return json(400, { error: '"limit" must be a number' })
+    }
+  }
+
+  try {
+    const records = await retrieveRecords({ id: params.id, limit })
+
+    return json(200, { records })
+  } catch (error) {
+    if (error instanceof InvalidQueryError) {
+      return json(400, { error: error.message })
+    }
+
+    throw error
+  }
+}
+
+/**
+ * HTTP API entry point.
+ *
+ * Routes:
+ * - `GET  /healthz`  liveness probe (open, no auth)
+ * - `POST /records`  store a record in S3
+ * - `GET  /records`  retrieve records via Athena (optional `id`, `limit`)
+ */
+export async function handler(
+  event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyResultV2> {
+  const method = event.requestContext.http.method
+  const path = event.rawPath
+
+  if (method === 'GET' && path === '/healthz') {
+    return json(200, { status: 'ok' })
+  }
+
+  if (!isAuthorized(event.headers)) {
+    return json(401, { error: 'Unauthorized' })
+  }
+
+  if (method === 'POST' && path === '/records') {
+    return handleStore(event)
+  }
+
+  if (method === 'GET' && path === '/records') {
+    return handleRetrieve(event)
+  }
+
+  return json(404, { error: 'Not found' })
+}

--- a/tools/analytics/src/lambda/retrieve.ts
+++ b/tools/analytics/src/lambda/retrieve.ts
@@ -1,0 +1,172 @@
+import {
+  AthenaClient,
+  GetQueryExecutionCommand,
+  GetQueryResultsCommand,
+  StartQueryExecutionCommand,
+} from '@aws-sdk/client-athena'
+import type { AnalyticsRecord } from '../types.js'
+
+const athena = new AthenaClient({})
+
+// Same shape allowed when a record is stored, so the id filter can never
+// contain characters that would break out of the SQL string literal.
+const ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+
+const POLL_INTERVAL_MS = 500
+// Keep the total poll window (MAX_POLLS * POLL_INTERVAL_MS = 25s) below the
+// Lambda timeout (30s) so this loop surfaces a clear "timed out" error before
+// the platform kills the invocation.
+const MAX_POLLS = 50
+
+/** Thrown when the caller supplies an invalid query parameter (maps to 400). */
+export class InvalidQueryError extends Error {}
+
+export type RetrieveOptions = {
+  id?: string
+  limit?: number
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+
+  if (!value) {
+    throw new Error(`${name} environment variable is not set`)
+  }
+
+  return value
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return DEFAULT_LIMIT
+  }
+
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT)
+}
+
+export { clampLimit }
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function startQuery(
+  query: string,
+  workgroup: string
+): Promise<string> {
+  const response = await athena.send(
+    new StartQueryExecutionCommand({
+      QueryString: query,
+      WorkGroup: workgroup,
+    })
+  )
+
+  if (!response.QueryExecutionId) {
+    throw new Error('Athena did not return a QueryExecutionId')
+  }
+
+  return response.QueryExecutionId
+}
+
+async function waitForQuery(queryExecutionId: string): Promise<void> {
+  for (let attempt = 0; attempt < MAX_POLLS; attempt++) {
+    const { QueryExecution } = await athena.send(
+      new GetQueryExecutionCommand({ QueryExecutionId: queryExecutionId })
+    )
+
+    const state = QueryExecution?.Status?.State
+
+    if (state === 'SUCCEEDED') {
+      return
+    }
+
+    if (state === 'FAILED' || state === 'CANCELLED') {
+      const reason =
+        QueryExecution?.Status?.StateChangeReason ?? 'unknown reason'
+      throw new Error(`Athena query ${state}: ${reason}`)
+    }
+
+    await delay(POLL_INTERVAL_MS)
+  }
+
+  throw new Error('Athena query timed out')
+}
+
+async function readResults(
+  queryExecutionId: string
+): Promise<AnalyticsRecord[]> {
+  const records: AnalyticsRecord[] = []
+
+  let nextToken: string | undefined
+  let isFirstPage = true
+
+  // GetQueryResults returns at most 1000 rows per page, so page through all of
+  // them. Only the very first page includes the column header row.
+  do {
+    const { ResultSet, NextToken } = await athena.send(
+      new GetQueryResultsCommand({
+        QueryExecutionId: queryExecutionId,
+        NextToken: nextToken,
+      })
+    )
+
+    const rows = ResultSet?.Rows ?? []
+    const dataRows = isFirstPage ? rows.slice(1) : rows
+    isFirstPage = false
+
+    for (const row of dataRows) {
+      const [id, name, value, createdat] = (row.Data ?? []).map(
+        (cell) => cell.VarCharValue
+      )
+
+      records.push({
+        id: id ?? '',
+        name: name ?? '',
+        value: value === undefined ? NaN : Number(value),
+        createdAt: createdat ?? '',
+      })
+    }
+
+    nextToken = NextToken
+  } while (nextToken)
+
+  return records
+}
+
+/**
+ * Retrieve records via Athena, most recent first.
+ *
+ * Database, table and workgroup come from the environment (trusted). The
+ * optional `id` filter is validated against {@link ID_PATTERN} before being
+ * interpolated, so the query is not vulnerable to injection.
+ */
+export async function retrieveRecords(
+  options: RetrieveOptions = {}
+): Promise<AnalyticsRecord[]> {
+  const database = requireEnv('GLUE_DATABASE')
+  const table = requireEnv('GLUE_TABLE')
+  const workgroup = requireEnv('ATHENA_WORKGROUP')
+
+  const limit = clampLimit(options.limit)
+
+  let where = ''
+  if (options.id !== undefined) {
+    if (!ID_PATTERN.test(options.id)) {
+      throw new InvalidQueryError(
+        '"id" query parameter has an invalid format'
+      )
+    }
+
+    where = `WHERE id = '${options.id}' `
+  }
+
+  const query = `SELECT id, name, value, createdat FROM "${database}"."${table}" ${where}ORDER BY createdat DESC LIMIT ${limit}`
+
+  const queryExecutionId = await startQuery(query, workgroup)
+  await waitForQuery(queryExecutionId)
+
+  return readResults(queryExecutionId)
+}

--- a/tools/analytics/src/lambda/retrieve.ts
+++ b/tools/analytics/src/lambda/retrieve.ts
@@ -10,7 +10,7 @@ const athena = new AthenaClient({})
 
 // Same shape allowed when a record is stored, so the id filter can never
 // contain characters that would break out of the SQL string literal.
-const ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/
+const ID_PATTERN = /^(?=.*[A-Za-z0-9])[A-Za-z0-9._-]{1,128}$/
 
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 1000

--- a/tools/analytics/src/lambda/store.ts
+++ b/tools/analytics/src/lambda/store.ts
@@ -1,0 +1,51 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import type { AnalyticsRecord, AnalyticsRecordInput } from '../types.js'
+
+const s3 = new S3Client({})
+
+function dataBucket(): string {
+  const bucket = process.env.DATA_BUCKET
+
+  if (!bucket) {
+    throw new Error('DATA_BUCKET environment variable is not set')
+  }
+
+  return bucket
+}
+
+/**
+ * Persist a record to S3 as a single JSON object.
+ *
+ * Objects are partitioned by date (`records/dt=YYYY-MM-DD/<id>.json`) so the
+ * Glue table can use partition projection and Athena only scans the relevant
+ * days. Keys are written lowercase to match the Glue column names.
+ */
+export async function storeRecord(
+  input: AnalyticsRecordInput
+): Promise<AnalyticsRecord> {
+  const record: AnalyticsRecord = {
+    ...input,
+    createdAt: new Date().toISOString(),
+  }
+
+  const dt = record.createdAt.slice(0, 10)
+  const key = `records/dt=${dt}/${record.id}.json`
+
+  const body = JSON.stringify({
+    id: record.id,
+    name: record.name,
+    value: record.value,
+    createdat: record.createdAt,
+  })
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: dataBucket(),
+      Key: key,
+      Body: body,
+      ContentType: 'application/json',
+    })
+  )
+
+  return record
+}

--- a/tools/analytics/src/types.ts
+++ b/tools/analytics/src/types.ts
@@ -1,0 +1,80 @@
+/**
+ * A generic, minimal analytics record.
+ *
+ * `createdAt` is set by the API when a record is stored, so callers only
+ * need to provide `id`, `name` and `value`.
+ */
+export type AnalyticsRecord = {
+  id: string
+  name: string
+  value: number
+  createdAt: string
+}
+
+/** The client-provided part of an {@link AnalyticsRecord} (without `createdAt`). */
+export type AnalyticsRecordInput = Omit<AnalyticsRecord, 'createdAt'>
+
+export type ValidationSuccess = {
+  ok: true
+  value: AnalyticsRecordInput
+}
+
+export type ValidationFailure = {
+  ok: false
+  errors: string[]
+}
+
+export type ValidationResult = ValidationSuccess | ValidationFailure
+
+/**
+ * Validate an untrusted payload and narrow it to a {@link AnalyticsRecordInput}.
+ *
+ * Validation happens at the system boundary (the HTTP handler), so all
+ * shapes are treated as untrusted here.
+ */
+export function validateRecordInput(input: unknown): ValidationResult {
+  const errors: string[] = []
+
+  if (
+    typeof input !== 'object' ||
+    input === null ||
+    Array.isArray(input)
+  ) {
+    return { ok: false, errors: ['Body must be a JSON object'] }
+  }
+
+  const record = input as Record<string, unknown>
+
+  const { id, name, value } = record
+
+  if (typeof id !== 'string' || id.trim() === '') {
+    errors.push('"id" must be a non-empty string')
+  } else if (!/^[A-Za-z0-9._-]{1,128}$/.test(id)) {
+    errors.push(
+      '"id" may only contain letters, numbers, ".", "_" and "-" (max 128 chars)'
+    )
+  }
+
+  if (typeof name !== 'string' || name.trim() === '') {
+    errors.push('"name" must be a non-empty string')
+  } else if (name.length > 256) {
+    errors.push('"name" must be at most 256 characters')
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    errors.push('"value" must be a finite number')
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors }
+  }
+
+  return {
+    ok: true,
+    value: {
+      id: id as string,
+      name: name as string,
+      value: value as number,
+    },
+  }
+}

--- a/tools/analytics/src/types.ts
+++ b/tools/analytics/src/types.ts
@@ -49,9 +49,9 @@ export function validateRecordInput(input: unknown): ValidationResult {
 
   if (typeof id !== 'string' || id.trim() === '') {
     errors.push('"id" must be a non-empty string')
-  } else if (!/^[A-Za-z0-9._-]{1,128}$/.test(id)) {
+  } else if (!/^(?=.*[A-Za-z0-9])[A-Za-z0-9._-]{1,128}$/.test(id)) {
     errors.push(
-      '"id" may only contain letters, numbers, ".", "_" and "-" (max 128 chars)'
+      '"id" must contain a letter or number and use only letters, numbers, ".", "_" and "-" (max 128 chars)'
     )
   }
 

--- a/tools/analytics/tsconfig.json
+++ b/tools/analytics/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../packages/dnb-design-system-portal/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./out",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2020",
+    "strict": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["node_modules", "out"]
+}

--- a/tools/analytics/vitest.config.ts
+++ b/tools/analytics/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    reporters: ['default'],
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.{ts,tsx,js,jsx}'],
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,361 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/sha1-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha1-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/239f4c59cce9abd33c01117b10553fbef868a063e74faf17edb798c250d759a2578841efa2837e5e51854f52ef57dbc40780b073cae20f89ebed6a8cc7fa06f1
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/sha256-js": "npm:^5.2.0"
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2b1b701ca6caa876333b4eb2b96e5187d71ebb51ebf8e2d632690dbcdedeff038202d23adcc97e023437ed42bb1963b7b463e343687edf0635fd4b98b2edad1a
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:5.2.0, @aws-crypto/sha256-js@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f46aace7b873c615be4e787ab0efd0148ef7de48f9f12c7d043e05c52e52b75bb0bf6dbcb9b2852d940d7724fab7b6d5ff1469160a3dd024efe7a68b5f70df8c
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:5.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/6ed0c7e17f4f6663d057630805c45edb35d5693380c24ab52d4c453ece303c6c8a6ade9ee93c97dda77d9f6cae376ffbb44467057161c513dffa3422250edaf5
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f80a174c404e1ad4364741c942f440e75f834c08278fa754349fe23a6edc679d480ea9ced5820774aee58091ed270067022d8059ecf1a7ef452d58134ac7e9e1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/checksums@npm:^3.1000.26":
+  version: 3.1000.26
+  resolution: "@aws-sdk/checksums@npm:3.1000.26"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d0c7b7d61c76c8674478d0b9db55b7d9b011c57b421a7ab14ef6d5c26f7820ec55cbb4684f4c99e5414c3c18637d6d8a1fadca90dfba8fbb7a643cf6c0a6a02b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-athena@npm:3.1075.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/client-athena@npm:3.1075.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c97c717240af290bdd36f5496609d0146defdacc6c107797415371b111beac62f21523e884223e2d04d4c7a4c4e9181bde06c2a855626e87ef7df1284753da00
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:3.1075.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/client-s3@npm:3.1075.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/middleware-flexible-checksums": "npm:^3.974.33"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.54"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.35"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7482774e4341a922b436931ffa3f0b002e6dbbce153d671a84f056459eba113d9ac01e1973238a525a17437d08f457502f07799795e1530c0e636c7b71205c17
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.974.23, @aws-sdk/core@npm:^3.977.6":
+  version: 3.977.6
+  resolution: "@aws-sdk/core@npm:3.977.6"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@aws-sdk/xml-builder": "npm:^3.972.37"
+    "@aws/lambda-invoke-store": "npm:^0.3.0"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.16.1"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/e5c0c4d485156975a63854ede3b880fac7bae31d29d0bfb46120238a2530aed56de782811185fa987fa60a8cf17391ec7c4044d962209034f9259c80b8c07136
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.67":
+  version: 3.972.67
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.67"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1754d024dcf2dab5afc3b30fc4668ed53780785b1b7a1bb47b12faea0d5a73d8f751443f3f42795cc1a79404e5017f2430b0d10622f270bc07c659363a161429
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.69":
+  version: 3.972.69
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.69"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3258d4878af27062fcee035352975f274e7f0af7558f0e0d2dc0773dde5fbac2ec4c3176bdab9bed70aeca72c5e4e0930943a19d50ce44e6ecc4bea34ab222cb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.973.12":
+  version: 3.973.12
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.973.12"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.67"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.69"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.74"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.67"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.11"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.73"
+    "@aws-sdk/nested-clients": "npm:^3.997.41"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/71689382274efb5e80e2ef31b2d741a10e24c6b2fb1017532939e58e121a9bca6c80a3d83571140eb0e7a7b0e9958b2038aed6d3951fbd61337e45e1521849bd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.74":
+  version: 3.972.74
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.74"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/nested-clients": "npm:^3.997.41"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/91ab722e9cb46ad498081485ac95626ea9966b18c085fde3d606a7ea19b50e8963777b7ed616d5c4b7c84f24185c90aa347d563b775970a67abd915c2522b127
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.58":
+  version: 3.972.78
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.78"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.67"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.69"
+    "@aws-sdk/credential-provider-ini": "npm:^3.973.12"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.67"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.11"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.73"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/402aa3b68bf10b15c9dcf14c7a03a576c757077c3c9d4d593d7deacb648274262e320a3c6626adb772c3a874e1c4bffd59ad66066c639d44dbd01d4e796adfd2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.67":
+  version: 3.972.67
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.67"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/696c7acb3ce40376700da6e59e3365486c6a9083472679aa7d8b5a578818ac6eced954bf8aa5dadd9928c702ea5068af9096b2ae50d9c2ef0d2c30ccab827de4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.973.11":
+  version: 3.973.11
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.973.11"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/nested-clients": "npm:^3.997.41"
+    "@aws-sdk/token-providers": "npm:3.1103.0"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/aeabd076d977890c705b7a8c0f56c9ff811fb673f35c9ebcfaf4b7d7fb1b6dbf406470f89c37d91ae6da179130a8e911989a0519f42b8f26b4473b029d59adfc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.73":
+  version: 3.972.73
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.73"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/nested-clients": "npm:^3.997.41"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/cd1ee1d17c5749dbb889f0c97ba99ade788d916dd605d4277be2932a71387039d47f5630d061d09b2d5b9904244e5bd7b0bfc423a3fc261f8bc85b781058d675
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:^3.974.33":
+  version: 3.974.51
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.974.51"
+  dependencies:
+    "@aws-sdk/checksums": "npm:^3.1000.26"
+    tslib: "npm:^2.6.2"
+  checksum: 10/55571fc529ec140c7005ebe50fbc9fa270890c889d254afe557dc6b8653132f3af42ce6ca7ce806b23d4eb18f17c5d26b1a0572fdbe781e878be80d30dcf82ce
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.54":
+  version: 3.972.72
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.72"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ff109ca1cade66a1f3dd48c8a69892d3f916392226d37ff0b348c37f47dde1423b760c0df8049b379ecffef4e6e678e5367342eb7443ead5d76ab09f86809861
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.41":
+  version: 3.997.41
+  resolution: "@aws-sdk/nested-clients@npm:3.997.41"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9bb39bbd68da8bc5448a4667cf486a78aaf49a9aebca29324129396e8d48500919736588bf9aa4d86ae560ed6284225a33bfc301aa4a5df63f5635bca40e7969
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.35, @aws-sdk/signature-v4-multi-region@npm:^3.996.43":
+  version: 3.996.43
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.43"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/07a95a47866ae69af40aa36c69a6105e97723aa6aef85daec19e28a7f1a19fb56f999e33c563e8fab8d65098b2f48a6fb309266bea2d60a7e756fd72409b5097
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1103.0":
+  version: 3.1103.0
+  resolution: "@aws-sdk/token-providers@npm:3.1103.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.6"
+    "@aws-sdk/nested-clients": "npm:^3.997.41"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/211447e0c2298f5cc7e129971ef4b5c8e1e275439106fde4a31c36a59baa50e40dd0f9f40f0a4df49497069fd91804123855f00e8885a3a234336261f7ad4e98
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.973.13, @aws-sdk/types@npm:^3.974.2":
+  version: 3.974.2
+  resolution: "@aws-sdk/types@npm:3.974.2"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/12a2a3c13507211881d91d9186c0d20b138a569ab8e1937744393d2bcb14dc01257a97de42dd7ef002500a49f0237ce1faeb11e5a9c607d4ad16fd63357cefee
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.965.8
+  resolution: "@aws-sdk/util-locate-window@npm:3.965.8"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/2244bb447b2c85eb764f8d7d283726a6c25e96999a349d0939cf8da44f6aee1f60c71b71d5aee11831c91706b4b8f00eee6613688124fbf752218fb5f36e9d4f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.37":
+  version: 3.972.37
+  resolution: "@aws-sdk/xml-builder@npm:3.972.37"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/20f221d158a12cb39b117e65cde8ecb19f629d5292def76adee8680dad176cf6c9f0e83a3534c65bcd40ffaf5fa8a2afd62de262c4c00b355d1c8c057c261acb
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@aws/lambda-invoke-store@npm:0.3.0"
+  checksum: 10/4a6c7af16477dd330d4dcd2269f89370be68295b54ae1e90ef8c2175efa4df6735f9a3f914ab7efa21ba7db5477031fe8488853adcd268eeb6cb8e34ad06b206
+  languageName: node
+  linkType: hard
+
 "@babel/cli@npm:7.28.3":
   version: 7.28.3
   resolution: "@babel/cli@npm:7.28.3"
@@ -5081,6 +5436,98 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.24.6, @smithy/core@npm:^3.31.1":
+  version: 3.31.1
+  resolution: "@smithy/core@npm:3.31.1"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/4a66d0f1f6b6aac8cbe424d0c9c6ca12e02b8b64c21065de396b60c203f163e245000e4607f02d1a8391028a669a78b666843dc5769af4c8f0101afd6858aba0
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.4.16":
+  version: 4.4.16
+  resolution: "@smithy/credential-provider-imds@npm:4.4.16"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/5a9d54b151ec9296db79f52e68c8fd1feddd4d75332f13dad0dc5efe2aabe3994092193ea532c2cb3e5133f099a650accbd2ff836b4aba916b96d0d796766a0c
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.4.6, @smithy/fetch-http-handler@npm:^5.6.13":
+  version: 5.6.13
+  resolution: "@smithy/fetch-http-handler@npm:5.6.13"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/272d367031096802c8ea7c8e7479e7522589018628064e01b5d101316091687eaa48b4029543e0a11486db6ec4ffbcd9a9ac26923f0a655150e33fe9e085e3ca
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/is-array-buffer@npm:2.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/d366743ecc7a9fc3bad21dbb3950d213c12bdd4aeb62b1265bf6cbe38309df547664ef3e51ab732e704485194f15e89d361943b0bfbe3fe1a4b3178b942913cc
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.7.6, @smithy/node-http-handler@npm:^4.9.13":
+  version: 4.9.13
+  resolution: "@smithy/node-http-handler@npm:4.9.13"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d52fac160d879b957c8092c70e9991c23a3775bb448a8c6d5836873afab1f5ea43dd72c63150da748879b29443f0af7f83fb777763975a81939e8806e18ba71a
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.6.12":
+  version: 5.6.12
+  resolution: "@smithy/signature-v4@npm:5.6.12"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0a14dac2c93118eb5fabdb34c8e3dd042fb645be959a6546e67c6b3d181a3df8f13ef210a8c2b9811371b8b0fc846d9e15e9bb3076bcb1c019e830f924fba60a
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.14.3, @smithy/types@npm:^4.16.1":
+  version: 4.16.1
+  resolution: "@smithy/types@npm:4.16.1"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/23651203f2e8800b2b2311ef163ddec166d91e15b30fa1c877be352aeef8ae7cc7b0189f99e07b0dcd52160b10adfb3fa4ca32c38a2d7195fc5428b8986d5201
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-buffer-from@npm:2.2.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/53253e4e351df3c4b7907dca48a0a6ceae783e98a8e73526820b122b3047a53fd127c19f4d8301f68d852011d821da519da783de57e0b22eed57c4df5b90d089
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@smithy/util-utf8@npm:2.3.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c766ead8dac6bc6169f4cac1cc47ef7bd86928d06255148f9528228002f669c8cc49f78dc2b9ba5d7e214d40315024a9e32c5c9130b33e20f0fe4532acd0dff5
+  languageName: node
+  linkType: hard
+
 "@speed-highlight/core@npm:^1.2.7":
   version: 1.2.14
   resolution: "@speed-highlight/core@npm:1.2.14"
@@ -6760,6 +7207,13 @@ __metadata:
   version: 2.19.5
   resolution: "bottleneck@npm:2.19.5"
   checksum: 10/ffb982185236fc42b135f88eb3cfc8b87c4307fb9c3e3658e843ed673ad1c77780b65a01ab532f9857fa0f75ad4d6c1857985b21c9b2bd7eac8ef3c378d7ebf6
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 10/a002f0795ef360314c75552b94daa42f74473f38b34255cfa959779e875806ef8e41b24ec63a533717798c8ef70bb991aef3037a2bb5dd32e8f507b39a509163
   languageName: node
   linkType: hard
 
@@ -9264,6 +9718,18 @@ __metadata:
   checksum: 10/571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
   languageName: node
   linkType: hard
+
+"eufemia-analytics@workspace:tools/analytics":
+  version: 0.0.0-use.local
+  resolution: "eufemia-analytics@workspace:tools/analytics"
+  dependencies:
+    "@aws-sdk/client-athena": "npm:3.1075.0"
+    "@aws-sdk/client-s3": "npm:3.1075.0"
+    "@types/aws-lambda": "npm:8.10.161"
+    esbuild: "npm:0.25.5"
+    vitest: "npm:4.1.10"
+  languageName: unknown
+  linkType: soft
 
 "eufemia-css-optimizer@workspace:tools/eufemia-css-optimizer":
   version: 0.0.0-use.local
@@ -18113,10 +18579,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
-  version: 2.6.0
-  resolution: "tslib@npm:2.6.0"
-  checksum: 10/52360693c62761f902e1946b350188be6505de297068b33421cb26bedd99591203a74cb2a49e1f43f0922d59b1fb3499fe5cfe61a61ca65a1743d5c92c69720a
+"tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,377 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/sha1-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha1-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/239f4c59cce9abd33c01117b10553fbef868a063e74faf17edb798c250d759a2578841efa2837e5e51854f52ef57dbc40780b073cae20f89ebed6a8cc7fa06f1
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/sha256-js": "npm:^5.2.0"
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2b1b701ca6caa876333b4eb2b96e5187d71ebb51ebf8e2d632690dbcdedeff038202d23adcc97e023437ed42bb1963b7b463e343687edf0635fd4b98b2edad1a
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:5.2.0, @aws-crypto/sha256-js@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f46aace7b873c615be4e787ab0efd0148ef7de48f9f12c7d043e05c52e52b75bb0bf6dbcb9b2852d940d7724fab7b6d5ff1469160a3dd024efe7a68b5f70df8c
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:5.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/6ed0c7e17f4f6663d057630805c45edb35d5693380c24ab52d4c453ece303c6c8a6ade9ee93c97dda77d9f6cae376ffbb44467057161c513dffa3422250edaf5
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f80a174c404e1ad4364741c942f440e75f834c08278fa754349fe23a6edc679d480ea9ced5820774aee58091ed270067022d8059ecf1a7ef452d58134ac7e9e1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/checksums@npm:^3.1000.24":
+  version: 3.1000.24
+  resolution: "@aws-sdk/checksums@npm:3.1000.24"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/52011393836552dbeaa8506011944d6995966f36414394faee920a5caab01be39b04d6a7216b1ef6a080ac12a6c3e427e2b2f9fe28bc7cce121627f7c4526147
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-athena@npm:3.1075.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/client-athena@npm:3.1075.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c97c717240af290bdd36f5496609d0146defdacc6c107797415371b111beac62f21523e884223e2d04d4c7a4c4e9181bde06c2a855626e87ef7df1284753da00
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:3.1075.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/client-s3@npm:3.1075.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/middleware-flexible-checksums": "npm:^3.974.33"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.54"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.35"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7482774e4341a922b436931ffa3f0b002e6dbbce153d671a84f056459eba113d9ac01e1973238a525a17437d08f457502f07799795e1530c0e636c7b71205c17
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.974.23":
+  version: 3.976.0
+  resolution: "@aws-sdk/core@npm:3.976.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@aws-sdk/xml-builder": "npm:^3.972.36"
+    "@aws/lambda-invoke-store": "npm:^0.3.0"
+    "@smithy/core": "npm:^3.29.4"
+    "@smithy/signature-v4": "npm:^5.6.5"
+    "@smithy/types": "npm:^4.16.1"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c2f34812e7fe3d80d4778a570bd17018251fe935a83cd47e0d0166be4b696aff1b114ade47b00235d8a7eebe36ce573e0e71a5c636a51681f787f84b3a353820
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.977.4":
+  version: 3.977.4
+  resolution: "@aws-sdk/core@npm:3.977.4"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@aws-sdk/xml-builder": "npm:^3.972.37"
+    "@aws/lambda-invoke-store": "npm:^0.3.0"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.16.1"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/b162f9d43093ab37aae3a5ffa30b9049d25cd1e6bbfc19e90a4cbe83a5fdd7c51306242cc9c8eec4cce4134f49337818c6e7ccb6811cab449eec4254f900dfee
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.65":
+  version: 3.972.65
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.65"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ddaddbb43455dd2c4f73ffe53a4879c333195d5de3ad1f5f832695abcf3ff59713dbe2f360473677d0e0eb676cb21c2af309db5af39bb124532850591a07595a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.67":
+  version: 3.972.67
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.67"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7b10976f178f8976b16fa97fff76f7e2100b8783c05a154bfb8f50b268b81703c7f33c3265ab86bfafaf77a1ca4ab0ebab91c4b55db4b1c8738dd5856da8b6b3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.973.10":
+  version: 3.973.10
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.973.10"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.65"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.67"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.72"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.65"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.9"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.71"
+    "@aws-sdk/nested-clients": "npm:^3.997.39"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/aad8d95b88ddd8c9e519f616051b0bbccb12c97fc85bff1ccea94ceacfb71045f16ae196c2831a43de0d708ec68300fd846a6df2115203b4ecb53e439cedb6bd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.72":
+  version: 3.972.72
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.72"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/nested-clients": "npm:^3.997.39"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/4ad6d0b4efb3ee4962390ef61e39b31686a2720124afba4accb58aaeea47874e3c29745db24e20e936dc288e1f6895d5cfc796d93fcd0fea6e39d465d4d62d56
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.58":
+  version: 3.972.76
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.76"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.65"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.67"
+    "@aws-sdk/credential-provider-ini": "npm:^3.973.10"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.65"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.9"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.71"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/dfd88cdead47500984f55921e7d94f8446c94dfd2948fad74f55ff1bd5f6b2ad3fca4947e683c82ac7823c179a970c1f69250bf026eb78c8d212c83631b1c065
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.65":
+  version: 3.972.65
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.65"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/cf97bca64e27db079ad54ea830aa3f04006e40c39ede5408f698bdf171c6d72143232d2e66a89b48a24ba3579c57de8cf4c421f33a2326bcc3bffe90f04857d6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.973.9":
+  version: 3.973.9
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.973.9"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/nested-clients": "npm:^3.997.39"
+    "@aws-sdk/token-providers": "npm:3.1100.0"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/cfa337293881567919f481a000b094e5b88bf676ae278c6c6e24ca6c096999c2713513342f84bc0f3fac51203073e83a9fb9c941998167c18a976cc6b3fa479c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.71":
+  version: 3.972.71
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.71"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/nested-clients": "npm:^3.997.39"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/6e78ea8dc445b11565db259da7da63f429c8ba32ea8e1eb7d7cbf8288da94a253ccb9f81bcb06092e05537fd573c75b37f8fbb2d1f1977a0a8b1676469ac80b0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:^3.974.33":
+  version: 3.974.49
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.974.49"
+  dependencies:
+    "@aws-sdk/checksums": "npm:^3.1000.24"
+    tslib: "npm:^2.6.2"
+  checksum: 10/5170e0adfe47b2cf337647df21097d7a598a977d887a46b24d0f11afbbd41877656049124a240c4b5f1bf2c04a34c8f519827265fccb2280b5e944e2acb41a84
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.54":
+  version: 3.972.70
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.70"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/09ce4bd2a8a95c4c5067963610c7d1ea5c05951c4a8de072e5cc7007a5c23ad5584b75b117222510cbfcfd9b7208a3605a5dc8e8cdb9e74c20c282b438148daf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.39":
+  version: 3.997.39
+  resolution: "@aws-sdk/nested-clients@npm:3.997.39"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.43"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/fetch-http-handler": "npm:^5.6.13"
+    "@smithy/node-http-handler": "npm:^4.9.13"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/74a765a9fc1a4a8442603808f10d6e92d576e43a75008d79cd26d00474adaf25ea1aad0b9d9933bd0a15f01da030853fe46757d2b3f254f45c76c78b46112bf4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.35, @aws-sdk/signature-v4-multi-region@npm:^3.996.43":
+  version: 3.996.43
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.43"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/07a95a47866ae69af40aa36c69a6105e97723aa6aef85daec19e28a7f1a19fb56f999e33c563e8fab8d65098b2f48a6fb309266bea2d60a7e756fd72409b5097
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1100.0":
+  version: 3.1100.0
+  resolution: "@aws-sdk/token-providers@npm:3.1100.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.4"
+    "@aws-sdk/nested-clients": "npm:^3.997.39"
+    "@aws-sdk/types": "npm:^3.974.2"
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1ccee85022bdeb85fc0966c943b862690f3ff08d58b95a3795d389fc24df3536f65a10b94e7ed2da59ad8a812f3ae82fef700faac3ff7f3c334e45fa83926a6c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.973.13, @aws-sdk/types@npm:^3.974.2":
+  version: 3.974.2
+  resolution: "@aws-sdk/types@npm:3.974.2"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/12a2a3c13507211881d91d9186c0d20b138a569ab8e1937744393d2bcb14dc01257a97de42dd7ef002500a49f0237ce1faeb11e5a9c607d4ad16fd63357cefee
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.965.8
+  resolution: "@aws-sdk/util-locate-window@npm:3.965.8"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/2244bb447b2c85eb764f8d7d283726a6c25e96999a349d0939cf8da44f6aee1f60c71b71d5aee11831c91706b4b8f00eee6613688124fbf752218fb5f36e9d4f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.36, @aws-sdk/xml-builder@npm:^3.972.37":
+  version: 3.972.37
+  resolution: "@aws-sdk/xml-builder@npm:3.972.37"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/20f221d158a12cb39b117e65cde8ecb19f629d5292def76adee8680dad176cf6c9f0e83a3534c65bcd40ffaf5fa8a2afd62de262c4c00b355d1c8c057c261acb
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@aws/lambda-invoke-store@npm:0.3.0"
+  checksum: 10/4a6c7af16477dd330d4dcd2269f89370be68295b54ae1e90ef8c2175efa4df6735f9a3f914ab7efa21ba7db5477031fe8488853adcd268eeb6cb8e34ad06b206
+  languageName: node
+  linkType: hard
+
 "@babel/cli@npm:7.28.3":
   version: 7.28.3
   resolution: "@babel/cli@npm:7.28.3"
@@ -5772,6 +6143,98 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.24.6, @smithy/core@npm:^3.29.4, @smithy/core@npm:^3.31.1":
+  version: 3.31.1
+  resolution: "@smithy/core@npm:3.31.1"
+  dependencies:
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/4a66d0f1f6b6aac8cbe424d0c9c6ca12e02b8b64c21065de396b60c203f163e245000e4607f02d1a8391028a669a78b666843dc5769af4c8f0101afd6858aba0
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.4.16":
+  version: 4.4.16
+  resolution: "@smithy/credential-provider-imds@npm:4.4.16"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/5a9d54b151ec9296db79f52e68c8fd1feddd4d75332f13dad0dc5efe2aabe3994092193ea532c2cb3e5133f099a650accbd2ff836b4aba916b96d0d796766a0c
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.4.6, @smithy/fetch-http-handler@npm:^5.6.13":
+  version: 5.6.13
+  resolution: "@smithy/fetch-http-handler@npm:5.6.13"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/272d367031096802c8ea7c8e7479e7522589018628064e01b5d101316091687eaa48b4029543e0a11486db6ec4ffbcd9a9ac26923f0a655150e33fe9e085e3ca
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/is-array-buffer@npm:2.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/d366743ecc7a9fc3bad21dbb3950d213c12bdd4aeb62b1265bf6cbe38309df547664ef3e51ab732e704485194f15e89d361943b0bfbe3fe1a4b3178b942913cc
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.7.6, @smithy/node-http-handler@npm:^4.9.13":
+  version: 4.9.13
+  resolution: "@smithy/node-http-handler@npm:4.9.13"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d52fac160d879b957c8092c70e9991c23a3775bb448a8c6d5836873afab1f5ea43dd72c63150da748879b29443f0af7f83fb777763975a81939e8806e18ba71a
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.6.12, @smithy/signature-v4@npm:^5.6.5":
+  version: 5.6.12
+  resolution: "@smithy/signature-v4@npm:5.6.12"
+  dependencies:
+    "@smithy/core": "npm:^3.31.1"
+    "@smithy/types": "npm:^4.16.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0a14dac2c93118eb5fabdb34c8e3dd042fb645be959a6546e67c6b3d181a3df8f13ef210a8c2b9811371b8b0fc846d9e15e9bb3076bcb1c019e830f924fba60a
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.14.3, @smithy/types@npm:^4.16.1":
+  version: 4.16.1
+  resolution: "@smithy/types@npm:4.16.1"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/23651203f2e8800b2b2311ef163ddec166d91e15b30fa1c877be352aeef8ae7cc7b0189f99e07b0dcd52160b10adfb3fa4ca32c38a2d7195fc5428b8986d5201
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-buffer-from@npm:2.2.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/53253e4e351df3c4b7907dca48a0a6ceae783e98a8e73526820b122b3047a53fd127c19f4d8301f68d852011d821da519da783de57e0b22eed57c4df5b90d089
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@smithy/util-utf8@npm:2.3.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c766ead8dac6bc6169f4cac1cc47ef7bd86928d06255148f9528228002f669c8cc49f78dc2b9ba5d7e214d40315024a9e32c5c9130b33e20f0fe4532acd0dff5
+  languageName: node
+  linkType: hard
+
 "@speed-highlight/core@npm:^1.2.7":
   version: 1.2.14
   resolution: "@speed-highlight/core@npm:1.2.14"
@@ -7667,6 +8130,13 @@ __metadata:
   version: 2.19.5
   resolution: "bottleneck@npm:2.19.5"
   checksum: 10/ffb982185236fc42b135f88eb3cfc8b87c4307fb9c3e3658e843ed673ad1c77780b65a01ab532f9857fa0f75ad4d6c1857985b21c9b2bd7eac8ef3c378d7ebf6
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 10/a002f0795ef360314c75552b94daa42f74473f38b34255cfa959779e875806ef8e41b24ec63a533717798c8ef70bb991aef3037a2bb5dd32e8f507b39a509163
   languageName: node
   linkType: hard
 
@@ -10643,6 +11113,18 @@ __metadata:
   checksum: 10/571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
   languageName: node
   linkType: hard
+
+"eufemia-analytics@workspace:tools/analytics":
+  version: 0.0.0-use.local
+  resolution: "eufemia-analytics@workspace:tools/analytics"
+  dependencies:
+    "@aws-sdk/client-athena": "npm:3.1075.0"
+    "@aws-sdk/client-s3": "npm:3.1075.0"
+    "@types/aws-lambda": "npm:8.10.161"
+    esbuild: "npm:0.25.5"
+    vitest: "npm:4.1.8"
+  languageName: unknown
+  linkType: soft
 
 "eufemia-llm-metadata@workspace:tools/eufemia-llm-metadata":
   version: 0.0.0-use.local
@@ -20888,6 +21370,13 @@ __metadata:
   version: 2.6.0
   resolution: "tslib@npm:2.6.0"
   checksum: 10/52360693c62761f902e1946b350188be6505de297068b33421cb26bedd99591203a74cb2a49e1f43f0922d59b1fb3499fe5cfe61a61ca65a1743d5c92c69720a
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.2":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

[EDS-937](https://dnb-asa.atlassian.net/browse/EDS-937) — we want a simple, low-maintenance place to collect analytics records and query them flexibly (group-by / trends) for a future dashboard, without standing up and operating a database.

## Summary

Adds `tools/analytics/` — internal AWS tooling to store and retrieve analytics records over an HTTP API (`POST /records`, `GET /records`, `GET /healthz`). Records are written to S3 (date-partitioned) and read back via Athena over a Glue table with partition projection. Internal tooling only; not part of the published `@dnb/eufemia` package.

## Why this way

S3 + Athena suits flexible group-by/trend queries far better than DynamoDB, and reusing the `tools/mcp-lambda` deploy pattern (pre-created role per ADR 0004, shared S3 state backend, OIDC deploy, `nodejs22.x`) keeps a single, consistent way to ship AWS tooling in this repo.
