### PR TITLE
feat(HeightAnimation): support hidden until found (`hidden="until-found"`)

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Anchor,
   P,
+  Space,
 } from '@dnb/eufemia/src'
 
 export function HeightAnimationDefault() {
@@ -173,6 +174,46 @@ export function HeightAnimationKeepInDOM() {
             transform: translateY(0);
           }
         `
+
+        return <Example />
+      }}
+    </ComponentBox>
+  )
+}
+
+export function HeightAnimationUntilFound() {
+  return (
+    <ComponentBox>
+      {() => {
+        const Example = () => {
+          const [openState, setOpenState] = useState(false)
+
+          return (
+            <>
+              <ToggleButton
+                checked={openState}
+                aria-expanded={openState}
+                aria-controls="until-found-content"
+                onChange={({ checked }) => setOpenState(checked)}
+              >
+                Open content
+              </ToggleButton>
+
+              <HeightAnimation
+                id="until-found-content"
+                open={openState}
+                untilFound
+                onBeforeMatch={() => setOpenState(true)}
+              >
+                <Space innerSpace>
+                  <Section variant="information" innerSpace>
+                    <P space={0}>Findable banking content</P>
+                  </Section>
+                </Space>
+              </HeightAnimation>
+            </>
+          )
+        }
 
         return <Example />
       }}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
@@ -6,6 +6,7 @@ import {
   HeightAnimationDefault,
   HeightAnimationAutosizing,
   HeightAnimationKeepInDOM,
+  HeightAnimationUntilFound,
 } from 'Docs/uilib/components/height-animation/Examples'
 
 ## Demos
@@ -27,3 +28,9 @@ This example removes its given children, when open is `open={false}`.
 When providing `keepInDOM={true}`, your nested content will never be removed from the DOM. But rather be "hidden" with `visually: hidden` and `aria-hidden`.
 
 <HeightAnimationKeepInDOM />
+
+### Find collapsed content
+
+The `untilFound` prop keeps collapsed content available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”**. HeightAnimation reveals the match itself, while the optional `onBeforeMatch` callback synchronizes the toggle's external state.
+
+<HeightAnimationUntilFound />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -33,7 +33,13 @@ Custom `duration` and `delay` props are applied after hydration via a DOM effect
 
 ## Accessibility
 
-It is important to never animate from 0 to e.g. 64px – because:
+Connect the control and animated content with `aria-controls`, and expose the current state with `aria-expanded`. HeightAnimation does not manage focus. Avoid closing content while focus is inside it, or move focus to a logical visible control first.
+
+When `keepInDOM` or `untilFound` keeps closed content in the DOM, HeightAnimation applies `aria-hidden="true"`. The collapsed content is therefore unavailable to assistive technologies until it opens.
+
+`untilFound` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
+
+Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 
 - The content may differ based on the viewport width (screen size)
 - The content itself may change

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -1,5 +1,5 @@
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { HTMLProps, RefObject } from 'react'
 import { clsx } from 'clsx'
 import type { UseHeightAnimationOptions } from './useHeightAnimation'
@@ -7,12 +7,23 @@ import { useHeightAnimation } from './useHeightAnimation'
 import Space from '../space/Space'
 
 import type { DynamicElement, SpacingProps } from '../../shared/types'
+import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
 
 export type HeightAnimationProps = {
   /**
    * Set to `true` to ensure the nested children content will be kept in the DOM. Defaults to `false`.
    */
   keepInDOM?: boolean
+
+  /**
+   * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. Defaults to `false`.
+   */
+  untilFound?: boolean
+
+  /**
+   * Is called after matching content inside a closed animation is revealed by the browser using `untilFound`. Use it to synchronize external open state and controls.
+   */
+  onBeforeMatch?: (event: Event) => void
 
   /**
    * Set to `true` to omit the usage of "overflow: hidden;". Defaults to `false`.
@@ -51,6 +62,7 @@ function HeightAnimation({
   open = true,
   animate = true,
   keepInDOM = false,
+  untilFound = false,
   showOverflow = false,
   element,
   duration,
@@ -63,10 +75,34 @@ function HeightAnimation({
   onOpen = null,
   onAnimationStart = null,
   onAnimationEnd = null,
+  onBeforeMatch = null,
   ...rest
 }: HeightAnimationAllProps) {
   const elementRef = useRef<HTMLElement>(undefined)
   const targetRef = ref || elementRef
+  const [isRevealedByMatch, setRevealedByMatch] = useState(false)
+  const resolvedOpen = open || (untilFound && isRevealedByMatch)
+
+  const handleAnimationStart: UseHeightAnimationOptions['onAnimationStart'] =
+    (state) => {
+      if (untilFound && state === 'opening') {
+        targetRef.current?.removeAttribute('hidden')
+      }
+      onAnimationStart?.(state)
+    }
+  const handleAnimationEnd: UseHeightAnimationOptions['onAnimationEnd'] = (
+    state
+  ) => {
+    if (untilFound) {
+      if (state === 'closed') {
+        targetRef.current?.style.removeProperty('visibility')
+        targetRef.current?.setAttribute('hidden', 'until-found')
+      } else if (state === 'opened') {
+        targetRef.current?.removeAttribute('hidden')
+      }
+    }
+    onAnimationEnd?.(state)
+  }
 
   const {
     isInDOM,
@@ -75,15 +111,58 @@ function HeightAnimation({
     isAnimating,
     firstPaintStyle,
   } = useHeightAnimation(targetRef, {
-    open,
+    open: resolvedOpen,
     animate,
     children,
     compensateForGap,
     onInit,
     onOpen,
-    onAnimationStart,
-    onAnimationEnd,
+    onAnimationStart: handleAnimationStart,
+    onAnimationEnd: handleAnimationEnd,
   })
+
+  useLayoutEffect(() => {
+    const element = targetRef.current
+    if (!element) {
+      return
+    }
+
+    if (
+      untilFound &&
+      !resolvedOpen &&
+      element.classList.contains('dnb-height-animation--hidden')
+    ) {
+      element.setAttribute('hidden', 'until-found')
+    } else if (element.getAttribute('hidden') === 'until-found') {
+      element.removeAttribute('hidden')
+    }
+  }, [resolvedOpen, targetRef, untilFound])
+
+  useLayoutEffect(() => {
+    if (isRevealedByMatch && (open || !untilFound)) {
+      setRevealedByMatch(false)
+    }
+  }, [isRevealedByMatch, open, untilFound])
+
+  useLayoutEffect(() => {
+    const element = targetRef.current
+    if (!element || !untilFound) {
+      return undefined
+    }
+
+    const handleBeforeMatch = (event: Event) => {
+      element.removeAttribute('hidden')
+      element.classList.remove('dnb-height-animation--hidden')
+      element.setAttribute('aria-hidden', 'false')
+      setRevealedByMatch(true)
+      onBeforeMatch?.(event)
+    }
+    element.addEventListener('beforematch', handleBeforeMatch)
+
+    return () => {
+      element.removeEventListener('beforematch', handleBeforeMatch)
+    }
+  }, [onBeforeMatch, targetRef, untilFound])
 
   // Set CSS custom properties via the DOM instead of React's style
   // prop. React's SSR serializes custom properties without spaces
@@ -108,7 +187,9 @@ function HeightAnimation({
     }
   }, [duration, delay, targetRef, isInDOM])
 
-  if (!keepInDOM && !isInDOM && !isAnimating) {
+  const shouldKeepInDOM = keepInDOM || untilFound
+
+  if (!shouldKeepInDOM && !isInDOM && !isAnimating) {
     return null
   }
 
@@ -124,13 +205,13 @@ function HeightAnimation({
         isAnimating && 'dnb-height-animation--animating',
         !isVisible &&
           !isAnimating &&
-          !open &&
+          !resolvedOpen &&
           'dnb-height-animation--hidden',
         showOverflow && 'dnb-height-animation--show-overflow',
         className
       )}
       style={{ ...firstPaintStyle, ...rest?.style }}
-      aria-hidden={keepInDOM ? !open : undefined}
+      aria-hidden={shouldKeepInDOM ? !resolvedOpen : undefined}
       {...rest}
     >
       {compensateForGap ? (

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -16,6 +16,11 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  untilFound: {
+    doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
   compensateForGap: {
     doc: 'To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
     type: 'string',
@@ -54,6 +59,11 @@ export const HeightAnimationProperties: PropertiesTableProps = {
 }
 
 export const HeightAnimationEvents: PropertiesTableProps = {
+  onBeforeMatch: {
+    doc: 'Is called after matching content inside a closed animation is revealed by the browser using `untilFound`. Use it to synchronize external open state and controls.',
+    type: 'function',
+    status: 'optional',
+  },
   onOpen: {
     doc: 'Is called when fully opened or closed. Returns `true` or `false` depending on the state.',
     type: 'function',

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -292,6 +292,101 @@ describe('HeightAnimation', () => {
     })
   })
 
+  describe('untilFound', () => {
+    it('should preserve a regular hidden attribute', () => {
+      const { rerender } = render(
+        <HeightAnimation hidden>content</HeightAnimation>
+      )
+
+      expect(getElement()).toHaveAttribute('hidden')
+
+      rerender(<HeightAnimation hidden={false}>content</HeightAnimation>)
+
+      expect(getElement()).not.toHaveAttribute('hidden')
+    })
+
+    it('should keep initially closed content findable', () => {
+      render(
+        <HeightAnimation open={false} untilFound>
+          <span className="content">content</span>
+        </HeightAnimation>
+      )
+
+      expect(document.querySelector('.content')).toBeInTheDocument()
+      expect(getElement()).toHaveAttribute('hidden', 'until-found')
+    })
+
+    it('should remove hidden before opening', () => {
+      const { rerender } = render(
+        <HeightAnimation open={false} untilFound>
+          content
+        </HeightAnimation>
+      )
+
+      rerender(
+        <HeightAnimation open untilFound>
+          content
+        </HeightAnimation>
+      )
+
+      expect(getElement()).not.toHaveAttribute('hidden')
+      expect(getElement()).toHaveClass('dnb-height-animation--animating')
+    })
+
+    it('should hide content only after the closing animation', () => {
+      const { rerender } = render(
+        <HeightAnimation untilFound>content</HeightAnimation>
+      )
+
+      mockHeight(100)
+      rerender(
+        <HeightAnimation open={false} untilFound>
+          content
+        </HeightAnimation>
+      )
+
+      expect(getElement()).not.toHaveAttribute('hidden')
+      expect(getElement()).toHaveClass('dnb-height-animation--animating')
+
+      simulateAnimationEnd()
+
+      expect(getElement()).toHaveAttribute('hidden', 'until-found')
+      expect(getElement()).not.toHaveStyle('visibility: hidden')
+    })
+
+    it('should reveal matched content without onBeforeMatch', () => {
+      render(
+        <HeightAnimation open={false} untilFound>
+          content
+        </HeightAnimation>
+      )
+
+      getElement().dispatchEvent(new Event('beforematch'))
+
+      expect(getElement()).not.toHaveAttribute('hidden')
+      expect(getElement()).not.toHaveClass('dnb-height-animation--hidden')
+      expect(getElement()).toHaveAttribute('aria-hidden', 'false')
+    })
+
+    it('should call onBeforeMatch when matched content is revealed', () => {
+      const onBeforeMatch = vi.fn()
+      render(
+        <HeightAnimation
+          open={false}
+          untilFound
+          onBeforeMatch={onBeforeMatch}
+        >
+          content
+        </HeightAnimation>
+      )
+
+      getElement().dispatchEvent(new Event('beforematch'))
+
+      expect(onBeforeMatch).toHaveBeenCalledTimes(1)
+      expect(getElement()).not.toHaveAttribute('hidden')
+    })
+  })
+
   it('should set custom style', () => {
     render(<HeightAnimation style={{ color: 'red' }} />)
 

--- a/packages/dnb-eufemia/src/components/height-animation/style/dnb-height-animation.scss
+++ b/packages/dnb-eufemia/src/components/height-animation/style/dnb-height-animation.scss
@@ -28,6 +28,10 @@
 
   &--hidden {
     display: none;
+
+    &[hidden='until-found'] {
+      display: block;
+    }
   }
 
   &--show-overflow {


### PR DESCRIPTION
## Summary

- add opt-in `hidden="until-found"` support to HeightAnimation
- coordinate find-in-page behavior with opening and closing animations
- document accessibility guidance and add an interactive example
- add regression tests for lifecycle and `beforematch` handling

## Preview

- https://feat-height-animation-until.eufemia-e25.pages.dev/uilib/components/height-animation/#find-collapsed-content