### PR TITLE
chore: remove orphaned root precommit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "main": "./packages/eufemia/index.js",
   "scripts": {
-    "precommit": "yarn workspace @dnb/eufemia precommit && yarn workspace dnb-design-system-portal precommit",
     "start": "yarn workspace dnb-design-system-portal start",
     "clean": "yarn workspace dnb-design-system-portal clean && yarn workspace @dnb/eufemia clean && find . -name .vite -type d -exec rm -rf {} +",
     "reset": "yarn workspace dnb-design-system-portal reset && yarn workspace @dnb/eufemia reset && rm -rf ./node_modules && yarn install",


### PR DESCRIPTION
The root `precommit` script delegated to `precommit` scripts in `@dnb/eufemia` and `dnb-design-system-portal` that don't exist, so `yarn precommit` just errors. Nothing invokes it — no git hook, CI workflow, or docs reference it — so it is dead and misleading.

Removing it rather than wiring it to real checks, because without an actual pre-commit hook the script would still never run on commit. A proper hook setup can reintroduce it later.
