### PR TITLE
chore(deps): upgrade nanoid to 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "joi": "17.13.4",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "path-to-regexp": "8.4.0",
     "postcss": "8.5.23",
     "qs": "6.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13390,12 +13390,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.17":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/54c3238ba6ea31c173ccf70922481814892075dbf1b4636abec249d0b34d5594fc9a8892c04872068674010a11fa3d18316dc06e59e700def131ff9d8e740426
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades nanoid to the patched release after the dependency audit began reporting GHSA-2v37-7h3g-55p8.