### PR TITLE
deps: bump maskito from 5.1.0 to 5.4.0

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -105,9 +105,9 @@
   "types": "./index.d.ts",
   "dependencies": {
     "@babel/runtime-corejs3": "7.28.4",
-    "@maskito/core": "5.1.0",
-    "@maskito/kit": "5.1.0",
-    "@maskito/react": "5.1.0",
+    "@maskito/core": "5.4.0",
+    "@maskito/kit": "5.4.0",
+    "@maskito/react": "5.4.0",
     "@navikt/fnrvalidator": "2.2.1",
     "@ungap/structured-clone": "1.3.1",
     "ajv": "8.20.0",

--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -529,7 +529,17 @@ function cleanNumericValue(value: string, rawMask: TextMaskMask): string {
     'maskParams' in rawMask
   ) {
     const mp = rawMask.maskParams as MaskParams
-    return stripAffixes(value, mp.prefix ?? '', mp.suffix ?? '')
+    const result = stripAffixes(value, mp.prefix ?? '', mp.suffix ?? '')
+
+    // A dynamic suffix (e.g. currency name "krone" vs "kroner") won't match the
+    // current suffix option; drop the trailing non-numeric characters so Maskito
+    // 5.4 can re-parse the value. Otherwise it drops the number and resets the
+    // caret. Digits, decimal/thousand separators and the minus sign are kept.
+    if (mp.suffix) {
+      return result.replace(/[^\d.,·-]+$/, '')
+    }
+
+    return result
   }
 
   return value

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -510,6 +510,17 @@ describe('Field.Currency', () => {
       expect(input.selectionStart).toBe(1)
       expect(input.selectionEnd).toBe(1)
     })
+
+    it('should keep decimals when the dynamic suffix changes', async () => {
+      render(<Field.Currency currencyDisplay="name" decimalLimit={2} />)
+
+      const input = document.querySelector('input')
+
+      await userEvent.type(input, '1,5')
+      expect(input).toHaveValue('1,5 kroner')
+      expect(input.selectionStart).toBe(3)
+      expect(input.selectionEnd).toBe(3)
+    })
   })
 
   describe('disallowLeadingZeroes', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Currency/__tests__/Currency.test.tsx
@@ -521,6 +521,17 @@ describe('Field.Currency', () => {
       expect(input.selectionStart).toBe(3)
       expect(input.selectionEnd).toBe(3)
     })
+
+    it('should keep the caret for negative values with a dynamic suffix', async () => {
+      render(<Field.Currency currencyDisplay="name" />)
+
+      const input = document.querySelector('input')
+
+      await userEvent.type(input, '-1')
+      expect(input).toHaveValue('-1 krone')
+      expect(input.selectionStart).toBe(2)
+      expect(input.selectionEnd).toBe(2)
+    })
   })
 
   describe('disallowLeadingZeroes', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,9 +2792,9 @@ __metadata:
     "@eslint/compat": "npm:2.1.0"
     "@eslint/eslintrc": "npm:3.3.5"
     "@eslint/js": "npm:10.0.1"
-    "@maskito/core": "npm:5.1.0"
-    "@maskito/kit": "npm:5.1.0"
-    "@maskito/react": "npm:5.1.0"
+    "@maskito/core": "npm:5.4.0"
+    "@maskito/kit": "npm:5.4.0"
+    "@maskito/react": "npm:5.4.0"
     "@modelcontextprotocol/node": "npm:2.0.0"
     "@modelcontextprotocol/server": "npm:2.0.0"
     "@modelcontextprotocol/server-legacy": "npm:2.0.0"
@@ -4050,30 +4050,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@maskito/core@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@maskito/core@npm:5.1.0"
-  checksum: 10/68c1ab53c0b95332087c8919a33255f429b4acb09d9756a3e936084e569ea19c2a7e6f26eeb59f7a6d7518916174791e77e6c1addd21e3b743d59d89c07eb946
+"@maskito/core@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@maskito/core@npm:5.4.0"
+  checksum: 10/aeef91c91eab13819f4136ae20b677229dee7b49c73a9de783f90eef910b1bb6df2514fbcad3f05bbb5ce372603479268b5c4a13dd3eb7ce77004c2c5bde0ffd
   languageName: node
   linkType: hard
 
-"@maskito/kit@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@maskito/kit@npm:5.1.0"
+"@maskito/kit@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@maskito/kit@npm:5.4.0"
   peerDependencies:
-    "@maskito/core": ^5.1.0
-  checksum: 10/dbfef7e4b2a61f649519df8f04b0f2f3c52278e1684d9a1e99281be9b23155a8f4bf28614d1b26a40e0a24b87c0b9a7a096fda19339448327a1a1bd324dccb18
+    "@maskito/core": ^5.4.0
+  checksum: 10/ad23f3ff2654982f12e594c09c1f5d83c5e8fa661936c1e64d6ec869ae389757fae4f1e57824821cefc20792d95c71197ce029bfa1313402c2ec3e4989b6f018
   languageName: node
   linkType: hard
 
-"@maskito/react@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@maskito/react@npm:5.1.0"
+"@maskito/react@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@maskito/react@npm:5.4.0"
   peerDependencies:
-    "@maskito/core": ^5.1.0
+    "@maskito/core": ^5.4.0
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 10/9f74bfeecacfa634ae441d9612bcefc0dab9e127e9b16b899c6d16e69a2fe35baa5383640a079610d351e0a9fc925c463df7e7e73510e8296bfebe6d2c977f03
+  checksum: 10/50db8382f0edc8c251a7a5b9bc3c0d6407f589bd8a3885c86872038586601338a9d72761071eae7b8e1e7731312cb00511c461e14af904e27c9a45d2125968fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the `@maskito` runtime packages (`@maskito/core`, `@maskito/kit`, `@maskito/react`) from 5.1.0 to 5.4.0. These power the masked inputs in `InputMasked` (Amount/currency/number, phone and date masks).

The 5.1 → 5.4 range fixes concrete masked-input typing bugs that affect end users, in exactly the `Number` mask and caret handling Eufemia uses (`maskitoNumberOptionsGenerator`, `maskitoCaretGuard`):

- `Number` deleting the previous non-selected character on the first deletion
- caret shift on minus insertion with `negativePattern=minusFirst` + prefix
- `Number` ignoring digits in affixes for min/max validation
- Date/Time separator-deletion fixes

5.4.0 also sets `sideEffects: false` across the packages, improving tree-shaking (smaller consumer bundles).
