### PR TITLE
chore(ci): add pinact check to enforce SHA-pinned actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -253,3 +253,28 @@ jobs:
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ github.token }}
         run: yarn workspace @dnb/eufemia build:size
+
+  actions-pins:
+    name: Check action pins
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Fail if any action isn't pinned to a full commit SHA. Offline syntactic
+      # check; .pinact.yaml extends the scan to the composite action + GHE templates.
+      - name: Verify actions are pinned to a full commit SHA
+        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+        with:
+          fix: 'false'
+          no_api: 'true'
+          config: .pinact.yaml

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+files:
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml
+  - pattern: .github/actions/*/action.yml
+  - pattern: .github/actions/*/action.yaml
+  # Deploy-workflow templates live outside .github/workflows, so neither Dependabot
+  # nor pinact's default scan sees them; list them explicitly.
+  - pattern: tools/*/ghe-deploy-workflow.yml


### PR DESCRIPTION
Adds a CI guard (pinact) that fails the build if any GitHub Action isn't pinned to a full commit SHA — the supply-chain hardening that protects against mutable-tag attacks (e.g. the `tj-actions/changed-files` compromise).

- Runs in `verify.yml` as a lightweight `actions-pins` job (offline: `--fix=false --no-api`, so no GitHub API calls or token needed).
- `.pinact.yaml` extends the scan beyond pinact's defaults to the composite action (`.github/actions/setup/action.yml`) and the GHE deploy templates (`tools/*/ghe-deploy-workflow.yml`) — the spots Dependabot doesn't watch.

Note: pinact's version-comment verification (`--verify`) is intentionally not enabled. It requires full-semver comments (e.g. `# v6.0.2`), which conflicts with this repo's major-only convention (`# v6`). Switching to full-semver comments to also catch comment drift can be a follow-up if the team wants it.
