### PR TITLE
deps: bump ajv from 8.18.0 to 8.20.0

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -110,7 +110,7 @@
     "@maskito/react": "5.1.0",
     "@navikt/fnrvalidator": "2.1.5",
     "@ungap/structured-clone": "1.3.1",
-    "ajv": "8.18.0",
+    "ajv": "8.20.0",
     "ajv-errors": "3.0.0",
     "clsx": "2.1.1",
     "core-js-pure": "3.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,7 +2802,7 @@ __metadata:
     "@vitest/browser": "npm:4.1.10"
     "@vitest/browser-playwright": "npm:4.1.10"
     "@vitest/eslint-plugin": "npm:1.6.19"
-    ajv: "npm:8.18.0"
+    ajv: "npm:8.20.0"
     ajv-errors: "npm:3.0.0"
     babel-plugin-fully-specified: "npm:1.3.1"
     babel-plugin-optimize-clsx: "npm:2.6.2"
@@ -6495,15 +6495,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.18.0, ajv@npm:^8.0.1":
-  version: 8.18.0
-  resolution: "ajv@npm:8.18.0"
+"ajv@npm:8.20.0, ajv@npm:^8.0.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10/bfed9de827a2b27c6d4084324eda76a4e32bdde27410b3e9b81d06e6f8f5c78370fc6b93fe1d869f1939ff1d7c4ae8896960995acb8425e3e9288c8884247c48
+  checksum: 10/5ce59c0537f4c2aca9a758b412659ec70acb4d5dde971c10ecf21d2e3d799f99acdb4a08e1f5fb2e067c8542930398aae793bb996bb07d3feb81dae22fe2ada9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `ajv` from 8.18.0 to 8.20.0. `ajv` powers JSON-schema validation in the Forms extension (`Form`/`Field` validation via `extensions/forms/utils/ajv.ts`).

Motivation:
- 8.19.0 fixes a prototype-pollution issue in the `format` keyword when used with a `$data` reference (security hardening for consumers validating with user-influenced schemas).
- 8.20.0 adds Node 22/24 support.

Drop-in minor upgrade. `yarn dedupe` unifies the transitive v8 copy onto 8.20.0; the separate `ajv@6` used by lint tooling is unaffected.
