### PR TITLE
chore(ci): enforce dependency audit

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,7 +49,6 @@ jobs:
     needs: setup
 
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message || '', '--skip-audit') && !(github.event.pull_request && contains(github.event.pull_request.title || '', '--skip-audit')) }}
 
     timeout-minutes: 10
 

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -79,7 +79,7 @@ These run continuously — you rarely need to hunt for issues:
 | --------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | **Dependabot alerts**       | Known advisories in dependencies (the source of truth)                                                 | [Security tab](https://github.com/dnbexperience/eufemia/security/dependabot) |
 | **CodeQL**                  | Static analysis of our own code                                                                        | on push, on PRs opened against `main`, + weekly (`codeql-analysis.yml`)      |
-| **CI audit gate**           | Fails PRs on **high/critical advisories in shipped deps**                                              | `verify.yml` → `audit:ci` (see below)                                        |
+| **CI audit gate**           | Fails PRs on **high/critical advisories in shipped deps**                                              | required `Audit dependencies` check → `audit:ci` (see below)                 |
 | **CI dedupe guard**         | Stops a plain `yarn install` re-introducing duplicate/vulnerable versions                              | `verify.yml` → `yarn dedupe --check`                                         |
 | **Install age gate**        | Refuses npm versions published less than **3 days** ago — blocks hijacked releases before they land    | `.yarnrc.yml` → `npmMinimalAgeGate: 3d`                                      |
 | **Dependabot security PRs** | Auto-PRs for fixable advisories (open even while scheduled version updates are disabled)               | PRs                                                                          |
@@ -279,9 +279,10 @@ DNB's central reporting as that capability expands.
 
 ## The CI audit gate
 
-`verify.yml` audits the shipped (production) dependency tree of the **two gated
-workspaces** — `@dnb/eufemia` (the published library) and `@dnb/eufemia-mcp` (the
-deployed Lambda) — with a native Yarn 4 audit; each workspace's `audit:ci` runs:
+The required `Audit dependencies` check from `verify.yml` audits the shipped
+(production) dependency tree of the **two gated workspaces** — `@dnb/eufemia`
+(the published library) and `@dnb/eufemia-mcp` (the deployed Lambda) — with a
+native Yarn 4 audit; each workspace's `audit:ci` runs:
 
 ```
 yarn npm audit --recursive --environment production --severity high
@@ -296,26 +297,9 @@ yarn npm audit --recursive --environment production --severity high
 - **Exceptions:** if a high/critical shipped advisory has no fix yet, add it to
   Yarn's `.yarnrc.yml` under `npmAuditIgnoreAdvisories` (with a comment: owner +
   reason + tracking link) to unblock while it's tracked. Remove it once fixed.
-- **Whole-gate bypass (`--skip-audit`):** the audit job is skipped whenever
-  `--skip-audit` appears **anywhere in the head commit message** — subject or
-  body. `verify.yml` runs on `push` only, so `github.event.pull_request` is never
-  populated and the PR-title half of the job's condition never fires; the commit
-  message is the only path that works. Note it skips **more than the audit**: the
-  lockfile-dedupe guard (`yarn dedupe --check`) is a step in the _same_ `audit`
-  job, so a bypassed push also drops the check that stops a plain `yarn install`
-  re-introducing duplicate (and potentially vulnerable) transitive versions. It
-  is an escape hatch for landing unrelated urgent work while the gate is red —
-  **not** a way to merge a shipped-dep advisory. Prefer a per-advisory
-  `npmAuditIgnoreAdvisories` entry (above), which stays tracked and auditable. If
-  you must use `--skip-audit`, say why in the PR and open a follow-up so the gate
-  goes green again.
-- **Careful — the match is a plain substring over the whole message**, not just
-  the subject line. So merely _mentioning_ the flag in a commit body skips the
-  audit for that push, even when the commit has nothing to do with
-  dependencies — a real risk when a commit message documents the flag. When
-  referring to it in a commit message, write it without the leading dashes, or
-  keep the mention out of the message entirely. A more robust design would
-  match only the subject line of the head commit in `verify.yml`.
+- **No whole-gate bypass:** the audit and lockfile-dedupe checks always run. If a
+  high/critical shipped advisory has no immediate fix, use the per-advisory
+  exception above so the accepted risk stays explicit and auditable.
 
 The same audit runs again outside the PR gate: `release.yml` audits `@dnb/eufemia`
 at publish time and `mcp-lambda.yml` audits `@dnb/eufemia-mcp` at deploy time, so

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
@@ -176,16 +176,6 @@ git commit -m "feat: implement new feature --run-all"
 
 This is useful when you want to see all visual test failures at once, rather than stopping at the first one. The CI/CD pipeline automatically detects this flag and adjusts test behavior accordingly.
 
-### Skip dependency audit in CI
-
-You can skip the dependency audit step in the Verify workflow by including `--skip-audit` in your commit message:
-
-```bash
-git commit -m "chore: update snapshots --skip-audit"
-```
-
-The CI will detect `--skip-audit` and skip the "Audit dependencies" step accordingly.
-
 **Playwright end-to-end tests:**
 
 ```bash


### PR DESCRIPTION
## What

- Always run the `Audit dependencies` job by removing the commit-message bypass.
- Remove the obsolete bypass instructions from the contributor docs.
- Update the vulnerability-management routine to describe the enforced gate and its auditable per-advisory exception.

## Why

PR #8807 says high/critical advisories in shipped dependencies block a PR, but `Audit dependencies` is not currently required by `main` branch protection and the workflow can be skipped through a commit message. This PR makes the workflow itself non-skippable.

After this PR is merged, add **`Audit dependencies`** to the required status checks for `main`. GitHub stores that repository setting outside this branch, so the PR cannot change it directly.
