### PR TITLE
chore(List, Stat): declare spacing marker via withComponentMarkers

### DIFF
--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -16,6 +16,7 @@ import HeightAnimation from '../height-animation/HeightAnimation'
 import SharedContext from '../../shared/Context'
 import { useSharedState } from '../../shared/helpers/useSharedState'
 import type { ListShowMoreButtonSharedState } from './ListShowMoreButton'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ListContainerProps = {
   id?: string
@@ -131,6 +132,8 @@ function ListContainer(props: ListContainerProps) {
   )
 }
 
-ListContainer._supportsSpacingProps = true
+withComponentMarkers(ListContainer, {
+  _supportsSpacingProps: true,
+})
 
 export default ListContainer

--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -29,6 +29,7 @@ import ItemTitle from './ItemTitle'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import { warn } from '../../shared/component-helper'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ItemAccordionIconPosition = 'left' | 'right'
 
@@ -148,7 +149,9 @@ function ItemAccordion(props: ItemAccordionProps) {
     </ItemAccordionContext>
   )
 }
-ItemAccordion._supportsSpacingProps = true
+withComponentMarkers(ItemAccordion, {
+  _supportsSpacingProps: true,
+})
 
 export type AccordionHeaderProps = {
   onClick?: (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void
@@ -231,7 +234,9 @@ function AccordionHeader(props: AccordionHeaderProps) {
   return content
 }
 ItemAccordion.Header = AccordionHeader
-AccordionHeader._supportsSpacingProps = true
+withComponentMarkers(AccordionHeader, {
+  _supportsSpacingProps: true,
+})
 
 function AccordionContent(props: ItemContentProps) {
   const { className, children, ...rest } = props
@@ -281,6 +286,8 @@ function AccordionContent(props: ItemContentProps) {
   return content
 }
 ItemAccordion.Content = AccordionContent
-AccordionContent._supportsSpacingProps = true
+withComponentMarkers(AccordionContent, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemAccordion

--- a/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemCenter.tsx
@@ -6,6 +6,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ItemCenterProps = FlexItemProps & {
   /**
@@ -63,6 +64,8 @@ function ItemCenter({
   return content
 }
 
-ItemCenter._supportsSpacingProps = true
+withComponentMarkers(ItemCenter, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemCenter

--- a/packages/dnb-eufemia/src/components/list/ItemContent.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemContent.tsx
@@ -7,6 +7,7 @@ import FlexContainer from '../flex/Container'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ItemContentProps = {
   id?: string
@@ -71,7 +72,9 @@ function ItemContent(props: ItemContentProps) {
 
   return content
 }
-ItemContent._supportsSpacingProps = true
+withComponentMarkers(ItemContent, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemContent
 
@@ -79,4 +82,6 @@ function Pending() {
   return <div className="dnb-list__item__pending" />
 }
 // To ensure it gets not wrapped by Flex, we pretend it supports spacing props
-Pending._supportsSpacingProps = true
+withComponentMarkers(Pending, {
+  _supportsSpacingProps: true,
+})

--- a/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemEnd.tsx
@@ -6,6 +6,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 /**
  * Props for List.Cell.End (ItemEnd).
@@ -67,6 +68,8 @@ function ItemEnd(props: ItemEndProps) {
 
   return content
 }
-ItemEnd._supportsSpacingProps = true
+withComponentMarkers(ItemEnd, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemEnd

--- a/packages/dnb-eufemia/src/components/list/ItemFooter.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemFooter.tsx
@@ -7,6 +7,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ItemFooterProps = FlexItemProps & {
   /**
@@ -55,6 +56,8 @@ function ItemFooter({
 
   return content
 }
-ItemFooter._supportsSpacingProps = true
+withComponentMarkers(ItemFooter, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemFooter

--- a/packages/dnb-eufemia/src/components/list/ItemIcon.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemIcon.tsx
@@ -6,6 +6,7 @@ import Icon, { type IconIcon } from '../icon/Icon'
 import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ItemIconProps = Omit<FlexItemProps, 'children'> & {
   children: IconIcon
@@ -38,6 +39,8 @@ function ItemIcon({
     </FlexItem>
   )
 }
-ItemIcon._supportsSpacingProps = true
+withComponentMarkers(ItemIcon, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemIcon

--- a/packages/dnb-eufemia/src/components/list/ItemOverline.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemOverline.tsx
@@ -6,6 +6,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 /**
  * Props for List.Cell.Title.Overline (ItemOverline).
@@ -65,6 +66,8 @@ function ItemOverline({
 
   return content
 }
-ItemOverline._supportsSpacingProps = true
+withComponentMarkers(ItemOverline, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemOverline

--- a/packages/dnb-eufemia/src/components/list/ItemStart.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemStart.tsx
@@ -6,6 +6,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 /**
  * Props for List.Cell.Start (ItemStart).
@@ -66,6 +67,8 @@ function ItemStart({
 
   return content
 }
-ItemStart._supportsSpacingProps = true
+withComponentMarkers(ItemStart, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemStart

--- a/packages/dnb-eufemia/src/components/list/ItemSubline.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemSubline.tsx
@@ -6,6 +6,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ItemSublineVariant = 'description'
 
@@ -73,6 +74,8 @@ function ItemSubline({
 
   return content
 }
-ItemSubline._supportsSpacingProps = true
+withComponentMarkers(ItemSubline, {
+  _supportsSpacingProps: true,
+})
 
 export default ItemSubline

--- a/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemTitle.tsx
@@ -8,6 +8,7 @@ import { ListContext } from './ListContext'
 import { createSkeletonClass } from '../skeleton/SkeletonHelper'
 import type { SkeletonShow } from '../Skeleton'
 import Context from '../../shared/Context'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 /**
  * Props for List.Cell.Title (ItemTitle).
@@ -73,7 +74,9 @@ function ItemTitleBase({
 
   return content
 }
-ItemTitleBase._supportsSpacingProps = true
+withComponentMarkers(ItemTitleBase, {
+  _supportsSpacingProps: true,
+})
 
 type ItemTitleComponent = typeof ItemTitleBase & {
   Overline: typeof ItemOverline

--- a/packages/dnb-eufemia/src/components/list/ListCard.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListCard.tsx
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx'
 import type { CardProps } from '../card/Card'
 import Card from '../card/Card'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ListCardProps = CardProps
 
@@ -14,6 +15,8 @@ function ListCard(props: ListCardProps) {
   )
 }
 
-ListCard._supportsSpacingProps = true
+withComponentMarkers(ListCard, {
+  _supportsSpacingProps: true,
+})
 
 export default ListCard

--- a/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListScrollView.tsx
@@ -9,6 +9,7 @@ import { ListContext } from './ListContext'
 import type { SkeletonShow } from '../Skeleton'
 
 import type { SpacingProps } from '../../shared/types'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ListScrollViewProps = {
   children: ReactNode
@@ -209,6 +210,8 @@ function doubleCssLength(value: string) {
   return `calc(${value} * 2)`
 }
 
-ListScrollView._supportsSpacingProps = true
+withComponentMarkers(ListScrollView, {
+  _supportsSpacingProps: true,
+})
 
 export default ListScrollView

--- a/packages/dnb-eufemia/src/components/list/ListShowMoreButton.tsx
+++ b/packages/dnb-eufemia/src/components/list/ListShowMoreButton.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../icons'
 import { useSharedState } from '../../shared/helpers/useSharedState'
 import useTranslation from '../../shared/useTranslation'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type ListShowMoreButtonSharedState = {
   expanded: boolean
@@ -58,6 +59,8 @@ function ListShowMoreButton(props: ListShowMoreButtonProps) {
   )
 }
 
-ListShowMoreButton._supportsSpacingProps = true
+withComponentMarkers(ListShowMoreButton, {
+  _supportsSpacingProps: true,
+})
 
 export default ListShowMoreButton

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react'
 import ItemAccordion from '../ItemAccordion'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemAccordion', () => {
   it('renders with Header and Content', () => {
@@ -621,7 +622,9 @@ describe('ItemAccordion', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemAccordion._supportsSpacingProps).toBe(true)
+    expect((ItemAccordion as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   describe('disabled', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemCenter.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemCenter.test.tsx
@@ -5,6 +5,7 @@ import ItemCenter from '../ItemCenter'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemCenter', () => {
   it('renders with children', () => {
@@ -98,7 +99,9 @@ describe('ItemCenter', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemCenter._supportsSpacingProps).toBe(true)
+    expect((ItemCenter as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemContent.test.tsx
@@ -5,6 +5,7 @@ import Container from '../Container'
 import type { ItemContentProps } from '../ItemContent'
 import ItemContent from '../ItemContent'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemContent', () => {
   it('renders with props as an object', () => {
@@ -190,7 +191,9 @@ describe('ItemContent', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemContent._supportsSpacingProps).toBe(true)
+    expect((ItemContent as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('has no axe violations', async () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemEnd.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemEnd.test.tsx
@@ -5,6 +5,7 @@ import ItemEnd from '../ItemEnd'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemEnd', () => {
   it('renders with children', () => {
@@ -92,7 +93,7 @@ describe('ItemEnd', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemEnd._supportsSpacingProps).toBe(true)
+    expect((ItemEnd as ComponentMarkers)._supportsSpacingProps).toBe(true)
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemFooter.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemFooter.test.tsx
@@ -5,6 +5,7 @@ import ItemFooter from '../ItemFooter'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemFooter', () => {
   it('renders with children', () => {
@@ -85,7 +86,9 @@ describe('ItemFooter', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemFooter._supportsSpacingProps).toBe(true)
+    expect((ItemFooter as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemIcon.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemIcon.test.tsx
@@ -4,6 +4,7 @@ import { fish_medium } from '../../../icons'
 import ItemIcon from '../ItemIcon'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemIcon', () => {
   it('renders with icon as children', () => {
@@ -61,7 +62,7 @@ describe('ItemIcon', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemIcon._supportsSpacingProps).toBe(true)
+    expect((ItemIcon as ComponentMarkers)._supportsSpacingProps).toBe(true)
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemOverline.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemOverline.test.tsx
@@ -5,6 +5,7 @@ import ItemOverline from '../ItemOverline'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemOverline', () => {
   it('renders with children', () => {
@@ -113,7 +114,9 @@ describe('ItemOverline', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemOverline._supportsSpacingProps).toBe(true)
+    expect((ItemOverline as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemStart.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemStart.test.tsx
@@ -5,6 +5,7 @@ import ItemStart from '../ItemStart'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemStart', () => {
   it('renders with children', () => {
@@ -101,7 +102,9 @@ describe('ItemStart', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemStart._supportsSpacingProps).toBe(true)
+    expect((ItemStart as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemSubline.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemSubline.test.tsx
@@ -5,6 +5,7 @@ import ItemSubline from '../ItemSubline'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemSubline', () => {
   it('renders with children', () => {
@@ -140,7 +141,9 @@ describe('ItemSubline', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemSubline._supportsSpacingProps).toBe(true)
+    expect((ItemSubline as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemTitle.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemTitle.test.tsx
@@ -5,6 +5,7 @@ import ItemTitle from '../ItemTitle'
 import ItemContent from '../ItemContent'
 import Container from '../Container'
 import Context from '../../../shared/Context'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('ItemTitle', () => {
   it('renders with children', () => {
@@ -117,7 +118,9 @@ describe('ItemTitle', () => {
   })
 
   it('declares _supportsSpacingProps for flex layout', () => {
-    expect(ItemTitle._supportsSpacingProps).toBe(true)
+    expect((ItemTitle as ComponentMarkers)._supportsSpacingProps).toBe(
+      true
+    )
   })
 
   it('does not accept unrelated ItemContent props', () => {

--- a/packages/dnb-eufemia/src/components/list/__tests__/ListCard.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ListCard.test.tsx
@@ -4,6 +4,7 @@ import List from '../List'
 import { List as RootList } from '../../../components'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import { fish_medium } from '../../../icons'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('List.Card', () => {
   it('renders with dnb-list__card class', () => {
@@ -99,7 +100,7 @@ describe('List.Card', () => {
   it('supports spacing props', async () => {
     const { default: ListCard } = await import('../ListCard')
 
-    expect(ListCard._supportsSpacingProps).toBe(true)
+    expect((ListCard as ComponentMarkers)._supportsSpacingProps).toBe(true)
   })
 
   it('does not expose ScrollView on List.Card', () => {
@@ -346,11 +347,15 @@ describe('List.ScrollView', () => {
   it('supports spacing props', async () => {
     const { default: ListScrollView } = await import('../ListScrollView')
 
-    expect(ListScrollView._supportsSpacingProps).toBe(true)
+    expect(
+      (ListScrollView as ComponentMarkers)._supportsSpacingProps
+    ).toBe(true)
   })
 
   it('is available from the public List export', () => {
-    expect(RootList.ScrollView._supportsSpacingProps).toBe(true)
+    expect(
+      (RootList.ScrollView as ComponentMarkers)._supportsSpacingProps
+    ).toBe(true)
   })
 
   it('renders a full composition with List.Card and List.Container', () => {

--- a/packages/dnb-eufemia/src/components/stat/Amount.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Amount.tsx
@@ -18,6 +18,7 @@ import { convertJsxToString } from '../../shared/component-helper'
 import StatValueContext from './StatValueContext'
 import useStatSkeleton from './useStatSkeleton'
 import { TextInternal as Text } from './Text'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 type AmountOwnProps = Omit<
   NumberFormatProps,
@@ -320,7 +321,9 @@ function AmountBase(props: AmountProps) {
   )
 }
 
-AmountBase._supportsSpacingProps = true
+withComponentMarkers(AmountBase, {
+  _supportsSpacingProps: true,
+})
 
 export { AmountBase }
 export default AmountBase

--- a/packages/dnb-eufemia/src/components/stat/Content.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Content.tsx
@@ -8,6 +8,7 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatRootContext from './StatRootContext'
 import useStatSkeleton from './useStatSkeleton'
 import Provider from '../../shared/Provider'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 type ContentOwnProps = {
   element?: ElementType
@@ -70,7 +71,9 @@ function Content(props: ContentProps) {
   )
 }
 
-Content._supportsSpacingProps = true
 Content._statRole = 'content'
+withComponentMarkers(Content, {
+  _supportsSpacingProps: true,
+})
 
 export default Content

--- a/packages/dnb-eufemia/src/components/stat/Currency.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Currency.tsx
@@ -1,4 +1,5 @@
 import { AmountBase, type AmountProps } from './Amount'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type CurrencyProps = Omit<AmountProps, 'percent'> & {
   percent?: never
@@ -10,6 +11,8 @@ function Currency(props: CurrencyProps) {
   return <AmountBase {...props} currency={currency} />
 }
 
-Currency._supportsSpacingProps = true
+withComponentMarkers(Currency, {
+  _supportsSpacingProps: true,
+})
 
 export default Currency

--- a/packages/dnb-eufemia/src/components/stat/Info.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Info.tsx
@@ -7,6 +7,7 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatValueContext from './StatValueContext'
 import StatRootContext from './StatRootContext'
 import { TextInternal as Text } from './Text'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 const infoContextValue = {
   useBasisSize: true,
@@ -66,6 +67,8 @@ function Info(props: InfoProps) {
   )
 }
 
-Info._supportsSpacingProps = true
+withComponentMarkers(Info, {
+  _supportsSpacingProps: true,
+})
 
 export default Info

--- a/packages/dnb-eufemia/src/components/stat/Inline.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Inline.tsx
@@ -8,6 +8,7 @@ import { warn } from '../../shared/component-helper'
 import StatRootContext from './StatRootContext'
 import useStatSkeleton from './useStatSkeleton'
 import Provider from '../../shared/Provider'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type InlineProps = FlexHorizontalProps & {
   id?: string
@@ -55,6 +56,8 @@ function Inline({
   )
 }
 
-Inline._supportsSpacingProps = true
+withComponentMarkers(Inline, {
+  _supportsSpacingProps: true,
+})
 
 export default Inline

--- a/packages/dnb-eufemia/src/components/stat/Label.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Label.tsx
@@ -13,6 +13,7 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatRootContext from './StatRootContext'
 import useStatSkeleton from './useStatSkeleton'
 import Provider from '../../shared/Provider'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 type LabelOwnProps = {
   element?: ElementType
@@ -93,7 +94,9 @@ function Label(props: LabelProps) {
   )
 }
 
-Label._supportsSpacingProps = true
 Label._statRole = 'label'
+withComponentMarkers(Label, {
+  _supportsSpacingProps: true,
+})
 
 export default Label

--- a/packages/dnb-eufemia/src/components/stat/Number.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Number.tsx
@@ -1,4 +1,5 @@
 import { AmountBase, type AmountProps } from './Amount'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type NumberProps = AmountProps
 
@@ -9,6 +10,8 @@ export type NumberProps = AmountProps
  */
 const Number = AmountBase
 
-Number._supportsSpacingProps = true
+withComponentMarkers(Number, {
+  _supportsSpacingProps: true,
+})
 
 export default Number

--- a/packages/dnb-eufemia/src/components/stat/Percent.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Percent.tsx
@@ -1,4 +1,5 @@
 import { AmountBase, type AmountProps } from './Amount'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 export type PercentProps = Omit<
   AmountProps,
@@ -9,6 +10,8 @@ function Percent(props: PercentProps) {
   return <AmountBase {...props} percent />
 }
 
-Percent._supportsSpacingProps = true
+withComponentMarkers(Percent, {
+  _supportsSpacingProps: true,
+})
 
 export default Percent

--- a/packages/dnb-eufemia/src/components/stat/Rating.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Rating.tsx
@@ -6,6 +6,7 @@ import type { SkeletonShow } from '../skeleton/Skeleton'
 import { useTranslation } from '../../shared'
 import { clamp } from '../../shared/helpers/clamp'
 import { TextInternal as Text } from './Text'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 const MAX_ALLOWED = 20
 
@@ -154,6 +155,8 @@ function StarIcon({ variant }: { variant: 'base' | 'active' }) {
   )
 }
 
-Rating._supportsSpacingProps = true
+withComponentMarkers(Rating, {
+  _supportsSpacingProps: true,
+})
 
 export default Rating

--- a/packages/dnb-eufemia/src/components/stat/Root.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Root.tsx
@@ -6,6 +6,7 @@ import type { SpacingProps } from '../../shared/types'
 import { warn } from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatRootContext from './StatRootContext'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 type RootOwnProps = {
   visualOrder?: 'label-content' | 'content-label'
@@ -63,7 +64,9 @@ function Root(props: RootProps) {
   )
 }
 
-Root._supportsSpacingProps = true
+withComponentMarkers(Root, {
+  _supportsSpacingProps: true,
+})
 
 export default Root
 

--- a/packages/dnb-eufemia/src/components/stat/Text.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Text.tsx
@@ -14,6 +14,7 @@ import {
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import useStatSkeleton from './useStatSkeleton'
 import type { SkeletonMethods } from '../skeleton/SkeletonHelper'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 type TextOwnProps = {
   /** @internal Not documented – used by internal sub-components only. */
@@ -91,13 +92,17 @@ function TextInternal(props: TextInternalProps) {
   return <Element {...attributes}>{children}</Element>
 }
 
-TextInternal._supportsSpacingProps = true
+withComponentMarkers(TextInternal, {
+  _supportsSpacingProps: true,
+})
 
 function Text(props: TextProps) {
   return <TextInternal {...props} />
 }
 
-Text._supportsSpacingProps = true
+withComponentMarkers(Text, {
+  _supportsSpacingProps: true,
+})
 
 function resolveSignTone(
   colorizeBySign: TextProps['colorizeBySign'],

--- a/packages/dnb-eufemia/src/components/stat/Trend.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Trend.tsx
@@ -6,6 +6,7 @@ import { convertJsxToString, warn } from '../../shared/component-helper'
 import type { SkeletonShow } from '../skeleton/Skeleton'
 import StatValueContext from './StatValueContext'
 import { TextInternal as Text } from './Text'
+import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
 const trendContextValue = {
   useBasisSize: true,
@@ -98,7 +99,9 @@ function Trend(props: TrendProps) {
   )
 }
 
-Trend._supportsSpacingProps = true
+withComponentMarkers(Trend, {
+  _supportsSpacingProps: true,
+})
 
 function getValueFromChildren(children: ReactNode): number | string {
   if (typeof children === 'string' || typeof children === 'number') {

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Number.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Number.test.tsx
@@ -6,6 +6,7 @@ import {
 import Provider from '../../../shared/Provider'
 import Stat from '../Stat'
 import NumberComponent from '../Number'
+import type { ComponentMarkers } from '../../../shared/helpers/withComponentMarkers'
 
 describe('Stat.Number', () => {
   let log: ReturnType<typeof spyOnEufemiaWarn>
@@ -18,7 +19,9 @@ describe('Stat.Number', () => {
     log.mockRestore()
   })
   it('declares _supportsSpacingProps', () => {
-    expect(NumberComponent._supportsSpacingProps).toBe(true)
+    expect(
+      (NumberComponent as ComponentMarkers)._supportsSpacingProps
+    ).toBe(true)
   })
 
   it('renders plain number without currency by default', () => {


### PR DESCRIPTION
The `list/` and `stat/` component families declared the `_supportsSpacingProps` flex-layout marker by assigning the static property directly (`Component._supportsSpacingProps = true`), whereas the rest of the components use the shared `withComponentMarkers` helper. This routes those two families through the helper as well, giving a single, type-safe way to declare component markers across the codebase.

No runtime change: the helper's `Object.assign` sets the same property. Because its assertion signature only narrows the local type (it does not add the marker to the exported type), the few tests that read the marker now cast via `ComponentMarkers`, matching the existing convention (`ItemBasic`, `ItemAction`).
