### PR TITLE
fix(Dialog): use full body height when locking scroll

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1190,7 +1190,7 @@ describe('Modal component', () => {
     fireEvent.click(elem)
 
     expect(document.body.style.overflow).toBe('hidden')
-    expect(document.body.style.height).toBe('')
+    expect(document.body.style.height).toBe('100%')
     expect(document.body.style.boxSizing).toBe('border-box')
     expect(document.body.style.marginRight).toBe('0px')
     expect(document.documentElement.style.height).toBe('100%')
@@ -1206,29 +1206,6 @@ describe('Modal component', () => {
     expect(document.documentElement).not.toHaveAttribute(
       'data-dnb-modal-active'
     )
-  })
-
-  it('preserves the body height while locking scroll', () => {
-    document.body.style.height = '100%'
-
-    render(
-      <Modal {...props}>
-        <DialogContent />
-      </Modal>
-    )
-    const elem = document.querySelector('button')
-
-    fireEvent.click(elem)
-
-    expect(document.body.style.overflow).toBe('hidden')
-    expect(document.body.style.height).toBe('100%')
-
-    fireEvent.click(elem)
-
-    expect(document.body.style.overflow).toBe('')
-    expect(document.body.style.height).toBe('100%')
-
-    document.body.style.height = ''
   })
 
   it('runs expected side effects on iOS pre 14', () => {
@@ -1314,7 +1291,7 @@ describe('Modal component', () => {
     expect(document.body.style.top).toBe('0px')
     expect(document.body.style.left).toBe('0px')
     expect(document.body.style.right).toBe('0px')
-    expect(document.body.style.height).toBe('')
+    expect(document.body.style.height).toBe('100%')
     expect(document.documentElement.style.height).toBe('100%')
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1190,7 +1190,7 @@ describe('Modal component', () => {
     fireEvent.click(elem)
 
     expect(document.body.style.overflow).toBe('hidden')
-    expect(document.body.style.height).toBe('auto')
+    expect(document.body.style.height).toBe('')
     expect(document.body.style.boxSizing).toBe('border-box')
     expect(document.body.style.marginRight).toBe('0px')
     expect(document.documentElement.style.height).toBe('100%')
@@ -1206,6 +1206,29 @@ describe('Modal component', () => {
     expect(document.documentElement).not.toHaveAttribute(
       'data-dnb-modal-active'
     )
+  })
+
+  it('preserves the body height while locking scroll', () => {
+    document.body.style.height = '100%'
+
+    render(
+      <Modal {...props}>
+        <DialogContent />
+      </Modal>
+    )
+    const elem = document.querySelector('button')
+
+    fireEvent.click(elem)
+
+    expect(document.body.style.overflow).toBe('hidden')
+    expect(document.body.style.height).toBe('100%')
+
+    fireEvent.click(elem)
+
+    expect(document.body.style.overflow).toBe('')
+    expect(document.body.style.height).toBe('100%')
+
+    document.body.style.height = ''
   })
 
   it('runs expected side effects on iOS pre 14', () => {
@@ -1291,7 +1314,7 @@ describe('Modal component', () => {
     expect(document.body.style.top).toBe('0px')
     expect(document.body.style.left).toBe('0px')
     expect(document.body.style.right).toBe('0px')
-    expect(document.body.style.height).toBe('auto')
+    expect(document.body.style.height).toBe('')
     expect(document.documentElement.style.height).toBe('100%')
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')

--- a/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
+++ b/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
@@ -40,6 +40,7 @@ const setOverflowHidden = () => {
     )
 
     bodyElement.style.overflow = 'hidden'
+    bodyElement.style.height = '100%'
     bodyElement.style.boxSizing = 'border-box'
     bodyElement.style.marginRight = `${scrollBarWidth}px`
 
@@ -48,7 +49,7 @@ const setOverflowHidden = () => {
         ;['overflow', 'height'].forEach((x) => {
           htmlElement.style[x] = htmlStyle[x] || ''
         })
-        ;['overflow', 'boxSizing', 'margin'].forEach((x) => {
+        ;['overflow', 'height', 'boxSizing', 'margin'].forEach((x) => {
           bodyElement.style[x] = bodyStyle[x] || ''
         })
         htmlElement.style.removeProperty('--scrollbar-width')

--- a/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
+++ b/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
@@ -40,7 +40,6 @@ const setOverflowHidden = () => {
     )
 
     bodyElement.style.overflow = 'hidden'
-    bodyElement.style.height = 'auto'
     bodyElement.style.boxSizing = 'border-box'
     bodyElement.style.marginRight = `${scrollBarWidth}px`
 
@@ -49,7 +48,7 @@ const setOverflowHidden = () => {
         ;['overflow', 'height'].forEach((x) => {
           htmlElement.style[x] = htmlStyle[x] || ''
         })
-        ;['overflow', 'height', 'boxSizing', 'margin'].forEach((x) => {
+        ;['overflow', 'boxSizing', 'margin'].forEach((x) => {
           bodyElement.style[x] = bodyStyle[x] || ''
         })
         htmlElement.style.removeProperty('--scrollbar-width')

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -834,7 +834,7 @@ describe('DrawerList component', () => {
     rerender(<MockComponent open />)
 
     expect(document.body.getAttribute('style')).toBe(
-      'overflow: hidden; height: auto; box-sizing: border-box; margin-right: 0px;'
+      'overflow: hidden; height: 100%; box-sizing: border-box; margin-right: 0px;'
     )
 
     rerender(<MockComponent open={false} />)


### PR DESCRIPTION
Opening a Modal currently forces the page body to `height: auto`. In Safari, this can change the page geometry for legacy documents and cause the modal layout to cover only part of the viewport.

Use `height: 100%` while the body is scroll-locked so the modal retains full-page geometry in these documents.

Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1786363232385539
Dialog: https://fix-modal-preserve-body-heig.eufemia-e25.pages.dev/uilib/components/dialog/demos