### PR TITLE
refactor(Autocomplete): extract text highlighting into a shared engine

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -52,6 +52,7 @@ import {
   getClosestParent,
 } from '../../shared/component-helper'
 import { IS_MAC, debounce, hasSelectedText } from '../../shared/helpers'
+import { highlightText } from '../../shared/helpers/highlightText'
 import useId from '../../shared/helpers/useId'
 import useMountEffect from '../../shared/helpers/useMountEffect'
 import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
@@ -1213,9 +1214,6 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
           })
       }
 
-      const strS = '\uFFFE'
-      const strE = '\uFFFF'
-
       const mappedIndex: Array<
         | DrawerListDataArrayObject
         | {
@@ -1267,153 +1265,16 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
             return cacheMemoryRef.current[cacheHash] as ReactNode
           }
 
-          const highlightText = (
-            text: string,
-            keyPart: string
-          ): ReactNode[] | string => {
-            let segment = text
-
-            searchWords.forEach((word, wordIndex) => {
-              if (segment) {
-                word = escapeRegexChars(word)
-
-                if (snParam) {
-                  const cleanedWord = word.replace(
-                    // @ts-expect-error Unicode property escapes are supported at runtime here
-                    /[^\p{L}\p{N}]+/gu,
-                    ''
-                  )
-                  if (cleanedWord) {
-                    const escapedWord = escapeRegexChars(cleanedWord)
-                    segment = segment.replace(
-                      new RegExp(`(${escapedWord})`, 'gi'),
-                      (match) => {
-                        if (match.includes(strS)) {
-                          return match
-                        }
-                        return `${strS}${match}${strE}`
-                      }
-                    )
-                  }
-                } else {
-                  if (wordIndex >= inWordIndex) {
-                    segment = segment.replace(
-                      new RegExp(`(${word})`, 'gi'),
-                      `${strS}$1${strE}`
-                    )
-                  } else {
-                    segment = segment.replace(
-                      new RegExp(
-                        `(${getWordBoundary(wordIndex)})(${word})`,
-                        'gi'
-                      ),
-                      `$1${strS}$2${strE}`
-                    )
-                  }
-                }
-              }
-            })
-
-            if (segment.includes(strS)) {
-              const startRepeatRegex = new RegExp(`(${strS})+`, 'g')
-              const endRepeatRegex = new RegExp(`(${strE})+`, 'g')
-              const adjacentRegex = new RegExp(`(${strE}${strS})`, 'g')
-              const splitRegex = new RegExp(`(${strS}|${strE})`, 'g')
-
-              const normalized = segment
-                .replace(startRepeatRegex, strS)
-                .replace(endRepeatRegex, strE)
-                .replace(adjacentRegex, '')
-
-              const tokens = normalized.split(splitRegex).filter(Boolean)
-
-              let isHighlighted = false
-              let highlightIndex = 0
-              const parts = tokens.map((token) => {
-                if (token === strS) {
-                  isHighlighted = true
-                  return null
-                }
-                if (token === strE) {
-                  isHighlighted = false
-                  return null
-                }
-
-                if (isHighlighted) {
-                  const key = `highlight-${cacheHash}-${keyPart}-${highlightIndex++}`
-                  return (
-                    <span
-                      key={key}
-                      className="dnb-drawer-list__option__item--highlight"
-                    >
-                      {token}
-                    </span>
-                  )
-                }
-
-                return token
-              })
-
-              return parts
-            }
-
-            return segment
-          }
-
-          const renderText = (
-            text: string,
-            keyPart: string,
-            wrapInSpan: boolean
-          ) => {
-            const result = highlightText(text, keyPart)
-
-            if (wrapInSpan) {
-              return <span key={cacheHash + keyPart}>{result}</span>
-            }
-
-            return result
-          }
-
-          const renderNode = (
-            node: ReactNode,
-            keyPart: string,
-            wrapText = false
-          ): ReactNode => {
-            if (Array.isArray(node)) {
-              return node.map((child, idx) =>
-                renderNode(child, `${keyPart}-${idx}`)
-              )
-            }
-
-            if (typeof node === 'string' || typeof node === 'number') {
-              return renderText(String(node), keyPart, wrapText)
-            }
-
-            if (isValidElement<{ children?: ReactNode }>(node)) {
-              const child = node.props.children
-
-              if (typeof child === 'undefined') {
-                return node
-              }
-
-              return createElement(
-                node.type as ComponentType<{ children?: ReactNode }>,
-                {
-                  ...node.props,
-                  key: node.key ?? 'clone' + cacheHash + keyPart,
-                },
-                renderNode(child, keyPart)
-              )
-            }
-
-            return node
-          }
-
-          const processed = Array.isArray(children)
-            ? children.map((child, idx) =>
-                renderNode(child, String(idx), true)
-              )
-            : renderNode(children, '0', true)
+          const processed = highlightText(children, {
+            search: searchWords,
+            className: 'dnb-drawer-list__option__item--highlight',
+            tag: 'span',
+            searchMatch: startsWithMatch ? 'starts-with' : 'word',
+            searchNumbers: snParam,
+            searchInWordIndex: inWordIndex,
+            wrapInSpan: true,
+            keyPrefix: cacheHash,
+          })
 
           return (cacheMemoryRef.current[cacheHash] = processed)
         }

--- a/packages/dnb-eufemia/src/components/filter/FilterHighlighting.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterHighlighting.tsx
@@ -1,6 +1,6 @@
-import { useContext, useMemo } from 'react'
-import type { ReactNode } from 'react'
+import { useContext } from 'react'
 import { useSharedState } from '../../shared/helpers/useSharedState'
+import { useHighlightText } from '../../shared/helpers/highlightText'
 import type { FilterState } from './FilterContext'
 import { FilterContext, FilterConnectedIdContext } from './FilterContext'
 
@@ -20,36 +20,13 @@ function FilterHighlighting({
 
   const search = data?.search ?? context?.state?.search ?? ''
 
-  return useMemo(() => highlightText(children, search), [children, search])
-}
-
-function highlightText(text: string, search: string): ReactNode {
-  if (!search || !text) {
-    return text
-  }
-
-  const escaped = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const regex = new RegExp(`(${escaped})`, 'gi')
-  const parts = text.split(regex)
-
-  if (parts.length === 1) {
-    return text
-  }
-
-  return parts.map((part, index) => {
-    if (regex.test(part)) {
-      // Reset lastIndex since RegExp with 'g' flag is stateful
-      regex.lastIndex = 0
-
-      return (
-        <mark key={index} className="dnb-filter__highlighting">
-          {part}
-        </mark>
-      )
-    }
-
-    return part
+  const highlight = useHighlightText({
+    search,
+    className: 'dnb-filter__highlighting',
+    tag: 'mark',
   })
+
+  return highlight(children, children)
 }
 
 export default FilterHighlighting

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterHighlighting.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterHighlighting.test.tsx
@@ -115,6 +115,24 @@ describe('Filter.Highlighting', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('highlights multiple search words', () => {
+    render(
+      <FilterRoot>
+        <FilterSearch label="Search" />
+        <FilterContent>
+          <FilterHighlighting>Hello Wonderful World</FilterHighlighting>
+        </FilterContent>
+      </FilterRoot>
+    )
+
+    changeSearch('Hello World')
+
+    const marks = document.querySelectorAll('.dnb-filter__highlighting')
+    expect(marks).toHaveLength(2)
+    expect(marks[0].textContent).toBe('Hello')
+    expect(marks[1].textContent).toBe('World')
+  })
+
   it('supports connectedTo prop directly', () => {
     function SetSearch() {
       const { extend } = useSharedState('highlight-connected')

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
@@ -1,9 +1,10 @@
-import { cloneElement, Fragment, isValidElement, useCallback } from 'react'
+import { Fragment, useCallback } from 'react'
 import type { ReactNode, MouseEvent } from 'react'
 import { clsx } from 'clsx'
 import { Checkbox } from '../../../../components'
 import ScrollView from '../../../../fragments/scroll-view/ScrollView'
 import { P } from '../../../../elements'
+import { useHighlightText } from '../../../../shared/helpers/highlightText'
 import type {
   FieldMultiSelectionProps,
   MultiSelectionItem,
@@ -39,76 +40,6 @@ export type MultiSelectionItemListProps = {
   someFilteredSelected: boolean
 }
 
-function highlightText(
-  text: string,
-  searchValue: string,
-  keyPrefix: string
-): ReactNode {
-  if (!searchValue || !text) {
-    return text
-  }
-
-  const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const regex = new RegExp(`(${escapedSearch})`, 'gi')
-  const exactRegex = new RegExp(`^${escapedSearch}$`, 'i')
-  const parts = text.split(regex)
-
-  if (parts.length === 1) {
-    return text
-  }
-
-  return parts.map((part, index) => {
-    if (exactRegex.test(part)) {
-      return (
-        <mark
-          key={`${keyPrefix}-${index}`}
-          className="dnb-forms-field-multi-selection__highlighting"
-        >
-          {part}
-        </mark>
-      )
-    }
-
-    return part
-  })
-}
-
-function highlightSearchValue(
-  node: ReactNode,
-  searchValue: string,
-  keyPrefix: string
-): ReactNode {
-  if (!searchValue) {
-    return node
-  }
-
-  if (Array.isArray(node)) {
-    return node.map((child, index) =>
-      highlightSearchValue(child, searchValue, `${keyPrefix}-${index}`)
-    )
-  }
-
-  if (typeof node === 'string' || typeof node === 'number') {
-    return highlightText(String(node), searchValue, keyPrefix)
-  }
-
-  if (isValidElement<{ children?: ReactNode }>(node)) {
-    const children = node.props.children
-
-    if (typeof children === 'undefined') {
-      return node
-    }
-
-    return cloneElement(
-      node,
-      undefined,
-      highlightSearchValue(children, searchValue, `${keyPrefix}-children`)
-    )
-  }
-
-  return node
-}
-
 export function MultiSelectionItemList({
   disabled,
   filteredItems,
@@ -125,6 +56,12 @@ export function MultiSelectionItemList({
   allFilteredSelected,
   someFilteredSelected,
 }: MultiSelectionItemListProps) {
+  const highlight = useHighlightText({
+    search: searchValue,
+    className: 'dnb-forms-field-multi-selection__highlighting',
+    tag: 'mark',
+  })
+
   const handleItemClick = useCallback(
     (
       event: MouseEvent<HTMLLIElement>,
@@ -193,11 +130,7 @@ export function MultiSelectionItemList({
                   : onToggleItem(item.value)
               }
               disabled={disabled || item.disabled}
-              label={highlightSearchValue(
-                item.title,
-                searchValue,
-                `${itemPath}-title`
-              )}
+              label={highlight(item.title)}
               className="dnb-forms-field-multi-selection__checkbox"
               {...htmlAttributes}
             />
@@ -205,20 +138,12 @@ export function MultiSelectionItemList({
               <div className="dnb-forms-field-multi-selection__item-details">
                 {item.text && (
                   <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-text">
-                    {highlightSearchValue(
-                      item.text,
-                      searchValue,
-                      `${itemPath}-text`
-                    )}
+                    {highlight(item.text)}
                   </span>
                 )}
                 {item.description && (
                   <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-description">
-                    {highlightSearchValue(
-                      item.description,
-                      searchValue,
-                      `${itemPath}-description`
-                    )}
+                    {highlight(item.description)}
                   </span>
                 )}
               </div>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -998,6 +998,36 @@ describe('MultiSelection', () => {
       )
     })
 
+    it('highlights multiple search words in item titles', async () => {
+      const data = [
+        { value: 'option1', title: 'Daily card account' },
+        { value: 'option2', title: 'Savings' },
+      ]
+
+      render(<Field.MultiSelection data={data} showSearchField />)
+
+      fireEvent.click(document.querySelector('button'))
+
+      const input = document.querySelector(
+        '.dnb-forms-field-multi-selection__search input'
+      ) as HTMLInputElement
+      fireEvent.change(input, { target: { value: 'daily card' } })
+
+      await waitFor(
+        () => {
+          const highlights = document.querySelectorAll(
+            '.dnb-forms-field-multi-selection__highlighting'
+          )
+
+          expect(highlights).toHaveLength(2)
+          expect(highlights[0]).toHaveTextContent('Daily')
+          expect(highlights[0].tagName).toBe('MARK')
+          expect(highlights[1]).toHaveTextContent('card')
+        },
+        { timeout: 3000 }
+      )
+    })
+
     it('focuses the search input when pressing ArrowDown on the trigger with showSearchField', async () => {
       const data = [
         { value: 'option1', title: 'Option 1' },

--- a/packages/dnb-eufemia/src/shared/helpers/__tests__/highlightText.test.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/__tests__/highlightText.test.tsx
@@ -1,0 +1,326 @@
+import { render } from '@testing-library/react'
+import { isValidElement } from 'react'
+import { highlightText, useHighlightText } from '../highlightText'
+
+function renderToContainer(node: React.ReactNode) {
+  const { container } = render(<div>{node}</div>)
+  return container.firstChild as HTMLElement
+}
+
+describe('highlightText', () => {
+  it('returns the node unchanged when there is no search', () => {
+    const result = highlightText('Hello World', {
+      search: '',
+      className: 'my-highlight',
+    })
+
+    expect(result).toBe('Hello World')
+  })
+
+  it('returns the node unchanged when there is no match', () => {
+    const container = renderToContainer(
+      highlightText('Hello World', {
+        search: 'xyz',
+        className: 'my-highlight',
+      })
+    )
+
+    expect(container.textContent).toBe('Hello World')
+    expect(container.querySelector('.my-highlight')).toBeNull()
+  })
+
+  it('highlights a single term with the default mark tag', () => {
+    const container = renderToContainer(
+      highlightText('Hello World', {
+        search: 'World',
+        className: 'my-highlight',
+      })
+    )
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark).not.toBeNull()
+    expect(mark?.tagName).toBe('MARK')
+    expect(mark?.textContent).toBe('World')
+  })
+
+  it('highlights every occurrence of a term', () => {
+    const container = renderToContainer(
+      highlightText('banana', {
+        search: 'a',
+        className: 'my-highlight',
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks).toHaveLength(3)
+    expect(container.textContent).toBe('banana')
+  })
+
+  it('highlights multiple terms', () => {
+    const container = renderToContainer(
+      highlightText('Hello World', {
+        search: 'Hello World',
+        className: 'my-highlight',
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks).toHaveLength(2)
+    expect(marks[0].textContent).toBe('Hello')
+    expect(marks[1].textContent).toBe('World')
+  })
+
+  it('accepts an array of terms', () => {
+    const container = renderToContainer(
+      highlightText('foo bar baz', {
+        search: ['foo', 'baz'],
+        className: 'my-highlight',
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks).toHaveLength(2)
+    expect(marks[0].textContent).toBe('foo')
+    expect(marks[1].textContent).toBe('baz')
+  })
+
+  it('is case-insensitive by default', () => {
+    const container = renderToContainer(
+      highlightText('Hello World', {
+        search: 'hello',
+        className: 'my-highlight',
+      })
+    )
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark?.textContent).toBe('Hello')
+  })
+
+  it('respects ignoreCase set to false', () => {
+    const container = renderToContainer(
+      highlightText('Hello hello', {
+        search: 'hello',
+        className: 'my-highlight',
+        ignoreCase: false,
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks).toHaveLength(1)
+    expect(marks[0].textContent).toBe('hello')
+  })
+
+  it('supports the span tag option', () => {
+    const container = renderToContainer(
+      highlightText('Hello World', {
+        search: 'World',
+        className: 'my-highlight',
+        tag: 'span',
+      })
+    )
+
+    const highlight = container.querySelector('.my-highlight')
+    expect(highlight?.tagName).toBe('SPAN')
+    expect(highlight?.textContent).toBe('World')
+  })
+
+  it('escapes regex special characters in the search', () => {
+    const container = renderToContainer(
+      highlightText('price is 10$ (net)', {
+        search: '(net)',
+        className: 'my-highlight',
+      })
+    )
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark?.textContent).toBe('(net)')
+  })
+
+  it('does not throw on regex special characters that would otherwise be invalid', () => {
+    const container = renderToContainer(
+      highlightText('a * b', {
+        search: '*',
+        className: 'my-highlight',
+      })
+    )
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark?.textContent).toBe('*')
+  })
+
+  it('highlights numbers', () => {
+    const container = renderToContainer(
+      highlightText('Account 12345678901', {
+        search: '123',
+        className: 'my-highlight',
+      })
+    )
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark?.textContent).toBe('123')
+  })
+
+  it('cleans terms when searchNumbers is enabled', () => {
+    const container = renderToContainer(
+      highlightText('1234 and 5678', {
+        search: '12.34 56 78',
+        className: 'my-highlight',
+        searchNumbers: true,
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks[0].textContent).toBe('1234')
+    expect(marks[1].textContent).toBe('5678')
+  })
+
+  it('walks nested element nodes', () => {
+    const node = (
+      <a href="/path">
+        Use <code>Card</code> now
+      </a>
+    )
+
+    const container = renderToContainer(
+      highlightText(node, {
+        search: 'Ca',
+        className: 'my-highlight',
+      })
+    )
+
+    const link = container.querySelector('a')
+    const code = link?.querySelector('code')
+    const mark = code?.querySelector('.my-highlight')
+
+    expect(link).not.toBeNull()
+    expect(code?.textContent).toBe('Card')
+    expect(mark?.textContent).toBe('Ca')
+  })
+
+  it('walks arrays of nodes', () => {
+    const container = renderToContainer(
+      highlightText(['Hello', ' ', 'World'], {
+        search: 'World',
+        className: 'my-highlight',
+      })
+    )
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark?.textContent).toBe('World')
+    expect(container.textContent).toBe('Hello World')
+  })
+
+  it('does not render HTML strings as markup', () => {
+    const container = renderToContainer(
+      highlightText('hello <em>world</em>', {
+        search: 'hello',
+        className: 'my-highlight',
+      })
+    )
+
+    expect(container.querySelector('em')).toBeNull()
+    expect(container.innerHTML).toContain('&lt;em&gt;')
+  })
+
+  it('handles a term that appears in multiple split parts (previously buggy repeated-part scenario)', () => {
+    // Reproduces the FilterHighlighting stateful g-flag regex bug where
+    // regex.test() with lastIndex made alternating parts fail to highlight.
+    const container = renderToContainer(
+      highlightText('a b a b a', {
+        search: 'a',
+        className: 'my-highlight',
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks).toHaveLength(3)
+    marks.forEach((mark) => {
+      expect(mark.textContent).toBe('a')
+    })
+  })
+
+  it('wraps top-level text in a span when wrapInSpan is enabled', () => {
+    const result = highlightText('item bb', {
+      search: 'bb',
+      className: 'my-highlight',
+      tag: 'span',
+      wrapInSpan: true,
+    })
+
+    expect(isValidElement(result)).toBe(true)
+
+    const { container } = render(<>{result}</>)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.tagName).toBe('SPAN')
+    expect(wrapper.querySelector('.my-highlight')?.textContent).toBe('bb')
+  })
+
+  it('anchors the first term with the starts-with match', () => {
+    const container = renderToContainer(
+      highlightText('the other the', {
+        search: ['the'],
+        className: 'my-highlight',
+        searchMatch: 'starts-with',
+        searchInWordIndex: 1,
+      })
+    )
+
+    const marks = container.querySelectorAll('.my-highlight')
+    expect(marks).toHaveLength(1)
+    expect(marks[0].textContent).toBe('the')
+    expect(container.textContent).toBe('the other the')
+  })
+})
+
+describe('useHighlightText', () => {
+  function Consumer({
+    node,
+    cacheKey,
+    onHighlight,
+  }: {
+    node: React.ReactNode
+    cacheKey?: string
+    onHighlight?: (result: React.ReactNode) => void
+  }) {
+    const highlight = useHighlightText({
+      search: 'World',
+      className: 'my-highlight',
+    })
+
+    const result = highlight(node, cacheKey)
+    onHighlight?.(result)
+
+    return <div>{result}</div>
+  }
+
+  it('highlights via the returned callback', () => {
+    const { container } = render(<Consumer node="Hello World" />)
+
+    const mark = container.querySelector('.my-highlight')
+    expect(mark?.tagName).toBe('MARK')
+    expect(mark?.textContent).toBe('World')
+  })
+
+  it('returns a cached result for the same cache key', () => {
+    const results: React.ReactNode[] = []
+
+    const { rerender } = render(
+      <Consumer
+        node="Hello World"
+        cacheKey="key-1"
+        onHighlight={(result) => results.push(result)}
+      />
+    )
+
+    rerender(
+      <Consumer
+        node="Hello World again"
+        cacheKey="key-1"
+        onHighlight={(result) => results.push(result)}
+      />
+    )
+
+    // Same cache key returns the identical (cached) result reference.
+    expect(results[0]).toBe(results[1])
+  })
+})

--- a/packages/dnb-eufemia/src/shared/helpers/highlightText.tsx
+++ b/packages/dnb-eufemia/src/shared/helpers/highlightText.tsx
@@ -1,0 +1,390 @@
+import { createElement, isValidElement, useCallback, useRef } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+import { escapeRegexChars } from '../component-helper'
+
+export type HighlightTextTag = 'mark' | 'span'
+export type HighlightTextSearchMatch = 'word' | 'starts-with'
+
+export type HighlightTextOptions = {
+  /**
+   * The term(s) to highlight. A string is split on whitespace into
+   * multiple terms, an array is used as-is.
+   */
+  search: string | string[]
+
+  /**
+   * The class name applied to every highlighted part.
+   */
+  className: string
+
+  /**
+   * The element used to wrap a highlighted part.
+   * Default: 'mark'
+   */
+  tag?: HighlightTextTag
+
+  /**
+   * Controls where the first term is allowed to match.
+   * - 'word' (default): terms match at the start of any word.
+   * - 'starts-with': the first term only matches at the start of the text.
+   */
+  searchMatch?: HighlightTextSearchMatch
+
+  /**
+   * When true, terms are stripped down to letters and numbers before
+   * matching, and matching is done anywhere in the text.
+   */
+  searchNumbers?: boolean
+
+  /**
+   * Case-insensitive matching.
+   * Default: true
+   */
+  ignoreCase?: boolean
+
+  /**
+   * Terms at this index or later match anywhere in the text instead of
+   * at a word boundary. Default: 0 (all terms match anywhere).
+   */
+  searchInWordIndex?: number
+
+  /**
+   * When true, a top-level text node is wrapped in a plain span. Used to
+   * preserve existing markup in some consumers.
+   * Default: false
+   */
+  wrapInSpan?: boolean
+
+  /**
+   * A prefix used when generating React keys.
+   */
+  keyPrefix?: string
+}
+
+const strS = '\uFFFE'
+const strE = '\uFFFF'
+
+function getWordBoundary(
+  wordIndex: number,
+  searchMatch: HighlightTextSearchMatch
+): string {
+  if (searchMatch === 'starts-with' && wordIndex === 0) {
+    return '^'
+  }
+
+  return '^|\\s'
+}
+
+function markText(
+  text: string,
+  terms: string[],
+  {
+    flags,
+    searchMatch,
+    searchNumbers,
+    inWordIndex,
+  }: {
+    flags: string
+    searchMatch: HighlightTextSearchMatch
+    searchNumbers: boolean
+    inWordIndex: number
+  }
+): string {
+  let segment = text
+
+  terms.forEach((word, wordIndex) => {
+    if (!segment) {
+      return
+    }
+
+    if (searchNumbers) {
+      const cleanedWord = word.replace(
+        // @ts-expect-error Unicode property escapes are supported at runtime here
+        /[^\p{L}\p{N}]+/gu,
+        ''
+      )
+
+      if (cleanedWord) {
+        const escapedWord = escapeRegexChars(cleanedWord)
+        segment = segment.replace(
+          new RegExp(`(${escapedWord})`, flags),
+          (match) => {
+            if (match.includes(strS)) {
+              return match
+            }
+            return `${strS}${match}${strE}`
+          }
+        )
+      }
+
+      return
+    }
+
+    const escapedWord = escapeRegexChars(word)
+
+    if (wordIndex >= inWordIndex) {
+      segment = segment.replace(
+        new RegExp(`(${escapedWord})`, flags),
+        `${strS}$1${strE}`
+      )
+    } else {
+      const wordBoundary = getWordBoundary(wordIndex, searchMatch)
+      segment = segment.replace(
+        new RegExp(`(${wordBoundary})(${escapedWord})`, flags),
+        `$1${strS}$2${strE}`
+      )
+    }
+  })
+
+  return segment
+}
+
+function renderMarkedSegment(
+  segment: string,
+  {
+    tag,
+    className,
+    keyBase,
+  }: { tag: HighlightTextTag; className: string; keyBase: string }
+): ReactNode[] | string {
+  if (!segment.includes(strS)) {
+    return segment
+  }
+
+  const startRepeatRegex = new RegExp(`(${strS})+`, 'g')
+  const endRepeatRegex = new RegExp(`(${strE})+`, 'g')
+  const adjacentRegex = new RegExp(`(${strE}${strS})`, 'g')
+  const splitRegex = new RegExp(`(${strS}|${strE})`, 'g')
+
+  const normalized = segment
+    .replace(startRepeatRegex, strS)
+    .replace(endRepeatRegex, strE)
+    .replace(adjacentRegex, '')
+
+  const tokens = normalized.split(splitRegex).filter(Boolean)
+
+  let isHighlighted = false
+  let highlightIndex = 0
+
+  return tokens.map((token) => {
+    // eslint-disable-next-line security/detect-possible-timing-attacks -- sentinel char comparison, not a secret
+    if (token === strS) {
+      isHighlighted = true
+      return null
+    }
+    // eslint-disable-next-line security/detect-possible-timing-attacks -- sentinel char comparison, not a secret
+    if (token === strE) {
+      isHighlighted = false
+      return null
+    }
+
+    if (isHighlighted) {
+      const key = `highlight-${keyBase}-${highlightIndex++}`
+      return createElement(tag, { key, className }, token)
+    }
+
+    return token
+  })
+}
+
+type WalkContext = {
+  terms: string[]
+  className: string
+  tag: HighlightTextTag
+  flags: string
+  searchMatch: HighlightTextSearchMatch
+  searchNumbers: boolean
+  inWordIndex: number
+  keyPrefix: string
+}
+
+function renderText(
+  text: string,
+  keyPart: string,
+  wrapInSpan: boolean,
+  ctx: WalkContext
+): ReactNode {
+  const result = renderMarkedSegment(
+    markText(text, ctx.terms, {
+      flags: ctx.flags,
+      searchMatch: ctx.searchMatch,
+      searchNumbers: ctx.searchNumbers,
+      inWordIndex: ctx.inWordIndex,
+    }),
+    {
+      tag: ctx.tag,
+      className: ctx.className,
+      keyBase: ctx.keyPrefix + keyPart,
+    }
+  )
+
+  if (wrapInSpan) {
+    return createElement('span', { key: ctx.keyPrefix + keyPart }, result)
+  }
+
+  return result
+}
+
+function renderNode(
+  node: ReactNode,
+  keyPart: string,
+  wrapText: boolean,
+  ctx: WalkContext
+): ReactNode {
+  if (Array.isArray(node)) {
+    return node.map((child, index) =>
+      renderNode(child, `${keyPart}-${index}`, false, ctx)
+    )
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return renderText(String(node), keyPart, wrapText, ctx)
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    const child = node.props.children
+
+    if (typeof child === 'undefined') {
+      return node
+    }
+
+    return createElement(
+      node.type as ComponentType<{ children?: ReactNode }>,
+      {
+        ...node.props,
+        key: node.key ?? 'clone' + ctx.keyPrefix + keyPart,
+      },
+      renderNode(child, keyPart, false, ctx)
+    )
+  }
+
+  return node
+}
+
+/**
+ * Highlights every occurrence of the given search term(s) inside a ReactNode
+ * by wrapping the matching text in the given tag with the given class name.
+ * Handles strings, numbers, arrays and nested elements.
+ */
+export function highlightText(
+  node: ReactNode,
+  options: HighlightTextOptions
+): ReactNode {
+  const {
+    search,
+    className,
+    tag = 'mark',
+    searchMatch = 'word',
+    searchNumbers = false,
+    ignoreCase = true,
+    searchInWordIndex = 0,
+    wrapInSpan = false,
+    keyPrefix = '',
+  } = options
+
+  const terms = (
+    Array.isArray(search) ? search : String(search ?? '').split(/\s+/g)
+  ).filter(Boolean)
+
+  if (terms.length === 0) {
+    return node
+  }
+
+  const ctx: WalkContext = {
+    terms,
+    className,
+    tag,
+    flags: ignoreCase ? 'gi' : 'g',
+    searchMatch,
+    searchNumbers,
+    inWordIndex: searchInWordIndex,
+    keyPrefix,
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((child, index) =>
+      renderNode(child, String(index), wrapInSpan, ctx)
+    )
+  }
+
+  return renderNode(node, '0', wrapInSpan, ctx)
+}
+
+/**
+ * Returns a stable callback that highlights a ReactNode using the shared
+ * {@link highlightText} engine. It owns a per-search render cache so repeated
+ * calls with the same cache key (within one search) reuse the result. The
+ * cache resets whenever the search or options change.
+ *
+ * The cache is keyed solely by `cacheKey`, so the caller must ensure the
+ * `cacheKey` fully determines the node's content. Passing a stable key while
+ * the node content changes (e.g. a position-based key) returns stale
+ * highlights. When in doubt, omit `cacheKey` to always recompute.
+ */
+export function useHighlightText(
+  options: HighlightTextOptions
+): (node: ReactNode, cacheKey?: string) => ReactNode {
+  const {
+    search,
+    className,
+    tag = 'mark',
+    searchMatch = 'word',
+    searchNumbers = false,
+    ignoreCase = true,
+    searchInWordIndex = 0,
+    wrapInSpan = false,
+    keyPrefix = '',
+  } = options
+
+  const searchKey = JSON.stringify([
+    search,
+    className,
+    tag,
+    searchMatch,
+    searchNumbers,
+    ignoreCase,
+    searchInWordIndex,
+    wrapInSpan,
+    keyPrefix,
+  ])
+
+  const cacheRef = useRef<{
+    key: string
+    map: Map<string, ReactNode>
+  } | null>(null)
+
+  return useCallback(
+    (node: ReactNode, cacheKey?: string) => {
+      if (!cacheRef.current || cacheRef.current.key !== searchKey) {
+        cacheRef.current = { key: searchKey, map: new Map() }
+      }
+
+      if (
+        typeof cacheKey === 'string' &&
+        cacheRef.current.map.has(cacheKey)
+      ) {
+        return cacheRef.current.map.get(cacheKey)
+      }
+
+      const result = highlightText(node, {
+        search,
+        className,
+        tag,
+        searchMatch,
+        searchNumbers,
+        ignoreCase,
+        searchInWordIndex,
+        wrapInSpan,
+        keyPrefix,
+      })
+
+      if (typeof cacheKey === 'string') {
+        cacheRef.current.map.set(cacheKey, result)
+      }
+
+      return result
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [searchKey]
+  )
+}


### PR DESCRIPTION
Motivation: https://dnb-asa.atlassian.net/jira/software/c/projects/EDS/boards/734?assignee=712020%3A11a274b8-3b2a-4c7f-9968-07cf788ff7dd&selectedIssue=EDS-926

Autocomplete, Filter and `Field.MultiSelection` each had their own text-highlighting implementation. This meant duplicated logic and inconsistent behaviour — for example, only Autocomplete supported multi-word matching, while Filter and MultiSelect were single-term and carried their own regex-escaping and a fragile stateful-regex pattern.

This extracts the highlighting into a single shared internal engine (a pure `highlightText` util plus a `useHighlightText` hook that owns the render cache), so the behaviour is consistent across all three and there is one place to maintain it. Filter and MultiSelect now get multi-word highlighting for free.

Each component keeps its existing markup (`<span>`/`<mark>` and class names) in this PR; unifying on a single `<mark>` is left as a follow-up.
