### PR TITLE
chore(docs): align Accordion and DrawerList property tables with implementation

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -116,11 +116,6 @@ export const AccordionProperties: PropertiesTableProps = {
     type: 'React.RefObject',
     status: 'optional',
   },
-  collapseAllHandleRef: {
-    doc: 'Ref handle to collapse all expanded accordions. Send in a ref and use `.current()` to collapse all accordions. Defaults to `undefined`.',
-    type: 'React.RefObject<() => void>',
-    status: 'optional',
-  },
   space: {
     doc: 'Spacing properties like `top` or `bottom` are supported.',
     type: ['string', 'object'],
@@ -185,6 +180,11 @@ export const AccordionProviderGroupProperties: PropertiesTableProps = {
   expandedId: {
     doc: 'Define an `id` of a nested accordion that will get expanded.',
     type: 'string',
+    status: 'optional',
+  },
+  collapseAllHandleRef: {
+    doc: 'Ref handle to collapse all expanded accordions. Send in a ref and use `.current()` to collapse all accordions. Defaults to `undefined`.',
+    type: 'React.RefObject<() => void>',
     status: 'optional',
   },
   space: {

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
@@ -31,11 +31,6 @@ export const DrawerListProperties: PropertiesTableProps = {
     type: ['"auto"', '"top"', '"bottom"'],
     status: 'optional',
   },
-  labelDirection: {
-    doc: 'Use `labelDirection="horizontal"` to change the label layout direction. Defaults to `vertical`.',
-    type: 'string',
-    status: 'optional',
-  },
   preventSelection: {
     doc: 'If set to `true`, the DrawerList will then not make any permanent selection.',
     type: 'boolean',


### PR DESCRIPTION
## Summary

Continuing the docs/prop-consistency audit (follow-up to #8913), comparing every `*Docs.ts` property table against the fully-resolved component `*Props` types via the TypeScript compiler API. Two components had a documented property that didn't match the component's actual props:

### Accordion — `collapseAllHandleRef` documented on the wrong component
`collapseAllHandleRef` is a member of `AccordionGroupProps` (not `AccordionProps`) and is only read from the Accordion provider context — it is set on `Accordion.Group` / `Accordion.Provider` (per the demo: `<Accordion.Group collapseAllHandleRef={...}>`). It was listed in the main `AccordionProperties` table. Moved it to `AccordionProviderGroupProperties`, next to the other group props (`allowCloseAll`, `expandBehavior`, `expandedId`).

### DrawerList — stale `labelDirection` entry
`labelDirection` is not a DrawerList prop (absent from the resolved `DrawerListProps` and from all drawer-list source). It's already documented on `Dropdown` and `Autocomplete`, whose properties pages also render the shared `DrawerListProperties` table — so the entry was a duplicate there and incorrectly appeared on the standalone DrawerList fragment page. Removed it.

## Notes

The rest of the library's docs held up well: **no `type` field mismatches**, no other prop-name (naming) bugs, and the remaining flagged differences were intentional — deprecated props kept for migration, shared/composed props documented centrally or via links (Field.* `useFieldProps`, Button-based components, Modal/Dialog/Drawer base, Dropdown/Autocomplete using the DrawerList table, Stat wrapping NumberFormat), and data-object reference tables (e.g. `DrawerListItem` documents the `data` item shape).

No unit tests added — consistent with the repo convention for `*Docs.ts` files.
