### PR TITLE
chore: replace ci commit type with deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,7 +67,7 @@ updates:
     labels:
       - 'dependencies'
     commit-message:
-      prefix: 'chore(ci)'
+      prefix: 'chore(deps)'
     groups:
       actions:
         patterns:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           if echo "$PR_TITLE" | grep -qE '^release of '; then
             echo "PR title is a release: $PR_TITLE"
-          elif echo "$PR_TITLE" | grep -qE '^(fix|feat|chore|docs|style|design|build|ci|refactor|perf|test)(\(.+\))?!?:'; then
+          elif echo "$PR_TITLE" | grep -qE '^(fix|feat|chore|docs|style|design|build|deps|refactor|perf|test)(\(.+\))?!?:'; then
             echo "PR title is valid: $PR_TITLE"
           else
             echo "::error::Invalid PR title: '$PR_TITLE'"
@@ -32,7 +32,7 @@ jobs:
             echo "The PR title must follow Conventional Commits format:"
             echo "  type(optional-scope): description"
             echo ""
-            echo "Valid types: fix, feat, chore, docs, style, design, build, ci, refactor, perf, test"
+            echo "Valid types: fix, feat, chore, docs, style, design, build, deps, refactor, perf, test"
             echo ""
             echo "Examples:"
             echo "  fix: correct button alignment"

--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
@@ -47,7 +47,7 @@ You can also use the following decorators – but keep in mind, they won't be in
 - `docs:`
 - `style:`
 - `build:`
-- `ci:`
+- `deps:`
 - `refactor:`
 - `perf:`
 - `test:`

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -342,8 +342,8 @@
                 "hidden": false
               },
               {
-                "type": "ci",
-                "section": ":repeat: CI",
+                "type": "deps",
+                "section": ":package: Dependencies",
                 "hidden": false
               }
             ]


### PR DESCRIPTION
The dependency-related Conventional Commit category is currently named `ci`, which is narrower than its intended use. Use `deps` consistently for PR title validation, generated dependency updates, contributor guidance, and release notes.