### PR TITLE
chore(Avatar): document Avatar.Group backgroundColor and color props

### DIFF
--- a/packages/dnb-eufemia/src/components/avatar/AvatarDocs.ts
+++ b/packages/dnb-eufemia/src/components/avatar/AvatarDocs.ts
@@ -79,6 +79,16 @@ export const AvatarGroupProperties: PropertiesTableProps = {
     type: ['"primary"', '"secondary"', '"tertiary"'],
     status: 'optional',
   },
+  backgroundColor: {
+    doc: 'Define a custom background color for the Avatars, instead of a variant. Use a Eufemia color.',
+    type: 'string',
+    status: 'optional',
+  },
+  color: {
+    doc: 'Define a custom color to complement the backgroundColor for the Avatars. Use a Eufemia color.',
+    type: 'string',
+    status: 'optional',
+  },
   maxElements: {
     doc: 'Number of max displayed elements, including the "elements hidden text (+x)". Defaults to `4`.',
     type: 'number',


### PR DESCRIPTION
## Summary

Continuing the docs/prop-consistency audit (follow-up to #8913 and #8917), this pass targets the **completeness** dimension — props declared directly on a component's own type (not inherited/composed) that are missing from its docs table.

### Avatar.Group — undocumented `backgroundColor` and `color`
`Avatar.Group` accepts `backgroundColor` and `color`, applied to every avatar in the group (destructured in `AvatarGroup.tsx` and passed through context). The individual `Avatar` documents both, but `AvatarGroupProperties` omitted them. Added both, using the group-specific descriptions from the component's own JSDoc.

## Notes

The rest of the library's own-prop coverage held up well — the other audit candidates were intentional or not genuine gaps:
- documented via a shared table rendered on the same page (e.g. Autocomplete `value`/`defaultValue` via the DrawerList table),
- documented in a sibling events table (e.g. Popover `onOpenChange`, Table `collapseAllHandleRef`),
- advanced/niche or internal props consistently left undocumented across components (`transitionState`, `internalClass`, Tooltip `targetRefreshKey`, Popover `onFocusComplete`),
- or ambiguous/low-value (e.g. Table's single-value `variant`).

No unit tests — consistent with the repo convention for `*Docs.ts` files.
