### PR TITLE
chore(MCP): rename GHE_DEPLOY_REPO secret to GHE_MCP_DEPLOY_REPO

### DIFF
--- a/.github/workflows/mcp-lambda.yml
+++ b/.github/workflows/mcp-lambda.yml
@@ -13,7 +13,7 @@ name: MCP Lambda
 #
 # Requires the following GitHub secrets:
 # - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
-# - GHE_DEPLOY_REPO: The GHE repo (e.g. `eufemia/eufemia-mcp`)
+# - GHE_MCP_DEPLOY_REPO: The GHE repo (e.g. `eufemia/eufemia-mcp`)
 #
 # See tools/mcp-lambda/README.md for manual deploy instructions.
 
@@ -97,7 +97,7 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         env:
           GHE_PAT: ${{ secrets.GHE_DEPLOY_PAT }}
-          GHE_REPO: ${{ secrets.GHE_DEPLOY_REPO }}
+          GHE_REPO: ${{ secrets.GHE_MCP_DEPLOY_REPO }}
           SOURCE_REF: ${{ github.ref_name }}
           SOURCE_SHA: ${{ github.sha }}
         run: |


### PR DESCRIPTION
## Summary

Renames the MCP-specific GHE deploy repo secret reference from `GHE_DEPLOY_REPO` to `GHE_MCP_DEPLOY_REPO`, to disambiguate it now that the analytics pipeline has its own `GHE_ANALYTICS_DEPLOY_REPO`.

## Changes

- `.github/workflows/mcp-lambda.yml`: use `secrets.GHE_MCP_DEPLOY_REPO` (env + doc comment).

## Deploy coordination (required)

Secrets can't be renamed in GitHub, so:

1. **Before merging:** create `GHE_MCP_DEPLOY_REPO` with the same value (`eufemia/eufemia-mcp`). Both secrets coexist during the transition so neither the old (`main`) nor new (this PR) workflow breaks.
2. **After merging:** delete the old `GHE_DEPLOY_REPO`.

`GHE_DEPLOY_PAT` is intentionally left unchanged — it is shared across both pipelines.

## Breaking changes

None (internal CI wiring only).
