### PR TITLE
chore: fix minor spelling mistakes in comments, tests and docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Number/Examples.tsx
@@ -347,7 +347,7 @@ export const ValidateMaximumCustomError = () => {
         defaultValue={200}
         maximum={250}
         errorMessages={{
-          maximum: "You can't enter a number THAR large.. Max 250!",
+          maximum: "You can't enter a number THAT large.. Max 250!",
         }}
         onChange={(value) => console.log('onChange', value)}
       />

--- a/packages/dnb-design-system-portal/src/docs/uilib/intro/01-about-design-systems.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/intro/01-about-design-systems.mdx
@@ -29,7 +29,7 @@ Eufemia as a Design System consists of many sub-systems, like:
 
 - Color systems
 - Typography system
-- Spacial systems
+- Spatial systems
 - Icon system
 - Grid system
 - Naming system

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -801,7 +801,7 @@ function groupNavItems(navItems: NavItem[], location: Location) {
     hashmap[itemId] = hashItem
 
     // Add all top level heading object references to topLevelHeadings array
-    // so that we wont have to loop through the array a second time to sort out top level headings
+    // so that we won't have to loop through the array a second time to sort out top level headings
     if (item.level === 1) {
       topLevelHeadings.push(hashmap[itemId])
     }

--- a/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/Layout.tsx
@@ -136,7 +136,7 @@ function Layout(props: LayoutProps) {
   }, [location.hash, location.pathname])
 
   const skipToContentHandler = (event) => {
-    // because we want to avoid that the hash get's set (#dnb-app-content)
+    // because we want to avoid that the hash gets set (#dnb-app-content)
     // we prevent the default and set it manually. The DOM elements have tabIndex="-1" and className="dnb-no-focus" in place
     try {
       event.preventDefault()

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -277,7 +277,7 @@ function AccordionDefault({
     hasAddedCallbackRef.current = true
   }
 
-  // Gets the initial expanded sate, to prevent the opening and closing of Accordion
+  // Gets the initial expanded state, to prevent the opening and closing of Accordion
   // That happens when if we put this logic in a useEffect that runs after the initial expanded state is set
   // Since useEffect runs after every render
   function getInitialExpandedState() {

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -3978,7 +3978,7 @@ describe('DatePicker component', () => {
     )
   })
 
-  it('should have todays date enabled in calendar if minDate is today', async () => {
+  it("should have today's date enabled in calendar if minDate is today", async () => {
     const minDate = new Date()
 
     render(<DatePicker minDate={minDate} />)

--- a/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
+++ b/packages/dnb-eufemia/src/components/slider/style/dnb-slider.scss
@@ -114,7 +114,7 @@
   }
 
   &__track {
-    // make sure we do not alow page scroll on touch devices
+    // make sure we do not allow page scroll on touch devices
     touch-action: none;
 
     position: relative;

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileInput.test.tsx
@@ -63,7 +63,7 @@ describe('UploadFileInput', () => {
     expect(element).toHaveAttribute('multiple')
   })
 
-  it('accepts ony one file when filesAmountLimit is 1', () => {
+  it('accepts only one file when filesAmountLimit is 1', () => {
     render(<UploadFileInput />, {
       wrapper: makeWrapper({
         filesAmountLimit: 1,

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx
@@ -68,7 +68,7 @@ function usePrerenderState() {
   // Track state changes to handle re-rendering
   const state = hasRenderedRef.current
   useEffect(() => {
-    // Ensure whe don't render the content after the content has been rendered
+    // Ensure we don't render the content after the content has been rendered
     if (hasRenderedRef.current === null) {
       hasRenderedRef.current = true
       forceUpdate()

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/WizardContainer.tsx
@@ -478,7 +478,7 @@ function WizardContainer(props: WizardContainerProps) {
             // In case steps were visited before, or they use the "keepInDOM" prop,
             // we need to check the step status, because other steps may report an error,
             // so the user will not be able to navigate to the next step,
-            // because the form contains errors. Thats why onSubmit will not be called via handleSubmitCall.
+            // because the form contains errors. That's why onSubmit will not be called via handleSubmitCall.
             if (
               !hasInvalidStepsState(activeIndexRef.current) &&
               !hasErrors?.() &&

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2153,7 +2153,7 @@ describe('useFieldProps', () => {
       expect(onBlurValidator).toHaveBeenCalledTimes(2)
     })
 
-    it('should yeld error object when returned by async onChange', async () => {
+    it('should yield error object when returned by async onChange', async () => {
       const onChange: OnChange<unknown> = async () => {
         return new Error('Error message')
       }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -636,7 +636,7 @@ describe('useFieldProps', () => {
         }
       )
 
-      // Error should nto be displayed initially when field is required and empty
+      // Error should not be displayed initially when field is required and empty
       // (validateContinuously should only validate on change, not initially)
       expect(result.current.hasError).toBeFalsy()
       expect(result.current.error).toBeUndefined()

--- a/packages/dnb-eufemia/src/shared/__tests__/IsolatedStyleScope.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/IsolatedStyleScope.test.tsx
@@ -447,7 +447,7 @@ describe('uniqueKey functionality', () => {
     render(
       <IsolatedStyleScope scopeHash="my-scope" uniqueKey="test-key">
         <div id="outer-content">Outer Content</div>
-        {/* Keep the scopeHash="auto" because we want to test whats inside the first if check */}
+        {/* Keep the scopeHash="auto" because we want to test what's inside the first if check */}
         <IsolatedStyleScope scopeHash="auto" uniqueKey="test-key">
           <div id="inner-content">Inner Content</div>
         </IsolatedStyleScope>

--- a/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/component-helper.test.tsx
@@ -291,7 +291,7 @@ describe('"validateDOMAttributes" should', () => {
     expect(res2).toHaveProperty('disabled')
   })
 
-  it('pass thru rest attributes', () => {
+  it('pass through rest attributes', () => {
     const props = {}
     const params = { 'aria-hidden': true }
     const res = validateDOMAttributes(props, params)


### PR DESCRIPTION
## Description

Fixes a batch of minor spelling mistakes found during a repo-wide spell-check deep dive (using `codespell` with the `clear,rare,code,informal` dictionaries). All changes are limited to **code comments, test descriptions, and documentation/demo prose** — no runtime code, public API, or user-facing production strings are affected.

### Fixes

| File | Before → After |
| --- | --- |
| `shared/__tests__/IsolatedStyleScope.test.tsx` | `whats` → `what's` (comment) |
| `extensions/forms/Wizard/Container/PrerenderFieldPropsOfOtherSteps.tsx` | `whe` → `we` (comment) |
| `extensions/forms/Wizard/Container/WizardContainer.tsx` | `Thats` → `That's` (comment) |
| `extensions/forms/hooks/__tests__/useFieldProps.test.tsx` | `yeld` → `yield`, `nto` → `not` (test title + comment) |
| `components/accordion/Accordion.tsx` | `sate` → `state` (comment) |
| `components/slider/style/dnb-slider.scss` | `alow` → `allow` (comment) |
| `components/upload/__tests__/UploadFileInput.test.tsx` | `ony` → `only` (test title) |
| `components/date-picker/__tests__/DatePicker.test.tsx` | `todays` → `today's` (test title) |
| `shared/__tests__/component-helper.test.tsx` | `thru` → `through` (test title) |
| `shared/menu/SidebarMenu.tsx` (portal) | `wont` → `won't` (comment) |
| `shared/parts/Layout.tsx` (portal) | `get's` → `gets` (comment) |
| `docs/uilib/intro/01-about-design-systems.mdx` | `Spacial` → `Spatial` (docs) |
| `docs/uilib/extensions/forms/base-fields/Number/Examples.tsx` | `THAR` → `THAT` (demo error message) |

### Notes

- Deliberately **not** changed: correct words flagged as false positives (`recuse`, `discreet`, `UIs`), Nordic/Latin demo text, code identifiers (`prevEnd`, `transformIn`, `waitFor`, `thead`), the `browsersl.ist` URL, and historical changelog/release notes (per repo guidelines).
- **Follow-up (not in this PR):** `src/icons/dnb/icons-meta.json` contains typos in icon search tags — `recieve` (`hand_money`), `referance` (`ref_number`), `firend` (`people_2`), `syncronize` (`cloud_sync`). That file is **auto-generated** from Figma component descriptions (`scripts/figma/tasks/assetsExtractors.ts`), so the fix belongs in the Figma source, not the generated JSON — editing the JSON would be overwritten on the next sync.
- No snapshot files reference the updated test titles. Prettier reports all files unchanged; no type/lint errors introduced.
