### PR TITLE
chore(security): scope CI workflow secrets to least privilege

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,13 +21,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  GH_EMAIL: ${{ secrets.GH_EMAIL }}
-  GH_NAME: ${{ secrets.GH_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
+# No job-wide `env:` on purpose: the StackBlitz/pkg.pr.new preview publish needs
+# no repository secrets, so none are injected (least privilege).
 
 jobs:
   publish:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,17 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  GH_EMAIL: ${{ secrets.GH_EMAIL }}
-  GH_NAME: ${{ secrets.GH_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
-  ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
-  ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-  ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
-  ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+# No job-wide `env:` on purpose: only the public Algolia search config is
+# needed, and it is scoped to the portal build step (least privilege).
 
 jobs:
   e2e:
@@ -78,6 +69,11 @@ jobs:
 
       - name: Build portal
         run: yarn workspace dnb-design-system-portal build:e2e
+        env:
+          # Public search config embedded into the client bundle at build time.
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
 
       - name: Run Playwright on Portal
         run: yarn workspace dnb-design-system-portal test:e2e:portal:ci

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,10 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+# No job-wide `env:` on purpose: the build needs no repository secrets, and the
+# Cloudflare credentials are scoped to the deploy step that uses them.
 
 jobs:
   deploy-preview:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,13 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GH_EMAIL: ${{ secrets.GH_EMAIL }}
-  GH_NAME: ${{ secrets.GH_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
+# No job-wide `env:` on purpose: these jobs only install, audit, lint,
+# type-check, test and build — none need repository secrets (least privilege).
 
 jobs:
   setup:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -30,17 +30,9 @@ permissions:
   pull-requests: read
 
 env:
-  GH_EMAIL: ${{ secrets.GH_EMAIL }}
-  GH_NAME: ${{ secrets.GH_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  # Only non-secret build flags and the ephemeral, permission-scoped
+  # GITHUB_TOKEN remain here; the public Algolia config is scoped to the build.
   GITHUB_TOKEN: ${{ github.token }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
-  ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
-  ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-  ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
-  ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
   RUN_POST_BUILD: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}
   RUN_VISUAL_TEST: ${{ !startsWith(github.ref, 'refs/heads/icon') }}
   PLAYWRIGHT_SCREENSHOT_WORKERS: 100%
@@ -167,6 +159,11 @@ jobs:
       - name: Build portal
         if: env.RUN_VISUAL_TEST == 'true'
         run: yarn workspace dnb-design-system-portal build:visual-test
+        env:
+          # Public search config embedded into the client bundle at build time.
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
 
       - name: Run visual tests
         if: env.RUN_VISUAL_TEST == 'true'


### PR DESCRIPTION
## Motivation

Several CI workflows declared a workflow-level `env:` block that injected long-lived secrets — the npm publish token (`NPM_TOKEN`), `GH_TOKEN`, `GH_EMAIL`/`GH_NAME`, `FIGMA_TOKEN`/`FIGMA_ICONS_FILE` and the Algolia **admin** key (`ALGOLIA_API_KEY`) — into every job. Those jobs only install, lint, type-check, test, run Playwright and build; none of them use these secrets.

Exposing them workflow-wide means every step that runs the full dev-dependency tree does so with the npm publish token (and an Algolia admin key) in its environment. A single compromised dev dependency executing during a test or build step could exfiltrate them — an unnecessary supply-chain blast radius.

## Change

Following the pattern from #8949 (which did this for `release.yml`):

- **verify, dev, preview** — drop the job-wide `env:` entirely; a short comment explains why (no secret is needed, or it is already scoped to the step that uses it, e.g. Cloudflare on preview's deploy step).
- **e2e, visual-regression** — scope only the public Algolia search config (`ALGOLIA_APP_ID`/`SEARCH_KEY`/`INDEX_NAME`) into the portal build step, where Vite embeds it into the client bundle. Only non-secret build flags (and visual-regression's scoped, ephemeral `GITHUB_TOKEN`) remain workflow-wide.

`icons-lib.yml` is intentionally left untouched — it genuinely uses the Figma and GH credentials to fetch icons and commit them back.

Supersedes the closed #8972, whose branch had gone stale against `main`.
