### PR TITLE
chore: remove unused exported dead code

### DIFF
--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationInstance.ts
@@ -22,7 +22,6 @@ export type HeightAnimationOnEndStack = Array<HeightAnimationOnEndCallback>
 export type HeightAnimationEventListener = (e: Event) => void
 export type HeightAnimationEvents = Array<HeightAnimationEventListener>
 export type HeightAnimationElement = HTMLElement
-export type HeightAnimationContainer = HTMLElement
 export type HeightAnimationFromHeight = number
 export type HeightAnimationToHeight = number
 

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -15,9 +15,6 @@ export type ModalCallbackInstance = {
 
 export type ModalFullscreen = 'auto' | boolean
 export type ModalAlignContent = 'left' | 'center' | 'centered' | 'right'
-export type ModalContainerPlacement = 'left' | 'right' | 'top' | 'bottom'
-export type ModalTriggerVariant = 'primary' | 'secondary' | 'tertiary'
-export type ModalTriggerIconPosition = 'left' | 'right'
 export type ModalContentMinWidth = string | number
 export type ModalContentMaxWidth = string | number
 

--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -101,9 +101,6 @@ const radioGroupDefaultProps: Partial<RadioGroupProps> = {
   onChange: null,
 }
 
-const parseChecked = (state: string | boolean | null | undefined) =>
-  /true|on/.test(String(state))
-
 /**
  * The radio component is our enhancement of the classic radio button. It acts like a radio. Example: On/off, yes/no.
  */
@@ -300,5 +297,4 @@ function RadioGroup(ownProps: RadioGroupProps) {
 
 withComponentMarkers(RadioGroup, { _supportsSpacingProps: true })
 
-export { parseChecked as RadioGroupParseChecked }
 export default RadioGroup

--- a/packages/dnb-eufemia/src/components/skeleton/SkeletonHelper.tsx
+++ b/packages/dnb-eufemia/src/components/skeleton/SkeletonHelper.tsx
@@ -24,14 +24,6 @@ export type SkeletonContextValue = ContextProps & {
   }
 }
 
-export type SkeletonDOMAttributesContext = {
-  translation?: {
-    Skeleton: {
-      ariaBusy?: string
-    }
-  }
-}
-
 export const skeletonDOMAttributes = (
   params: HTMLProps<HTMLElement>,
   skeleton: SkeletonShow,

--- a/packages/dnb-eufemia/src/shared/helpers/withComponentMarkers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/withComponentMarkers.ts
@@ -41,12 +41,6 @@ export type ComponentMarkers = {
 }
 
 /**
- * A component (function or class) that has marker properties attached.
- * Use this type when you need to reference a component with its markers.
- */
-export type MarkedComponent<T> = T & ComponentMarkers
-
-/**
  * Attaches component markers to a component function in a type-safe way.
  *
  * Mutates the component by assigning the marker properties. Uses TypeScript


### PR DESCRIPTION
I think these exports should be very safe to remove, as they are not referenced anywhere in the monorepo (library, portal, tests, MDX) and are not part of the public API:

- skeleton/SkeletonHelper: `SkeletonDOMAttributesContext` type
- height-animation/HeightAnimationInstance: `HeightAnimationContainer` type (unused since 2022)
- shared/helpers/withComponentMarkers: `MarkedComponent` type
- modal/types: `ModalContainerPlacement`, `ModalTriggerVariant` and `ModalTriggerIconPosition` types (superseded by inline unions; two unused since 2021)
- radio/RadioGroup: internal `parseChecked` helper and its `RadioGroupParseChecked` re-export

