### PR TITLE
docs(Flex): v13 migration snippets + fix keep CSS dividers under non-stretch alignment

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -98,7 +98,7 @@ function MyComponent({ className, ...props }) {
 }
 ```
 
-For a component that already applied spacing to its root, deleting the marker is the only change. The rendered `<div>` is now a flex item automatically, and `useSpacing` keeps the component's own `top`, `right`, `bottom`, and `left` props working — in CSS mode those values are added to the container gap. If a component did not previously apply spacing to its root, adopt `useSpacing` as shown so authors can keep adjusting spacing per instance. A component that never needs per-instance spacing can simply drop the marker and receive the container gap.
+For a component that already applied spacing to its root, deleting the marker is the only change. The rendered `<div>` is now a flex item automatically, and `useSpacing` keeps the component's own `top`, `right`, `bottom`, and `left` props working — in CSS mode those values participate in pairwise spacing and may replace the adjacent container gap. If a component did not previously apply spacing to its root, adopt `useSpacing` as shown so authors can keep adjusting spacing per instance. A component that never needs per-instance spacing can simply drop the marker and receive the container gap.
 
 #### Wrapper components
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -61,7 +61,7 @@ Flex now uses native CSS gap and renders React children unchanged. The following
 
 #### Custom components
 
-The `_supportsSpacingProps` marker is gone. A custom component becomes a flex item through its rendered root, so no marker is needed to participate in the layout. When the component should accept [spacing properties](/uilib/layout/space/), apply them to its root with `useSpacing` so an author can still adjust the spacing per instance.
+The `_supportsSpacingProps` marker is no longer needed. A custom component becomes a flex item through its rendered root, so nothing needs to opt it in to the layout. When the component should accept [spacing properties](/uilib/layout/space/), apply them to its root with `useSpacing` so an author can still adjust the spacing per instance.
 
 **Before (v11):**
 
@@ -102,7 +102,7 @@ For a component that already applied spacing to its root, deleting the marker is
 
 #### Wrapper components
 
-`Flex.withChildren` is removed. It never hoisted a wrapper's children into the outer container's flex line. When the HOC marked a wrapper, `Flex.Container` automatically injected a nested `Flex.Container` inside the wrapper's root — inheriting the outer container's props — and laid the wrapper's children out there. The rendered DOM was already outer container → wrapper root → inner container. To keep that layout in v13, render the inner `Flex.Container` yourself.
+`Flex.withChildren` is deprecated. It never hoisted a wrapper's children into the outer container's flex line. When the HOC marked a wrapper, `Flex.Container` automatically injected a nested `Flex.Container` inside the wrapper's root — inheriting the outer container's props — and laid the wrapper's children out there. The rendered DOM was already outer container → wrapper root → inner container. To keep that layout in v13, render the inner `Flex.Container` yourself.
 
 **Before (v11):**
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -102,15 +102,15 @@ For a component that already applied spacing to its root, deleting the marker is
 
 #### Wrapper components
 
-`Flex.withChildren` is removed. In the legacy engine the HOC hoisted a wrapper's children into the parent container's spacing calculation, so items rendered inside the wrapper were spaced as if they were direct children of the outer `Flex.Container`. To lay out a wrapper's children in v13, render an explicit `Flex.Container` inside the wrapper.
+`Flex.withChildren` is removed. It never hoisted a wrapper's children into the outer container's flex line. When the HOC marked a wrapper, `Flex.Container` automatically injected a nested `Flex.Container` inside the wrapper's root — inheriting the outer container's props — and laid the wrapper's children out there. The rendered DOM was already outer container → wrapper root → inner container. To keep that layout in v13, render the inner `Flex.Container` yourself.
 
 **Before (v11):**
 
 ```tsx
 import { Flex } from '@dnb/eufemia'
 
-// The HOC marked the wrapper so Flex.Container applied the
-// between-item spacing to the wrapper's children.
+// The HOC marked the wrapper, so Flex.Container injected a nested
+// Flex.Container inside it to lay out the wrapper's children.
 const Wrapper = Flex.withChildren(({ children }) => <div>{children}</div>)
 
 render(
@@ -130,8 +130,8 @@ render(
 ```tsx
 import { Flex } from '@dnb/eufemia'
 
-// Render an explicit Flex.Container inside the wrapper so its
-// children get their own gap.
+// Render the inner Flex.Container yourself — this is the container
+// the HOC used to inject automatically.
 function Wrapper({ children }) {
   return (
     <div>
@@ -152,7 +152,7 @@ render(
 )
 ```
 
-Note the behavior difference: the wrapper's `<div>` is now a single flex item of the outer container, and the inner `Flex.Container` lays out its children as a nested group rather than merging them into the outer container's line. Set the inner container's own props (`direction`, `gap`, `divider`, …) to match the spacing you need. If a wrapper renders no DOM of its own — for example a Fragment, a context provider, or another transparent component — its children already become direct flex items of the outer container and need no inner `Flex.Container`.
+The DOM structure is unchanged from v11 — a wrapper root containing a nested `Flex.Container`. The only difference is that you now provide that inner container explicitly and set its own props (`direction`, `gap`, `divider`, …) instead of inheriting them from the outer container. If a wrapper renders no DOM of its own — for example a Fragment, a context provider, or another transparent component — its children already become direct flex items of the outer container and need no inner `Flex.Container`.
 
 When using `divider="line"` or `divider="line-framed"`, the CSS engine paints the divider without rendering `<hr>` elements. This removes the corresponding separator roles from the accessibility tree. If a divider conveys semantic separation, render explicit `Hr` elements instead of relying on the `divider` property.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -59,9 +59,100 @@ Flex now uses native CSS gap and renders React children unchanged. The following
 - `wrapChildrenInSpace`
 - `layoutEngine="legacy"`
 
-Remove `Flex.withChildren` and `_supportsSpacingProps` from ordinary custom components. Their rendered DOM root participates in Flex automatically. Components that accept spacing properties should apply them to their rendered root with `useSpacing`.
+#### Custom components
 
-If a wrapper's children need their own Flex layout, render an explicit `Flex.Container` inside the wrapper instead of using `Flex.withChildren`.
+The `_supportsSpacingProps` marker is gone. A custom component becomes a flex item through its rendered root, so no marker is needed to participate in the layout. When the component should accept [spacing properties](/uilib/layout/space/), apply them to its root with `useSpacing` so an author can still adjust the spacing per instance.
+
+**Before (v11):**
+
+```tsx
+import { clsx } from 'clsx'
+import { useSpacing } from '@dnb/eufemia/components/space/SpacingUtils'
+
+function MyComponent({ className, ...props }) {
+  const params = useSpacing(props, {
+    ...props,
+    className: clsx('my-component', className),
+  })
+
+  return <div {...params} />
+}
+
+// Opted the component in to receive spacing from Flex.Container.
+MyComponent._supportsSpacingProps = true
+```
+
+**After (v13):**
+
+```tsx
+import { clsx } from 'clsx'
+import { useSpacing } from '@dnb/eufemia/components/space/SpacingUtils'
+
+function MyComponent({ className, ...props }) {
+  const params = useSpacing(props, {
+    ...props,
+    className: clsx('my-component', className),
+  })
+
+  return <div {...params} />
+}
+```
+
+For a component that already applied spacing to its root, deleting the marker is the only change. The rendered `<div>` is now a flex item automatically, and `useSpacing` keeps the component's own `top`, `right`, `bottom`, and `left` props working — in CSS mode those values are added to the container gap. If a component did not previously apply spacing to its root, adopt `useSpacing` as shown so authors can keep adjusting spacing per instance. A component that never needs per-instance spacing can simply drop the marker and receive the container gap.
+
+#### Wrapper components
+
+`Flex.withChildren` is removed. In the legacy engine the HOC hoisted a wrapper's children into the parent container's spacing calculation, so items rendered inside the wrapper were spaced as if they were direct children of the outer `Flex.Container`. To lay out a wrapper's children in v13, render an explicit `Flex.Container` inside the wrapper.
+
+**Before (v11):**
+
+```tsx
+import { Flex } from '@dnb/eufemia'
+
+// The HOC marked the wrapper so Flex.Container applied the
+// between-item spacing to the wrapper's children.
+const Wrapper = Flex.withChildren(({ children }) => <div>{children}</div>)
+
+render(
+  <Flex.Container direction="vertical">
+    <Item />
+    <Wrapper>
+      <Item />
+      <Item />
+    </Wrapper>
+    <Item />
+  </Flex.Container>
+)
+```
+
+**After (v13):**
+
+```tsx
+import { Flex } from '@dnb/eufemia'
+
+// Render an explicit Flex.Container inside the wrapper so its
+// children get their own gap.
+function Wrapper({ children }) {
+  return (
+    <div>
+      <Flex.Container direction="vertical">{children}</Flex.Container>
+    </div>
+  )
+}
+
+render(
+  <Flex.Container direction="vertical">
+    <Item />
+    <Wrapper>
+      <Item />
+      <Item />
+    </Wrapper>
+    <Item />
+  </Flex.Container>
+)
+```
+
+Note the behavior difference: the wrapper's `<div>` is now a single flex item of the outer container, and the inner `Flex.Container` lays out its children as a nested group rather than merging them into the outer container's line. Set the inner container's own props (`direction`, `gap`, `divider`, …) to match the spacing you need. If a wrapper renders no DOM of its own — for example a Fragment, a context provider, or another transparent component — its children already become direct flex items of the outer container and need no inner `Flex.Container`.
 
 When using `divider="line"` or `divider="line-framed"`, the CSS engine paints the divider without rendering `<hr>` elements. This removes the corresponding separator roles from the accessibility tree. If a divider conveys semantic separation, render explicit `Hr` elements instead of relying on the `divider` property.
 


### PR DESCRIPTION
## Summary

Follow-up to #8942, targeting its branch (`refactor/flex-css-gap`). Two related changes to the CSS-gap Flex work: concrete migration docs, plus a fix for a divider bug found while reviewing.

## 1. Docs — concrete v13 migration snippets (`v13-info.mdx`)

The Flex section explained *what* to migrate but gave no code. Added worked **before/after** snippets for the two most common cases:

- **Custom components** — `_supportsSpacingProps` -> `useSpacing` on the rendered root. Clarifies the minimal case: for a component that already applies spacing to its root, deleting the marker is the only change; spacing props stay additive to the container gap in CSS mode.
- **Wrapper components** — `Flex.withChildren` -> an explicit nested `Flex.Container`. Documents the behavior change flagged in the #8942 review: the legacy engine *hoisted* a wrapper's children into the parent's spacing line, whereas the CSS engine treats the wrapper root as one flex item and lays its children out as a **nested group**. Transparent wrappers (Fragment/provider) need no inner container.

Import path and Before/After format match the existing `v11-info` notes and the shipped `useSpacing` example.

## 2. Fix — CSS dividers dropped under non-stretch alignment (`FlexDividers`)

Also from the #8942 review: the divider engine inferred flex-line wrapping from the raw `top` delta between adjacent items. Under any cross-axis alignment other than `stretch`/`flex-start` (`center`, `flex-end`, `baseline`, or a per-item `alignSelf`), same-line items legitimately sit at different `top` values, so they were misread as *wrapped* and their dividers were **silently dropped** — for both `divider="line"` and `divider="line-framed"`.

**Fix:** detect wrapping from the cross axis instead. Items on the same flex line always overlap on the cross axis regardless of alignment or writing direction, whereas a wrapped item is pushed entirely past the previous item. The vertical branch keeps its main-axis `top` comparison (alignment never affects it).

- Extracted the decision into a pure, exported `isItemWrapped` helper.
- Added unit tests covering stretch/flex-start/center/flex-end/alignSelf (painted) and real wraps in both directions (dropped).
- Default `flex-start` and `stretch` layouts are unchanged, so existing divider screenshots are unaffected.

### Verification

- New + existing Flex tests pass locally (`FlexDividers` 9, `Container` 61, `Item` 21).
- `prettier --check` clean on all changed files.
- Full geometry is exercised by the existing browser screenshot suite / branch preview; the unit test locks the decision boundary that regressed.
