### PR TITLE
deps: bump @navikt/fnrvalidator from 2.1.5 to 2.2.1 - add support for fødselsnummer from 2032

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -108,7 +108,7 @@
     "@maskito/core": "5.1.0",
     "@maskito/kit": "5.1.0",
     "@maskito/react": "5.1.0",
-    "@navikt/fnrvalidator": "2.1.5",
+    "@navikt/fnrvalidator": "2.2.1",
     "@ungap/structured-clone": "1.3.1",
     "ajv": "8.18.0",
     "ajv-errors": "3.0.0",

--- a/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/NationalIdentityNumber/__tests__/NationalIdentityNumber.test.tsx
@@ -383,7 +383,7 @@ describe('Field.NationalIdentityNumber', () => {
 
     const invalidDNum = [
       '69020112345',
-      '53097248032',
+      '53097248031',
       '53097248023',
       '72127248022',
       '53137248022',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,7 +2780,7 @@ __metadata:
     "@modelcontextprotocol/node": "npm:2.0.0"
     "@modelcontextprotocol/server": "npm:2.0.0"
     "@modelcontextprotocol/server-legacy": "npm:2.0.0"
-    "@navikt/fnrvalidator": "npm:2.1.5"
+    "@navikt/fnrvalidator": "npm:2.2.1"
     "@playwright/test": "npm:1.60.0"
     "@semantic-release/changelog": "npm:6.0.3"
     "@semantic-release/commit-analyzer": "npm:13.0.1"
@@ -4213,10 +4213,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/fnrvalidator@npm:2.1.5":
-  version: 2.1.5
-  resolution: "@navikt/fnrvalidator@npm:2.1.5"
-  checksum: 10/6004890b3046d957f117b8566d6b12bc254cb5417a6fa9dd800a807bbb78d6775165d8c2aba5f1c1561b499341d4e97d662589a9d708651ae59aee06411ce66d
+"@navikt/fnrvalidator@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@navikt/fnrvalidator@npm:2.2.1"
+  checksum: 10/a072275b24aa6332d403d7f98c30ce408e5638649b3bca98b12462ce88b8492599516c6ee5d3d7d3b7f27cd9314e0f70c4e131cd963ba38271907bb56403fedf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Routine maintenance bump of the `@navikt/fnrvalidator` runtime dependency (used for Norwegian national identity number validation, shipped to consumers) from 2.1.5 to 2.2.1 to stay current with upstream fixes.
