### PR TITLE
chore(DrawerList): correct article in index comment (a -> an)

### DIFF
--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -222,7 +222,7 @@ export const getCurrentIndex = (value, data) => {
       return index
     }
   }
-  // 3. if is numeric, and no matching "selectedKey", handle it as a index.
+  // 3. if is numeric, and no matching "selectedKey", handle it as an index.
   if (!isNaN(parseFloat(value))) {
     return value
   }


### PR DESCRIPTION
Fixes a small grammar slip in a code comment in `DrawerListHelpers.ts`: "handle it as a index" -> "handle it as an index". This matches the sibling comment two lines above, which already correctly reads "an index".
