### PR TITLE
chore(analytics): validate deploy repo and store it as a variable

### DIFF
--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -13,7 +13,10 @@ name: Analytics Lambda
 #
 # Requires the following GitHub secrets:
 # - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
-# - GHE_ANALYTICS_DEPLOY_REPO: The GHE repo (e.g. `eufemia/eufemia-analytics`)
+#
+# And the following GitHub variables:
+# - GHE_ANALYTICS_DEPLOY_REPO: The GHE repo, as `owner/repo` (e.g. `eufemia/eufemia-analytics`).
+#   A variable (not a secret) so a wrong value is visible in logs, not masked.
 #
 # See tools/analytics/README.md for manual deploy instructions.
 
@@ -125,11 +128,23 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         env:
           GHE_PAT: ${{ secrets.GHE_DEPLOY_PAT }}
-          GHE_REPO: ${{ secrets.GHE_ANALYTICS_DEPLOY_REPO }}
+          GHE_REPO: ${{ vars.GHE_ANALYTICS_DEPLOY_REPO }}
           SOURCE_REF: ${{ github.ref_name }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+
+          # Fail loudly on a misconfigured GHE_REPO (e.g. a token pasted where
+          # owner/repo belongs) instead of an opaque SSO redirect on push.
+          if [[ ! "$GHE_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+            echo "::error::GHE_ANALYTICS_DEPLOY_REPO must be 'owner/repo' (got ${#GHE_REPO} chars)."
+            exit 1
+          fi
+          case "$GHE_REPO" in
+            github_pat_*|ghp_*|gho_*|ghs_*)
+              echo "::error::GHE_ANALYTICS_DEPLOY_REPO looks like a token, not a repo name."
+              exit 1 ;;
+          esac
 
           DEPLOY_DIR=$(mktemp -d)
           cd "$DEPLOY_DIR"

--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -11,13 +11,7 @@ name: Analytics Lambda
 # - Any branch named `**/analytics` (e.g. `feat/analytics`).
 # - `workflow_dispatch` — manual deploy from the Actions tab.
 #
-# Requires the following GitHub secrets:
-# - GHE_DEPLOY_PAT: A GitHub Enterprise PAT with repo + workflow push access
-#
-# And the following GitHub variables:
-# - GHE_ANALYTICS_DEPLOY_REPO: The GHE repo, as `owner/repo` (e.g. `eufemia/eufemia-analytics`).
-#   A variable (not a secret) so a wrong value is visible in logs, not masked.
-#
+# See tools/analytics/README.md for deploy details.
 # See tools/analytics/README.md for manual deploy instructions.
 
 on:

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -79,10 +79,10 @@ public GitHub (.github/workflows/analytics-lambda.yml)
 
 ### Required configuration
 
-On the **public repo** (secrets):
+On the **public repo**:
 
-- `GHE_DEPLOY_PAT` — GHE PAT with repo + workflow push scope (shared with the MCP pipeline).
-- `GHE_ANALYTICS_DEPLOY_REPO` — the GHE deploy repo, e.g. `eufemia/eufemia-analytics`.
+- `GHE_DEPLOY_PAT` — GHE PAT with repo + workflow push scope (secret; shared with the MCP pipeline).
+- `GHE_ANALYTICS_DEPLOY_REPO` — the GHE deploy repo, e.g. `eufemia/eufemia-analytics` (variable, not a secret, so a wrong value is visible in logs).
 
 On the **GHE deploy repo** (variables/secrets):
 

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -75,20 +75,11 @@ public GitHub (.github/workflows/analytics-lambda.yml)
 
 - **Triggers** (`analytics-lambda.yml`): the `release` branch, any `**/analytics` branch, `v*` tags, or manual `workflow_dispatch`.
 - The public workflow copies `ghe-deploy-workflow.yml` onto the GHE `deploy` branch, so the deploy job is self-installing — no manual workflow setup in the GHE repo.
-- If `GHE_DEPLOY_PAT` is unset, the build-and-push step is skipped (tests still run), so forks and PRs are safe.
+- On forks and PRs without deploy credentials, the build-and-push step is skipped (tests still run).
 
 ### Required configuration
 
-On the **public repo**:
-
-- `GHE_DEPLOY_PAT` — GHE PAT with repo + workflow push scope (secret; shared with the MCP pipeline).
-- `GHE_ANALYTICS_DEPLOY_REPO` — the GHE deploy repo, e.g. `eufemia/eufemia-analytics` (variable, not a secret, so a wrong value is visible in logs).
-
-On the **GHE deploy repo** (variables/secrets):
-
-- `AWS_ROLE_ARN` (variable) — the OIDC deploy role to assume.
-- `COST_ALLOCATION` (variable) — passed as `TF_VAR_cost_allocation`.
-- `API_TOKEN` (secret, optional) — passed as `TF_VAR_api_token` to enable bearer auth.
+Deploy credentials and configuration are provided via repository secrets and variables (managed in the repository settings), not stored in this repo.
 
 ### One-time bootstrap (admin, out-of-band)
 


### PR DESCRIPTION
## Motivation

Applies the same hardening as the MCP pipeline (#8991) to the analytics deploy: a misconfigured deploy-repo value (e.g. a token pasted where `owner/repo` belongs) would otherwise fail as an opaque `git push` redirect to `/sso`. This fails loudly at the source, and storing the repo name as a variable rather than a secret keeps a wrong value visible in logs instead of masked.

## Notes

Stacked on `chore/analytics-storage-tool` (#8916) since the workflow only exists there; will retarget to `main` once that merges. The `GHE_ANALYTICS_DEPLOY_REPO` variable is already created; the same-named secret can be removed once this lands.