### PR TITLE
chore(GlobalStatus): correct documented default for the show prop

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatusDocs.ts
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatusDocs.ts
@@ -42,7 +42,7 @@ export const GlobalStatusProperties: PropertiesTableProps = {
     status: 'optional',
   },
   show: {
-    doc: 'Set to `true` or `false` to manually make the global status visible. Defaults to `true`.',
+    doc: 'Set to `true` or `false` to manually make the global status visible. Defaults to `auto`.',
     type: ['boolean', '"auto"'],
     status: 'optional',
   },


### PR DESCRIPTION
## Summary

Continuing the docs/prop-consistency audit (follow-up to #8913, #8917, #8918), this pass targets **default-value accuracy** — comparing the default stated in each `*Docs.ts` entry ("Defaults to `X`") against the component's actual default (`defaultProps` / destructuring).

### GlobalStatus `show` — wrong documented default
The docs said `show` "Defaults to `true`", but the component default is `auto` (`globalStatusDefaultProps` has `show: 'auto'`; the type is `boolean | 'auto'`). Updated the docs to `auto`.

## Flagged for a maintainer (not changed here)

**WizardContainer `outset`** looks like a *code* bug rather than a docs bug, so I left it alone: the JSDoc and docs both say it "defaults to `true`" (explicitly contrasting Card), but the component destructures `outset = false`. Either the code default should be `true` or the docs should say `false` — since that changes behavior, it needs a human decision.

## Notes

The other audit candidates were false positives, verified against source:
- HTML-element notation (`<span>` vs `span`, `<section>`, `<button>`),
- props whose real per-component default already matches the docs (Flex.Stack `direction`/`align`, List `Item*` font sizes/weights, CardAction `element`) — the audit's directory-wide default scan had picked a sibling component's default,
- values describing something other than the prop default (DrawerList `scrollable` "50vh" is the max-height, not the boolean default),
- state-driven/opaque defaults (GlobalStatus `icon`).

No unit tests — consistent with the repo convention for `*Docs.ts` files.
