### PR TITLE
ci(security): make dependency audit gate non-bypassable via commit/PR text

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,7 +49,13 @@ jobs:
     needs: setup
 
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message || '', '--skip-audit') && !(github.event.pull_request && contains(github.event.pull_request.title || '', '--skip-audit')) }}
+    # The dependency audit is a security gate, so it cannot be disabled from a
+    # commit message or PR title (which any contributor controls). If the npm
+    # audit service is down and blocking CI, a repository admin can set the
+    # `SKIP_DEPENDENCY_AUDIT` repository variable to `true` to unblock, then
+    # unset it once the service recovers. For a single advisory with no fix yet,
+    # prefer `npmAuditIgnoreAdvisories` in `.yarnrc.yml` instead.
+    if: ${{ vars.SKIP_DEPENDENCY_AUDIT != 'true' }}
 
     timeout-minutes: 10
 

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
@@ -178,13 +178,9 @@ This is useful when you want to see all visual test failures at once, rather tha
 
 ### Skip dependency audit in CI
 
-You can skip the dependency audit step in the Verify workflow by including `--skip-audit` in your commit message:
+The dependency audit in the Verify workflow is a security gate and cannot be skipped from a commit message or PR title. If the npm audit service has an outage and is blocking CI, a repository admin can temporarily disable it by setting the `SKIP_DEPENDENCY_AUDIT` repository variable to `true` (Settings → Secrets and variables → Actions → Variables), then removing it once the service recovers.
 
-```bash
-git commit -m "chore: update snapshots --skip-audit"
-```
-
-The CI will detect `--skip-audit` and skip the "Audit dependencies" step accordingly.
+For a specific advisory that has no available fix yet, prefer adding it to `npmAuditIgnoreAdvisories` in `.yarnrc.yml` instead, so the rest of the audit keeps protecting the codebase.
 
 **Playwright end-to-end tests:**
 


### PR DESCRIPTION
## Summary

The `Audit dependencies` job in [`verify.yml`](.github/workflows/verify.yml) was
skipped whenever `--skip-audit` appeared in the head commit message (or, in the
expression, a PR title):

```yaml
if: ${{ !contains(github.event.head_commit.message || '', '--skip-audit') && !(github.event.pull_request && contains(github.event.pull_request.title || '', '--skip-audit')) }}
```

`verify.yml` is **push-triggered**, so the live, reachable vector is the **head
commit message**: any push (including pushes to a same-repo PR branch) whose
latest commit message contains `--skip-audit` silently disables the dependency
security gate. Commit messages are free text controlled by the pusher, so a
contributor could land changes — e.g. one that pulls in a high/critical
production advisory — with the audit never running while the Verify workflow
still reports green (a skipped job doesn't fail the run).

> Note: the `github.event.pull_request.title` half of the old expression was
> latent — on a `push` event `github.event.pull_request` is null, so that branch
> never triggered in this workflow. It's removed anyway for correctness.

## Verification

Faithfully evaluated the old `if:` expression for `push` events:

| Scenario | Audit job |
| --- | --- |
| Normal commit message | RUNS |
| `--skip-audit` in the head commit message | **SKIPPED (gate silently bypassed)** |

## Fix

`--skip-audit` was originally added to tolerate **npm audit service outages**
(#5738), which is a legitimate need — but the mechanism was far too broad.

This replaces it with a **privileged, auditable escape hatch**: the audit is
skipped only when a repository admin sets the `SKIP_DEPENDENCY_AUDIT` repository
variable to `true` (Settings → Secrets and variables → Actions → Variables), and
is re-enabled by removing it. The gate now:

- **runs by default** (unset variable ⇒ audit runs — fail-safe),
- can only be turned off by someone with repo settings access (not via commit
  text), and
- is a single, visible, central toggle rather than per-commit free text.

For a single advisory that has no fix yet, `npmAuditIgnoreAdvisories` in
`.yarnrc.yml` remains the preferred, granular mechanism (documented in the change
too).

## Behaviour of the new gate

| `SKIP_DEPENDENCY_AUDIT` | Audit |
| --- | --- |
| unset (default) | RUNS |
| `true` / `TRUE` | SKIPPED |
| `false` / `1` / anything else | RUNS |

## Testing

- Faithfully evaluated both the old and new `if:` expressions (results above).
- `yarn exec prettier --check` passes on both changed files.
- Docs (`make-and-run-tests.mdx`) updated to describe the new mechanism.

## Note for maintainers

If npm's audit service has an outage, set the `SKIP_DEPENDENCY_AUDIT` repo
variable to `true` to unblock CI, then remove it once the service recovers.
