### PR TITLE
chore(List): use design token in custom background color example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
@@ -326,7 +326,7 @@ export const BackgroundColor = () => {
         <List.Item.Basic
           style={{
             ['--list-item-background-color' as string]:
-              'var(--color-mint-green-12)',
+              'var(--token-color-background-positive-subtle)',
           }}
         >
           Custom background color (not selected)


### PR DESCRIPTION
The custom background color example in the List documentation used a fixed palette color (`--color-mint-green-12`), which looks washed out in dark mode.

Replace it with the semantic design token `--token-color-background-positive-subtle` (green-50 in light mode, green-950 in dark mode) so the example adapts properly to both color schemes and stays consistent with the rest of the documentation.