### PR TITLE
chore(ScrollView): fix grammar in SCSS comment

### DIFF
--- a/packages/dnb-eufemia/src/components/scroll-view/style/dnb-scroll-view.scss
+++ b/packages/dnb-eufemia/src/components/scroll-view/style/dnb-scroll-view.scss
@@ -10,7 +10,7 @@
 
   @include utilities.scrollY(auto);
 
-  // Ensure the user still can scroll a ancestor scrollarea (body)
+  // Ensure the user still can scroll an ancestor scrollarea (body)
   overscroll-behavior: auto;
 
   &--scrollbar-gutter-stable {


### PR DESCRIPTION
Fixes an incorrect article in a `ScrollView` SCSS comment: `a ancestor` → `an ancestor`.
