### PR TITLE
fix(Field.Upload): reveal required error on submit when validateInitially={false}

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Visibility/__tests__/Visibility.test.tsx
@@ -1233,4 +1233,57 @@ describe('Visibility', () => {
 
     expect(container.innerHTML).toMatchInlineSnapshot(`"Child"`)
   })
+
+  describe('validateInitially={false} with show-all-errors after submit', () => {
+    // Pins the behavior introduced by the #4989 fix: once the form has
+    // attempted to submit (show-all-errors mode), a required field that is
+    // revealed afterwards shows its error immediately, even though the user
+    // never interacted with it and it uses validateInitially={false}. Before a
+    // submit, the same field stays silent. If this trade-off is revisited, this
+    // test should be updated together with the fix.
+    it('reveals a conditionally shown required field error once the form has attempted to submit', async () => {
+      render(
+        <Form.Handler>
+          {/* Always-present required field, so an attempted submit puts the
+              whole form into "show all errors" mode. */}
+          <Field.String path="/existing" required />
+
+          <Field.Boolean path="/show" variant="checkbox" />
+
+          <Form.Visibility visibleWhen={{ path: '/show', hasValue: true }}>
+            <Field.String
+              path="/conditional"
+              required
+              validateInitially={false}
+            />
+          </Form.Visibility>
+
+          <Form.SubmitButton />
+        </Form.Handler>
+      )
+
+      const checkbox = () =>
+        document.querySelector('input[type="checkbox"]')
+      const errorStatuses = () =>
+        document.querySelectorAll('.dnb-form-status--error')
+
+      // Before any submit, revealing the field keeps its error hidden,
+      // because validateInitially={false} suppresses initial validation.
+      await userEvent.click(checkbox())
+      expect(errorStatuses()).toHaveLength(0)
+      await userEvent.click(checkbox())
+
+      // Attempt to submit: the always-present required field errors, which
+      // switches the form into "show all errors" mode.
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+      expect(errorStatuses()).toHaveLength(1)
+
+      // Revealing the conditional field now surfaces its required error
+      // immediately, as a consequence of forcing the reveal on submit.
+      await userEvent.click(checkbox())
+      expect(errorStatuses()).toHaveLength(2)
+    })
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -1761,6 +1761,38 @@ describe('Wizard.Container', () => {
       })
     })
 
+    it('should show required error and prevent navigation when a required Field.Upload has validateInitially={false} (issue #4989)', async () => {
+      render(
+        <Form.Handler>
+          <Wizard.Container omitFocusManagement expandedInitially>
+            <Wizard.Step title="Step 1">
+              <output>Step 1</output>
+              <Field.Upload
+                required
+                validateInitially={false}
+                path="/myFiles"
+              />
+              <Wizard.NextButton />
+            </Wizard.Step>
+
+            <Wizard.Step title="Step 2">
+              <output>Step 2</output>
+            </Wizard.Step>
+          </Wizard.Container>
+        </Form.Handler>
+      )
+
+      expect(output()).toHaveTextContent('Step 1')
+
+      await userEvent.click(nextButton())
+
+      // Navigation is prevented and the required error is shown to the user
+      expect(output()).toHaveTextContent('Step 1')
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        nb.Upload.errorRequired
+      )
+    })
+
     it('should handle async onChangeValidator', async () => {
       const asyncValidator = async () => null
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldError.ts
@@ -544,17 +544,25 @@ export default function useFieldError<Value>({
   )
 
   // Will reveal the error as a visible error (hasVisibleError)
-  const revealError = useCallback(() => {
-    // To support "validateInitially={false}" prop
-    if (validateInitially === false && revealErrorRef.current === false) {
-      revealErrorRef.current = undefined
-      return undefined // stop here
-    }
+  const revealError = useCallback(
+    (force?: boolean) => {
+      // To support "validateInitially={false}" prop. A forced reveal (e.g. an
+      // explicit submit) must bypass the one-time skip so the error is shown.
+      if (
+        !force &&
+        validateInitially === false &&
+        revealErrorRef.current === false
+      ) {
+        revealErrorRef.current = undefined
+        return undefined // stop here
+      }
 
-    const hasError = Boolean(localErrorRef.current)
-    revealErrorRef.current = true
-    setErrorState(hasError)
-  }, [validateInitially, setErrorState])
+      const hasError = Boolean(localErrorRef.current)
+      revealErrorRef.current = true
+      setErrorState(hasError)
+    },
+    [validateInitially, setErrorState]
+  )
 
   const hideError = useCallback(() => {
     if (revealErrorRef.current) {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1602,7 +1602,13 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       if (fieldStateRef.current !== 'validating') {
         // If showError on a surrounding data context was changed and set to true, it is because the user clicked next, submit or
         // something else that should lead to showing the user all errors.
-        revealError()
+        // An explicit submit stores a timestamp (number), while the initial
+        // "validateInitially" stores a boolean. Force the reveal on submit so a
+        // "validateInitially={false}" field still shows its error.
+        const force =
+          typeof showAllErrors === 'number' ||
+          typeof showBoundaryErrors === 'number'
+        revealError(force)
       }
     } else if (showBoundaryErrors === false) {
       hideError()


### PR DESCRIPTION
When a required `Field.Upload` (or any required field) uses `validateInitially={false}` inside a Wizard, clicking "Next" correctly blocked navigation but showed no error message — the button appeared to do nothing.

The one-time reveal skip for `validateInitially={false}` relied on an initial reveal (e.g. from an ancestor `validateInitially`) to consume it, which is why it worked inside `Form.Section`. In a bare Wizard/Form there is no initial reveal, so the first submit-driven reveal was swallowed.

The reveal now bypasses the skip when it originates from an explicit submit (`showAllErrors`/`showBoundaryErrors` hold a timestamp) but not from the initial `validateInitially` (a boolean), so the functionality matches the behavior without `validateInitially={false}`.

**Trade-off:** since `showAllErrors`/`showBoundaryErrors` remain set after a submit attempt, a `validateInitially={false}` field that is mounted or made visible _after_ that attempt now reveals its error immediately — consistent with fields that don't set `validateInitially={false}`. A dedicated test documents this.

Refs #4989 — in the reproduced case navigation was already prevented, so this restores the missing required-error message; leaving the issue open to confirm the reporter's intermittent navigation case.
