### PR TITLE
refactor(HeightAnimation): deprecate untilFound in favor of openOnFind

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
@@ -181,7 +181,7 @@ export function HeightAnimationKeepInDOM() {
   )
 }
 
-export function HeightAnimationRevealOnFind() {
+export function HeightAnimationOpenOnFind() {
   return (
     <ComponentBox>
       {() => {
@@ -193,16 +193,16 @@ export function HeightAnimationRevealOnFind() {
               <ToggleButton
                 checked={openState}
                 aria-expanded={openState}
-                aria-controls="reveal-on-find-content"
+                aria-controls="open-on-find-content"
                 onChange={({ checked }) => setOpenState(checked)}
               >
                 Open content
               </ToggleButton>
 
               <HeightAnimation
-                id="reveal-on-find-content"
+                id="open-on-find-content"
                 open={openState}
-                revealOnFind
+                openOnFind
                 onBeforeMatch={() => setOpenState(true)}
               >
                 <Space innerSpace>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/Examples.tsx
@@ -181,7 +181,7 @@ export function HeightAnimationKeepInDOM() {
   )
 }
 
-export function HeightAnimationUntilFound() {
+export function HeightAnimationRevealOnFind() {
   return (
     <ComponentBox>
       {() => {
@@ -193,16 +193,16 @@ export function HeightAnimationUntilFound() {
               <ToggleButton
                 checked={openState}
                 aria-expanded={openState}
-                aria-controls="until-found-content"
+                aria-controls="reveal-on-find-content"
                 onChange={({ checked }) => setOpenState(checked)}
               >
                 Open content
               </ToggleButton>
 
               <HeightAnimation
-                id="until-found-content"
+                id="reveal-on-find-content"
                 open={openState}
-                untilFound
+                revealOnFind
                 onBeforeMatch={() => setOpenState(true)}
               >
                 <Space innerSpace>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
@@ -6,7 +6,7 @@ import {
   HeightAnimationDefault,
   HeightAnimationAutosizing,
   HeightAnimationKeepInDOM,
-  HeightAnimationUntilFound,
+  HeightAnimationRevealOnFind,
 } from 'Docs/uilib/components/height-animation/Examples'
 
 ## Demos
@@ -31,6 +31,6 @@ When providing `keepInDOM={true}`, your nested content will never be removed fro
 
 ### Find collapsed content
 
-The `untilFound` prop keeps collapsed content available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”**. HeightAnimation reveals the match itself, while the optional `onBeforeMatch` callback synchronizes the toggle's external state.
+The `revealOnFind` prop keeps collapsed content available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”**. HeightAnimation reveals the match itself, while the optional `onBeforeMatch` callback synchronizes the toggle's external state.
 
-<HeightAnimationUntilFound />
+<HeightAnimationRevealOnFind />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/demos.mdx
@@ -6,7 +6,7 @@ import {
   HeightAnimationDefault,
   HeightAnimationAutosizing,
   HeightAnimationKeepInDOM,
-  HeightAnimationRevealOnFind,
+  HeightAnimationOpenOnFind,
 } from 'Docs/uilib/components/height-animation/Examples'
 
 ## Demos
@@ -31,6 +31,6 @@ When providing `keepInDOM={true}`, your nested content will never be removed fro
 
 ### Find collapsed content
 
-The `revealOnFind` prop keeps collapsed content available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”**. HeightAnimation reveals the match itself, while the optional `onBeforeMatch` callback synchronizes the toggle's external state.
+The `openOnFind` prop keeps collapsed content available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”**. HeightAnimation opens the match itself, while the optional `onBeforeMatch` callback synchronizes the toggle's external state.
 
-<HeightAnimationRevealOnFind />
+<HeightAnimationOpenOnFind />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -35,11 +35,11 @@ Custom `duration` and `delay` props are applied after hydration via a DOM effect
 
 Connect the control and animated content with `aria-controls`, and expose the current state with `aria-expanded`. HeightAnimation does not manage focus. Avoid closing content while focus is inside it, or move focus to a logical visible control first.
 
-When `keepInDOM` or `revealOnFind` keeps closed content in the DOM, HeightAnimation applies `aria-hidden="true"`. The collapsed content is therefore unavailable to assistive technologies until it opens.
+When `keepInDOM` or `openOnFind` keeps closed content in the DOM, HeightAnimation applies `aria-hidden="true"`. The collapsed content is therefore unavailable to assistive technologies until it opens.
 
-`revealOnFind` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
+`openOnFind` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation opens matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
-`revealOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `revealOnFind` off) instead.
+`openOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `openOnFind` off) instead.
 
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -35,11 +35,11 @@ Custom `duration` and `delay` props are applied after hydration via a DOM effect
 
 Connect the control and animated content with `aria-controls`, and expose the current state with `aria-expanded`. HeightAnimation does not manage focus. Avoid closing content while focus is inside it, or move focus to a logical visible control first.
 
-When `keepInDOM` or `untilFound` keeps closed content in the DOM, HeightAnimation applies `aria-hidden="true"`. The collapsed content is therefore unavailable to assistive technologies until it opens.
+When `keepInDOM` or `revealOnFind` keeps closed content in the DOM, HeightAnimation applies `aria-hidden="true"`. The collapsed content is therefore unavailable to assistive technologies until it opens.
 
-`untilFound` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
+`revealOnFind` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation reveals matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
-`untilFound` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `untilFound` off) instead.
+`revealOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `revealOnFind` off) instead.
 
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -22,10 +22,16 @@ export type HeightAnimationProps = {
   /**
    * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.
    */
+  revealOnFind?: boolean
+
+  /**
+   * Deprecated. Use `revealOnFind` instead.
+   * @deprecated Use `revealOnFind` instead.
+   */
   untilFound?: boolean
 
   /**
-   * Is called after matching content inside a closed animation is revealed by the browser using `untilFound`. Use it to synchronize external open state and controls.
+   * Is called after matching content inside a closed animation is revealed by the browser using `revealOnFind`. Use it to synchronize external open state and controls.
    */
   onBeforeMatch?: (event: Event) => void
 
@@ -66,7 +72,8 @@ function HeightAnimation({
   open = true,
   animate = true,
   keepInDOM = false,
-  untilFound = false,
+  revealOnFind,
+  untilFound,
   showOverflow = false,
   element,
   duration,
@@ -86,11 +93,12 @@ function HeightAnimation({
   const elementRef = useRef<HTMLElement>(undefined)
   const targetRef = ref || elementRef
   const [isRevealedByMatch, setRevealedByMatch] = useState(false)
-  const resolvedOpen = open || (untilFound && isRevealedByMatch)
+  const shouldRevealOnFind = revealOnFind ?? untilFound ?? false
+  const resolvedOpen = open || (shouldRevealOnFind && isRevealedByMatch)
 
   const handleAnimationStart: UseHeightAnimationOptions['onAnimationStart'] =
     (state) => {
-      if (untilFound && state === 'opening') {
+      if (shouldRevealOnFind && state === 'opening') {
         targetRef.current?.removeAttribute('hidden')
       }
       onAnimationStart?.(state)
@@ -98,7 +106,7 @@ function HeightAnimation({
   const handleAnimationEnd: UseHeightAnimationOptions['onAnimationEnd'] = (
     state
   ) => {
-    if (untilFound) {
+    if (shouldRevealOnFind) {
       if (state === 'closed') {
         targetRef.current?.style.removeProperty('visibility')
         targetRef.current?.setAttribute('hidden', 'until-found')
@@ -134,7 +142,7 @@ function HeightAnimation({
     }
 
     if (
-      untilFound &&
+      shouldRevealOnFind &&
       !resolvedOpen &&
       element.classList.contains('dnb-height-animation--hidden')
     ) {
@@ -142,17 +150,17 @@ function HeightAnimation({
     } else if (element.getAttribute('hidden') === 'until-found') {
       element.removeAttribute('hidden')
     }
-  }, [resolvedOpen, targetRef, untilFound])
+  }, [resolvedOpen, shouldRevealOnFind, targetRef])
 
   useLayoutEffect(() => {
-    if (isRevealedByMatch && (open || !untilFound)) {
+    if (isRevealedByMatch && (open || !shouldRevealOnFind)) {
       setRevealedByMatch(false)
     }
-  }, [isRevealedByMatch, open, untilFound])
+  }, [isRevealedByMatch, open, shouldRevealOnFind])
 
   useLayoutEffect(() => {
     const element = targetRef.current
-    if (!element || !untilFound) {
+    if (!element || !shouldRevealOnFind) {
       return undefined
     }
 
@@ -168,7 +176,7 @@ function HeightAnimation({
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
     }
-  }, [onBeforeMatch, targetRef, untilFound])
+  }, [onBeforeMatch, shouldRevealOnFind, targetRef])
 
   // Set CSS custom properties via the DOM instead of React's style
   // prop. React's SSR serializes custom properties without spaces
@@ -193,7 +201,7 @@ function HeightAnimation({
     }
   }, [duration, delay, targetRef, isInDOM])
 
-  const shouldKeepInDOM = keepInDOM || untilFound
+  const shouldKeepInDOM = keepInDOM || shouldRevealOnFind
 
   if (!shouldKeepInDOM && !isInDOM && !isAnimating) {
     return null

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -22,16 +22,16 @@ export type HeightAnimationProps = {
   /**
    * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.
    */
-  revealOnFind?: boolean
+  openOnFind?: boolean
 
   /**
-   * Deprecated. Use `revealOnFind` instead.
-   * @deprecated Use `revealOnFind` instead.
+   * Deprecated. Use `openOnFind` instead.
+   * @deprecated Use `openOnFind` instead.
    */
   untilFound?: boolean
 
   /**
-   * Is called after matching content inside a closed animation is revealed by the browser using `revealOnFind`. Use it to synchronize external open state and controls.
+   * Is called after matching content inside a closed animation is opened using `openOnFind`. Use it to synchronize external open state and controls.
    */
   onBeforeMatch?: (event: Event) => void
 
@@ -72,7 +72,7 @@ function HeightAnimation({
   open = true,
   animate = true,
   keepInDOM = false,
-  revealOnFind,
+  openOnFind,
   untilFound,
   showOverflow = false,
   element,
@@ -92,13 +92,13 @@ function HeightAnimation({
   const flexLayout = useContext(FlexLayoutContext)
   const elementRef = useRef<HTMLElement>(undefined)
   const targetRef = ref || elementRef
-  const [isRevealedByMatch, setRevealedByMatch] = useState(false)
-  const shouldRevealOnFind = revealOnFind ?? untilFound ?? false
-  const resolvedOpen = open || (shouldRevealOnFind && isRevealedByMatch)
+  const [isOpenedByFind, setOpenedByFind] = useState(false)
+  const shouldOpenOnFind = openOnFind ?? untilFound ?? false
+  const resolvedOpen = open || (shouldOpenOnFind && isOpenedByFind)
 
   const handleAnimationStart: UseHeightAnimationOptions['onAnimationStart'] =
     (state) => {
-      if (shouldRevealOnFind && state === 'opening') {
+      if (shouldOpenOnFind && state === 'opening') {
         targetRef.current?.removeAttribute('hidden')
       }
       onAnimationStart?.(state)
@@ -106,7 +106,7 @@ function HeightAnimation({
   const handleAnimationEnd: UseHeightAnimationOptions['onAnimationEnd'] = (
     state
   ) => {
-    if (shouldRevealOnFind) {
+    if (shouldOpenOnFind) {
       if (state === 'closed') {
         targetRef.current?.style.removeProperty('visibility')
         targetRef.current?.setAttribute('hidden', 'until-found')
@@ -142,7 +142,7 @@ function HeightAnimation({
     }
 
     if (
-      shouldRevealOnFind &&
+      shouldOpenOnFind &&
       !resolvedOpen &&
       element.classList.contains('dnb-height-animation--hidden')
     ) {
@@ -150,17 +150,17 @@ function HeightAnimation({
     } else if (element.getAttribute('hidden') === 'until-found') {
       element.removeAttribute('hidden')
     }
-  }, [resolvedOpen, shouldRevealOnFind, targetRef])
+  }, [resolvedOpen, shouldOpenOnFind, targetRef])
 
   useLayoutEffect(() => {
-    if (isRevealedByMatch && (open || !shouldRevealOnFind)) {
-      setRevealedByMatch(false)
+    if (isOpenedByFind && (open || !shouldOpenOnFind)) {
+      setOpenedByFind(false)
     }
-  }, [isRevealedByMatch, open, shouldRevealOnFind])
+  }, [isOpenedByFind, open, shouldOpenOnFind])
 
   useLayoutEffect(() => {
     const element = targetRef.current
-    if (!element || !shouldRevealOnFind) {
+    if (!element || !shouldOpenOnFind) {
       return undefined
     }
 
@@ -168,7 +168,7 @@ function HeightAnimation({
       element.removeAttribute('hidden')
       element.classList.remove('dnb-height-animation--hidden')
       element.setAttribute('aria-hidden', 'false')
-      setRevealedByMatch(true)
+      setOpenedByFind(true)
       onBeforeMatch?.(event)
     }
     element.addEventListener('beforematch', handleBeforeMatch)
@@ -176,7 +176,7 @@ function HeightAnimation({
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
     }
-  }, [onBeforeMatch, shouldRevealOnFind, targetRef])
+  }, [onBeforeMatch, shouldOpenOnFind, targetRef])
 
   // Set CSS custom properties via the DOM instead of React's style
   // prop. React's SSR serializes custom properties without spaces
@@ -201,7 +201,7 @@ function HeightAnimation({
     }
   }, [duration, delay, targetRef, isInDOM])
 
-  const shouldKeepInDOM = keepInDOM || shouldRevealOnFind
+  const shouldKeepInDOM = keepInDOM || shouldOpenOnFind
 
   if (!shouldKeepInDOM && !isInDOM && !isAnimating) {
     return null

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -21,11 +21,6 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  untilFound: {
-    doc: 'Deprecated. Use `openOnFind` instead.',
-    type: 'boolean',
-    status: 'deprecated',
-  },
   compensateForGap: {
     doc: 'To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
     type: 'string',

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -16,10 +16,15 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  untilFound: {
+  revealOnFind: {
     doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
+  },
+  untilFound: {
+    doc: 'Deprecated. Use `revealOnFind` instead.',
+    type: 'boolean',
+    status: 'deprecated',
   },
   compensateForGap: {
     doc: 'To compensate for CSS gap between the rows, so animation does not jump during the animation. Provide a CSS unit or `auto`. Defaults to `null`.',
@@ -60,7 +65,7 @@ export const HeightAnimationProperties: PropertiesTableProps = {
 
 export const HeightAnimationEvents: PropertiesTableProps = {
   onBeforeMatch: {
-    doc: 'Is called after matching content inside a closed animation is revealed by the browser using `untilFound`. Use it to synchronize external open state and controls.',
+    doc: 'Is called after matching content inside a closed animation is revealed by the browser using `revealOnFind`. Use it to synchronize external open state and controls.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -16,13 +16,13 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
-  revealOnFind: {
+  openOnFind: {
     doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },
   untilFound: {
-    doc: 'Deprecated. Use `revealOnFind` instead.',
+    doc: 'Deprecated. Use `openOnFind` instead.',
     type: 'boolean',
     status: 'deprecated',
   },
@@ -65,7 +65,7 @@ export const HeightAnimationProperties: PropertiesTableProps = {
 
 export const HeightAnimationEvents: PropertiesTableProps = {
   onBeforeMatch: {
-    doc: 'Is called after matching content inside a closed animation is revealed by the browser using `revealOnFind`. Use it to synchronize external open state and controls.',
+    doc: 'Is called after matching content inside a closed animation is opened using `openOnFind`. Use it to synchronize external open state and controls.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -292,7 +292,7 @@ describe('HeightAnimation', () => {
     })
   })
 
-  describe('revealOnFind', () => {
+  describe('openOnFind', () => {
     it('should preserve a regular hidden attribute', () => {
       const { rerender } = render(
         <HeightAnimation hidden>content</HeightAnimation>
@@ -307,7 +307,7 @@ describe('HeightAnimation', () => {
 
     it('should keep initially closed content findable', () => {
       render(
-        <HeightAnimation open={false} revealOnFind>
+        <HeightAnimation open={false} openOnFind>
           <span className="content">content</span>
         </HeightAnimation>
       )
@@ -318,13 +318,13 @@ describe('HeightAnimation', () => {
 
     it('should remove hidden before opening', () => {
       const { rerender } = render(
-        <HeightAnimation open={false} revealOnFind>
+        <HeightAnimation open={false} openOnFind>
           content
         </HeightAnimation>
       )
 
       rerender(
-        <HeightAnimation open revealOnFind>
+        <HeightAnimation open openOnFind>
           content
         </HeightAnimation>
       )
@@ -335,12 +335,12 @@ describe('HeightAnimation', () => {
 
     it('should hide content only after the closing animation', () => {
       const { rerender } = render(
-        <HeightAnimation revealOnFind>content</HeightAnimation>
+        <HeightAnimation openOnFind>content</HeightAnimation>
       )
 
       mockHeight(100)
       rerender(
-        <HeightAnimation open={false} revealOnFind>
+        <HeightAnimation open={false} openOnFind>
           content
         </HeightAnimation>
       )
@@ -356,7 +356,7 @@ describe('HeightAnimation', () => {
 
     it('should reveal matched content without onBeforeMatch', () => {
       render(
-        <HeightAnimation open={false} revealOnFind>
+        <HeightAnimation open={false} openOnFind>
           content
         </HeightAnimation>
       )
@@ -373,7 +373,7 @@ describe('HeightAnimation', () => {
       render(
         <HeightAnimation
           open={false}
-          revealOnFind
+          openOnFind
           onBeforeMatch={onBeforeMatch}
         >
           content
@@ -396,9 +396,9 @@ describe('HeightAnimation', () => {
       expect(getElement()).toHaveAttribute('hidden', 'until-found')
     })
 
-    it('should prioritize revealOnFind over untilFound', () => {
+    it('should prioritize openOnFind over untilFound', () => {
       render(
-        <HeightAnimation open={false} revealOnFind={false} untilFound>
+        <HeightAnimation open={false} openOnFind={false} untilFound>
           content
         </HeightAnimation>
       )

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -292,7 +292,7 @@ describe('HeightAnimation', () => {
     })
   })
 
-  describe('untilFound', () => {
+  describe('revealOnFind', () => {
     it('should preserve a regular hidden attribute', () => {
       const { rerender } = render(
         <HeightAnimation hidden>content</HeightAnimation>
@@ -307,7 +307,7 @@ describe('HeightAnimation', () => {
 
     it('should keep initially closed content findable', () => {
       render(
-        <HeightAnimation open={false} untilFound>
+        <HeightAnimation open={false} revealOnFind>
           <span className="content">content</span>
         </HeightAnimation>
       )
@@ -318,13 +318,13 @@ describe('HeightAnimation', () => {
 
     it('should remove hidden before opening', () => {
       const { rerender } = render(
-        <HeightAnimation open={false} untilFound>
+        <HeightAnimation open={false} revealOnFind>
           content
         </HeightAnimation>
       )
 
       rerender(
-        <HeightAnimation open untilFound>
+        <HeightAnimation open revealOnFind>
           content
         </HeightAnimation>
       )
@@ -335,12 +335,12 @@ describe('HeightAnimation', () => {
 
     it('should hide content only after the closing animation', () => {
       const { rerender } = render(
-        <HeightAnimation untilFound>content</HeightAnimation>
+        <HeightAnimation revealOnFind>content</HeightAnimation>
       )
 
       mockHeight(100)
       rerender(
-        <HeightAnimation open={false} untilFound>
+        <HeightAnimation open={false} revealOnFind>
           content
         </HeightAnimation>
       )
@@ -356,7 +356,7 @@ describe('HeightAnimation', () => {
 
     it('should reveal matched content without onBeforeMatch', () => {
       render(
-        <HeightAnimation open={false} untilFound>
+        <HeightAnimation open={false} revealOnFind>
           content
         </HeightAnimation>
       )
@@ -373,7 +373,7 @@ describe('HeightAnimation', () => {
       render(
         <HeightAnimation
           open={false}
-          untilFound
+          revealOnFind
           onBeforeMatch={onBeforeMatch}
         >
           content
@@ -384,6 +384,26 @@ describe('HeightAnimation', () => {
 
       expect(onBeforeMatch).toHaveBeenCalledTimes(1)
       expect(getElement()).not.toHaveAttribute('hidden')
+    })
+
+    it('should support the deprecated untilFound prop', () => {
+      render(
+        <HeightAnimation open={false} untilFound>
+          content
+        </HeightAnimation>
+      )
+
+      expect(getElement()).toHaveAttribute('hidden', 'until-found')
+    })
+
+    it('should prioritize revealOnFind over untilFound', () => {
+      render(
+        <HeightAnimation open={false} revealOnFind={false} untilFound>
+          content
+        </HeightAnimation>
+      )
+
+      expect(getElement()).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
`openOnFind` better communicates that collapsed content opens when browser find-in-page locates a match. This keeps `untilFound` as a deprecated compatibility alias while guiding consumers toward the clearer API.

Thanks @kimroen for the good input.