### PR TITLE
chore(Wizard): correct documented outset default to false

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -94,7 +94,7 @@ export type WizardContainerProps = ComponentProps & {
    */
   keepInDOM?: boolean
   /**
-   * Whether or not to break out (using negative margins) on larger screens. Same as `outset` in [Card](/uilib/components/card/properties). But defaults to `true`.
+   * Whether or not to break out (using negative margins) on larger screens. Same as `outset` in [Card](/uilib/components/card/properties). Defaults to `false`.
    */
   outset?: boolean
   /**

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainerDocs.ts
@@ -42,7 +42,7 @@ export const WizardContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   outset: {
-    doc: 'Whether or not to break out (using negative margins) on larger screens. Same as `outset` in [Card](/uilib/components/card/properties). But defaults to `true`.',
+    doc: 'Whether or not to break out (using negative margins) on larger screens. Same as `outset` in [Card](/uilib/components/card/properties). Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },


### PR DESCRIPTION
## Summary

The `outset` prop on `Wizard.Container` was documented (and its JSDoc) as "defaults to `true`", but the component destructures `outset = false`.

Investigating the history, this is a **stale docs** bug, not a code bug:
- The default was intentionally removed in the breaking change #6929 (Mar 2026): *"feat(Forms)!: remove default `outset` from Form.Card, Wizard, and inline help"* — so `outset = false` is correct.
- The "But defaults to `true`" wording was later re-introduced by the JSDoc-sync commit (#8639, Jun 2026), which synced the JSDoc from the still-stale Docs string.
- `Card` (which the Wizard doc references as "Same as `outset` in Card") already correctly documents `Defaults to \`false\``.

## Change

Updated both the docs table (`WizardContainerDocs.ts`) and the synced JSDoc (`WizardContainer.tsx`) from "But defaults to `true`." to "Defaults to `false`." — matching the actual default and the Card docs.

No behavior change; no unit tests (per the repo convention for `*Docs.ts`).
