### PR TITLE
fix: rebase asset paths when copying styles into module bundles

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -9,6 +9,7 @@
 import fs from 'fs-extra'
 import path from 'path'
 import { getCommittedFiles } from '../../tools/cliTools'
+import { rebaseAssetUrls } from '../copyStyles'
 
 const PKG_ROOT = path.resolve(__dirname, '../../..')
 
@@ -23,6 +24,37 @@ const getBuildStages = (stages: string[]) => {
   const shouldSkipEs = process.env.BUILD_MINI
   return shouldSkipEs ? stages.filter((s) => s !== '/es') : stages
 }
+
+describe('rebaseAssetUrls (copyStyles)', () => {
+  const buildAbs = path.resolve(PKG_ROOT, 'build')
+
+  it('adds one level for module-format copies of top-level bundles', () => {
+    const css = '.fi{background-image:url(../assets/flags/1x1/no.svg)}'
+    const dest = path.join(buildAbs, 'cjs/style/dnb-ui-components.css')
+    expect(rebaseAssetUrls(css, dest)).toContain(
+      'url(../../assets/flags/1x1/no.svg)'
+    )
+  })
+
+  it('rebases nested theme bundles to their deeper location', () => {
+    const css =
+      '@font-face{src:url("../../../assets/fonts/dnb/DNB-Regular.woff2")}'
+    const dest = path.join(
+      buildAbs,
+      'es/style/themes/ui/ui-theme-basis.css'
+    )
+    expect(rebaseAssetUrls(css, dest)).toContain(
+      'url("../../../../assets/fonts/dnb/DNB-Regular.woff2")'
+    )
+  })
+
+  it('leaves absolute and data urls untouched', () => {
+    const css =
+      '@font-face{src:url(https://assets.dnb.no/fonts/x.woff2)}.b{background:url(data:image/svg+xml;base64,AAAA)}'
+    const dest = path.join(buildAbs, 'cjs/style/x.css')
+    expect(rebaseAssetUrls(css, dest)).toBe(css)
+  })
+})
 
 describe('type definitions', () => {
   const buildStages = getBuildStages(['/es', '/esm', '/cjs'])
@@ -774,8 +806,11 @@ describe('style build', () => {
       )
       expect(content).toContain(`.dnb-typo-regular`)
       expect(content).toContain(`@font-face`)
+      // The /es and /cjs copies live one level deeper than the top-level
+      // bundle, so their relative asset paths gain one extra "../".
+      const fontsPrefix = stage === '' ? '../../../' : '../../../../'
       expect(content).toContain(
-        `src: url("../../../assets/fonts/dnb/DNB-Regular.woff2") format("woff2"),`
+        `src: url("${fontsPrefix}assets/fonts/dnb/DNB-Regular.woff2") format("woff2"),`
       )
       expect(normalizeCss(content)).toContain(
         normalizeCss(`
@@ -864,6 +899,16 @@ describe('style build', () => {
         'utf-8'
       )
       expect(content).not.toContain(`.dnb-forms-`)
+
+      if (stage !== '') {
+        // The /es and /cjs copies must keep flag assets resolving in-package.
+        expect(content).toMatch(
+          /url\(\s*["']?\.\.\/\.\.\/assets\/flags\/1x1\//
+        )
+        expect(content).not.toMatch(
+          /url\(\s*["']?\.\.\/\.\.\/\.\.\/assets\/flags\//
+        )
+      }
     }
 
     {

--- a/packages/dnb-eufemia/scripts/postbuild/copyStyles.js
+++ b/packages/dnb-eufemia/scripts/postbuild/copyStyles.js
@@ -7,6 +7,8 @@ import fs from 'fs-extra'
 import path from 'path'
 import globby from 'globby'
 
+const BUILD_DIR = path.resolve('./build')
+
 if (require.main === module) {
   copyCSSFiles(process.env.OUT_DIR)
 }
@@ -24,9 +26,22 @@ async function copyCSSFiles(dist) {
     const src = path.resolve(file)
     const dest = path.resolve(dist, file.replace('/build/', '/'))
 
-    await fs.copy(src, dest, {
-      overwrite: false,
-      errorOnExist: false,
-    })
+    // Copying nests each stylesheet under a module-format dir (cjs/es/esm),
+    // deeper than its build/ source, which would break the relative
+    // url(../assets/…) references. Rebase them to the destination's own depth
+    // so they keep resolving to build/assets instead of pointing outside the package.
+    const content = await fs.readFile(src, 'utf-8')
+    await fs.outputFile(dest, rebaseAssetUrls(content, dest))
   }
+}
+
+export function rebaseAssetUrls(css, destPath) {
+  const relativeDir = path.relative(BUILD_DIR, path.dirname(destPath))
+  const depth = relativeDir ? relativeDir.split(path.sep).length : 0
+  const prefix = '../'.repeat(depth)
+
+  return css.replace(
+    /url\(\s*(['"]?)(?:\.\.\/)+assets\//g,
+    (_match, quote) => `url(${quote}${prefix}assets/`
+  )
 }


### PR DESCRIPTION
## Summary

The postbuild step copies every compiled stylesheet from `build/style` into the module-format dirs (`build/cjs/style`, `build/es/style`, `build/esm/style`) — one level deeper — **verbatim**. The relative `url(../assets/…)` references were not adjusted, so flags and fonts in those copies resolved **outside** the package (e.g. `build/cjs/assets` instead of `build/assets`). Complements #8951 / #8952, which fix the top-level `build/style` bundles.

## Root cause

`copyStyles.js` copied files with `fs.copy(src, dest)`, where `dest` is the same relative path nested under `cjs`/`es`/`esm`. Sass keeps `url()` literals verbatim, so e.g. `build/style/dnb-ui-components.css` (`url(../assets/…)`, correct at depth 1) became `build/es/style/dnb-ui-components.css` at depth 2 with the *same* `../assets/…` — one level too high. Every module-format CSS copy pointed out of package (~1104 refs in `cjs`, ~1104 in `es`).

## Fix

Rebase the `url(../…assets/…)` references to each destination file's **actual depth under `build/`** during the copy, so the copies resolve `build/assets` regardless of the source bundle's own depth. Being depth-derived, it's correct for both top-level bundles (`…/style/*.css`) and nested theme bundles (`…/style/themes/<theme>/*.css`).

## Verification

- Rebuilt the styles with **this branch's** (pre-#8951) `makeMainStyle` and re-ran the copy: `build/es/style/dnb-ui-components.min.css` emits `url(../../assets/flags/1x1/…)` even though the source bundle was still the buggy `url(../../../assets/…)`. A full scan of `build/**/*.css` then reports **0** out-of-package refs in `cjs`/`es` (was 1104 each); the only remaining refs live in top-level `build/style` — i.e. #8951's domain.
- Added `rebaseAssetUrls` unit tests and made the `postbuild.test.ts` asset-path assertions stage-aware (the `/es` and `/cjs` copies now expect the extra `../`). `prettier`/`eslint` clean, no type errors.

## Notes

- Order-independent from #8951: this only rewrites the copies under `cjs`/`es`/`esm` and never touches `build/style`. Once both land, `build/**/*.css` is fully in-package.
