### PR TITLE
chore(Portal): use camelCase for sidebar menu graphic names

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Deployment'
 order: 4
-icon: 'getting_started'
+icon: 'gettingStarted'
 ---
 
 # Deployment

--- a/packages/dnb-design-system-portal/src/docs/contribute/faq.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'FAQ'
 order: 7
-icon: 'helper_classes'
+icon: 'helperClasses'
 ---
 
 # Frequently Asked Questions (FAQ)

--- a/packages/dnb-design-system-portal/src/docs/design-system/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/design-system/changelog.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Change log'
-icon: 'change_log'
+icon: 'changeLog'
 draft: true
 order: 1
 ---

--- a/packages/dnb-design-system-portal/src/docs/icons/other.mdx
+++ b/packages/dnb-design-system-portal/src/docs/icons/other.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Other icons'
 description: 'Other icons used inside of Eufemia components.'
-icon: 'helper_classes'
+icon: 'helperClasses'
 order: 4
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/ui-resources.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/ui-resources.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Resources'
-icon: 'ui_guides'
+icon: 'uiGuides'
 ---
 
 # UI Resources

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'About the Library'
-icon: 'about_the_lib'
+icon: 'aboutTheLib'
 order: 1
 accordion: true
 ---

--- a/packages/dnb-design-system-portal/src/docs/uilib/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Getting Started'
 description: 'A fast path to using Eufemia in your app. Install, import styles, render your first component, and explore theming and customization.'
-icon: 'getting_started'
+icon: 'gettingStarted'
 order: 2
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Helpers'
 description: 'A couple of helper functions used inside of components and extensions.'
-icon: 'helper_classes'
+icon: 'helperClasses'
 order: 4
 ---
 

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarGraphics.ts
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarGraphics.ts
@@ -3,18 +3,18 @@
  *
  */
 
-import about_the_lib from './graphics/about_the_lib'
-import getting_started from './graphics/getting_started'
+import aboutTheLib from './graphics/aboutTheLib'
+import gettingStarted from './graphics/gettingStarted'
 import usage from './graphics/usage'
 import typography from './graphics/typography'
-import helper_classes from './graphics/helper_classes'
+import helperClasses from './graphics/helperClasses'
 import components from './graphics/components'
 import extensions from './graphics/extensions'
 import development from './graphics/development'
 import info from './graphics/info'
 import contact from './graphics/contact'
 import email from './graphics/email'
-import change_log from './graphics/change_log'
+import changeLog from './graphics/changeLog'
 import story from './graphics/story'
 import accessibility from './graphics/accessibility'
 import colors from './graphics/colors'
@@ -24,7 +24,7 @@ import tools from './graphics/tools'
 import fonts from './graphics/fonts'
 import inspiration from './graphics/inspiration'
 import principles from './graphics/principles'
-import ui_guides from './graphics/ui_guides'
+import uiGuides from './graphics/uiGuides'
 import logos from './graphics/logos'
 import secondary from './graphics/secondary'
 import primary from './graphics/primary'
@@ -32,18 +32,18 @@ import elements from './graphics/elements'
 import OverviewIcon from './graphics/OverviewIcon'
 
 const SidebarGraphics = {
-  about_the_lib,
-  getting_started,
+  aboutTheLib,
+  gettingStarted,
   usage,
   typography,
-  helper_classes,
+  helperClasses,
   components,
   extensions,
   development,
   info,
   contact,
   email,
-  change_log,
+  changeLog,
   story,
   accessibility,
   colors,
@@ -53,7 +53,7 @@ const SidebarGraphics = {
   fonts,
   inspiration,
   principles,
-  ui_guides,
+  uiGuides,
   logos,
   secondary,
   primary,

--- a/packages/dnb-design-system-portal/src/shared/menu/graphics/aboutTheLib.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/graphics/aboutTheLib.tsx
@@ -5,9 +5,7 @@
 
 import type { SVGProps } from 'react'
 
-export default function about_the_lib(
-  props: SVGProps<SVGSVGElement> = {}
-) {
+export default function aboutTheLib(props: SVGProps<SVGSVGElement> = {}) {
   return (
     <svg
       width="24"

--- a/packages/dnb-design-system-portal/src/shared/menu/graphics/changeLog.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/graphics/changeLog.tsx
@@ -5,7 +5,7 @@
 
 import type { SVGProps } from 'react'
 
-export default function change_log(props: SVGProps<SVGSVGElement> = {}) {
+export default function changeLog(props: SVGProps<SVGSVGElement> = {}) {
   return (
     <svg
       width="24"

--- a/packages/dnb-design-system-portal/src/shared/menu/graphics/gettingStarted.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/graphics/gettingStarted.tsx
@@ -5,7 +5,7 @@
 
 import type { SVGProps } from 'react'
 
-export default function getting_started(
+export default function gettingStarted(
   props: SVGProps<SVGSVGElement> = {}
 ) {
   return (

--- a/packages/dnb-design-system-portal/src/shared/menu/graphics/helperClasses.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/graphics/helperClasses.tsx
@@ -5,7 +5,7 @@
 
 import type { SVGProps } from 'react'
 
-export default function helper_classes(
+export default function helperClasses(
   props: SVGProps<SVGSVGElement> = {}
 ) {
   return (

--- a/packages/dnb-design-system-portal/src/shared/menu/graphics/uiGuides.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/graphics/uiGuides.tsx
@@ -5,7 +5,7 @@
 
 import type { SVGProps } from 'react'
 
-export default function ui_guides(props: SVGProps<SVGSVGElement> = {}) {
+export default function uiGuides(props: SVGProps<SVGSVGElement> = {}) {
   return (
     <svg
       width="24"


### PR DESCRIPTION
## Summary

Our codebase uses camelCase for identifiers, but a handful of sidebar menu graphic components in the portal still used snake_case. This renames them to camelCase.

## Changes

Renamed the following menu graphic components — their files, the `SidebarGraphics` map keys, and the matching `icon` frontmatter values in the docs:

| Before | After |
| --- | --- |
| `about_the_lib` | `aboutTheLib` |
| `change_log` | `changeLog` |
| `getting_started` | `gettingStarted` |
| `helper_classes` | `helperClasses` |
| `ui_guides` | `uiGuides` |

The `icon:` frontmatter values are resolved as keys into `SidebarGraphics` (`graphics[icon]`), so the docs frontmatter was updated in lockstep with the map keys.

## Scope / notes

A full-repo scan found no other genuine snake_case identifiers to convert. The remaining snake_case occurrences are intentional external contracts and were left untouched:

- Eufemia icon names (e.g. `chevron_down`, `file_pdf_medium`)
- Zod error codes (`too_big`, `invalid_format`)
- Bring address API fields (explicitly documented as matching the external API contract)
- MCP tool names (`docs_read`, `component_props`, …)
- Open Graph meta (`og:site_name`) and `data-visual-test` selectors

## Verification

- `prettier` and `eslint` pass on the changed files
- No type errors
- No remaining git-tracked references to the old names
