### PR TITLE
chore: remove unused RUN_POST_BUILD from the e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,6 @@ env:
   ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
   ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
   ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-  RUN_POST_BUILD: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}
 
 jobs:
   e2e:


### PR DESCRIPTION
## Motivation

`RUN_POST_BUILD` gates the prebuild/postbuild steps in `visual-regression.yml` (they run only on `main`/`v*` branches). `e2e.yml`, however, runs `prebuild:ci`/`postbuild:ci` **unconditionally** — its Playwright tests need the built `@dnb/eufemia` on every branch — and never references the variable.

So the `RUN_POST_BUILD` entry in `e2e.yml` is copy-pasted cruft: it is computed but never read. Removing it is behaviour-neutral (grep-verified that only `visual-regression.yml` reads `RUN_POST_BUILD`).

Split out from #8972 (workflow secret least-privilege) to keep that PR focused on secrets.
