### PR TITLE
chore(Iterate.Array): fix "Minium" typo to "Minimum"

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Iterate/Array/demos.mdx
@@ -76,7 +76,7 @@ With a [Iterate.PushButton](/uilib/extensions/forms/Iterate/PushButton/) to add 
 
 <Examples.RequiredWithPushButton />
 
-### Minium one item
+### Minimum one item
 
 There are several ways to achieve this:
 


### PR DESCRIPTION
## Description

Fixes a minor spelling mistake in the `Iterate.Array` documentation. The heading `### Minium one item` should read `### Minimum one item` — the section describes how to require a *minimum* of one item in an array (using `minItems`).

## Type of change

- [x] Documentation (typo fix)

## Checklist

- [x] Prettier reports the file as already formatted (no changes)
- [x] No internal links reference the old heading anchor (`#minium-one-item`)
