### PR TITLE
chore(HeightAnimation): fall back to keepInDOM when hidden=until-found is unsupported

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -39,6 +39,8 @@ When `keepInDOM` or `untilFound` keeps closed content in the DOM, HeightAnimatio
 
 `untilFound` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
+`untilFound` is a progressive enhancement. In browsers without support for `hidden="until-found"`, it falls back to `keepInDOM` behavior: the collapsed content stays in the DOM but is hidden and not available to find-in-page.
+
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 
 - The content may differ based on the viewport width (screen size)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -39,7 +39,7 @@ When `keepInDOM` or `untilFound` keeps closed content in the DOM, HeightAnimatio
 
 `untilFound` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
-`untilFound` is a progressive enhancement. In browsers without support for `hidden="until-found"`, it falls back to `keepInDOM` behavior: the collapsed content stays in the DOM but is hidden and not available to find-in-page.
+`untilFound` is a progressive enhancement that depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, it falls back to `keepInDOM` behavior: the collapsed content stays in the DOM and hidden, but is not available to find-in-page.
 
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -80,12 +80,20 @@ function HeightAnimation({
 }: HeightAnimationAllProps) {
   const elementRef = useRef<HTMLElement>(undefined)
   const targetRef = ref || elementRef
+  // Only browsers that implement hidden="until-found" hide the content (via
+  // content-visibility). Without support the attribute would leave the content
+  // visible, so gate the behavior on feature detection and fall back to the
+  // regular display:none collapse instead.
+  const untilFoundEnabled =
+    untilFound &&
+    typeof document !== 'undefined' &&
+    'onbeforematch' in document.documentElement
   const [isRevealedByMatch, setRevealedByMatch] = useState(false)
-  const resolvedOpen = open || (untilFound && isRevealedByMatch)
+  const resolvedOpen = open || (untilFoundEnabled && isRevealedByMatch)
 
   const handleAnimationStart: UseHeightAnimationOptions['onAnimationStart'] =
     (state) => {
-      if (untilFound && state === 'opening') {
+      if (untilFoundEnabled && state === 'opening') {
         targetRef.current?.removeAttribute('hidden')
       }
       onAnimationStart?.(state)
@@ -93,7 +101,7 @@ function HeightAnimation({
   const handleAnimationEnd: UseHeightAnimationOptions['onAnimationEnd'] = (
     state
   ) => {
-    if (untilFound) {
+    if (untilFoundEnabled) {
       if (state === 'closed') {
         targetRef.current?.style.removeProperty('visibility')
         targetRef.current?.setAttribute('hidden', 'until-found')
@@ -128,7 +136,7 @@ function HeightAnimation({
     }
 
     if (
-      untilFound &&
+      untilFoundEnabled &&
       !resolvedOpen &&
       element.classList.contains('dnb-height-animation--hidden')
     ) {
@@ -136,17 +144,17 @@ function HeightAnimation({
     } else if (element.getAttribute('hidden') === 'until-found') {
       element.removeAttribute('hidden')
     }
-  }, [resolvedOpen, targetRef, untilFound])
+  }, [resolvedOpen, targetRef, untilFoundEnabled])
 
   useLayoutEffect(() => {
-    if (isRevealedByMatch && (open || !untilFound)) {
+    if (isRevealedByMatch && (open || !untilFoundEnabled)) {
       setRevealedByMatch(false)
     }
-  }, [isRevealedByMatch, open, untilFound])
+  }, [isRevealedByMatch, open, untilFoundEnabled])
 
   useLayoutEffect(() => {
     const element = targetRef.current
-    if (!element || !untilFound) {
+    if (!element || !untilFoundEnabled) {
       return undefined
     }
 
@@ -162,7 +170,7 @@ function HeightAnimation({
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
     }
-  }, [onBeforeMatch, targetRef, untilFound])
+  }, [onBeforeMatch, targetRef, untilFoundEnabled])
 
   // Set CSS custom properties via the DOM instead of React's style
   // prop. React's SSR serializes custom properties without spaces

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -293,6 +293,30 @@ describe('HeightAnimation', () => {
   })
 
   describe('untilFound', () => {
+    // Simulate a browser without hidden="until-found" support by hiding the
+    // beforematch handler the component uses for feature detection.
+    function simulateUntilFoundUnsupported() {
+      const restores: Array<() => void> = []
+      let target: object | null = document.documentElement
+      while (target) {
+        if (
+          Object.prototype.hasOwnProperty.call(target, 'onbeforematch')
+        ) {
+          const owner = target
+          const descriptor = Object.getOwnPropertyDescriptor(
+            owner,
+            'onbeforematch'
+          )
+          delete (owner as Record<string, unknown>).onbeforematch
+          restores.push(() =>
+            Object.defineProperty(owner, 'onbeforematch', descriptor)
+          )
+        }
+        target = Object.getPrototypeOf(target)
+      }
+      return () => restores.forEach((restore) => restore())
+    }
+
     it('should preserve a regular hidden attribute', () => {
       const { rerender } = render(
         <HeightAnimation hidden>content</HeightAnimation>
@@ -384,6 +408,33 @@ describe('HeightAnimation', () => {
 
       expect(onBeforeMatch).toHaveBeenCalledTimes(1)
       expect(getElement()).not.toHaveAttribute('hidden')
+    })
+
+    it('falls back to a display:none collapse when the browser lacks hidden="until-found" support', () => {
+      const restore = simulateUntilFoundUnsupported()
+
+      try {
+        render(
+          <HeightAnimation open={false} untilFound>
+            <span className="content">content</span>
+          </HeightAnimation>
+        )
+
+        // Content stays in the DOM (untilFound implies keepInDOM), but without
+        // the hidden="until-found" attribute it collapses via the regular
+        // display:none path instead of relying on content-visibility, which
+        // unsupported browsers do not apply (so the content would be visible).
+        expect(document.querySelector('.content')).toBeInTheDocument()
+        expect(getElement()).not.toHaveAttribute('hidden')
+        expect(getElement()).toHaveClass('dnb-height-animation--hidden')
+        expect(getElement()).toHaveAttribute('aria-hidden', 'true')
+
+        // beforematch is a no-op because the feature is disabled.
+        getElement().dispatchEvent(new Event('beforematch'))
+        expect(getElement()).toHaveClass('dnb-height-animation--hidden')
+      } finally {
+        restore()
+      }
     })
   })
 

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -299,14 +299,12 @@ describe('HeightAnimation', () => {
       const restores: Array<() => void> = []
       let target: object | null = document.documentElement
       while (target) {
-        if (
-          Object.prototype.hasOwnProperty.call(target, 'onbeforematch')
-        ) {
-          const owner = target
-          const descriptor = Object.getOwnPropertyDescriptor(
-            owner,
-            'onbeforematch'
-          )
+        const owner = target
+        const descriptor = Object.getOwnPropertyDescriptor(
+          owner,
+          'onbeforematch'
+        )
+        if (descriptor) {
           delete (owner as Record<string, unknown>).onbeforematch
           restores.push(() =>
             Object.defineProperty(owner, 'onbeforematch', descriptor)


### PR DESCRIPTION
## Motivation

`HeightAnimation`'s `untilFound` prop sets `hidden="until-found"` on the collapsed element and overrides the collapsed `display: none` to `display: block` so the browser's find-in-page can reveal it. That hiding then relies entirely on the `content-visibility: hidden` that browsers apply for `hidden="until-found"`.

In browsers that do **not** support `hidden="until-found"` (Safari before 26.2, Firefox before 148), no `content-visibility` is applied, so the `display: block` override leaves the **initially collapsed content fully visible** on first paint — the opposite of what a collapsed section should do. Verified in a browser by neutralizing `content-visibility`: the closed demo expands from 0 to 208px and paints its content.

## Thoughts

Not entirely sure if we need this or not. 
If not, we should probably document the limitations of the `untilFound` prop, so that devs/users will only use it with caution, as it's not supported in all browsers that we should support https://eufemia.dnb.no/uilib/usage#supported-browsers-and-platforms

## Alternatives

This PR **fixes** the behavior in code. As an alternative, #8977 **documents** the `untilFound` browser-support limitation instead of changing behavior.

We should merge **either #8976 (fix) or #8977 (docs)** — not both. Merging one makes the other redundant.
