### PR TITLE
docs(Portal): fix broken external documentation links

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
@@ -29,7 +29,7 @@ For inline expandable groups, use `Menu.Accordion` instead of a nested `Menu.Roo
 
 - The menu uses ARIA `role="menu"` and `role="menuitem"` semantics.
 - The trigger receives `aria-haspopup="menu"` and `aria-expanded` attributes automatically.
-- Keyboard navigation follows the [WAI-ARIA Menu Pattern](https://www.w3.org/WAI/ARIA/apd/patterns/menu/):
+- Keyboard navigation follows the [WAI-ARIA Menu Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu/):
   - **Arrow Up/Down**: Move focus between items (wraps around).
   - **Home/End**: Jump to first/last item.
   - **Enter/Space**: Activate the focused item.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/number-format/info.mdx
@@ -313,7 +313,7 @@ If you run the component or `format` function in [Node.js](https://nodejs.org), 
 
 Edge Browser on Windows 10 is converting numbers automatically to followable links. This makes the experience on NVDA bad, as it reads also the new, unformatted link number.
 
-You can [disable this behavior](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/x-ms-format-detection):
+You can disable this behavior:
 
 ```html
 <html x-ms-format-detection="none">

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/code/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/code/info.mdx
@@ -31,4 +31,4 @@ font-family: var(--font-family-monospace);
 
 - `@dnb/eufemia/style/themes/ui/prism/dnb-prism-theme.js`
 
-You can find the theme and its definitions in the [GitHub repository](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/style/themes/ui/prism/dnb-prism-theme.js).
+You can find the theme and its definitions in the [GitHub repository](https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-eufemia/src/style/themes/ui/prism/dnb-prism-theme.ts).

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/location-hooks/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Wizard/location-hooks/info.mdx
@@ -24,7 +24,7 @@ The `id` parameter is used to identify the `Wizard.Container` component. But it 
 If you use a router, you may connect one of the supported hooks to it. This way your application will not import unnecessary and unused code.
 
 - [react-router](https://reactrouter.com/) via [useReactRouter](#with-react-router)
-- [@reach/router](https://reach.tech/router/) via [useReachRouter](#with-reachrouter)
+- [@reach/router](https://github.com/reach/router) via [useReachRouter](#with-reachrouter)
 - [Next.js](https://nextjs.org/) via [useNextRouter](#with-nextnavigation)
 
 If you do not use a router, you can make use of the [useQueryLocator](#without-a-router) hook.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/demos.mdx
@@ -52,7 +52,7 @@ Below is an example of the error message displayed when there's an invalid Norwe
 
 ### Validation - D numbers
 
-It validates [D numbers](https://www.skatteetaten.no/en/person/national-registry/identitetsnummer/d-nummer/) using the [fnrvalidator](https://github.com/navikt/fnrvalidator).
+It validates [D numbers](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/d-nummer/) using the [fnrvalidator](https://github.com/navikt/fnrvalidator).
 
 Below is an example of the error message displayed when there's an invalid D number(a D number has its first number in the identification number increased by 4):
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/feature-fields/NationalIdentityNumber/info.mdx
@@ -13,10 +13,10 @@ render(<Field.NationalIdentityNumber />)
 
 `Field.NationalIdentityNumber` is a wrapper component for [string input](/uilib/extensions/forms/base-fields/String), with user experience tailored for national identity number values.
 
-This field is meant for [Norwegian national identity numbers (fnr)](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/fodselsnummer/) and [D numbers](https://www.skatteetaten.no/en/person/national-registry/identitetsnummer/d-nummer/), and therefore takes an 11-digit string as a value. A Norwegian national identity number can have a leading zero, which is why it's a string and not a number.
+This field is meant for [Norwegian national identity numbers (fnr)](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/fodselsnummer/) and [D numbers](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/d-nummer/), and therefore takes an 11-digit string as a value. A Norwegian national identity number can have a leading zero, which is why it's a string and not a number.
 More info can be found at [Skatteetaten](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/fodselsnummer/#:~:text=A%20national%20identity%20number%20consists,national%20identity%20number%20are%20220676).
 
-It validates input for [Norwegian national identity numbers (fnr)](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/fodselsnummer/) and [D numbers](https://www.skatteetaten.no/en/person/national-registry/identitetsnummer/d-nummer/) using the [fnrvalidator](https://github.com/navikt/fnrvalidator).
+It validates input for [Norwegian national identity numbers (fnr)](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/fodselsnummer/) and [D numbers](https://www.skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/d-nummer/) using the [fnrvalidator](https://github.com/navikt/fnrvalidator).
 The validation happens on blur, internally using the `onBlurValidator` [property](/uilib/extensions/forms/feature-fields/NationalIdentityNumber/properties/#field-specific-properties).
 
 There is a corresponding [Value.NationalIdentityNumber](/uilib/extensions/forms/Value/NationalIdentityNumber) component.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/payment-card/info.mdx
@@ -55,4 +55,3 @@ Resources:
 
 - [Figma design](https://www.figma.com/file/461cAN5Qc3Nks4ztZ9pjtM)
 - [Confluence specifications](https://confluence.tech.dnb.no/pages/viewpage.action?spaceKey=PMDT&title=Cards+mapping)
-- [Kortprodukter med egenskaper](http://team.erf01.net/sites/8974/Shared%20Documents/Kortprodukter_med_egenskaper.pdf)

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/focus.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/accessibility/focus.mdx
@@ -27,7 +27,7 @@ Here is an example of how it should look when implemented:
 
 Focus is an important part of keyboard-only and screen reader navigation.
 
-Make sure you set the focus properly on page or context changes. Consider using Reach Router [because of its built-in accessibility features](https://reach.tech/router/accessibility).
+Make sure you set the focus properly on page or context changes. Consider using Reach Router because of its built-in accessibility features.
 
 From a technical perspective, we need to assign an _invisible_ focus so the user can continue navigating inside this new content.
 


### PR DESCRIPTION
## Summary

Follow-up to #8966 (internal links). This PR fixes the confirmed-**dead** external links found while crawling `/uilib`. Links that only fail for bots/rate-limits (Figma, Språkrådet, commission.europa.eu, VS Marketplace, unpkg) were left untouched — they work for real users.

## Fixed (updated to a correct URL)

| Page | Before (dead) | After |
| --- | --- | --- |
| components/menu | `w3.org/WAI/ARIA/apd/patterns/menu/` (404) | `…/apg/patterns/menu/` |
| forms/…/NationalIdentityNumber (info + demos, ×3) | `skatteetaten.no/en/person/national-registry/identitetsnummer/d-nummer/` (404) | `skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/d-nummer/` |
| elements/code | `…/prism/dnb-prism-theme.js` (404) | `…/prism/dnb-prism-theme.ts` (source migrated to TS) |
| forms/Wizard/location-hooks | `reach.tech/router/` (dead SSL, 526) | `github.com/reach/router` |

## Dropped (no valid replacement — link removed, surrounding text kept)

| Page | Removed | Why |
| --- | --- | --- |
| components/number-format | MDN `x-ms-format-detection` | Page removed from MDN; kept the sentence and the `x-ms-format-detection="none"` code example |
| usage/accessibility/focus | `reach.tech/router/accessibility` | reach.tech is dead; the Reach Router repo README has no accessibility section to link to |
| extensions/payment-card | `team.erf01.net/…/Kortprodukter_med_egenskaper.pdf` | Unreachable internal intranet host (ERR_EMPTY_RESPONSE) |

## Verification

All four replacement URLs return HTTP 200 (curl, following redirects):
- `w3.org/WAI/ARIA/apg/patterns/menu/`
- `skatteetaten.no/person/folkeregister/identitetsnummer-og-elektronisk-id/d-nummer/`
- `github.com/reach/router`
- `github.com/dnbexperience/eufemia/blob/main/…/prism/dnb-prism-theme.ts`

## Out of scope (verified to work for real users / only block bots)

All Figma design links (CloudFront 403 to automated browsers), Språkrådet (403), commission.europa.eu (403), VS Marketplace (200 in browser), unpkg `properties.js` (transient timeout; sibling loads). One CodeSandbox preview (`r8ljo.csb.app` in elements/horizontal-rule) returns 400 in-browser and may be an expired sandbox — flagged for manual review rather than guessed at.
