### PR TITLE
docs(HeightAnimation): document untilFound browser-support limitation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -39,6 +39,8 @@ When `keepInDOM` or `untilFound` keeps closed content in the DOM, HeightAnimatio
 
 `untilFound` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
+`untilFound` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `untilFound` off) instead.
+
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 
 - The content may differ based on the viewport width (screen size)

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -16,7 +16,7 @@ export type HeightAnimationProps = {
   keepInDOM?: boolean
 
   /**
-   * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. Defaults to `false`.
+   * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.
    */
   untilFound?: boolean
 

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -17,7 +17,7 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     status: 'optional',
   },
   untilFound: {
-    doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. Defaults to `false`.',
+    doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },


### PR DESCRIPTION
## Motivation

Alternative to #8976.

`untilFound` relies on the native `hidden="until-found"` behavior, which is only supported in some browsers (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). Where it is unsupported, a closed `untilFound` section is **not reliably hidden** — the collapsed content can remain visible — because the hiding depends on the browser applying `content-visibility` for `hidden="until-found"`.

#8976 **fixes** this in code (feature-detect support and fall back to `keepInDOM`). This PR is the **document-instead-of-fix** alternative: it keeps the current behavior and instead documents the limitation — in the component guide and the `untilFound` prop description — so consumers can opt in consciously.

Merging either one makes the other redundant. This lets you decide whether to fix the behavior or document the limitation.
