### PR TITLE
chore(mcp): rename MCP endpoint route to /mcp/web

### DIFF
--- a/tools/mcp-lambda/README.md
+++ b/tools/mcp-lambda/README.md
@@ -5,7 +5,7 @@ MCP server that exposes the Eufemia documentation to AI tools, deployed as an AW
 ## Architecture
 
 ```
-POST /mcp → API Gateway HTTP API → Lambda (Node.js 22) → MCP SDK → Docs on disk
+POST /mcp/web → API Gateway HTTP API → Lambda (Node.js 22) → MCP SDK → Docs on disk
 ```
 
 The server is stateless — each request creates a fresh MCP transport, processes the JSON-RPC call, and tears down. No session state is kept between invocations.
@@ -128,7 +128,7 @@ Managed via Terraform in `infra/`:
 | Resource    | Configuration                                      |
 | ----------- | -------------------------------------------------- |
 | Lambda      | Node.js 22, 512 MB, 30s timeout, 30 max concurrent |
-| API Gateway | HTTP API, `POST /mcp` + `GET /healthz`             |
+| API Gateway | HTTP API, `POST /mcp/web` + `GET /healthz`         |
 | Throttling  | 200 burst / 400 requests per second                |
 | CloudWatch  | 30-day log retention                               |
 | Region      | eu-north-1                                         |

--- a/tools/mcp-lambda/infra/main.tf
+++ b/tools/mcp-lambda/infra/main.tf
@@ -84,9 +84,11 @@ resource "aws_apigatewayv2_integration" "mcp" {
 
 # POST-only: GET (SSE) and DELETE (session cleanup) are not needed
 # because sessionIdGenerator is disabled in the Lambda transport.
-resource "aws_apigatewayv2_route" "mcp" {
+# The /mcp/<client> namespace leaves room for a future native endpoint
+# (e.g. /mcp/native); /mcp/web is the canonical path for the web docs server.
+resource "aws_apigatewayv2_route" "mcp_web" {
   api_id    = aws_apigatewayv2_api.mcp.id
-  route_key = "POST /mcp"
+  route_key = "POST /mcp/web"
   target    = "integrations/${aws_apigatewayv2_integration.mcp.id}"
 }
 
@@ -98,12 +100,12 @@ resource "aws_apigatewayv2_route" "health" {
   target    = "integrations/${aws_apigatewayv2_integration.mcp.id}"
 }
 
-resource "aws_lambda_permission" "apigw" {
-  statement_id  = "AllowAPIGateway"
+resource "aws_lambda_permission" "apigw_web" {
+  statement_id  = "AllowAPIGatewayWeb"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.mcp.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.mcp.execution_arn}/*/POST/mcp"
+  source_arn    = "${aws_apigatewayv2_api.mcp.execution_arn}/*/POST/mcp/web"
 }
 
 resource "aws_lambda_permission" "apigw_health" {

--- a/tools/mcp-lambda/infra/outputs.tf
+++ b/tools/mcp-lambda/infra/outputs.tf
@@ -3,7 +3,7 @@ output "api_endpoint" {
 }
 
 output "custom_domain" {
-  value = "https://${var.domain_name}/mcp"
+  value = "https://${var.domain_name}/mcp/web"
 }
 
 output "function_name" {


### PR DESCRIPTION
## Summary

Namespaces the MCP HTTP API route as `/mcp/web` instead of `/mcp`, so a future native MCP endpoint can live alongside it under the same prefix (e.g. `/mcp/native`).

The `/mcp` URL has not been shared yet, so this is a straight rename rather than an additive/deprecation change.

## Changes

- `infra/main.tf`: route `POST /mcp` → `POST /mcp/web` and the matching Lambda permission `source_arn`.
- `infra/outputs.tf`: `custom_domain` output → `/mcp/web`.
- `README.md`: architecture diagram + infra table updated.

## Not changed

- **Lambda handler** — path-agnostic apart from the `/healthz` short-circuit; the MCP transport processes the request regardless of path.
- **Akamai edge** — the property forwards all paths to the origin, so `/mcp/web` flows through with no delivery-repo change.

## Deploy impact

`terraform apply` removes the `POST /mcp` route and adds `POST /mcp/web`. After deploy the endpoint is `https://server.eufemia.dnb.no/mcp/web`; `/mcp` returns 404.