### PR TITLE
feat(Form.Section.EditContainer): prevent navigation with unconfirmed changes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/Examples.tsx
@@ -1,5 +1,10 @@
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
-import { Field, Form, Value } from '@dnb/eufemia/src/extensions/forms'
+import {
+  Field,
+  Form,
+  Value,
+  Wizard,
+} from '@dnb/eufemia/src/extensions/forms'
 
 export const ViewAndEditContainer = () => {
   return (
@@ -49,6 +54,35 @@ export const ViewAndEditContainer = () => {
           </Form.Handler>
         )
       }}
+    </ComponentBox>
+  )
+}
+
+export const PreventUncommittedChanges = () => {
+  return (
+    <ComponentBox>
+      <Form.Handler>
+        <Wizard.Container>
+          <Wizard.Step title="Profile">
+            <Form.Section path="/profile" containerMode="edit">
+              <Form.Section.EditContainer preventUncommittedChanges>
+                <Field.Name.First path="/firstName" />
+              </Form.Section.EditContainer>
+
+              <Form.Section.ViewContainer>
+                <Value.Name.First path="/firstName" />
+              </Form.Section.ViewContainer>
+            </Form.Section>
+
+            <Wizard.Buttons />
+          </Wizard.Step>
+
+          <Wizard.Step title="Summary">
+            <Value.Name.First path="/profile/firstName" />
+            <Wizard.Buttons />
+          </Wizard.Step>
+        </Wizard.Container>
+      </Form.Handler>
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
@@ -7,6 +7,14 @@ import * as Examples from './Examples'
 
 ## Demos
 
+### View and edit container
+
 This demo shows the edit container opened by default by using the `containerMode="edit"` property.
 
 <Examples.ViewAndEditContainer />
+
+### Prevent uncommitted changes
+
+With `preventUncommittedChanges`, the user must select "Done" or "Cancel" before continuing to the next Wizard step, even when no values have changed.
+
+<Examples.PreventUncommittedChanges />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/info.mdx
@@ -16,6 +16,8 @@ render(<Form.Section.EditContainer />)
 
 By default, it features a toolbar containing a "Done" button and a "Cancel" button. The "Cancel" button resets any changes made to the item content, restoring it to its original state.
 
+Use `preventUncommittedChanges` when users must confirm the section before submitting the form or continuing to the next Wizard step. Navigation is blocked while the section is in edit mode, until the user selects "Done" or "Cancel". The parent `Form.Section` must have a `path`.
+
 ```tsx
 import { Form, Field, Value } from '@dnb/eufemia/extensions/forms'
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/useHandleStatus.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Isolation/useHandleStatus.ts
@@ -36,7 +36,7 @@ export default function useHandleStatus({
 }
 
 // This hook/state is used to not show the status right away, after the user has cleared the PushContainer data.
-function useShowStatus({
+export function useShowStatus({
   outerContext,
   hasContentChanged,
   preventUncommittedChanges,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
@@ -7,6 +7,7 @@ import { Button, Dialog } from '../../../../../components'
 import { close } from '../../../../../icons'
 import useContainerDataStore from './useContainerDataStore'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
+import EditContainerContext from './EditContainerContext'
 
 type Props = ComponentProps<typeof Button> & {
   showConfirmDialog?: boolean
@@ -17,7 +18,12 @@ export default function CancelButton({
   ...buttonProps
 }: Props) {
   const { onCancel, setShowError } = useContext(ToolbarContext) || {}
-  const { restoreOriginalData } = useContainerDataStore()
+  const editContainerContext = useContext(EditContainerContext)
+  const fallbackDataStore = useContainerDataStore({
+    enabled: !editContainerContext,
+    trackChanges: !editContainerContext,
+  })
+  const { restoreOriginalData } = editContainerContext || fallbackDataStore
   const { switchContainerMode } = useContext(SectionContainerContext) || {}
   const { setShowBoundaryErrors, verifyFieldError, hasVisibleError } =
     useContext(FieldBoundaryContext) || {}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
@@ -21,7 +21,6 @@ export default function CancelButton({
   const editContainerContext = useContext(EditContainerContext)
   const fallbackDataStore = useContainerDataStore({
     enabled: !editContainerContext,
-    trackChanges: !editContainerContext,
   })
   const { restoreOriginalData } = editContainerContext || fallbackDataStore
   const { switchContainerMode } = useContext(SectionContainerContext) || {}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '../../../hooks'
 import { Button } from '../../../../../components'
 import { check } from '../../../../../icons'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
+import EditContainerContext from './EditContainerContext'
 
 export default function DoneEditButton() {
   const { onDone, setShowError } = useContext(ToolbarContext) || {}
@@ -14,6 +15,7 @@ export default function DoneEditButton() {
     useContext(FieldBoundaryContext) || {}
 
   const translation = useTranslation().SectionEditContainer
+  const { confirmChanges } = useContext(EditContainerContext) || {}
 
   const doneHandler = useCallback(() => {
     if (hasError) {
@@ -24,12 +26,14 @@ export default function DoneEditButton() {
     } else {
       setShowError(false)
       setShowBoundaryErrors?.(false)
+      confirmChanges?.()
       switchContainerMode?.('view')
       onDone?.()
     }
   }, [
     hasError,
     hasVisibleError,
+    confirmChanges,
     onDone,
     setShowBoundaryErrors,
     setShowError,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from '../../../hooks'
 import { Button } from '../../../../../components'
 import { check } from '../../../../../icons'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
-import EditContainerContext from './EditContainerContext'
 
 export default function DoneEditButton() {
   const { onDone, setShowError } = useContext(ToolbarContext) || {}
@@ -15,8 +14,6 @@ export default function DoneEditButton() {
     useContext(FieldBoundaryContext) || {}
 
   const translation = useTranslation().SectionEditContainer
-  const { confirmChanges } = useContext(EditContainerContext) || {}
-
   const doneHandler = useCallback(() => {
     if (hasError) {
       setShowBoundaryErrors?.(true)
@@ -26,14 +23,12 @@ export default function DoneEditButton() {
     } else {
       setShowError(false)
       setShowBoundaryErrors?.(false)
-      confirmChanges?.()
       switchContainerMode?.('view')
       onDone?.()
     }
   }, [
     hasError,
     hasVisibleError,
-    confirmChanges,
     onDone,
     setShowBoundaryErrors,
     setShowError,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -8,7 +8,7 @@ import {
 import type { ReactNode } from 'react'
 import { clsx } from 'clsx'
 import { convertJsxToString } from '../../../../../shared/component-helper'
-import { Flex } from '../../../../../components'
+import { Flex, FormStatus } from '../../../../../components'
 import type { FlexContainerAllProps as FlexContainerProps } from '../../../../../components/flex/Container'
 import { Lead } from '../../../../../elements'
 import FieldBoundaryProvider from '../../../DataContext/FieldBoundary/FieldBoundaryProvider'
@@ -20,11 +20,21 @@ import type { SectionContainerProps } from '../containers/SectionContainer'
 import SectionContainer from '../containers/SectionContainer'
 import type { Path } from '../../../types'
 import withComponentMarkers from '../../../../../shared/helpers/withComponentMarkers'
+import DataContext from '../../../DataContext/Context'
+import { useTranslation } from '../../../hooks'
+import useReportError from '../../Isolation/useReportError'
+import { useShowStatus } from '../../Isolation/useHandleStatus'
+import useContainerDataStore from './useContainerDataStore'
+import EditContainerContext from './EditContainerContext'
 
 export type FormSectionEditContainerProps = {
   title?: ReactNode
   onDone?: () => void
   onCancel?: () => void
+  /**
+   * Prevents form submission and Wizard navigation until changes are confirmed with the Done button or discarded with the Cancel button.
+   */
+  preventUncommittedChanges?: boolean
 }
 
 export type FormSectionEditContainerAllProps =
@@ -33,8 +43,15 @@ export type FormSectionEditContainerAllProps =
     FlexContainerProps
 
 function EditContainer(props: FormSectionEditContainerAllProps) {
-  const { children, className, title, onDone, onCancel, ...restProps } =
-    props || {}
+  const {
+    children,
+    className,
+    title,
+    onDone,
+    onCancel,
+    preventUncommittedChanges = false,
+    ...restProps
+  } = props || {}
   const ariaLabel = useMemo(() => convertJsxToString(title), [title])
   const {
     containerMode,
@@ -44,6 +61,26 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
     disableEditing,
   } = useContext(SectionContainerContext) || {}
   const omitFocusManagementRef = useRef(false)
+  const dataContext = useContext(DataContext)
+  const dataStore = useContainerDataStore({
+    enabled: true,
+    trackChanges: preventUncommittedChanges,
+  })
+  const hasUncommittedChanges =
+    preventUncommittedChanges && dataStore.hasUncommittedChanges
+  const { preventUncommittedChangesText } =
+    useTranslation().SectionEditContainer
+
+  useReportError(
+    hasUncommittedChanges ? uncommittedChangesError : undefined,
+    dataContext,
+    'section-edit-container'
+  )
+  const showUncommittedChangesStatus = useShowStatus({
+    outerContext: dataContext,
+    hasContentChanged: hasUncommittedChanges,
+    preventUncommittedChanges,
+  })
 
   const onPathError = useCallback(
     (path: Path, error: Error) => {
@@ -73,31 +110,45 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   )
 
   return (
-    <FieldBoundaryProvider
-      showErrors={validateInitially}
-      onPathError={onPathError}
-    >
-      <SectionContainer
-        mode="edit"
-        ariaLabel={ariaLabel}
-        omitFocusManagementRef={omitFocusManagementRef}
-        className={clsx('dnb-forms-section-edit-block', className)}
-        {...restProps}
+    <EditContainerContext value={dataStore}>
+      <FieldBoundaryProvider
+        showErrors={validateInitially}
+        onPathError={onPathError}
       >
-        <Flex.Stack>
-          {title && <Lead size="basis">{title}</Lead>}
-          {children}
-          {hasToolbar ? null : (
-            <Toolbar onDone={onDone} onCancel={onCancel}>
-              <DoneButton />
-              <CancelButton />
-            </Toolbar>
-          )}
-        </Flex.Stack>
-      </SectionContainer>
-    </FieldBoundaryProvider>
+        <SectionContainer
+          mode="edit"
+          ariaLabel={ariaLabel}
+          omitFocusManagementRef={omitFocusManagementRef}
+          className={clsx('dnb-forms-section-edit-block', className)}
+          {...restProps}
+        >
+          <Flex.Stack>
+            {title && <Lead size="basis">{title}</Lead>}
+            {children}
+            {hasToolbar ? null : (
+              <Toolbar onDone={onDone} onCancel={onCancel}>
+                <DoneButton />
+                <CancelButton />
+              </Toolbar>
+            )}
+            {preventUncommittedChanges && (
+              <FormStatus
+                noAnimation={false}
+                show={Boolean(showUncommittedChangesStatus)}
+              >
+                {preventUncommittedChangesText}
+              </FormStatus>
+            )}
+          </Flex.Stack>
+        </SectionContainer>
+      </FieldBoundaryProvider>
+    </EditContainerContext>
   )
 }
+
+const uncommittedChangesError = new Error(
+  'Form.Section.EditContainer has uncommitted changes'
+)
 
 EditContainer.DoneButton = DoneButton
 EditContainer.CancelButton = CancelButton

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -2,14 +2,12 @@ import {
   isValidElement,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
 } from 'react'
 import type { ReactNode } from 'react'
 import { clsx } from 'clsx'
 import { convertJsxToString } from '../../../../../shared/component-helper'
-import { warn } from '../../../../../shared/helpers'
 import { Flex, FormStatus } from '../../../../../components'
 import type { FlexContainerAllProps as FlexContainerProps } from '../../../../../components/flex/Container'
 import { Lead } from '../../../../../elements'
@@ -69,20 +67,17 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   const dataStore = useContainerDataStore({
     enabled: true,
   })
-  const preventNavigation =
-    preventUncommittedChanges && Boolean(sectionPath)
+  const preventNavigation = preventUncommittedChanges
   const hasUncommittedChanges =
     preventNavigation && dataStore.hasUncommittedChanges
   const { preventUncommittedChangesText } =
     useTranslation().SectionEditContainer
 
-  useEffect(() => {
-    if (preventUncommittedChanges && !sectionPath) {
-      warn(
-        'Form.Section.EditContainer requires Form.Section to have a path when preventUncommittedChanges is enabled.'
-      )
-    }
-  }, [preventUncommittedChanges, sectionPath])
+  if (preventUncommittedChanges && !sectionPath) {
+    throw new Error(
+      'Form.Section.EditContainer requires its parent Form.Section to have a path when preventUncommittedChanges is enabled.'
+    )
+  }
 
   useReportError(
     hasUncommittedChanges ? uncommittedChangesError : undefined,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -32,7 +32,7 @@ export type FormSectionEditContainerProps = {
   onDone?: () => void
   onCancel?: () => void
   /**
-   * Prevents form submission and Wizard navigation until changes are confirmed with the Done button or discarded with the Cancel button.
+   * Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected.
    */
   preventUncommittedChanges?: boolean
 }
@@ -64,7 +64,6 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   const dataContext = useContext(DataContext)
   const dataStore = useContainerDataStore({
     enabled: true,
-    trackChanges: preventUncommittedChanges,
   })
   const hasUncommittedChanges =
     preventUncommittedChanges && dataStore.hasUncommittedChanges

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -2,12 +2,14 @@ import {
   isValidElement,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
 } from 'react'
 import type { ReactNode } from 'react'
 import { clsx } from 'clsx'
 import { convertJsxToString } from '../../../../../shared/component-helper'
+import { warn } from '../../../../../shared/helpers'
 import { Flex, FormStatus } from '../../../../../components'
 import type { FlexContainerAllProps as FlexContainerProps } from '../../../../../components/flex/Container'
 import { Lead } from '../../../../../elements'
@@ -26,13 +28,14 @@ import useReportError from '../../Isolation/useReportError'
 import { useShowStatus } from '../../Isolation/useHandleStatus'
 import useContainerDataStore from './useContainerDataStore'
 import EditContainerContext from './EditContainerContext'
+import SectionContext from '../SectionContext'
 
 export type FormSectionEditContainerProps = {
   title?: ReactNode
   onDone?: () => void
   onCancel?: () => void
   /**
-   * Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected.
+   * Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected. Requires Form.Section to have a path.
    */
   preventUncommittedChanges?: boolean
 }
@@ -62,13 +65,24 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   } = useContext(SectionContainerContext) || {}
   const omitFocusManagementRef = useRef(false)
   const dataContext = useContext(DataContext)
+  const { path: sectionPath } = useContext(SectionContext) || {}
   const dataStore = useContainerDataStore({
     enabled: true,
   })
+  const preventNavigation =
+    preventUncommittedChanges && Boolean(sectionPath)
   const hasUncommittedChanges =
-    preventUncommittedChanges && dataStore.hasUncommittedChanges
+    preventNavigation && dataStore.hasUncommittedChanges
   const { preventUncommittedChangesText } =
     useTranslation().SectionEditContainer
+
+  useEffect(() => {
+    if (preventUncommittedChanges && !sectionPath) {
+      warn(
+        'Form.Section.EditContainer requires Form.Section to have a path when preventUncommittedChanges is enabled.'
+      )
+    }
+  }, [preventUncommittedChanges, sectionPath])
 
   useReportError(
     hasUncommittedChanges ? uncommittedChangesError : undefined,
@@ -78,7 +92,7 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   const showUncommittedChangesStatus = useShowStatus({
     outerContext: dataContext,
     hasContentChanged: hasUncommittedChanges,
-    preventUncommittedChanges,
+    preventUncommittedChanges: preventNavigation,
   })
 
   const onPathError = useCallback(
@@ -130,7 +144,7 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
                 <CancelButton />
               </Toolbar>
             )}
-            {preventUncommittedChanges && (
+            {preventNavigation && (
               <FormStatus
                 noAnimation={false}
                 show={Boolean(showUncommittedChangesStatus)}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react'
+
+export type EditContainerContextState = {
+  confirmChanges: () => void
+  restoreOriginalData: () => void
+}
+
+const EditContainerContext = createContext<
+  EditContainerContextState | undefined
+>(undefined)
+
+export default EditContainerContext

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerContext.ts
@@ -1,7 +1,6 @@
 import { createContext } from 'react'
 
 export type EditContainerContextState = {
-  confirmChanges: () => void
   restoreOriginalData: () => void
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
@@ -11,6 +11,11 @@ export const EditContainerProperties: PropertiesTableProps = {
     type: ['"outline"', '"filled"', '"basic"'],
     status: 'optional',
   },
+  preventUncommittedChanges: {
+    doc: 'Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected. Requires Form.Section to have a path.',
+    type: 'boolean',
+    status: 'optional',
+  },
 
   '[FlexVertical](/uilib/layout/flex/container/properties)': {
     doc: 'All Flex.Vertical properties.',

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -89,29 +89,35 @@ describe('EditContainer and ViewContainer', () => {
         document.querySelector('.dnb-forms-submit-button')
       )
 
-      expect(onSubmit).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
       expect(onSubmit).toHaveBeenLastCalledWith(
         { name: 'Ada' },
         expect.anything()
       )
     })
 
-    it('should allow submission after changes are cancelled', async () => {
-      const onSubmit = vi.fn()
-
+    it('should clear the navigation block after changes are cancelled', async () => {
       render(
-        <Form.Handler
-          defaultData={{ person: { name: 'Ada' } }}
-          onSubmit={onSubmit}
-        >
-          <Form.Section path="/person" containerMode="edit">
-            <Form.Section.EditContainer preventUncommittedChanges>
-              <Field.String path="/name" />
-            </Form.Section.EditContainer>
-            <Form.Section.ViewContainer>Person</Form.Section.ViewContainer>
-          </Form.Section>
-
-          <Form.SubmitButton />
+        <Form.Handler defaultData={{ person: { name: 'Ada' } }}>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Form.Section path="/person" containerMode="edit">
+                <Form.Section.EditContainer preventUncommittedChanges>
+                  <Field.String path="/name" />
+                </Form.Section.EditContainer>
+                <Form.Section.ViewContainer>
+                  Person
+                </Form.Section.ViewContainer>
+              </Form.Section>
+              <Wizard.NextButton />
+            </Wizard.Step>
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+            </Wizard.Step>
+          </Wizard.Container>
         </Form.Handler>
       )
 
@@ -119,10 +125,10 @@ describe('EditContainer and ViewContainer', () => {
       await userEvent.clear(input)
       await userEvent.type(input, 'Grace')
       await userEvent.click(
-        document.querySelector('.dnb-forms-submit-button')
+        document.querySelector('.dnb-forms-next-button')
       )
 
-      expect(onSubmit).toHaveBeenCalledTimes(0)
+      expect(document.querySelector('output')).toHaveTextContent('Step 1')
 
       const buttons = document.querySelectorAll(
         '.dnb-forms-section-edit-block .dnb-button'
@@ -131,18 +137,19 @@ describe('EditContainer and ViewContainer', () => {
       await userEvent.click(
         document.querySelector('.dnb-dialog .dnb-button--primary')
       )
+      await waitFor(() => {
+        expect(
+          document.querySelector('.dnb-forms-section-edit-block')
+        ).toHaveAttribute('aria-hidden', 'true')
+      })
       await userEvent.click(
-        document.querySelector('.dnb-forms-submit-button')
+        document.querySelector('.dnb-forms-next-button')
       )
 
-      expect(onSubmit).toHaveBeenCalledTimes(1)
-      expect(onSubmit).toHaveBeenLastCalledWith(
-        { person: { name: 'Ada' } },
-        expect.anything()
-      )
+      expect(document.querySelector('output')).toHaveTextContent('Step 2')
     })
 
-    it('should not prevent navigation when values are unchanged', async () => {
+    it('should prevent navigation while the section is in edit mode', async () => {
       render(
         <Form.Handler>
           <Wizard.Container>
@@ -166,10 +173,13 @@ describe('EditContainer and ViewContainer', () => {
         document.querySelector('.dnb-forms-next-button')
       )
 
-      expect(document.querySelector('output')).toHaveTextContent('Step 2')
+      expect(document.querySelector('output')).toHaveTextContent('Step 1')
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.SectionEditContainer.preventUncommittedChangesText
+      )
     })
 
-    it('should not prevent navigation when changes are reverted', async () => {
+    it('should prevent navigation when changes are reverted', async () => {
       render(
         <Form.Handler defaultData={{ name: 'Ada' }}>
           <Wizard.Container>
@@ -198,7 +208,7 @@ describe('EditContainer and ViewContainer', () => {
         document.querySelector('.dnb-forms-next-button')
       )
 
-      expect(document.querySelector('output')).toHaveTextContent('Step 2')
+      expect(document.querySelector('output')).toHaveTextContent('Step 1')
     })
   })
 
@@ -399,7 +409,7 @@ describe('EditContainer and ViewContainer', () => {
       const mockUseContainerDataStore = vi
         .spyOn(useContainerDataStoreModule, 'default')
         .mockImplementation(() => {
-          const res = originalHook({ enabled: true, trackChanges: true })
+          const res = originalHook({ enabled: true })
           return {
             ...res,
             restoreOriginalData: () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -9,6 +9,32 @@ const nb = nbNO['nb-NO']
 
 describe('EditContainer and ViewContainer', () => {
   describe('preventUncommittedChanges', () => {
+    it('should not block submission when Form.Section has no path', async () => {
+      const onSubmit = vi.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Form.Section containerMode="edit">
+            <Form.Section.EditContainer preventUncommittedChanges>
+              <Field.String path="/insideSection" />
+            </Form.Section.EditContainer>
+          </Form.Section>
+
+          <Field.String path="/outsideSection" />
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      await userEvent.type(document.querySelectorAll('input')[1], 'hello')
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it('should prevent Wizard navigation until changes are confirmed', async () => {
       render(
         <Form.Handler>
@@ -65,7 +91,7 @@ describe('EditContainer and ViewContainer', () => {
 
       render(
         <Form.Handler onSubmit={onSubmit}>
-          <Form.Section containerMode="edit">
+          <Form.Section path="/section" containerMode="edit">
             <Form.Section.EditContainer preventUncommittedChanges>
               <Field.String path="/name" />
             </Form.Section.EditContainer>
@@ -93,7 +119,7 @@ describe('EditContainer and ViewContainer', () => {
         expect(onSubmit).toHaveBeenCalledTimes(1)
       })
       expect(onSubmit).toHaveBeenLastCalledWith(
-        { name: 'Ada' },
+        { section: { name: 'Ada' } },
         expect.anything()
       )
     })
@@ -155,7 +181,7 @@ describe('EditContainer and ViewContainer', () => {
           <Wizard.Container>
             <Wizard.Step title="Step 1">
               <output>Step 1</output>
-              <Form.Section containerMode="edit">
+              <Form.Section path="/section" containerMode="edit">
                 <Form.Section.EditContainer preventUncommittedChanges>
                   <Field.String path="/name" />
                 </Form.Section.EditContainer>
@@ -181,11 +207,11 @@ describe('EditContainer and ViewContainer', () => {
 
     it('should prevent navigation when changes are reverted', async () => {
       render(
-        <Form.Handler defaultData={{ name: 'Ada' }}>
+        <Form.Handler defaultData={{ section: { name: 'Ada' } }}>
           <Wizard.Container>
             <Wizard.Step title="Step 1">
               <output>Step 1</output>
-              <Form.Section containerMode="edit">
+              <Form.Section path="/section" containerMode="edit">
                 <Form.Section.EditContainer preventUncommittedChanges>
                   <Field.String path="/name" />
                 </Form.Section.EditContainer>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -1,13 +1,207 @@
 import { useContext } from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import SectionContainerContext from '../../containers/SectionContainerContext'
-import { Field, Form } from '../../../..'
+import { Field, Form, Wizard } from '../../../..'
 import userEvent from '@testing-library/user-event'
 import nbNO from '../../../../constants/locales/nb-NO'
 
 const nb = nbNO['nb-NO']
 
 describe('EditContainer and ViewContainer', () => {
+  describe('preventUncommittedChanges', () => {
+    it('should prevent Wizard navigation until changes are confirmed', async () => {
+      render(
+        <Form.Handler>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+
+              <Form.Section path="/person" containerMode="edit">
+                <Form.Section.EditContainer preventUncommittedChanges>
+                  <Field.String path="/name" />
+                </Form.Section.EditContainer>
+                <Form.Section.ViewContainer>
+                  Person
+                </Form.Section.ViewContainer>
+              </Form.Section>
+
+              <Wizard.NextButton />
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      await userEvent.type(document.querySelector('input'), 'Ada')
+      await userEvent.click(
+        document.querySelector('.dnb-forms-next-button')
+      )
+
+      expect(document.querySelector('output')).toHaveTextContent('Step 1')
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.SectionEditContainer.preventUncommittedChangesText
+      )
+
+      await userEvent.type(document.querySelector('input'), ' Lovelace')
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.SectionEditContainer.preventUncommittedChangesText
+      )
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-section-edit-block .dnb-button')
+      )
+      await userEvent.click(
+        document.querySelector('.dnb-forms-next-button')
+      )
+
+      expect(document.querySelector('output')).toHaveTextContent('Step 2')
+    })
+
+    it('should prevent Form.Handler submission until changes are confirmed', async () => {
+      const onSubmit = vi.fn()
+
+      render(
+        <Form.Handler onSubmit={onSubmit}>
+          <Form.Section containerMode="edit">
+            <Form.Section.EditContainer preventUncommittedChanges>
+              <Field.String path="/name" />
+            </Form.Section.EditContainer>
+          </Form.Section>
+
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      await userEvent.type(document.querySelector('input'), 'Ada')
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+
+      expect(onSubmit).toHaveBeenCalledTimes(0)
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-section-edit-block .dnb-button')
+      )
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenLastCalledWith(
+        { name: 'Ada' },
+        expect.anything()
+      )
+    })
+
+    it('should allow submission after changes are cancelled', async () => {
+      const onSubmit = vi.fn()
+
+      render(
+        <Form.Handler
+          defaultData={{ person: { name: 'Ada' } }}
+          onSubmit={onSubmit}
+        >
+          <Form.Section path="/person" containerMode="edit">
+            <Form.Section.EditContainer preventUncommittedChanges>
+              <Field.String path="/name" />
+            </Form.Section.EditContainer>
+            <Form.Section.ViewContainer>Person</Form.Section.ViewContainer>
+          </Form.Section>
+
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.clear(input)
+      await userEvent.type(input, 'Grace')
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+
+      expect(onSubmit).toHaveBeenCalledTimes(0)
+
+      const buttons = document.querySelectorAll(
+        '.dnb-forms-section-edit-block .dnb-button'
+      )
+      await userEvent.click(buttons[1])
+      await userEvent.click(
+        document.querySelector('.dnb-dialog .dnb-button--primary')
+      )
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenLastCalledWith(
+        { person: { name: 'Ada' } },
+        expect.anything()
+      )
+    })
+
+    it('should not prevent navigation when values are unchanged', async () => {
+      render(
+        <Form.Handler>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Form.Section containerMode="edit">
+                <Form.Section.EditContainer preventUncommittedChanges>
+                  <Field.String path="/name" />
+                </Form.Section.EditContainer>
+              </Form.Section>
+              <Wizard.NextButton />
+            </Wizard.Step>
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-next-button')
+      )
+
+      expect(document.querySelector('output')).toHaveTextContent('Step 2')
+    })
+
+    it('should not prevent navigation when changes are reverted', async () => {
+      render(
+        <Form.Handler defaultData={{ name: 'Ada' }}>
+          <Wizard.Container>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Form.Section containerMode="edit">
+                <Form.Section.EditContainer preventUncommittedChanges>
+                  <Field.String path="/name" />
+                </Form.Section.EditContainer>
+              </Form.Section>
+              <Wizard.NextButton />
+            </Wizard.Step>
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      await userEvent.clear(input)
+      await userEvent.type(input, 'Grace')
+      await userEvent.clear(input)
+      await userEvent.type(input, 'Ada')
+      await userEvent.click(
+        document.querySelector('.dnb-forms-next-button')
+      )
+
+      expect(document.querySelector('output')).toHaveTextContent('Step 2')
+    })
+  })
+
   it('should switch mode on pressing edit button', async () => {
     let containerMode = null
 
@@ -205,7 +399,7 @@ describe('EditContainer and ViewContainer', () => {
       const mockUseContainerDataStore = vi
         .spyOn(useContainerDataStoreModule, 'default')
         .mockImplementation(() => {
-          const res = originalHook()
+          const res = originalHook({ enabled: true, trackChanges: true })
           return {
             ...res,
             restoreOriginalData: () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -9,32 +9,6 @@ const nb = nbNO['nb-NO']
 
 describe('EditContainer and ViewContainer', () => {
   describe('preventUncommittedChanges', () => {
-    it('should not block submission when Form.Section has no path', async () => {
-      const onSubmit = vi.fn()
-
-      render(
-        <Form.Handler onSubmit={onSubmit}>
-          <Form.Section containerMode="edit">
-            <Form.Section.EditContainer preventUncommittedChanges>
-              <Field.String path="/insideSection" />
-            </Form.Section.EditContainer>
-          </Form.Section>
-
-          <Field.String path="/outsideSection" />
-          <Form.SubmitButton />
-        </Form.Handler>
-      )
-
-      await userEvent.type(document.querySelectorAll('input')[1], 'hello')
-      await userEvent.click(
-        document.querySelector('.dnb-forms-submit-button')
-      )
-
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledTimes(1)
-      })
-    })
-
     it('should prevent Wizard navigation until changes are confirmed', async () => {
       render(
         <Form.Handler>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
@@ -2,25 +2,21 @@ import { render } from '@testing-library/react'
 import { Form } from '../../../..'
 import nbNO from '../../../../constants/locales/nb-NO'
 import Toolbar from '../../Toolbar'
-import { spyOnEufemiaWarn } from '../../../../../../core/test-utils/testSetup'
 
 const nb = nbNO['nb-NO']
 
 describe('EditContainer', () => {
-  it('should warn when preventUncommittedChanges is used without a section path', () => {
-    const log = spyOnEufemiaWarn()
-
-    render(
-      <Form.Section>
-        <Form.Section.EditContainer preventUncommittedChanges>
-          Edit Content
-        </Form.Section.EditContainer>
-      </Form.Section>
-    )
-
-    expect(log).toHaveBeenCalledWith(
-      expect.any(String),
-      'Form.Section.EditContainer requires Form.Section to have a path when preventUncommittedChanges is enabled.'
+  it('should throw when preventUncommittedChanges is used without a section path', () => {
+    expect(() =>
+      render(
+        <Form.Section>
+          <Form.Section.EditContainer preventUncommittedChanges>
+            Edit Content
+          </Form.Section.EditContainer>
+        </Form.Section>
+      )
+    ).toThrow(
+      'Form.Section.EditContainer requires its parent Form.Section to have a path when preventUncommittedChanges is enabled.'
     )
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
@@ -2,10 +2,28 @@ import { render } from '@testing-library/react'
 import { Form } from '../../../..'
 import nbNO from '../../../../constants/locales/nb-NO'
 import Toolbar from '../../Toolbar'
+import { spyOnEufemiaWarn } from '../../../../../../core/test-utils/testSetup'
 
 const nb = nbNO['nb-NO']
 
 describe('EditContainer', () => {
+  it('should warn when preventUncommittedChanges is used without a section path', () => {
+    const log = spyOnEufemiaWarn()
+
+    render(
+      <Form.Section>
+        <Form.Section.EditContainer preventUncommittedChanges>
+          Edit Content
+        </Form.Section.EditContainer>
+      </Form.Section>
+    )
+
+    expect(log).toHaveBeenCalledWith(
+      expect.any(String),
+      'Form.Section.EditContainer requires Form.Section to have a path when preventUncommittedChanges is enabled.'
+    )
+  })
+
   it('should render default toolbar', () => {
     render(
       <Form.Section>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/useContainerDataStore.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/useContainerDataStore.ts
@@ -1,41 +1,60 @@
-import { useCallback, useContext, useEffect, useRef } from 'react'
-import { extendDeep } from '../../../../../shared/component-helper'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import DataContext from '../../../DataContext/Context'
 import SectionContext from '../SectionContext'
 import SectionContainerContext from '../containers/SectionContainerContext'
 import useDataValue from '../../../hooks/useDataValue'
+import { structuredClone } from '../../../../../shared/helpers/structuredClone'
+import { hasValueChanged } from '../../Isolation/useHasContentChanged'
 
-export default function useContainerDataStore() {
-  const valueBackupRef = useRef<unknown>(undefined)
-
-  const { getData, moveValueToPath } = useDataValue()
-  const { data: dataFromContext, setData } = useContext(DataContext)
+export default function useContainerDataStore({
+  enabled,
+  trackChanges = false,
+}: {
+  enabled: boolean
+  trackChanges?: boolean
+}) {
+  const { value, getData, moveValueToPath } = useDataValue<unknown>(
+    trackChanges ? '/' : undefined
+  )
+  const { internalDataRef, setData } = useContext(DataContext)
   const { path } = useContext(SectionContext) || {}
   const { containerMode } = useContext(SectionContainerContext) || {}
+  const [snapshot, setSnapshot] = useState<{ value: unknown }>()
 
   useEffect(() => {
-    if (containerMode === 'edit' && !valueBackupRef.current) {
-      valueBackupRef.current = getData('/', {
-        includeCurrentPath: true,
-      })
+    if (!enabled) {
+      return
     }
-    if (containerMode === 'view') {
-      valueBackupRef.current = null
+    if (containerMode === 'edit' && !snapshot) {
+      setSnapshot({ value: structuredClone(getData('/')) })
+    } else if (containerMode === 'view' && snapshot) {
+      setSnapshot(undefined)
     }
-  }, [containerMode, getData])
+  }, [containerMode, enabled, getData, snapshot])
+
+  const confirmChanges = useCallback(() => {
+    setSnapshot({ value: structuredClone(getData('/')) })
+  }, [getData])
 
   const restoreOriginalData = useCallback(() => {
-    if (valueBackupRef.current) {
-      const data = extendDeep(
-        {},
-        dataFromContext,
-        moveValueToPath(path, valueBackupRef.current)
+    if (snapshot) {
+      const data = moveValueToPath(
+        path,
+        structuredClone(snapshot.value),
+        structuredClone(internalDataRef?.current)
       )
-      setData?.(data)
+      setData(data)
+      setSnapshot({ value: structuredClone(snapshot.value) })
     }
-  }, [dataFromContext, moveValueToPath, path, setData])
+  }, [internalDataRef, moveValueToPath, path, setData, snapshot])
 
   return {
+    confirmChanges,
     restoreOriginalData,
+    hasUncommittedChanges:
+      trackChanges &&
+      containerMode === 'edit' &&
+      Boolean(snapshot) &&
+      hasValueChanged(value, snapshot?.value),
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/useContainerDataStore.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/useContainerDataStore.ts
@@ -4,18 +4,13 @@ import SectionContext from '../SectionContext'
 import SectionContainerContext from '../containers/SectionContainerContext'
 import useDataValue from '../../../hooks/useDataValue'
 import { structuredClone } from '../../../../../shared/helpers/structuredClone'
-import { hasValueChanged } from '../../Isolation/useHasContentChanged'
 
 export default function useContainerDataStore({
   enabled,
-  trackChanges = false,
 }: {
   enabled: boolean
-  trackChanges?: boolean
 }) {
-  const { value, getData, moveValueToPath } = useDataValue<unknown>(
-    trackChanges ? '/' : undefined
-  )
+  const { getData, moveValueToPath } = useDataValue<unknown>()
   const { internalDataRef, setData } = useContext(DataContext)
   const { path } = useContext(SectionContext) || {}
   const { containerMode } = useContext(SectionContainerContext) || {}
@@ -32,10 +27,6 @@ export default function useContainerDataStore({
     }
   }, [containerMode, enabled, getData, snapshot])
 
-  const confirmChanges = useCallback(() => {
-    setSnapshot({ value: structuredClone(getData('/')) })
-  }, [getData])
-
   const restoreOriginalData = useCallback(() => {
     if (snapshot) {
       const data = moveValueToPath(
@@ -49,12 +40,7 @@ export default function useContainerDataStore({
   }, [internalDataRef, moveValueToPath, path, setData, snapshot])
 
   return {
-    confirmChanges,
     restoreOriginalData,
-    hasUncommittedChanges:
-      trackChanges &&
-      containerMode === 'edit' &&
-      Boolean(snapshot) &&
-      hasValueChanged(value, snapshot?.value),
+    hasUncommittedChanges: enabled && containerMode === 'edit',
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
@@ -59,6 +59,8 @@ export default {
     SectionEditContainer: {
       doneButton: 'Færdig',
       cancelButton: 'Annuller',
+      preventUncommittedChangesText:
+        'Du skal afslutte redigeringen, før du kan fortsætte.',
       errorInSection: 'Du skal rette fejlene ovenfor.',
       confirmCancelText:
         'Er du sikker på, at du vil forkaste dine ændringer?',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -59,6 +59,8 @@ export default {
     SectionEditContainer: {
       doneButton: 'Done',
       cancelButton: 'Cancel',
+      preventUncommittedChangesText:
+        'You must finish editing before continuing.',
       errorInSection: 'You must correct the errors above.',
       confirmCancelText: 'Are you sure you want to discard your changes?',
     },

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -59,6 +59,8 @@ export default {
     SectionEditContainer: {
       doneButton: 'Ferdig',
       cancelButton: 'Avbryt',
+      preventUncommittedChangesText:
+        'Du må fullføre redigeringen før du kan fortsette.',
       errorInSection: 'Du må rette feilene over.',
       confirmCancelText: 'Er du sikker på at du vil forkaste endringene?',
     },

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -59,6 +59,8 @@ export default {
     SectionEditContainer: {
       doneButton: 'Klar',
       cancelButton: 'Avbryt',
+      preventUncommittedChangesText:
+        'Du måste avsluta redigeringen innan du kan fortsätta.',
       errorInSection: 'Du måste rätta felen ovan.',
       confirmCancelText:
         'Är du säker på att du vill ångra dina ändringar?',


### PR DESCRIPTION
## Description

Adds `preventUncommittedChanges` to `Form.Section.EditContainer`. When enabled, both `Form.Handler` submission and Wizard navigation are blocked while the section is in edit mode, until Done or Cancel is selected—even when no values have changed.

The parent `Form.Section` must have a `path`; using the property without one throws an error to avoid guarding or restoring the whole form.

Includes tests covering `Form.Handler` submission and Wizard navigation, translations, documentation, and a Wizard example.

Preview: https://feat-form-section-prevent-un.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Section/EditContainer#prevent-uncommitted-changes

Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1786088982839399