### PR TITLE
fix(Modal): don't focus the trigger on spurious close of a never-opened modal

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/Modal.tsx
+++ b/packages/dnb-eufemia/src/components/modal/Modal.tsx
@@ -239,7 +239,10 @@ function ModalComponent(ownProps: ModalAllProps) {
         removeActiveState()
       }
 
-      if (currentPreventAutoFocus) {
+      // Only clear after a genuine open, so a modal that is rendered closed
+      // and only receives spurious close side effects (e.g. on parent
+      // re-renders) never auto-focuses its trigger and steals page focus.
+      if (isModalActive && currentPreventAutoFocus) {
         setPreventAutoFocus(false)
       }
     },


### PR DESCRIPTION
## Summary

Fixes the flaky e2e test `dnb-design-system-portal` › `src/e2e/routeFocus.spec.ts` › **"should focus content when navigating to a route without hash"** (e.g. [this run](https://github.com/dnbexperience/eufemia/actions/runs/31161203599/job/92811723319)).

## Root cause (found by instrumenting `focus()` in a real browser)

After a client‑side navigation, the **closed** "Portal Tools" `Drawer`'s `Modal` restored focus to its trigger button (`#portal-tools`), stealing focus from the content heading. Because it races with the route focus effect, `Tab` sometimes started from the wrong place and the assertion timed out — intermittently.

In `Modal`, `preventAutoFocus` was cleared on the **first** side effect. A modal that is rendered **closed** (never opened) still runs a spurious "close" side effect whenever its parent re‑renders with new props (`isNewProps`). That first spurious close cleared `preventAutoFocus`; the next spurious close then focused the trigger — stealing page focus.

## Fix

Only clear `preventAutoFocus` after a **genuine open** (`isModalActive === true`). A modal rendered closed therefore never auto‑focuses its trigger, so navigation no longer steals focus. `preventAutoFocus` only gates the trigger‑focus‑on‑close (it is not passed to `ModalContent`), so focus‑into‑modal on open and focus‑return on a real close are unchanged.

```diff
-      if (currentPreventAutoFocus) {
+      if (isModalActive && currentPreventAutoFocus) {
         setPreventAutoFocus(false)
       }
```

## Validation

- Reproduced the flake in Firefox (portal dev server, 2 workers): **without** the fix the test failed **9/25** under load; **with** the fix it passes **25/25** (and **20/20** again on a warm server).
- Instrumented `HTMLElement.prototype.focus` and captured the stack: `Modal.tsx` `handleSideEffects` → `focus(#portal-tools)`.
- `Modal`, `Drawer`, `Dialog`, `Tooltip` unit suites: **214/214 pass** (no regression), including the existing "focus the trigger on close" tests.

## Tests

The existing `routeFocus.spec.ts` test is the behavioural regression guard (it fails without this fix, passes with it). This browser focus race does not reproduce under jsdom, so no unit test is added.
