### PR TITLE
chore: fix grammar in recently changed docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Prefer fewer dependencies — a little code we own usually beats a new runtime d
 - **License** — compatible with DNB policy.
 - **Alternatives considered** — what else you evaluated.
 
-Remove dependencies once they are no longer used — the cheapest vulnerability to handle is the one on code you deleted.
+Remove dependencies once they are no longer used — the cheapest vulnerability to handle is the one in code you deleted.
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,9 @@ Report it privately using one of the following, in order of preference:
    collaborate on a fix and a coordinated disclosure. Prefer this route: it
    reaches the whole maintainer team, so it does not depend on one person being
    available.
-2. **Email** — if that form is unavailable, the Eufemia Security Champion at
-   [anders.langseth@dnb.no](mailto:anders.langseth@dnb.no), or a maintainer at
-   [tobias.hoegh@dnb.no](mailto:tobias.hoegh@dnb.no).
+2. **Email** — if that form is unavailable, email the Eufemia Security Champion
+   at [anders.langseth@dnb.no](mailto:anders.langseth@dnb.no), or a maintainer
+   at [tobias.hoegh@dnb.no](mailto:tobias.hoegh@dnb.no).
 
 Please include, where possible:
 

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -93,7 +93,7 @@ including Dependabot's.
 
 > **Control coverage is reviewed, not assumed.** The table above is the
 > authoritative list of what runs today. Verify against the repository's
-> **Settings → Code security** rather than assuming a GitHub default is switched
+> **Settings → Code security** rather than assuming GitHub defaults are switched
 > on — some are not. Because this file is public, the full control inventory, its
 > mapping to DNB's SECARC requirements, and any open gaps live on the EDS
 > **Security** page in Confluence and are reviewed at the monthly triage. Do not
@@ -141,7 +141,7 @@ everything else is tracked but non-blocking. Shipped **Moderate** and **Low**
 findings still carry a deadline — unlike dev/build tooling, they are never parked
 in the quarterly batch, because shipped code has to stay inside the ceiling
 below. Every cell is a number (in **calendar days**) for the same reason: a
-target you can measure is auditable, where "promptly" or "immediately" is not.
+target you can measure is auditable, whereas "promptly" or "immediately" is not.
 
 > **DNB compliance ceiling (SI-02 Flaw Remediation).** DNB's
 > flaw-remediation limits are **Critical within 1 month** and **all others

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/info.mdx
@@ -124,7 +124,7 @@ In CSS mode, `divider="line"` and `divider="line-framed"` are painted visual lin
 
 ## Backwards compatibility
 
-The existing React child inspection engine remains the default, so applications do not need to annotate every established layout:
+The existing React child-inspection engine remains the default, so applications do not need to annotate every established layout:
 
 ```tsx
 <Flex.Container>...</Flex.Container>

--- a/packages/dnb-eufemia/src/components/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/scroll-view/ScrollView.tsx
@@ -108,7 +108,7 @@ function useInteractive({ interactive, children, ref }) {
 
   function hasScrollbar() {
     if (!ref.current) {
-      return true // fallback and assume, there is a scrollbar
+      return true // fall back and assume there is a scrollbar
     }
 
     /**

--- a/packages/dnb-eufemia/src/components/scroll-view/ScrollView.tsx
+++ b/packages/dnb-eufemia/src/components/scroll-view/ScrollView.tsx
@@ -39,7 +39,7 @@ export type ScrollViewAllProps = ScrollViewProps &
 function ScrollView(localProps: ScrollViewAllProps) {
   const context = useContext(Context)
 
-  // use only the props from context, who are available here anyway
+  // use only the props from context, which are available here anyway
   const props = extendPropsWithContext(localProps, {}, context.ScrollView)
 
   const {


### PR DESCRIPTION
While reviewing the last 10 commits on `main`, I noticed a few small grammar slips in prose that was recently added or moved — the security policy and vulnerability-management docs, the Flex and ScrollView documentation, and a couple of code comments in the newly promoted `ScrollView` component.

These are wording-only fixes for readability and correctness: a missing verb in the reporting step, a number-agreement slip, "in code" vs "on code", "whereas" vs "where", a hyphenated compound modifier, and two stray code comments. No behavior or API changes.
