### PR TITLE
chore(TabBar): make fullscreen control a real button so Space activates it

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/fullscreen.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/fullscreen.spec.ts
@@ -10,17 +10,51 @@ test.describe('Fullscreen', () => {
   }) => {
     await page.waitForSelector('nav#portal-sidebar-menu')
 
-    await page.click('a.fullscreen')
+    await page.click('button.fullscreen')
     await page.waitForURL('**/uilib/components/button/demos/?fullscreen')
 
     expect(page.url()).toContain(
       '/uilib/components/button/demos/?fullscreen'
     )
 
-    await page.click('a.fullscreen')
+    await page.click('button.fullscreen')
     await page.waitForURL('**/uilib/components/button/demos/')
 
     expect(page.url()).toContain('/uilib/components/button/demos/')
+  })
+
+  test('should toggle fullscreen when pressing Space on the fullscreen button', async ({
+    page,
+  }) => {
+    await page.waitForSelector('nav#portal-sidebar-menu')
+
+    await page.locator('button.fullscreen').focus()
+    await page.keyboard.press('Space')
+    await page.waitForURL('**/uilib/components/button/demos/?fullscreen')
+
+    expect(page.url()).toContain(
+      '/uilib/components/button/demos/?fullscreen'
+    )
+
+    await page.locator('button.fullscreen').focus()
+    await page.keyboard.press('Space')
+    await page.waitForURL('**/uilib/components/button/demos/')
+
+    expect(page.url()).toContain('/uilib/components/button/demos/')
+  })
+
+  test('should enter fullscreen when pressing Enter on the fullscreen button', async ({
+    page,
+  }) => {
+    await page.waitForSelector('nav#portal-sidebar-menu')
+
+    await page.locator('button.fullscreen').focus()
+    await page.keyboard.press('Enter')
+    await page.waitForURL('**/uilib/components/button/demos/?fullscreen')
+
+    expect(page.url()).toContain(
+      '/uilib/components/button/demos/?fullscreen'
+    )
   })
 
   test('should not produce hydration errors when visiting a fullscreen URL directly', async ({
@@ -54,7 +88,7 @@ test.describe('Fullscreen', () => {
     await expect(page.locator('nav#portal-sidebar-menu')).toHaveCount(0)
 
     // Quit fullscreen
-    await page.click('a.fullscreen')
+    await page.click('button.fullscreen')
     await page.waitForURL('**/uilib/components/button/demos/')
 
     // Header and sidebar should reappear

--- a/packages/dnb-design-system-portal/src/e2e/routeFocus.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/routeFocus.spec.ts
@@ -88,7 +88,7 @@ test.describe('Route Focus', () => {
     await page.goto('/uilib/components/accordion#relevant-links')
     await waitForApp(page)
 
-    await page.getByRole('link', { name: 'Fullscreen' }).click()
+    await page.getByRole('button', { name: 'Fullscreen' }).click()
 
     await expect(page).toHaveURL(
       '/uilib/components/accordion/?fullscreen#relevant-links'

--- a/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/TabBar.tsx
@@ -43,14 +43,6 @@ export default function TabBar({
   const cleanFullscreen = (s) =>
     s.replace(/\?fullscreen$|&fullscreen|fullscreen|\?$/, '')
 
-  const openFullscreen = () => {
-    setFullscreen(true)
-  }
-
-  const quitFullscreen = () => {
-    setFullscreen(false)
-  }
-
   const fullscreenPath = [
     location.pathname,
     location.search ? location.search + '&' : '?',
@@ -63,6 +55,12 @@ export default function TabBar({
     cleanFullscreen(location.search),
     location.hash,
   ].join('')
+
+  // Use a real <button> (not a link) so both Enter and Space activate it; navigate keeps the URL shareable.
+  const toggleFullscreen = () => {
+    setFullscreen(!wasFullscreen)
+    navigate(wasFullscreen ? quitFullscreenPath : fullscreenPath)
+  }
 
   const preparedTabs = useMemo(() => {
     return (
@@ -130,12 +128,7 @@ export default function TabBar({
               <TabsList>
                 <Tabs />
                 <Button
-                  onClick={wasFullscreen ? quitFullscreen : openFullscreen}
-                  href={
-                    wasFullscreen ? quitFullscreenPath : fullscreenPath
-                  }
-                  // @ts-expect-error -- strictFunctionTypes
-                  element={Link}
+                  onClick={toggleFullscreen}
                   variant="tertiary"
                   title={wasFullscreen ? 'Quit Fullscreen' : 'Fullscreen'}
                   aria-label={

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/TabBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/TabBar.test.tsx
@@ -59,6 +59,7 @@ describe('TabBar fullscreen control', () => {
     const button = container.querySelector('button.fullscreen')
     expect(button).toBeTruthy()
     expect(button?.tagName).toBe('BUTTON')
+    expect(button?.getAttribute('type')).toBe('button')
     expect(container.querySelector('a.fullscreen')).toBeNull()
     expect(button?.getAttribute('aria-label')).toBe('Fullscreen')
   })
@@ -74,6 +75,7 @@ describe('TabBar fullscreen control', () => {
     expect(navigate).toHaveBeenCalledWith(
       '/uilib/components/button/demos/?fullscreen'
     )
+    expect(navigate).toHaveBeenCalledTimes(1)
     expect(
       container
         .querySelector('button.fullscreen')
@@ -94,5 +96,6 @@ describe('TabBar fullscreen control', () => {
     expect(navigate).toHaveBeenCalledWith(
       '/uilib/components/button/demos/'
     )
+    expect(navigate).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/TabBar.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/TabBar.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup, render, fireEvent } from '@testing-library/react'
+
+const navigate = vi.hoisted(() => vi.fn())
+
+vi.mock('portal-query', () => ({
+  navigate,
+}))
+
+vi.mock('../Anchor', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ children, to, ...props }: any) => <a {...props}>{children}</a>,
+}))
+
+vi.mock('../AutoLinkHeader', () => ({
+  default: ({ children }: { children: unknown }) => (
+    <h1>{children as never}</h1>
+  ),
+}))
+
+vi.mock('../TabBar.module.scss', () => ({
+  tabsWrapperStyle: 'tabsWrapperStyle',
+}))
+
+import TabBar from '../TabBar'
+
+afterEach(() => {
+  cleanup()
+  navigate.mockClear()
+})
+
+const tabs = [
+  { title: 'Demos', key: '/uilib/components/button/demos/' },
+  { title: 'Properties', key: '/uilib/components/button/properties/' },
+]
+
+function renderTabBar(search = '') {
+  const location = {
+    pathname: '/uilib/components/button/demos/',
+    search,
+    hash: '',
+  } as Location
+
+  return render(
+    <TabBar
+      location={location}
+      title="Button"
+      hideTabs={[]}
+      rootPath="/uilib/components/button/"
+      tabs={tabs}
+    />
+  )
+}
+
+describe('TabBar fullscreen control', () => {
+  it('renders as a native button (not a link) so Space and Enter both activate it', () => {
+    const { container } = renderTabBar()
+
+    const button = container.querySelector('button.fullscreen')
+    expect(button).toBeTruthy()
+    expect(button?.tagName).toBe('BUTTON')
+    expect(container.querySelector('a.fullscreen')).toBeNull()
+    expect(button?.getAttribute('aria-label')).toBe('Fullscreen')
+  })
+
+  it('navigates to the fullscreen URL and updates the label when activated', () => {
+    const { container } = renderTabBar()
+
+    const button = container.querySelector(
+      'button.fullscreen'
+    ) as HTMLButtonElement
+    fireEvent.click(button)
+
+    expect(navigate).toHaveBeenCalledWith(
+      '/uilib/components/button/demos/?fullscreen'
+    )
+    expect(
+      container
+        .querySelector('button.fullscreen')
+        ?.getAttribute('aria-label')
+    ).toBe('Quit Fullscreen')
+  })
+
+  it('navigates back to the non-fullscreen URL when quitting', () => {
+    const { container } = renderTabBar('?fullscreen')
+
+    const button = container.querySelector(
+      'button.fullscreen'
+    ) as HTMLButtonElement
+    expect(button.getAttribute('aria-label')).toBe('Quit Fullscreen')
+
+    fireEvent.click(button)
+
+    expect(navigate).toHaveBeenCalledWith(
+      '/uilib/components/button/demos/'
+    )
+  })
+})


### PR DESCRIPTION
Issue: Pressing **Space** on the fullscreen toggle in the docs portal's `TabBar` did nothing — only **Enter** worked. For a control that looks and reads like a button, both keys should activate it.
