### PR TITLE
chore(ci): prevent shell injection from untrusted PR branch name

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,7 +55,7 @@ jobs:
 
           OUTPUT="$(yarn workspace dnb-design-system-portal wrangler pages deploy ./public \
             --project-name eufemia \
-            --branch "${{ github.head_ref || github.ref_name }}" \
+            --branch "$BRANCH" \
             --commit-dirty=true)"
 
           echo "$OUTPUT"
@@ -68,6 +68,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Passed via env (not inlined into the script) so an untrusted PR
+          # branch name cannot inject shell commands into the run step.
+          BRANCH: ${{ github.head_ref || github.ref_name }}
 
       - name: Post or update preview comment
         if: success() && github.event.pull_request


### PR DESCRIPTION
Pass the branch name through an `env:` variable and reference it as `"$BRANCH"`,
so the value is never parsed as shell. This matches the pattern already used in
`mcp-worker.yml` (`REF_NAME`) and `pr-checks.yml` (`PR_TITLE`).
