### PR TITLE
docs(Portal): restore narrow sidebar usability

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/responsiveness.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/responsiveness.spec.ts
@@ -18,11 +18,23 @@ test.describe('Responsiveness', () => {
     )
     await page.setViewportSize({ width: 375, height: 667 }) // Set viewport size to iPhone 6 dimensions
 
+    const menuButton = page.locator('#toggle-sidebar-menu')
+    await expect(menuButton).toHaveCSS('margin-left', '8px')
+
     await expect(page.locator('nav#portal-sidebar-menu')).toHaveCSS(
       'display',
       'none'
     )
-    await page.click('#toggle-sidebar-menu')
+    await menuButton.click()
+
+    const sidebar = page.locator('nav#portal-sidebar-menu')
+    await expect(sidebar).toHaveCSS('overflow-y', 'auto')
+
+    const scrollPosition = await sidebar.evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+      return element.scrollTop
+    })
+    expect(scrollPosition).toBeGreaterThan(0)
 
     const sidebarLink =
       'nav#portal-sidebar-menu a[href="/uilib/components"]'

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.module.scss
@@ -297,7 +297,7 @@
     position: relative;
 
     width: 100%;
-    height: auto;
+    height: calc(100dvh - var(--portal-sidebar-top));
   }
 
   @include utilities.allAbove(medium) {

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.tsx
@@ -55,6 +55,7 @@ export default function StickyMenuBar({
             id="toggle-sidebar-menu"
             size="default"
             iconSize="default"
+            left="x-small"
             aria-haspopup={true}
             aria-controls="portal-sidebar-menu"
             aria-expanded={isOpen}


### PR DESCRIPTION
The section menu could not be scrolled on narrow screens, leaving content inaccessible. Constraining it to the available viewport also restores scrolling, while spacing the adjacent header controls keeps them visually distinct.