### PR TITLE
feat(List): support element prop on List.Item to allow non-li rows

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -725,7 +725,9 @@ export const AutocompleteWithListItemContent = () => (
         const data = [
           {
             selectedKey: 'accounts',
+            // selectedValue is the plain text shown in the input once selected;
             // searchContent keeps typing/filtering working with rich content
+            selectedValue: 'Accounts',
             searchContent: 'Accounts Bills Savings',
             content: (
               <List.Item.Basic element="div" title="Accounts">
@@ -735,6 +737,7 @@ export const AutocompleteWithListItemContent = () => (
           },
           {
             selectedKey: 'loans',
+            selectedValue: 'Loans',
             searchContent: 'Loans Mortgage Car',
             content: (
               <List.Item.Basic element="div" title="Loans">
@@ -744,6 +747,7 @@ export const AutocompleteWithListItemContent = () => (
           },
           {
             selectedKey: 'cards',
+            selectedValue: 'Cards',
             searchContent: 'Cards Visa Mastercard',
             content: (
               <List.Item.Basic element="div" title="Cards">

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -720,8 +720,21 @@ export const AutocompleteContentDecoupledExample = () => (
 
 export const AutocompleteWithListItemContent = () => (
   <Wrapper>
-    <ComponentBox scope={{ List }}>
+    <ComponentBox
+      scope={{ List }}
+      data-visual-test="autocomplete-list-item-content"
+    >
       {() => {
+        // A List row keeps its end cell at content width, so the row needs
+        // horizontal room. Give the Autocomplete a width of its own, or the
+        // title column will be squeezed by the end cell.
+        const AccountAutocomplete = styled(Autocomplete)`
+          .dnb-autocomplete__shell,
+          .dnb-drawer-list__root {
+            width: 22rem;
+          }
+        `
+
         const data = [
           {
             selectedKey: 'accounts',
@@ -757,7 +770,7 @@ export const AutocompleteWithListItemContent = () => (
           },
         ]
 
-        return <Autocomplete data={data} label="Label" />
+        return <AccountAutocomplete data={data} label="Label" />
       }}
     </ComponentBox>
   </Wrapper>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -17,6 +17,7 @@ import {
   Flex,
   IconPrimary,
   NumberFormat,
+  List,
 } from '@dnb/eufemia/src'
 
 const Wrapper = styled.div`
@@ -713,6 +714,47 @@ export const AutocompleteContentDecoupledExample = () => (
         ]}
         label="Label"
       />
+    </ComponentBox>
+  </Wrapper>
+)
+
+export const AutocompleteWithListItemContent = () => (
+  <Wrapper>
+    <ComponentBox scope={{ List }}>
+      {() => {
+        const data = [
+          {
+            selectedKey: 'accounts',
+            // searchContent keeps typing/filtering working with rich content
+            searchContent: 'Accounts Bills Savings',
+            content: (
+              <List.Item.Basic element="div" title="Accounts">
+                <List.Cell.End>Bills, Savings</List.Cell.End>
+              </List.Item.Basic>
+            ),
+          },
+          {
+            selectedKey: 'loans',
+            searchContent: 'Loans Mortgage Car',
+            content: (
+              <List.Item.Basic element="div" title="Loans">
+                <List.Cell.End>Mortgage, Car</List.Cell.End>
+              </List.Item.Basic>
+            ),
+          },
+          {
+            selectedKey: 'cards',
+            searchContent: 'Cards Visa Mastercard',
+            content: (
+              <List.Item.Basic element="div" title="Cards">
+                <List.Cell.End>Visa, Mastercard</List.Cell.End>
+              </List.Item.Basic>
+            ),
+          },
+        ]
+
+        return <Autocomplete data={data} label="Label" />
+      }}
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -743,8 +743,11 @@ export const AutocompleteWithListItemContent = () => (
             selectedValue: 'Accounts',
             searchContent: 'Accounts Bills Savings',
             content: (
-              <List.Item.Basic element="div" title="Accounts">
-                <List.Cell.End>Bills, Savings</List.Cell.End>
+              <List.Item.Basic element="span">
+                <List.Cell.Title element="span">Accounts</List.Cell.Title>
+                <List.Cell.End element="span">
+                  Bills, Savings
+                </List.Cell.End>
               </List.Item.Basic>
             ),
           },
@@ -753,8 +756,9 @@ export const AutocompleteWithListItemContent = () => (
             selectedValue: 'Loans',
             searchContent: 'Loans Mortgage Car',
             content: (
-              <List.Item.Basic element="div" title="Loans">
-                <List.Cell.End>Mortgage, Car</List.Cell.End>
+              <List.Item.Basic element="span">
+                <List.Cell.Title element="span">Loans</List.Cell.Title>
+                <List.Cell.End element="span">Mortgage, Car</List.Cell.End>
               </List.Item.Basic>
             ),
           },
@@ -763,8 +767,11 @@ export const AutocompleteWithListItemContent = () => (
             selectedValue: 'Cards',
             searchContent: 'Cards Visa Mastercard',
             content: (
-              <List.Item.Basic element="div" title="Cards">
-                <List.Cell.End>Visa, Mastercard</List.Cell.End>
+              <List.Item.Basic element="span">
+                <List.Cell.Title element="span">Cards</List.Cell.Title>
+                <List.Cell.End element="span">
+                  Visa, Mastercard
+                </List.Cell.End>
               </List.Item.Basic>
             ),
           },

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -105,7 +105,7 @@ const data = [
 
 ### Autocomplete with List item content
 
-Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Provide `searchContent` with the plain text so typing still filters the options.
+Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Provide `selectedValue` with the plain text so the input shows a sensible value once an option is selected, and `searchContent` so typing still filters the options.
 
 <AutocompleteWithListItemContent />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -105,7 +105,7 @@ const data = [
 
 ### Autocomplete with List item content
 
-Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Provide `selectedValue` with the plain text so the input shows a sensible value once an option is selected, and `searchContent` so typing still filters the options.
+Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Give the `Autocomplete` a width that fits both the title and the end value. Provide `selectedValue` with the plain text so the input shows a sensible value once an option is selected, and `searchContent` so typing still filters the options. See [rendering a row outside a `List.Container`](/uilib/components/list/info#rendering-a-row-outside-a-listcontainer) for the details.
 
 <AutocompleteWithListItemContent />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -105,7 +105,7 @@ const data = [
 
 ### Autocomplete with List item content
 
-Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Give the `Autocomplete` a width that fits both the title and the end value. Provide `selectedValue` with the plain text so the input shows a sensible value once an option is selected, and `searchContent` so typing still filters the options. See [rendering a row outside a `List.Container`](/uilib/components/list/info#rendering-a-row-outside-a-listcontainer) for the details.
+Reuse the [List](/uilib/components/list) row layout for rich option content. The option is already an `<li>` and wraps its content in `<span>` elements, so use `element="span"` on `List.Item.Basic` and its cells to keep the markup valid. Give the `Autocomplete` a width that fits both the title and the end value. Provide `selectedValue` with the plain text so the input shows a sensible value once an option is selected, and `searchContent` so typing still filters the options. See [rendering a row outside a `List.Container`](/uilib/components/list/info#rendering-a-row-outside-a-listcontainer) for the details.
 
 <AutocompleteWithListItemContent />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -16,6 +16,7 @@ import {
   AutocompleteSuffix,
   AutocompleteStatusInfoExample,
   AutocompleteStatusErrorExample,
+  AutocompleteWithListItemContent,
   AutocompleteGroups,
   AutocompleteNoDivider,
 } from 'Docs/uilib/components/autocomplete/Examples'
@@ -101,6 +102,12 @@ const data = [
 <VisibleWhenVisualTest>
   <AutocompleteStatusErrorExample />
 </VisibleWhenVisualTest>
+
+### Autocomplete with List item content
+
+Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Provide `searchContent` with the plain text so typing still filters the options.
+
+<AutocompleteWithListItemContent />
 
 ### Groups
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
@@ -631,8 +631,21 @@ export const DropdownCustomizedLook = () => {
 export const DropdownWithListItemContent = () => {
   return (
     <Wrapper>
-      <ComponentBox scope={{ List }}>
+      <ComponentBox
+        scope={{ List }}
+        data-visual-test="dropdown-list-item-content"
+      >
         {() => {
+          // A List row keeps its end cell at content width, so the row needs
+          // horizontal room. Give the Dropdown a width of its own, or the
+          // title column will be squeezed by the end cell.
+          const AccountDropdown = styled(Dropdown)`
+            .dnb-dropdown__shell,
+            .dnb-drawer-list__root {
+              width: 22rem;
+            }
+          `
+
           const data = [
             {
               selectedKey: 'accounts',
@@ -665,7 +678,7 @@ export const DropdownWithListItemContent = () => {
             },
           ]
 
-          return <Dropdown data={data} value="accounts" />
+          return <AccountDropdown data={data} value="accounts" />
         }}
       </ComponentBox>
     </Wrapper>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
@@ -650,11 +650,16 @@ export const DropdownWithListItemContent = () => {
             {
               selectedKey: 'accounts',
               selectedValue: 'Accounts',
-              // Use element="div" so the List row does not render its own
-              // <li> inside the Dropdown option, which already is an <li>
+              // The option is already an <li> and wraps its content in spans.
+              // Use spans for the List row and cells to keep the markup valid.
               content: (
-                <List.Item.Basic element="div" title="Accounts">
-                  <List.Cell.End>Bills, Savings</List.Cell.End>
+                <List.Item.Basic element="span">
+                  <List.Cell.Title element="span">
+                    Accounts
+                  </List.Cell.Title>
+                  <List.Cell.End element="span">
+                    Bills, Savings
+                  </List.Cell.End>
                 </List.Item.Basic>
               ),
             },
@@ -662,8 +667,11 @@ export const DropdownWithListItemContent = () => {
               selectedKey: 'loans',
               selectedValue: 'Loans',
               content: (
-                <List.Item.Basic element="div" title="Loans">
-                  <List.Cell.End>Mortgage, Car</List.Cell.End>
+                <List.Item.Basic element="span">
+                  <List.Cell.Title element="span">Loans</List.Cell.Title>
+                  <List.Cell.End element="span">
+                    Mortgage, Car
+                  </List.Cell.End>
                 </List.Item.Basic>
               ),
             },
@@ -671,8 +679,11 @@ export const DropdownWithListItemContent = () => {
               selectedKey: 'cards',
               selectedValue: 'Cards',
               content: (
-                <List.Item.Basic element="div" title="Cards">
-                  <List.Cell.End>Visa, Mastercard</List.Cell.End>
+                <List.Item.Basic element="span">
+                  <List.Cell.Title element="span">Cards</List.Cell.Title>
+                  <List.Cell.End element="span">
+                    Visa, Mastercard
+                  </List.Cell.End>
                 </List.Item.Basic>
               ),
             },

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/Examples.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   P,
   Flex,
+  List,
 } from '@dnb/eufemia/src'
 import {
   chevron_down,
@@ -621,6 +622,50 @@ export const DropdownCustomizedLook = () => {
               )}
             />
           )
+        }}
+      </ComponentBox>
+    </Wrapper>
+  )
+}
+
+export const DropdownWithListItemContent = () => {
+  return (
+    <Wrapper>
+      <ComponentBox scope={{ List }}>
+        {() => {
+          const data = [
+            {
+              selectedKey: 'accounts',
+              selectedValue: 'Accounts',
+              // Use element="div" so the List row does not render its own
+              // <li> inside the Dropdown option, which already is an <li>
+              content: (
+                <List.Item.Basic element="div" title="Accounts">
+                  <List.Cell.End>Bills, Savings</List.Cell.End>
+                </List.Item.Basic>
+              ),
+            },
+            {
+              selectedKey: 'loans',
+              selectedValue: 'Loans',
+              content: (
+                <List.Item.Basic element="div" title="Loans">
+                  <List.Cell.End>Mortgage, Car</List.Cell.End>
+                </List.Item.Basic>
+              ),
+            },
+            {
+              selectedKey: 'cards',
+              selectedValue: 'Cards',
+              content: (
+                <List.Item.Basic element="div" title="Cards">
+                  <List.Cell.End>Visa, Mastercard</List.Cell.End>
+                </List.Item.Basic>
+              ),
+            },
+          ]
+
+          return <Dropdown data={data} value="accounts" />
         }}
       </ComponentBox>
     </Wrapper>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
@@ -20,6 +20,7 @@ import {
   DropdownDisabledTertiary,
   DropdownEllipsisOverflow,
   DropdownCustomizedLook,
+  DropdownWithListItemContent,
   DropdownGroups,
   DropdownNoDivider,
 } from 'Docs/uilib/components/dropdown/Examples'
@@ -86,6 +87,12 @@ Individual options can also be disabled.
 An example of how you can customize the look of your `Dropdown`
 
 <DropdownCustomizedLook />
+
+### Dropdown with List item content
+
+Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid.
+
+<DropdownWithListItemContent />
 
 ### DrawerList opened
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
@@ -90,7 +90,7 @@ An example of how you can customize the look of your `Dropdown`
 
 ### Dropdown with List item content
 
-Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid.
+Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Give the `Dropdown` a width that fits both the title and the end value, and provide `selectedValue` with the plain text to show once an option is selected. See [rendering a row outside a `List.Container`](/uilib/components/list/info#rendering-a-row-outside-a-listcontainer) for the details.
 
 <DropdownWithListItemContent />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/dropdown/demos.mdx
@@ -90,7 +90,7 @@ An example of how you can customize the look of your `Dropdown`
 
 ### Dropdown with List item content
 
-Reuse the [List](/uilib/components/list) row layout for rich option content. Set `element="div"` on `List.Item.Basic` so it does not render its own `<li>` inside the option (which is already an `<li>`), keeping the markup valid. Give the `Dropdown` a width that fits both the title and the end value, and provide `selectedValue` with the plain text to show once an option is selected. See [rendering a row outside a `List.Container`](/uilib/components/list/info#rendering-a-row-outside-a-listcontainer) for the details.
+Reuse the [List](/uilib/components/list) row layout for rich option content. The option is already an `<li>` and wraps its content in `<span>` elements, so use `element="span"` on `List.Item.Basic` and its cells to keep the markup valid. Give the `Dropdown` a width that fits both the title and the end value, and provide `selectedValue` with the plain text to show once an option is selected. See [rendering a row outside a `List.Container`](/uilib/components/list/info#rendering-a-row-outside-a-listcontainer) for the details.
 
 <DropdownWithListItemContent />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -113,6 +113,8 @@ A [Dropdown](/uilib/components/dropdown) or [Autocomplete](/uilib/components/aut
 </List.Item.Basic>
 ```
 
+The `title` and `icon` convenience props on `List.Item.Basic` follow the row `element` automatically, so `<List.Item.Basic element="span" title="Accounts" />` renders the title as a `span`, never a `div`. Cells you add yourself (`List.Cell.*`) take their own `element` prop – set it to `span` to match the row, as shown above.
+
 ### What you get, and what you don't
 
 Outside a `List.Container` you get the row layout and the cell styling, but not the list surface. Row height, padding, background and border are applied by `List.Container`, so a standalone row does not receive them. In a `Dropdown` or `Autocomplete` option this is what you want, because the option already brings its own padding, hover and selected styling.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -100,6 +100,18 @@ Set `_supportsSpacingProps = true` on your component to opt in, and forward the 
 
 <Examples.CustomItemComponent />
 
+## Rendering a row outside a `List.Container`
+
+`List.Item.Basic` renders an `<li>` by default for correct list semantics. When you reuse the row layout inside markup that already provides the list item – for example a [Dropdown](/uilib/components/dropdown) option, which is already an `<li>` – set the `element` prop to avoid invalid nested `<li>` elements:
+
+```jsx
+<List.Item.Basic element="div" title="Accounts">
+  <List.Cell.End>Bills, Savings</List.Cell.End>
+</List.Item.Basic>
+```
+
+Only reuse the presentational cells (`List.Cell.*`) this way. Do not place interactive items (`List.Item.Action`, `List.Item.Accordion`) or a nested `List.Container` inside a `Dropdown` option, as that breaks the listbox semantics and keyboard navigation.
+
 ## Loading states
 
 - **pending** – On `List.Item.Basic` or `List.Item.Action`: shows a skeleton overlay and disables pointer events. On `List.Item.Action`, click and keyboard are disabled (`tabIndex={-1}`, `aria-disabled`). Use while data is loading.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -110,6 +110,22 @@ Set `_supportsSpacingProps = true` on your component to opt in, and forward the 
 </List.Item.Basic>
 ```
 
+### What you get, and what you don't
+
+Outside a `List.Container` you get the row layout and the cell styling, but not the list surface. Row height, padding, background and border are applied by `List.Container`, so a standalone row does not receive them. In a `Dropdown` or `Autocomplete` option this is what you want, because the option already brings its own padding, hover and selected styling.
+
+Keep it that way, and do not re-apply the list surface on a row inside an option (for instance by setting `variant`). The row would then paint its own light background and border on top of the option, and the white text of a selected option becomes unreadable against it.
+
+### Give the row room
+
+`List.Cell.End` keeps its content width, so in a narrow drawer the title column is squeezed and the title wraps mid-word. Set a width that fits both the title and the end value – see [custom width](/uilib/components/dropdown/demos#custom-width) for the `Dropdown`.
+
+### Provide plain text for value and search
+
+Text passed through the `title` prop is invisible to the value and search text that `Dropdown` and `Autocomplete` derive from `content`. Provide `selectedValue` with the plain text to show once an option is selected, and for `Autocomplete` also `searchContent` with the plain text to filter on.
+
+### Keep the option semantics intact
+
 Only reuse the presentational cells (`List.Cell.*`) this way. Do not place interactive items (`List.Item.Action`, `List.Item.Accordion`) or a nested `List.Container` inside a `Dropdown` or `Autocomplete` option, as that breaks the listbox semantics and keyboard navigation.
 
 ## Loading states

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -102,11 +102,14 @@ Set `_supportsSpacingProps = true` on your component to opt in, and forward the 
 
 ## Rendering a row outside a `List.Container`
 
-`List.Item.Basic` renders an `<li>` by default for correct list semantics. When you reuse the row layout inside markup that already provides the list item – for example a [Dropdown](/uilib/components/dropdown) or [Autocomplete](/uilib/components/autocomplete) option, which is already an `<li>` – set the `element` prop to avoid invalid nested `<li>` elements:
+`List.Item.Basic` renders an `<li>` by default for correct list semantics. When you reuse the row layout inside markup that already provides the list item, set the `element` prop to an element that is valid in the surrounding markup.
+
+A [Dropdown](/uilib/components/dropdown) or [Autocomplete](/uilib/components/autocomplete) option is already an `<li>` and wraps its content in `<span>` elements. Use `element="span"` on the row and its cells to avoid both a nested `<li>` and block elements inside those spans:
 
 ```jsx
-<List.Item.Basic element="div" title="Accounts">
-  <List.Cell.End>Bills, Savings</List.Cell.End>
+<List.Item.Basic element="span">
+  <List.Cell.Title element="span">Accounts</List.Cell.Title>
+  <List.Cell.End element="span">Bills, Savings</List.Cell.End>
 </List.Item.Basic>
 ```
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -102,7 +102,7 @@ Set `_supportsSpacingProps = true` on your component to opt in, and forward the 
 
 ## Rendering a row outside a `List.Container`
 
-`List.Item.Basic` renders an `<li>` by default for correct list semantics. When you reuse the row layout inside markup that already provides the list item – for example a [Dropdown](/uilib/components/dropdown) option, which is already an `<li>` – set the `element` prop to avoid invalid nested `<li>` elements:
+`List.Item.Basic` renders an `<li>` by default for correct list semantics. When you reuse the row layout inside markup that already provides the list item – for example a [Dropdown](/uilib/components/dropdown) or [Autocomplete](/uilib/components/autocomplete) option, which is already an `<li>` – set the `element` prop to avoid invalid nested `<li>` elements:
 
 ```jsx
 <List.Item.Basic element="div" title="Accounts">
@@ -110,7 +110,7 @@ Set `_supportsSpacingProps = true` on your component to opt in, and forward the 
 </List.Item.Basic>
 ```
 
-Only reuse the presentational cells (`List.Cell.*`) this way. Do not place interactive items (`List.Item.Action`, `List.Item.Accordion`) or a nested `List.Container` inside a `Dropdown` option, as that breaks the listbox semantics and keyboard navigation.
+Only reuse the presentational cells (`List.Cell.*`) this way. Do not place interactive items (`List.Item.Action`, `List.Item.Accordion`) or a nested `List.Container` inside a `Dropdown` or `Autocomplete` option, as that breaks the listbox semantics and keyboard navigation.
 
 ## Loading states
 

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -5131,8 +5131,9 @@ describe('Autocomplete with List item content', () => {
       selectedValue: 'Accounts',
       searchContent: 'Accounts Bills Savings',
       content: (
-        <List.Item.Basic element="div" title="Accounts">
-          <List.Cell.End>Bills, Savings</List.Cell.End>
+        <List.Item.Basic element="span">
+          <List.Cell.Title element="span">Accounts</List.Cell.Title>
+          <List.Cell.End element="span">Bills, Savings</List.Cell.End>
         </List.Item.Basic>
       ),
     },
@@ -5141,14 +5142,15 @@ describe('Autocomplete with List item content', () => {
       selectedValue: 'Loans',
       searchContent: 'Loans Mortgage Car',
       content: (
-        <List.Item.Basic element="div" title="Loans">
-          <List.Cell.End>Mortgage, Car</List.Cell.End>
+        <List.Item.Basic element="span">
+          <List.Cell.Title element="span">Loans</List.Cell.Title>
+          <List.Cell.End element="span">Mortgage, Car</List.Cell.End>
         </List.Item.Basic>
       ),
     },
   ]
 
-  it('renders the List row with element="div" so the option has no nested li', () => {
+  it('renders the List row and cells as spans inside the option', () => {
     render(
       <Autocomplete
         open
@@ -5163,11 +5165,17 @@ describe('Autocomplete with List item content', () => {
       'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
     )
 
-    // The option itself is the only li; the List row uses element="div"
     expect(option.querySelectorAll('li')).toHaveLength(0)
+    expect(option.querySelectorAll('div')).toHaveLength(0)
 
     const listItem = option.querySelector('.dnb-list__item')
-    expect(listItem.tagName).toBe('DIV')
+    expect(listItem.tagName).toBe('SPAN')
+    expect(listItem.querySelector('.dnb-list__item__title').tagName).toBe(
+      'SPAN'
+    )
+    expect(listItem.querySelector('.dnb-list__item__end').tagName).toBe(
+      'SPAN'
+    )
   })
 
   it('renders the List title and cell content inside the option', () => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -5128,6 +5128,7 @@ describe('Autocomplete with List item content', () => {
   const listData = [
     {
       selectedKey: 'accounts',
+      selectedValue: 'Accounts',
       searchContent: 'Accounts Bills Savings',
       content: (
         <List.Item.Basic element="div" title="Accounts">
@@ -5137,6 +5138,7 @@ describe('Autocomplete with List item content', () => {
     },
     {
       selectedKey: 'loans',
+      selectedValue: 'Loans',
       searchContent: 'Loans Mortgage Car',
       content: (
         <List.Item.Basic element="div" title="Loans">
@@ -5211,6 +5213,29 @@ describe('Autocomplete with List item content', () => {
 
     expect(titles).toContain('Loans')
     expect(titles).not.toContain('Accounts')
+  })
+
+  it('shows the selectedValue in the input when an option is selected', () => {
+    render(
+      <Autocomplete
+        open
+        noAnimation
+        skipPortal
+        data={listData}
+        label="Choose account"
+      />
+    )
+
+    const input = document.querySelector('input') as HTMLInputElement
+
+    fireEvent.click(
+      document.querySelector(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+      )
+    )
+
+    // selectedValue is used as the input value, not the rich cell content
+    expect(input.value).toBe('Accounts')
   })
 
   it('should validate with ARIA rules', async () => {

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -14,6 +14,7 @@ import * as helpers from '../../../shared/helpers'
 import type { AutocompleteAllProps } from '../Autocomplete'
 import Autocomplete from '../Autocomplete'
 import { SubmitButton } from '../../input/Input'
+import { List } from '../../lib'
 import {
   formatBankAccountNumber,
   formatCurrency,
@@ -5120,6 +5121,110 @@ describe('Autocomplete markup', () => {
         `option-${props.id}-1`
       )
     })
+  })
+})
+
+describe('Autocomplete with List item content', () => {
+  const listData = [
+    {
+      selectedKey: 'accounts',
+      searchContent: 'Accounts Bills Savings',
+      content: (
+        <List.Item.Basic element="div" title="Accounts">
+          <List.Cell.End>Bills, Savings</List.Cell.End>
+        </List.Item.Basic>
+      ),
+    },
+    {
+      selectedKey: 'loans',
+      searchContent: 'Loans Mortgage Car',
+      content: (
+        <List.Item.Basic element="div" title="Loans">
+          <List.Cell.End>Mortgage, Car</List.Cell.End>
+        </List.Item.Basic>
+      ),
+    },
+  ]
+
+  it('renders the List row with element="div" so the option has no nested li', () => {
+    render(
+      <Autocomplete
+        open
+        noAnimation
+        skipPortal
+        data={listData}
+        label="Choose account"
+      />
+    )
+
+    const option = document.querySelector(
+      'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+    )
+
+    // The option itself is the only li; the List row uses element="div"
+    expect(option.querySelectorAll('li')).toHaveLength(0)
+
+    const listItem = option.querySelector('.dnb-list__item')
+    expect(listItem.tagName).toBe('DIV')
+  })
+
+  it('renders the List title and cell content inside the option', () => {
+    render(
+      <Autocomplete
+        open
+        noAnimation
+        skipPortal
+        data={listData}
+        label="Choose account"
+      />
+    )
+
+    const option = document.querySelector(
+      'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all)'
+    )
+
+    expect(
+      option.querySelector('.dnb-list__item__title').textContent
+    ).toContain('Accounts')
+    expect(
+      option.querySelector('.dnb-list__item__end').textContent
+    ).toContain('Bills, Savings')
+  })
+
+  it('filters options by searchContent when typing', () => {
+    render(
+      <Autocomplete
+        open
+        noAnimation
+        skipPortal
+        data={listData}
+        inputValue="loans"
+        label="Choose account"
+      />
+    )
+
+    const titles = Array.from(
+      document.querySelectorAll(
+        'li.dnb-drawer-list__option:not(.dnb-autocomplete__show-all) .dnb-list__item__title'
+      )
+    ).map((element) => element.textContent)
+
+    expect(titles).toContain('Loans')
+    expect(titles).not.toContain('Accounts')
+  })
+
+  it('should validate with ARIA rules', async () => {
+    const Comp = render(
+      <Autocomplete
+        open
+        noAnimation
+        skipPortal
+        data={listData}
+        label="Choose account"
+      />
+    )
+
+    expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 })
 

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -2124,8 +2124,9 @@ describe('Dropdown with List item content', () => {
       selectedKey: 'accounts',
       selectedValue: 'Accounts',
       content: (
-        <List.Item.Basic element="div" title="Accounts">
-          <List.Cell.End>Bills, Savings</List.Cell.End>
+        <List.Item.Basic element="span">
+          <List.Cell.Title element="span">Accounts</List.Cell.Title>
+          <List.Cell.End element="span">Bills, Savings</List.Cell.End>
         </List.Item.Basic>
       ),
     },
@@ -2133,23 +2134,30 @@ describe('Dropdown with List item content', () => {
       selectedKey: 'loans',
       selectedValue: 'Loans',
       content: (
-        <List.Item.Basic element="div" title="Loans">
-          <List.Cell.End>Mortgage, Car</List.Cell.End>
+        <List.Item.Basic element="span">
+          <List.Cell.Title element="span">Loans</List.Cell.Title>
+          <List.Cell.End element="span">Mortgage, Car</List.Cell.End>
         </List.Item.Basic>
       ),
     },
   ]
 
-  it('renders the List row with element="div" so the option has no nested li', () => {
+  it('renders the List row and cells as spans inside the option', () => {
     render(<Dropdown skipPortal noAnimation open data={listData} />)
 
     const option = document.querySelector('li.dnb-drawer-list__option')
 
-    // The option itself is the only li; the List row uses element="div"
     expect(option.querySelectorAll('li')).toHaveLength(0)
+    expect(option.querySelectorAll('div')).toHaveLength(0)
 
     const listItem = option.querySelector('.dnb-list__item')
-    expect(listItem.tagName).toBe('DIV')
+    expect(listItem.tagName).toBe('SPAN')
+    expect(listItem.querySelector('.dnb-list__item__title').tagName).toBe(
+      'SPAN'
+    )
+    expect(listItem.querySelector('.dnb-list__item__end').tagName).toBe(
+      'SPAN'
+    )
   })
 
   it('renders the List title and cell content inside the option', () => {

--- a/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/__tests__/Dropdown.test.tsx
@@ -29,7 +29,7 @@ import type {
 import { bank } from '../../../icons'
 import Icon from '../../Icon'
 import NumberFormat from '../../NumberFormat'
-import { CountryFlag } from '../../lib'
+import { CountryFlag, List } from '../../lib'
 import Dialog from '../../dialog/Dialog'
 
 import Provider from '../../../shared/Provider'
@@ -2115,6 +2115,68 @@ describe('Dropdown markup', () => {
     )
 
     expect(await axeComponent(CheckComponent)).toHaveNoViolations()
+  })
+})
+
+describe('Dropdown with List item content', () => {
+  const listData = [
+    {
+      selectedKey: 'accounts',
+      selectedValue: 'Accounts',
+      content: (
+        <List.Item.Basic element="div" title="Accounts">
+          <List.Cell.End>Bills, Savings</List.Cell.End>
+        </List.Item.Basic>
+      ),
+    },
+    {
+      selectedKey: 'loans',
+      selectedValue: 'Loans',
+      content: (
+        <List.Item.Basic element="div" title="Loans">
+          <List.Cell.End>Mortgage, Car</List.Cell.End>
+        </List.Item.Basic>
+      ),
+    },
+  ]
+
+  it('renders the List row with element="div" so the option has no nested li', () => {
+    render(<Dropdown skipPortal noAnimation open data={listData} />)
+
+    const option = document.querySelector('li.dnb-drawer-list__option')
+
+    // The option itself is the only li; the List row uses element="div"
+    expect(option.querySelectorAll('li')).toHaveLength(0)
+
+    const listItem = option.querySelector('.dnb-list__item')
+    expect(listItem.tagName).toBe('DIV')
+  })
+
+  it('renders the List title and cell content inside the option', () => {
+    render(<Dropdown skipPortal noAnimation open data={listData} />)
+
+    const option = document.querySelector('li.dnb-drawer-list__option')
+
+    expect(
+      option.querySelector('.dnb-list__item__title').textContent
+    ).toContain('Accounts')
+    expect(
+      option.querySelector('.dnb-list__item__end').textContent
+    ).toContain('Bills, Savings')
+  })
+
+  it('should validate with ARIA rules', async () => {
+    const Comp = render(
+      <Dropdown
+        label="Choose account"
+        skipPortal
+        noAnimation
+        open
+        data={listData}
+      />
+    )
+
+    expect(await axeComponent(Comp)).toHaveNoViolations()
   })
 })
 

--- a/packages/dnb-eufemia/src/components/list/ItemBasic.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemBasic.tsx
@@ -13,12 +13,21 @@ export type ItemBasicProps = {
 } & Omit<ItemContentProps, 'title'>
 
 function ItemBasic(props: ItemBasicProps) {
-  const { icon, title, children, ...rest } = props
+  const { icon, title, children, element, ...rest } = props
+
+  // The auto-rendered icon and title must be valid inside the row element.
+  // When the row is a phrasing element (`element="span"`, e.g. for a Dropdown
+  // or Autocomplete option) they must be phrasing content too, or they would
+  // render a `<div>` inside a `<span>` — the exact invalid nesting the
+  // `element` prop exists to avoid. Follow the row element in that case.
+  const cellElement = element === 'span' ? 'span' : undefined
 
   return (
-    <ItemContent {...rest}>
-      {icon && <ItemIcon>{icon}</ItemIcon>}
-      {title !== undefined && <ItemTitle>{title}</ItemTitle>}
+    <ItemContent element={element} {...rest}>
+      {icon && <ItemIcon element={cellElement}>{icon}</ItemIcon>}
+      {title !== undefined && (
+        <ItemTitle element={cellElement}>{title}</ItemTitle>
+      )}
       {children}
     </ItemContent>
   )

--- a/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
@@ -5,6 +5,7 @@ import FlexItem from '../flex/Item'
 import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
+import type { DynamicElement } from '../../shared/types'
 import Context from '../../shared/Context'
 
 export type ItemCenterProps = FlexItemProps & {
@@ -22,6 +23,11 @@ export type ItemCenterProps = FlexItemProps & {
    * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
    */
   skeleton?: SkeletonShow
+  /**
+   * Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.
+   * Default: `'div'`
+   */
+  element?: DynamicElement
 }
 
 function ItemCenter({

--- a/packages/dnb-eufemia/src/components/list/ItemContent.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemContent.tsx
@@ -6,6 +6,7 @@ import type { FlexContainerAllProps as FlexProps } from '../flex/Container'
 import FlexContainer from '../flex/Container'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
+import type { DynamicElement } from '../../shared/types'
 import Context from '../../shared/Context'
 
 export type ItemContentProps = {
@@ -15,6 +16,11 @@ export type ItemContentProps = {
   pending?: boolean
   disabled?: boolean
   skeleton?: SkeletonShow
+  /**
+   * Define the HTML element used for the row. Defaults to `li` for correct list semantics. Set to e.g. `div` when the row is rendered inside markup that already provides the list item (for example a `Dropdown` option) to avoid invalid nested `li` elements.
+   * Default: `'li'`
+   */
+  element?: DynamicElement
 } & FlexProps
 
 function ItemContent(props: ItemContentProps) {
@@ -26,6 +32,7 @@ function ItemContent(props: ItemContentProps) {
     pending,
     disabled,
     skeleton,
+    element = 'li',
     ...rest
   } = props
   const context = useContext(Context)
@@ -38,7 +45,7 @@ function ItemContent(props: ItemContentProps) {
 
   const content = (
     <FlexContainer
-      element="li"
+      element={element}
       direction="horizontal"
       justify="space-between"
       wrap={false}

--- a/packages/dnb-eufemia/src/components/list/ItemContent.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemContent.tsx
@@ -17,7 +17,7 @@ export type ItemContentProps = {
   disabled?: boolean
   skeleton?: SkeletonShow
   /**
-   * Define the HTML element used for the row. Defaults to `li` for correct list semantics. Set to e.g. `div` when the row is rendered inside markup that already provides the list item (for example a `Dropdown` option) to avoid invalid nested `li` elements.
+   * Define the HTML element used for the row. Defaults to `li` for correct list semantics. Use an element that is valid inside the surrounding markup when the row is rendered inside markup that already provides the list item. For example, use `span` for a `Dropdown` or `Autocomplete` option.
    * Default: `'li'`
    */
   element?: DynamicElement

--- a/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
@@ -5,6 +5,7 @@ import FlexItem from '../flex/Item'
 import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
+import type { DynamicElement } from '../../shared/types'
 import Context from '../../shared/Context'
 
 /**
@@ -26,6 +27,11 @@ export type ItemEndProps = {
    * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
    */
   skeleton?: SkeletonShow
+  /**
+   * Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.
+   * Default: `'div'`
+   */
+  element?: DynamicElement
 } & FlexItemProps
 
 function ItemEnd(props: ItemEndProps) {

--- a/packages/dnb-eufemia/src/components/list/ItemStart.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemStart.tsx
@@ -5,6 +5,7 @@ import FlexItem from '../flex/Item'
 import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
+import type { DynamicElement } from '../../shared/types'
 import Context from '../../shared/Context'
 
 /**
@@ -26,6 +27,11 @@ export type ItemStartProps = FlexItemProps & {
    * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
    */
   skeleton?: SkeletonShow
+  /**
+   * Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.
+   * Default: `'div'`
+   */
+  element?: DynamicElement
 }
 
 function ItemStart({

--- a/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
@@ -7,6 +7,7 @@ import ItemSubline from './ItemSubline'
 import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
+import type { DynamicElement } from '../../shared/types'
 import Context from '../../shared/Context'
 
 /**
@@ -28,6 +29,11 @@ export type ItemTitleProps = FlexItemProps & {
    * When `true`, applies skeleton font styling to all child items inside the scroll view. Propagated via context so nested `List.Container` and items inherit it.
    */
   skeleton?: SkeletonShow
+  /**
+   * Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.
+   * Default: `'div'`
+   */
+  element?: DynamicElement
 }
 
 function ItemTitleBase({

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -64,6 +64,12 @@ export const ItemContentProperties: PropertiesTableProps = {
     type: 'React.ReactNode',
     status: 'optional',
   },
+  element: {
+    doc: 'Define the HTML element used for the row. Defaults to `li` for correct list semantics. Set to e.g. `div` when the row is rendered inside markup that already provides the list item (for example a `Dropdown` option) to avoid invalid nested `li` elements.',
+    type: ['string', 'React.Element'],
+    defaultValue: `'li'`,
+    status: 'optional',
+  },
   children: {
     doc: 'Item content. Typically `List.Cell.Start`, `List.Cell.Center`, `List.Cell.End`, `List.Cell.Title` (use `List.Cell.Title.Overline`/`List.Cell.Title.Subline` for overline/subline text), or the drop-in `List.Cell.Title.Overline`/`List.Cell.Title.Subline` components, or `List.Cell.Footer`.',
     type: 'React.ReactNode',

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -95,6 +95,12 @@ export const ItemCenterProperties: PropertiesTableProps = {
     defaultValue: '"regular"',
     status: 'optional',
   },
+  element: {
+    doc: 'Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.',
+    type: ['string', 'React.Element'],
+    defaultValue: `'div'`,
+    status: 'optional',
+  },
   children: {
     doc: 'Center content of the list item. Grows to fill available space.',
     type: 'React.ReactNode',
@@ -112,6 +118,12 @@ export const ItemTitleProperties: PropertiesTableProps = {
     doc: 'Font size of the title content. Defaults to `basis`. Use `small` for smaller text.',
     type: ['"small"', '"basis"'],
     defaultValue: '"basis"',
+    status: 'optional',
+  },
+  element: {
+    doc: 'Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.',
+    type: ['string', 'React.Element'],
+    defaultValue: `'div'`,
     status: 'optional',
   },
   children: {
@@ -206,6 +218,12 @@ export const ItemEndProperties: PropertiesTableProps = {
     defaultValue: '"basis"',
     status: 'optional',
   },
+  element: {
+    doc: 'Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.',
+    type: ['string', 'React.Element'],
+    defaultValue: `'div'`,
+    status: 'optional',
+  },
   children: {
     doc: 'End content of the list item (e.g. value, action).',
     type: 'React.ReactNode',
@@ -229,6 +247,12 @@ export const ItemStartProperties: PropertiesTableProps = {
     doc: 'Font weight of the start content. Defaults to `regular`.',
     type: ['"regular"', '"medium"'],
     defaultValue: '"regular"',
+    status: 'optional',
+  },
+  element: {
+    doc: 'Define the HTML element used for the cell. Defaults to `div`. When the row is rendered outside a `List.Container` inside phrasing markup (for example a `Dropdown` or `Autocomplete` option, where the row is a `span`), set this to `span` so the cell stays valid phrasing content.',
+    type: ['string', 'React.Element'],
+    defaultValue: `'div'`,
     status: 'optional',
   },
   children: {

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -348,7 +348,7 @@ export const ItemActionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   element: {
-    doc: 'Define what HTML or React element should be used for the link (e.g. `element={Link}` for React Router). Only applicable when `href` or `to` is set.',
+    doc: 'Define what HTML or React element should be used for the link (e.g. `element={Link}` for React Router). Only applicable when `href` or `to` is set. Note that this is the link element – unlike `List.Item.Basic`, where `element` defines the row element.',
     type: 'React.Element',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -65,7 +65,7 @@ export const ItemContentProperties: PropertiesTableProps = {
     status: 'optional',
   },
   element: {
-    doc: 'Define the HTML element used for the row. Defaults to `li` for correct list semantics. Set to e.g. `div` when the row is rendered inside markup that already provides the list item (for example a `Dropdown` option) to avoid invalid nested `li` elements.',
+    doc: 'Define the HTML element used for the row. Defaults to `li` for correct list semantics. Use an element that is valid inside the surrounding markup when the row is rendered inside markup that already provides the list item. For example, use `span` for a `Dropdown` or `Autocomplete` option.',
     type: ['string', 'React.Element'],
     defaultValue: `'li'`,
     status: 'optional',

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemBasic.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemBasic.test.tsx
@@ -26,6 +26,27 @@ describe('ItemBasic', () => {
     expect(element.tagName).toBe('LI')
   })
 
+  it('renders as a custom element while keeping icon, title and cells', () => {
+    render(
+      <ItemBasic element="div" icon={fish_medium} title="Title">
+        <span data-testid="cell">Cell</span>
+      </ItemBasic>
+    )
+
+    const element = document.querySelector('.dnb-list__item')
+
+    expect(element.tagName).toBe('DIV')
+    expect(
+      element.querySelector('.dnb-list__item__icon')
+    ).toBeInTheDocument()
+    expect(
+      element.querySelector('.dnb-list__item__title').textContent
+    ).toContain('Title')
+    expect(
+      element.querySelector('[data-testid="cell"]')
+    ).toBeInTheDocument()
+  })
+
   it('renders item content', () => {
     const text = 'List item content'
 

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemBasic.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemBasic.test.tsx
@@ -47,6 +47,23 @@ describe('ItemBasic', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders the auto-rendered icon and title as spans when element is span', () => {
+    render(<ItemBasic element="span" icon={fish_medium} title="Title" />)
+
+    const element = document.querySelector('.dnb-list__item')
+
+    expect(element.tagName).toBe('SPAN')
+    // The auto-rendered icon and title must stay phrasing content inside a
+    // span row – a <div> here would be invalid nesting.
+    expect(element.querySelectorAll('div')).toHaveLength(0)
+    expect(element.querySelector('.dnb-list__item__icon').tagName).toBe(
+      'SPAN'
+    )
+    expect(element.querySelector('.dnb-list__item__title').tagName).toBe(
+      'SPAN'
+    )
+  })
+
   it('renders item content', () => {
     const text = 'List item content'
 

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemCenter.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemCenter.test.tsx
@@ -15,6 +15,13 @@ describe('ItemCenter', () => {
     expect(element.textContent).toContain('Center content')
   })
 
+  it('renders as a custom element when the element prop is set', () => {
+    render(<ItemCenter element="span">Content</ItemCenter>)
+
+    const element = document.querySelector('.dnb-list__item__center')
+    expect(element.tagName).toBe('SPAN')
+  })
+
   it('has dnb-t__size--basis class', () => {
     render(<ItemCenter>Content</ItemCenter>)
 

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemContent.test.tsx
@@ -26,6 +26,14 @@ describe('ItemContent', () => {
     expect(element.tagName).toBe('LI')
   })
 
+  it('renders as a custom element when the element prop is set', () => {
+    render(<ItemContent element="div">Content</ItemContent>)
+
+    const element = document.querySelector('.dnb-list__item')
+
+    expect(element.tagName).toBe('DIV')
+  })
+
   it('merges custom className', () => {
     render(
       <ItemContent className="custom-class">

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemContent.test.tsx
@@ -34,6 +34,14 @@ describe('ItemContent', () => {
     expect(element.tagName).toBe('DIV')
   })
 
+  it('falls back to li when the element prop is undefined', () => {
+    render(<ItemContent element={undefined}>Content</ItemContent>)
+
+    const element = document.querySelector('.dnb-list__item')
+
+    expect(element.tagName).toBe('LI')
+  })
+
   it('merges custom className', () => {
     render(
       <ItemContent className="custom-class">

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemEnd.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemEnd.test.tsx
@@ -15,6 +15,13 @@ describe('ItemEnd', () => {
     expect(element.textContent).toContain('End content')
   })
 
+  it('renders as a custom element when the element prop is set', () => {
+    render(<ItemEnd element="span">Content</ItemEnd>)
+
+    const element = document.querySelector('.dnb-list__item__end')
+    expect(element.tagName).toBe('SPAN')
+  })
+
   it('has dnb-t__size--basis class by default', () => {
     render(<ItemEnd>Content</ItemEnd>)
 

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemStart.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemStart.test.tsx
@@ -15,6 +15,13 @@ describe('ItemStart', () => {
     expect(element.textContent).toContain('Start content')
   })
 
+  it('renders as a custom element when the element prop is set', () => {
+    render(<ItemStart element="span">Content</ItemStart>)
+
+    const element = document.querySelector('.dnb-list__item__start')
+    expect(element.tagName).toBe('SPAN')
+  })
+
   it('has dnb-t__size--basis class by default', () => {
     render(<ItemStart>Content</ItemStart>)
 

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemTitle.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemTitle.test.tsx
@@ -16,6 +16,14 @@ describe('ItemTitle', () => {
     expect(element.textContent).toContain('Title text')
   })
 
+  it('renders as a custom element when the element prop is set', () => {
+    render(<ItemTitle element="span">Title</ItemTitle>)
+
+    const element = document.querySelector('.dnb-list__item__title')
+
+    expect(element.tagName).toBe('SPAN')
+  })
+
   it('has dnb-list__item__title class and wraps children with default fontSize basis', () => {
     render(<ItemTitle>Title</ItemTitle>)
 


### PR DESCRIPTION
Motivation: @karini6 

## Summary

A consumer asked to reuse the `List` component's row/cell layout inside a `Dropdown` (and, by extension, `Autocomplete`) option. Those options are already an `<li role="option">` whose content is wrapped in a `<span>`, and `List.Item.Basic` renders its own `<li class="dnb-list__item">` with `<div>` cells — so the naive composition produces both invalid nested `<li>` elements and block elements inside a `<span>`.

This PR makes the escape hatch explicit: `List.Item.Basic` (via `ItemContent`) and the presentational cells (`List.Cell.*`) take an `element` prop. Set `element="span"` on the row and its cells to reuse the List row layout inside markup that already provides the list item, keeping the markup valid phrasing content.

**Note on prior behaviour:** `element` was already reachable on the row, because `ItemContentProps` extends `FlexContainerAllProps` and the spread of the remaining props came after the hardcoded `element="li"` — so a consumer-supplied `element` already won, and the type already accepted it. What this PR changes:

- The prop is now intentional, typed with JSDoc, documented and tested, instead of an accident of prop ordering — on both the row (`List.Item.Basic`) and the presentational cells (`List.Cell.Start`/`Center`/`Title`/`End`).
- It fixes a real bug: `element={undefined}` — what you get when forwarding an optional prop — used to fall through to the Flex container's own `'div'` default and render a `<div>` instead of an `<li>`. With the explicit `element = 'li'` default it now renders an `<li>`. Covered by a test.
- The `title` and `icon` convenience props on `List.Item.Basic` now follow the row `element`, so `<List.Item.Basic element="span" title="…" />` renders a `<span>` title (not a `<div>`) rather than silently reintroducing the invalid nesting the prop exists to avoid.

## What changed

- **`List.Item` `element` prop** — `ItemContent` forwards an `element` prop (default `li`) to the underlying Flex container. `List.Item.Basic` also forwards it to its auto-rendered icon and title so they stay valid phrasing content inside a `span` row. Fully backwards compatible.
- **`List.Cell.*` `element` prop** — the presentational cells (`Start`, `Center`, `Title`, `End`) take a typed, documented `element` prop (default `div`). Set it to `span` inside an option.
- **Types & docs** — typed with JSDoc, documented in the List properties tables, plus a new "Rendering a row outside a `List.Container`" section in the List docs covering what the row does and does not get, the width requirement, and the plain-text props needed for value and search.
- **Dropdown** — new "Dropdown with List item content" demo + integration tests (assert no nested `<li>`, no `<div>`, cells render, axe clean).
- **Autocomplete** — the same pattern works out of the box because `Dropdown` and `Autocomplete` share the `DrawerList` engine and data model (`AutocompleteData = DrawerListData`). Added a demo + integration tests, including one asserting the input value after selecting. No source change was needed for Autocomplete.

## Using it in an option — three things to get right

1. **Give the row width.** A List row keeps the end cell at content width and the title in a flexible column, so a short row squeezes the title. In the default 256px drawer the title column collapsed to 46px and "Accounts" wrapped as "Acc/oun/ts". Both demos now set a width (22rem) with the documented custom-width pattern. This is not caused by `element="span"` — a row inside a `List.Container` behaves the same when squeezed.
2. **Don't re-apply the list surface.** Outside a `List.Container` the row gets the layout and cell styling but no row height, padding, background or border — which is what you want, since the option supplies its own. Setting `variant` to bring them back paints a light background on top of the option, and the white text of a selected option then sits on white.
3. **Provide plain text.** Text passed through the `title` prop is invisible to the value and search text that `Dropdown`/`Autocomplete` derive from `content`, so provide `selectedValue` (and `searchContent` for `Autocomplete`).

## Why this layer

The `element` prop lives on the **List** side (the reusable content), not on the shared `DrawerList` fragment. `DrawerList` powers both `Dropdown` and `Autocomplete` and owns strict `listbox`/`option` ARIA semantics and a grid-based option layout, so it is intentionally left untouched. The composition approach solves the need for any host that already provides an `<li>`.

## Example

Dropdown:

```jsx
<Dropdown
  data={[
    {
      selectedKey: 'accounts',
      selectedValue: 'Accounts',
      content: (
        <List.Item.Basic element="span">
          <List.Cell.Title element="span">Accounts</List.Cell.Title>
          <List.Cell.End element="span">Bills, Savings</List.Cell.End>
        </List.Item.Basic>
      ),
    },
  ]}
/>
```

Autocomplete (provide `selectedValue` and `searchContent` so the input value and filtering keep working with rich content):

```jsx
<Autocomplete
  data={[
    {
      selectedKey: 'accounts',
      selectedValue: 'Accounts',
      searchContent: 'Accounts Bills Savings',
      content: (
        <List.Item.Basic element="span">
          <List.Cell.Title element="span">Accounts</List.Cell.Title>
          <List.Cell.End element="span">Bills, Savings</List.Cell.End>
        </List.Item.Basic>
      ),
    },
  ]}
  label="Label"
/>
```

## Accessibility note

`Dropdown`/`Autocomplete` are `listbox`/`combobox`; options must stay flat `<li role="option">` with phrasing content. Only reuse the presentational `List.Cell.*` this way — do not place interactive items (`List.Item.Action`, `List.Item.Accordion`) or a nested `List.Container` inside an option.

## Follow-up

Both demos carry a `data-visual-test` marker but no screenshot test: the baselines have to be generated in an environment that reproduces the committed ones, which this branch does not include.

## Breaking changes

None. The `element` prop defaults to `li` on the row and `div` on the cells, so all existing usage renders identically.
