### PR TITLE
fix(css): keep dnb-ui-components asset paths inside the package

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeMainStyle.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeMainStyle.test.ts
@@ -80,6 +80,14 @@ if (isCI) {
       expect(global.components[0]).toMatch(new RegExp('.dnb-button\\s?{'))
     })
 
+    it('keeps flag assets at the theme bundle depth (three levels up)', () => {
+      // ui-theme-components lives at build/style/themes/ui/, so its assets
+      // correctly resolve three levels up.
+      expect(global.components[0]).toMatch(
+        /url\(\s*["']?\.\.\/\.\.\/\.\.\/assets\/flags\/1x1\//
+      )
+    })
+
     it('has proper animation names after the cssnano transform', () => {
       expect(global.components[0]).not.toMatch(/animation:[a-z] /)
     })
@@ -104,6 +112,50 @@ if (isCI) {
       )
       expect(global.files[1]).toContain(
         '/style/themes/ui/ui-theme-components.min.css'
+      )
+    })
+  })
+
+  describe('makeMainStyle transforms the "dnb-ui-components" bundle', () => {
+    let base: string
+    let min: string
+
+    beforeAll(async () => {
+      const result = (await runFactory(
+        './src/style/dnb-ui-components.scss',
+        {
+          returnResult: true,
+        }
+      )) as string[]
+      base = result[0]
+      min = result[1]
+    })
+
+    it('has to have valid components css', () => {
+      const css = loadScss(null, { data: base })
+      // @ts-expect-error - strictFunctionTypes
+      expect(/^Error/.test(css)).toBe(false)
+    })
+
+    // Regression for #8951: the bundle lives at build/style/, so its assets
+    // must resolve one level up (../assets/…). The previous transform emitted a
+    // path two levels too high, which broke webpack/Next.js bundling.
+    it('references flag assets inside the package (../assets/…)', () => {
+      expect(base).toMatch(/url\(\s*["']?\.\.\/assets\/flags\/1x1\//)
+      expect(min).toMatch(/url\(\s*["']?\.\.\/assets\/flags\/1x1\//)
+    })
+
+    it('does not reference flag assets outside the package', () => {
+      expect(base).not.toMatch(/\.\.\/\.\.\/\.\.\/assets\/flags\//)
+      expect(min).not.toMatch(/\.\.\/\.\.\/\.\.\/assets\/flags\//)
+    })
+
+    it('references skeleton font assets inside the package', () => {
+      expect(base).toMatch(
+        /url\(\s*["']?\.\.\/assets\/fonts\/dnb\/skeleton\//
+      )
+      expect(base).not.toMatch(
+        /\.\.\/\.\.\/\.\.\/assets\/fonts\/dnb\/skeleton\//
       )
     })
   })

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeMainStyle.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeMainStyle.ts
@@ -24,6 +24,7 @@ import { getFontBasePath } from '../../../src/plugins/postcss-font-url-rewrite/c
 import postcssConfig from '../config/postcssConfig'
 
 const ROOT_DIR = path.resolve(__dirname, '../../..')
+const SRC_DIR = path.resolve(ROOT_DIR, 'src')
 
 export default async function makeMainStyle() {
   // info: use this approach to process files because:
@@ -66,7 +67,6 @@ export const runFactory = async (
   const sassTransform = transformSass()
   const postcssTransform = transformPostcss(await postcssConfig({ sass }))
   const cssnanoTransform = transformCssnano({ reduceIdents: false })
-  const pathsTransform = transformPaths('../../assets/', '../assets/')
 
   const files = await globby(src, { cwd: ROOT_DIR })
 
@@ -79,6 +79,17 @@ export const runFactory = async (
     // Transform SCSS to CSS
     const cssContent = sassTransform(content, { path: absolutePath })
     const cssPath = absolutePath.replace(/\.scss$/, '.css')
+
+    // Sass keeps url() literals verbatim, so bundles inherit the source's
+    // four-level asset prefix ("../../../../assets/"); rewrite it to this file's
+    // own depth under build/. A fixed one-level strip only fit the three-deep
+    // theme bundles and pointed top-level bundles outside the package (#8951).
+    const outputDir = path.dirname(path.relative(SRC_DIR, cssPath))
+    const depth = outputDir === '.' ? 0 : outputDir.split(path.sep).length
+    const pathsTransform = transformPaths(
+      '../../../../assets/',
+      `${'../'.repeat(depth)}assets/`
+    )
 
     // Branch 1: base (postcss processed)
     const baseContent = await postcssTransform(cssContent, {


### PR DESCRIPTION
## Summary

The prebuilt `@dnb/eufemia/style/dnb-ui-components.min.css` (and its `--isolated` variant) referenced the flag SVGs with a `url()` pointing **outside** the package — `url(../../../assets/flags/1x1/*.svg)`, two levels too high. From `node_modules/@dnb/eufemia/style/` that resolves to `node_modules/assets/…` instead of `node_modules/@dnb/eufemia/assets/…`, so webpack/Next.js consumers fail the production build (Vite only warns and the flags 404 at runtime). Fixes #8951.

## Root cause

Source SCSS references assets four levels up (`../../../../assets/…`), and Sass keeps `url()` literals **verbatim** (no rebasing), so every aggregated bundle inherits that prefix regardless of where it ends up. `makeMainStyle` then stripped a **single** level via `transformPaths('../../assets/', '../assets/')` — correct only for the theme bundles that live three levels deep (`build/style/themes/<theme>/`), but wrong for the top-level `build/style/*.css` bundles, which are one level deep and need `../assets/`.

## Fix

Rewrite the asset prefix **per output file, based on its own depth** under `build/`: `'../'.repeat(depth) + 'assets/'`. Top-level bundles now emit `../assets/…`; theme bundles keep `../../../assets/…`. No source SCSS changes, and `makeLibStyles` (per-component files, always three levels deep) was already correct and is left untouched. This also corrects the skeleton `@font-face` URLs that were off in the same bundle for the same reason.

## Verification

- New regression tests: the `dnb-ui-components` bundle (base + min) now references `../assets/flags/1x1/…` and **not** `../../../assets/flags/…`, plus a guard that theme bundles keep the deeper path. Confirmed they fail on the old transform and pass with the fix.
- `19` makeMainStyle + `7` makeLibStyles tests pass; `prettier` and `eslint` clean; no type errors.
