### PR TITLE
chore(MCP): trigger deploy on mcp-server/ prefixed branches

### DIFF
--- a/.github/workflows/mcp-lambda.yml
+++ b/.github/workflows/mcp-lambda.yml
@@ -8,7 +8,7 @@ name: MCP Lambda
 #
 # Triggers:
 # - `release` branch and `v*` / `v*.*.*` tags — deploys automatically.
-# - Any branch named `**/mcp-server` (e.g. `feat/mcp-server`).
+# - Any branch under the `mcp-server/` prefix (e.g. `mcp-server/new-tool`).
 # - `workflow_dispatch` — manual deploy from the Actions tab.
 #
 # Requires the following GitHub secrets:
@@ -21,7 +21,7 @@ on:
   push:
     branches:
       - release
-      - '**/mcp-server'
+      - 'mcp-server/**'
     tags:
       - 'v*'
       - 'v*.*.*'

--- a/tools/mcp-lambda/README.md
+++ b/tools/mcp-lambda/README.md
@@ -108,7 +108,7 @@ The build & push workflow triggers on:
 | Trigger                            | Deploys? |
 | ---------------------------------- | -------- |
 | Push to `release`                  | Yes      |
-| Push to any `**/mcp-server` branch | Yes      |
+| Push to any `mcp-server/**` branch | Yes      |
 | Push of a `v*` / `v*.*.*` tag      | Yes      |
 | Manual `workflow_dispatch`         | Yes      |
 


### PR DESCRIPTION
## Summary

Switches the MCP Lambda deploy trigger from `**/mcp-server` (branches *ending* in `mcp-server`) to `mcp-server/**` (branches under a deliberate `mcp-server/` prefix).

This makes the convention explicit: name a branch `mcp-server/<something>` when you want it to build + deploy the MCP Lambda. Avoids both the too-strict ends-with rule and an overly lenient "contains anywhere" match.

## Changes

- `.github/workflows/mcp-lambda.yml`: trigger branch glob + doc comment.
- `tools/mcp-lambda/README.md`: trigger table row.

## Breaking changes

None (internal CI wiring only). Branches previously named `*/mcp-server` no longer auto-trigger; use the `mcp-server/` prefix instead.