### PR TITLE
chore(Portal): remove duplicate mobile Portal Tools trigger

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/responsiveness.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/responsiveness.spec.ts
@@ -27,6 +27,10 @@ test.describe('Responsiveness', () => {
     )
     await menuButton.click()
 
+    await expect(
+      page.locator('#portal-sidebar-menu').getByText('Portal Tools')
+    ).toHaveCount(0)
+
     const sidebar = page.locator('nav#portal-sidebar-menu')
     await expect(sidebar).toHaveCSS('overflow-y', 'auto')
 

--- a/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/SidebarMenu.tsx
@@ -28,7 +28,6 @@ import {
   setPageFocusElement,
   applyPageFocus,
 } from '@dnb/eufemia/src/shared/helpers'
-import PortalToolsMenu from './PortalToolsMenu'
 import { navStyle, resizeHandleStyle } from './SidebarMenu.module.scss'
 import { defaultTabsValue } from '../tags/defaultValues'
 
@@ -175,18 +174,6 @@ export default function SidebarLayout({
         )}
         ref={scrollRef}
       >
-        <PortalToolsMenu
-          triggerProps={{
-            left: 'large',
-            top: 'large',
-            bottom: 'large',
-            text: 'Portal Tools',
-            icon: 'chevron_right',
-            iconPosition: 'right',
-          }}
-          tooltipPosition="bottom"
-          hideWhenMediaLarge
-        />
         <ul className="dev-grid">{navItems}</ul>
       </nav>
 


### PR DESCRIPTION
The mobile sidebar duplicates the Portal Tools button that already exists in the portal header. Removing only the sidebar button leaves a single, consistent entry point.
