### PR TITLE
chore(GlobalStatus): sync show prop JSDoc default with docs

### DIFF
--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -119,7 +119,7 @@ export type GlobalStatusProps = {
    */
   state?: GlobalStatusState
   /**
-   * Set to `true` or `false` to manually make the global status visible. Defaults to `true`.
+   * Set to `true` or `false` to manually make the global status visible. Defaults to `auto`.
    */
   show?: GlobalStatusShow
   /**
@@ -233,7 +233,7 @@ export type GlobalStatusInterceptorProps = {
   text?: string
   statusId?: GlobalStatusStatusId
   /**
-   * Set to `true` or `false` to manually make the global status visible. Defaults to `true`.
+   * Set to `true` or `false` to manually make the global status visible. Defaults to `auto`.
    */
   show?: boolean
   item?: GlobalStatusItem


### PR DESCRIPTION
## Summary

Fixes JSDoc↔docs drift for the `GlobalStatus` `show` prop. The docs (corrected in #8921) and the actual default (`globalStatusDefaultProps.show = 'auto'`, type `boolean | 'auto'`) are `auto`, but the JSDoc comments still said "Defaults to `true`".

Because `docs-types/sync-docs-jsdoc` is enforced at **error** level (elevated in #8641), this drift currently produces **2 lint errors on `main`** (`GlobalStatusProps.show` and `GlobalStatusInterceptorProps.show`). This PR syncs both JSDoc comments to `auto`, bringing the rule back to green.

## Context

While auditing the broader JSDoc↔docs consistency I confirmed (by running the enforced `sync-docs-jsdoc` rule across `src`) that this is the **only** remaining violation in the library — the rest of the property tables are already in sync. So this is the complete fix for that dimension.

No behavior change; no unit tests (per the repo convention for `*Docs.ts` / JSDoc).
