### PR TITLE
chore(ScrollView): move _supportsSpacingProps baseline entry to components path

### DIFF
--- a/packages/dnb-eufemia/src/components/flex/__tests__/supportsSpacingProps.baseline.json
+++ b/packages/dnb-eufemia/src/components/flex/__tests__/supportsSpacingProps.baseline.json
@@ -83,6 +83,7 @@
   "components/progress-indicator/ProgressIndicator.tsx": 1,
   "components/radio/Radio.tsx": 1,
   "components/radio/RadioGroup.tsx": 1,
+  "components/scroll-view/ScrollView.tsx": 1,
   "components/section/Section.tsx": 1,
   "components/skeleton/Skeleton.tsx": 1,
   "components/skip-content/SkipContent.tsx": 1,
@@ -226,7 +227,6 @@
   "extensions/forms/blocks/ChildrenWithAge/ChildrenWithAge.tsx": 1,
   "extensions/forms/utils/TestElement/TestElement.tsx": 1,
   "fragments/drawer-list/DrawerList.tsx": 1,
-  "fragments/scroll-view/ScrollView.tsx": 1,
   "shared/Theme.tsx": 1,
   "shared/helpers/withComponentMarkers.ts": 3
 }


### PR DESCRIPTION
### Motivation

#8981 promoted `ScrollView` from a fragment to a component, moving the file from `fragments/scroll-view/` to `components/scroll-view/`. The `_supportsSpacingProps` guardrail baseline still pointed at the old `fragments/scroll-view/ScrollView.tsx` path, so the marker at the new `components/scroll-view/ScrollView.tsx` had no allowance and the `supportsSpacingProps` test started failing on CI.

This moves the baseline entry to the new component path. The fragment now re-exports the component and no longer carries the marker, so the guardrail reflects reality again.
