### PR TITLE
chore: add .editorconfig for consistent editor defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig — https://editorconfig.org
+# Baseline editor defaults, aligned with the repo's Prettier config.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown uses trailing spaces for hard line breaks.
+[*.{md,mdx}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Adds a root `.editorconfig` so editors apply consistent defaults (indentation, charset, line endings, final newline, trailing-whitespace trimming) before Prettier runs — useful for file types and moments Prettier doesn't cover, and for contributors whose editors aren't configured.

## Details

Values are intentionally aligned with the existing `.prettierrc` so there is **no change to Prettier's behavior** (Prettier reads `.editorconfig` automatically):

- `indent_style = space`, `indent_size = 2` (matches `tabWidth: 2`, `useTabs: false`)
- `end_of_line = lf`, `charset = utf-8`
- `insert_final_newline = true`, `trim_trailing_whitespace = true`
- Markdown/MDX keep trailing whitespace (hard line breaks)

## Verification

- `yarn exec prettier --check` on a representative mix of `.tsx`, `.json`, `.md`, and `.mdx` files still reports "All matched files use Prettier code style!" — confirming the new `.editorconfig` introduces no formatting drift.

This is part of a set of small, independent coding-standard improvements (each in its own PR).
