### PR TITLE
ci(release): adopt npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
   contents: write # Required for semantic-release to push tags and changelog
   issues: write # Required for semantic-release to comment on issues
   pull-requests: write # Required for semantic-release to comment on PRs
-  id-token: write # Required for npm provenance
+  id-token: write # Required for npm Trusted Publishing (OIDC) and provenance
 
 # No job-wide `env:` on purpose: secrets are scoped to the individual steps that
 # need them (least privilege), so install, prebuild and build never see the
@@ -42,7 +42,10 @@ jobs:
         uses: ./.github/actions/setup
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
+          # No `registry-url`: it makes actions/setup-node write an .npmrc with
+          # an empty NODE_AUTH_TOKEN, which conflicts with semantic-release's
+          # OIDC auth (EINVALIDNPMTOKEN). semantic-release publishes to the
+          # default public registry and handles Trusted Publishing itself.
 
       - name: Audit dependencies
         run: yarn workspace @dnb/eufemia audit:ci
@@ -89,8 +92,11 @@ jobs:
           endsWith(github.ref, '.x'))
         run: yarn workspace @dnb/eufemia publish:ci
         env:
-          # semantic-release: npm publish + GitHub release/tag/changelog push.
+          # semantic-release publishes to npm via Trusted Publishing (OIDC): it
+          # exchanges this workflow's id-token for a short-lived npm token, so no
+          # long-lived NPM_TOKEN is needed. Requires a Trusted Publisher for
+          # @dnb/eufemia configured on npmjs.com pointing at this workflow.
+          # GH_* are for the GitHub release and the changelog/tag commit push.
           GH_EMAIL: ${{ secrets.GH_EMAIL }}
           GH_NAME: ${{ secrets.GH_NAME }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
@@ -100,7 +100,7 @@ The release pipeline (`.github/workflows/release.yml`) and this process are owne
 ### Controls in place
 
 - **Provenance** — packages are published with npm provenance (`publishConfig.provenance: true` plus `id-token: write` on the release job), so each release has a verifiable, signed link back to the source commit and workflow.
-- **Least-privilege secrets** — `release.yml` has no job-wide `env:`; each secret is injected only into the step that needs it (Algolia config for the portal build and search push; npm and GitHub credentials only for the publish step). Unused tokens are never exposed to the install, prebuild or build steps.
+- **Least-privilege secrets** — `release.yml` has no job-wide `env:`; each secret is injected only into the step that needs it (Algolia config for the portal build and search push; the GitHub token only for the publish step). npm needs no stored publish secret at all — it authenticates with a short-lived OIDC token (see [Publishing method](#publishing-method)). Unused tokens are never exposed to the install, prebuild or build steps.
 - **Package-content validation** — before publishing, `yarn validate:package` runs `npm pack --dry-run` on the built package and fails the release if the tarball would contain files that must never ship (tests, stories, `.env`, `.npmrc`, `node_modules`, editor/OS junk), is missing a declared entry point (the `main`, `module`, `types` or `exports` targets from the built `package.json`) or an essential CSS bundle, or is suspiciously small. It runs from `publish:prepare`, so it also runs during `yarn workspace @dnb/eufemia build:pack`.
 - **Consumer smoke tests** — `.github/workflows/consumer-smoke.yml` packs the built library and production-builds it in minimal Vite and Next.js consumers (`smoke/`), asserting that exports (including the forms extension subpath), a subpath type import, peer dependencies and CSS imports resolve and bundle. The fixtures also import the `dnb-ui-components.min.css` bundle, so the Next.js (webpack) build guards against a regression of the out-of-package flag-SVG `url()` bug fixed in [#8952](https://github.com/dnbexperience/eufemia/pull/8952).
 - **Dependency audit** — `yarn workspace @dnb/eufemia audit:ci` runs as a release step and blocks a release on known high-severity vulnerabilities in the shipped dependency tree.
@@ -118,8 +118,12 @@ At release time, `release.yml` additionally enforces the dependency audit and th
 
 ### Permissions and trigger
 
-The release job runs with `contents: write` (so `semantic-release` can push the changelog commit and version tag), `issues: write` and `pull-requests: write` (release comments), and `id-token: write` (provenance). Releases run only from the protected release branches on a clean CI checkout — never from a developer machine.
+The release job runs with `contents: write` (so `semantic-release` can push the changelog commit and version tag), `issues: write` and `pull-requests: write` (release comments), and `id-token: write` (OIDC publishing and provenance). Releases run only from the protected release branches on a clean CI checkout — never from a developer machine.
 
 ### Build, validate and smoke-test
 
 Within a workflow, the library is built once into `build/` before it is checked: `validate:package` inspects that build's packed contents, and the consumer smoke tests install and build a packed copy of it. The release workflow builds separately, and `semantic-release` creates the published tarball at publish time — so the smoke-tested tarball is not yet byte-for-byte identical to the published one. Publishing the exact validated tarball is a planned follow-up.
+
+### Publishing method
+
+Releases publish to npm using **Trusted Publishing** (OpenID Connect): the release workflow authenticates with a short-lived, GitHub-issued OIDC token instead of a long-lived `NPM_TOKEN`, and every package is published with provenance. There is no static publish secret to store, rotate or leak.


### PR DESCRIPTION
Adopts **npm Trusted Publishing (OIDC)** for `@dnb/eufemia` releases and documents it. Split out of #8949.

The `Release` step no longer uses a long-lived `NPM_TOKEN`: `@semantic-release/npm` exchanges the workflow's short-lived `id-token` for a scoped npm token at publish time, and every package is published with provenance.

## ⚠️ Merge gate (npm package owner)
**Do not merge or release until a Trusted Publisher for `@dnb/eufemia` is configured on npmjs.com** (repo `dnbexperience/eufemia`, workflow `.github/workflows/release.yml`). Until that exists an OIDC publish fails, so this PR is kept as a **draft**. Once configured, the next release from a protected branch publishes over OIDC with no stored secret.

## What's here
- **`release.yml`** — removes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the `Release` step; keeps `id-token: write` (OIDC auth + provenance) and `GH_*` (GitHub release + changelog/tag push).
- **`deploy.mdx`** — a concise "Publishing method" section plus reconciled least-privilege/permission notes so the docs match the workflow.

## Why the tooling is ready
- `@semantic-release/npm` added Trusted Publishing in **v13.1.0**; the repo is on **13.1.5**, so the plugin performs the OIDC token exchange itself (passes the GitHub `id-token` as a bearer token) — the local npm CLI version is not the gating factor. Node is pinned to **24.16.0** (npm 11.x).
- `contents: write` stays on the release job because `@semantic-release/git` pushes the changelog commit and version tag; OIDC only removes the npm auth secret.

Base: `refactor/ci-release-least-privilege-secrets` (stacks on #8949); retarget to `main` after that merges.
