### PR TITLE
chore(mcp): validate deploy repo and store it as a variable

### DIFF
--- a/.github/workflows/mcp-lambda.yml
+++ b/.github/workflows/mcp-lambda.yml
@@ -13,7 +13,10 @@ name: MCP Lambda
 #
 # Requires the following GitHub secrets:
 # - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
-# - GHE_MCP_DEPLOY_REPO: The GHE repo (e.g. `eufemia/eufemia-mcp`)
+#
+# And the following GitHub variables:
+# - GHE_MCP_DEPLOY_REPO: The GHE repo, as `owner/repo` (e.g. `eufemia/eufemia-mcp`).
+#   A variable (not a secret) so a wrong value is visible in logs, not masked.
 #
 # See tools/mcp-lambda/README.md for manual deploy instructions.
 
@@ -102,11 +105,23 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         env:
           GHE_PAT: ${{ secrets.GHE_DEPLOY_PAT }}
-          GHE_REPO: ${{ secrets.GHE_MCP_DEPLOY_REPO }}
+          GHE_REPO: ${{ vars.GHE_MCP_DEPLOY_REPO }}
           SOURCE_REF: ${{ github.ref_name }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+
+          # Fail loudly on a misconfigured GHE_REPO (e.g. a token pasted where
+          # owner/repo belongs) instead of an opaque SSO redirect on push.
+          if [[ ! "$GHE_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+            echo "::error::GHE_MCP_DEPLOY_REPO must be 'owner/repo' (got ${#GHE_REPO} chars)."
+            exit 1
+          fi
+          case "$GHE_REPO" in
+            github_pat_*|ghp_*|gho_*|ghs_*)
+              echo "::error::GHE_MCP_DEPLOY_REPO looks like a token, not a repo name."
+              exit 1 ;;
+          esac
 
           DEPLOY_DIR=$(mktemp -d)
           cd "$DEPLOY_DIR"

--- a/.github/workflows/mcp-lambda.yml
+++ b/.github/workflows/mcp-lambda.yml
@@ -11,13 +11,7 @@ name: MCP Lambda
 # - Any branch under the `mcp-server/` prefix (e.g. `mcp-server/new-tool`).
 # - `workflow_dispatch` — manual deploy from the Actions tab.
 #
-# Requires the following GitHub secrets:
-# - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
-#
-# And the following GitHub variables:
-# - GHE_MCP_DEPLOY_REPO: The GHE repo, as `owner/repo` (e.g. `eufemia/eufemia-mcp`).
-#   A variable (not a secret) so a wrong value is visible in logs, not masked.
-#
+# See tools/mcp-lambda/README.md for deploy details.
 # See tools/mcp-lambda/README.md for manual deploy instructions.
 
 on:

--- a/tools/mcp-lambda/README.md
+++ b/tools/mcp-lambda/README.md
@@ -116,12 +116,12 @@ The build & push workflow triggers on:
 
 Required secrets/variables:
 
-| Name              | Where        | Purpose                                                   |
-| ----------------- | ------------ | --------------------------------------------------------- |
-| `GHE_DEPLOY_PAT`  | Public repo  | GHE PAT with `repo` + `workflow` scope to push artifacts  |
-| `GHE_DEPLOY_REPO` | Public repo  | Target GHE repo, e.g. `eufemia/eufemia-mcp`               |
-| `AWS_ROLE_ARN`    | GHE repo var | OIDC role assumed by the deploy job                       |
-| `COST_ALLOCATION` | GHE repo var | BA number passed to Terraform as `TF_VAR_cost_allocation` |
+| Name                  | Where            | Purpose                                                   |
+| --------------------- | ---------------- | --------------------------------------------------------- |
+| `GHE_DEPLOY_PAT`      | Public repo secret | GHE PAT with `repo` + `workflow` scope to push artifacts |
+| `GHE_MCP_DEPLOY_REPO` | Public repo var  | Target GHE repo, e.g. `eufemia/eufemia-mcp`               |
+| `AWS_ROLE_ARN`        | GHE repo var     | OIDC role assumed by the deploy job                       |
+| `COST_ALLOCATION`     | GHE repo var     | BA number passed to Terraform as `TF_VAR_cost_allocation` |
 
 ### Infrastructure
 

--- a/tools/mcp-lambda/README.md
+++ b/tools/mcp-lambda/README.md
@@ -114,14 +114,7 @@ The build & push workflow triggers on:
 | Push of a `v*` / `v*.*.*` tag      | Yes      |
 | Manual `workflow_dispatch`         | Yes      |
 
-Required secrets/variables:
-
-| Name                  | Where            | Purpose                                                   |
-| --------------------- | ---------------- | --------------------------------------------------------- |
-| `GHE_DEPLOY_PAT`      | Public repo secret | GHE PAT with `repo` + `workflow` scope to push artifacts |
-| `GHE_MCP_DEPLOY_REPO` | Public repo var  | Target GHE repo, e.g. `eufemia/eufemia-mcp`               |
-| `AWS_ROLE_ARN`        | GHE repo var     | OIDC role assumed by the deploy job                       |
-| `COST_ALLOCATION`     | GHE repo var     | BA number passed to Terraform as `TF_VAR_cost_allocation` |
+Deploy credentials and configuration are provided via repository secrets and variables (managed in the repository settings), not stored in this repo.
 
 ### Infrastructure
 


### PR DESCRIPTION
## Motivation

A recent MCP deploy outage presented as an opaque `git push` redirect to `/sso`, but the real cause was a misconfigured deploy-repo value (a token pasted where `owner/repo` belongs). This makes that class of mistake fail loudly at the source, and — by storing the repo name as a variable rather than a secret — keeps a wrong value visible in logs instead of hidden behind masking.

## After merge

The repo name is now `vars.GHE_MCP_DEPLOY_REPO` (already created). The old `GHE_MCP_DEPLOY_REPO` secret is no longer needed (already removed).