### PR TITLE
chore: point README CI badge to the Verify workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Downloads](https://img.shields.io/npm/dt/@dnb/eufemia?style=flat-square)
 ![NPM version](https://img.shields.io/npm/v/@dnb/eufemia?style=flat-square)
 ![Last commit](https://img.shields.io/github/last-commit/dnbexperience/eufemia?style=flat-square)
-[![Eufemia Actions](https://github.com/dnbexperience/eufemia/actions/workflows/actions.yml/badge.svg)](https://github.com/dnbexperience/eufemia/actions/workflows/actions.yml)
+[![Verify](https://github.com/dnbexperience/eufemia/actions/workflows/verify.yml/badge.svg)](https://github.com/dnbexperience/eufemia/actions/workflows/verify.yml)
 [![CodeQL](https://github.com/dnbexperience/eufemia/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/dnbexperience/eufemia/actions/workflows/codeql-analysis.yml)
 
 </div>


### PR DESCRIPTION
The **Eufemia Actions** status badge in the README pointed to `actions.yml`, a workflow that was [split up and removed](https://github.com/dnbexperience/eufemia/commit/3ac61eeceae3d41ca8a50acbd3c8b71b564f6704) some time ago. Because that workflow no longer exists, the badge rendered as **"no status"** on the repository landing page.

This repoints the badge to `verify.yml` — the core CI workflow that runs on every push to `main` (lint, typecheck, test, audit, build) — so it again reflects the build status. The label is updated to **Verify** to match the workflow name, consistent with the neighbouring CodeQL badge.
