### PR TITLE
chore(analytics): Akamai origin lock and custom domain

### DIFF
--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -15,11 +15,11 @@ Records are written to S3 as one JSON object per record, partitioned by date. A 
 
 | Route           | Auth   | Description                                             |
 | --------------- | ------ | ------------------------------------------------------- |
-| `GET /healthz`  | open   | Liveness probe                                          |
+| `GET /healthz`  | edge   | Liveness probe                                          |
 | `POST /records` | bearer | Store a record: `{ "id", "name", "value" }`             |
 | `GET /records`  | bearer | Retrieve records; optional `?id=` and `?limit=` filters |
 
-Auth is a bearer token compared against the `API_TOKEN` environment variable. When `API_TOKEN` is unset, auth is disabled (local/demo only).
+Auth is a bearer token compared against the `API_TOKEN` environment variable, and the origin additionally requires the Akamai `X-Edge-Auth` header.
 
 ### Record shape
 

--- a/tools/analytics/__tests__/http.test.ts
+++ b/tools/analytics/__tests__/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { isAuthorized } from '../src/lambda/http.js'
+import { isAuthorized, isEdgeAuthorized } from '../src/lambda/http.js'
 
 describe('isAuthorized', () => {
   const original = process.env.API_TOKEN
@@ -47,5 +47,41 @@ describe('isAuthorized', () => {
     expect(isAuthorized({ authorization: 'Basic secret-token' })).toBe(
       false
     )
+  })
+})
+
+describe('isEdgeAuthorized', () => {
+  const original = process.env.EDGE_AUTH_SECRET
+
+  beforeEach(() => {
+    delete process.env.EDGE_AUTH_SECRET
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.EDGE_AUTH_SECRET
+    } else {
+      process.env.EDGE_AUTH_SECRET = original
+    }
+  })
+
+  it('allows any request when EDGE_AUTH_SECRET is not set', () => {
+    expect(isEdgeAuthorized(undefined)).toBe(true)
+    expect(isEdgeAuthorized({})).toBe(true)
+  })
+
+  it('accepts a matching X-Edge-Auth header', () => {
+    process.env.EDGE_AUTH_SECRET = 'edge-secret'
+
+    expect(isEdgeAuthorized({ 'x-edge-auth': 'edge-secret' })).toBe(true)
+    expect(isEdgeAuthorized({ 'X-Edge-Auth': 'edge-secret' })).toBe(true)
+  })
+
+  it('rejects a wrong or missing header when the secret is set', () => {
+    process.env.EDGE_AUTH_SECRET = 'edge-secret'
+
+    expect(isEdgeAuthorized(undefined)).toBe(false)
+    expect(isEdgeAuthorized({})).toBe(false)
+    expect(isEdgeAuthorized({ 'x-edge-auth': 'wrong' })).toBe(false)
   })
 })

--- a/tools/analytics/__tests__/index.test.ts
+++ b/tools/analytics/__tests__/index.test.ts
@@ -179,3 +179,49 @@ describe('handler', () => {
     expect(res.statusCode).toBe(404)
   })
 })
+
+describe('handler origin auth (X-Edge-Auth)', () => {
+  beforeEach(() => {
+    storeRecord.mockReset()
+    retrieveRecords.mockReset()
+    process.env.API_TOKEN = 'secret'
+    process.env.EDGE_AUTH_SECRET = 'edge-secret'
+  })
+
+  afterEach(() => {
+    delete process.env.API_TOKEN
+    delete process.env.EDGE_AUTH_SECRET
+  })
+
+  it('requires the edge header for /healthz when the edge secret is set', async () => {
+    const missing = await invoke(event('GET', '/healthz'))
+    expect(missing.statusCode).toBe(403)
+
+    const withHeader = await invoke(
+      event('GET', '/healthz', {
+        headers: { 'x-edge-auth': 'edge-secret' },
+      })
+    )
+    expect(withHeader.statusCode).toBe(200)
+  })
+
+  it('rejects with 403 when the edge header is missing', async () => {
+    const res = await invoke(
+      event('POST', '/records', { body: '{}', headers: auth })
+    )
+
+    expect(res.statusCode).toBe(403)
+    expect(storeRecord).not.toHaveBeenCalled()
+  })
+
+  it('lets the request through when the edge header matches', async () => {
+    const res = await invoke(
+      event('GET', '/records', {
+        headers: { ...auth, 'x-edge-auth': 'edge-secret' },
+        query: { id: 'abc' },
+      })
+    )
+
+    expect(res.statusCode).toBe(200)
+  })
+})

--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           TF_VAR_cost_allocation: ${{ vars.COST_ALLOCATION }}
           TF_VAR_api_token: ${{ secrets.API_TOKEN }}
+          TF_VAR_edge_auth_secret: ${{ secrets.EDGE_AUTH_SECRET }}
         run: |
           set -euo pipefail
           cd infra

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -200,6 +200,9 @@ resource "aws_lambda_function" "analytics" {
       GLUE_TABLE       = aws_glue_catalog_table.records.name
       ATHENA_WORKGROUP = aws_athena_workgroup.analytics.name
       API_TOKEN        = var.api_token
+
+      # Shared secret for the X-Edge-Auth origin check (injected by Akamai).
+      EDGE_AUTH_SECRET = var.edge_auth_secret
     }
   }
 
@@ -260,4 +263,74 @@ resource "aws_lambda_permission" "apigw" {
   function_name = aws_lambda_function.analytics.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.analytics.execution_arn}/*/*"
+}
+
+# ---------------------------------------------------------------------------
+# Custom domain (origin for Akamai)
+# ---------------------------------------------------------------------------
+
+# Custom domain used as the Akamai origin.
+data "aws_route53_zone" "eufemia" {
+  name = var.domain_zone
+}
+
+resource "aws_acm_certificate" "analytics" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+  tags              = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.analytics.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.eufemia.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 300
+}
+
+resource "aws_acm_certificate_validation" "analytics" {
+  certificate_arn         = aws_acm_certificate.analytics.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}
+
+resource "aws_apigatewayv2_domain_name" "analytics" {
+  domain_name = var.domain_name
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate_validation.analytics.certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_apigatewayv2_api_mapping" "analytics" {
+  api_id      = aws_apigatewayv2_api.analytics.id
+  domain_name = aws_apigatewayv2_domain_name.analytics.id
+  stage       = aws_apigatewayv2_stage.analytics.id
+}
+
+resource "aws_route53_record" "analytics" {
+  zone_id = data.aws_route53_zone.eufemia.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.analytics.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.analytics.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
 }

--- a/tools/analytics/infra/outputs.tf
+++ b/tools/analytics/infra/outputs.tf
@@ -3,6 +3,11 @@ output "api_endpoint" {
   value       = aws_apigatewayv2_stage.analytics.invoke_url
 }
 
+output "origin_domain" {
+  description = "Custom origin hostname for Akamai to point at"
+  value       = aws_apigatewayv2_domain_name.analytics.domain_name
+}
+
 output "function_name" {
   value = aws_lambda_function.analytics.function_name
 }

--- a/tools/analytics/infra/variables.tf
+++ b/tools/analytics/infra/variables.tf
@@ -26,6 +26,29 @@ variable "api_token" {
 
   validation {
     condition     = length(var.api_token) > 0
-    error_message = "api_token must be non-empty; an empty token would leave the HTTP API publicly readable and writable."
+    error_message = "api_token must be a non-empty value."
+  }
+}
+
+variable "domain_zone" {
+  type        = string
+  description = "Route 53 hosted zone name (trailing dot is required by AWS)."
+  default     = "dev.eufemia.tech-03.net."
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Custom origin domain for the analytics API (no trailing dot)."
+  default     = "analytics.dev.eufemia.tech-03.net"
+}
+
+variable "edge_auth_secret" {
+  type        = string
+  description = "Shared secret for the X-Edge-Auth header injected by Akamai."
+  sensitive   = true
+
+  validation {
+    condition     = length(var.edge_auth_secret) > 0
+    error_message = "edge_auth_secret must be a non-empty value."
   }
 }

--- a/tools/analytics/src/lambda/http.ts
+++ b/tools/analytics/src/lambda/http.ts
@@ -26,11 +26,8 @@ export function json(
 }
 
 /**
- * Simple bearer-token check.
- *
- * The expected token is read from the `API_TOKEN` environment variable. When
- * `API_TOKEN` is not set, auth is disabled (useful for local testing only).
- * Returns `true` when the request is authorized.
+ * Bearer-token check against the `API_TOKEN` environment variable.
+ * Returns `true` when the request carries a matching bearer token.
  */
 export function isAuthorized(
   headers: Record<string, string | undefined> | undefined
@@ -49,4 +46,22 @@ export function isAuthorized(
     token !== undefined &&
     safeEqual(token, expected)
   )
+}
+
+/**
+ * Origin lock: verifies the `X-Edge-Auth` header (injected by Akamai) against
+ * `EDGE_AUTH_SECRET`, so only the edge can reach the origin directly.
+ */
+export function isEdgeAuthorized(
+  headers: Record<string, string | undefined> | undefined
+): boolean {
+  const expected = process.env.EDGE_AUTH_SECRET
+
+  if (!expected) {
+    return true
+  }
+
+  const provided = headers?.['x-edge-auth'] ?? headers?.['X-Edge-Auth']
+
+  return provided !== undefined && safeEqual(provided, expected)
 }

--- a/tools/analytics/src/lambda/index.ts
+++ b/tools/analytics/src/lambda/index.ts
@@ -2,7 +2,7 @@ import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyResultV2,
 } from 'aws-lambda'
-import { isAuthorized, json } from './http.js'
+import { isAuthorized, isEdgeAuthorized, json } from './http.js'
 import { storeRecord } from './store.js'
 import { InvalidQueryError, retrieveRecords } from './retrieve.js'
 import { validateRecordInput } from '../types.js'
@@ -72,7 +72,7 @@ async function handleRetrieve(
  * HTTP API entry point.
  *
  * Routes:
- * - `GET  /healthz`  liveness probe (open, no auth)
+ * - `GET  /healthz`  liveness probe (no bearer token)
  * - `POST /records`  store a record in S3
  * - `GET  /records`  retrieve records via Athena (optional `id`, `limit`)
  */
@@ -81,6 +81,10 @@ export async function handler(
 ): Promise<APIGatewayProxyResultV2> {
   const method = event.requestContext.http.method
   const path = event.rawPath
+
+  if (!isEdgeAuthorized(event.headers)) {
+    return json(403, { error: 'Forbidden' })
+  }
 
   if (method === 'GET' && path === '/healthz') {
     return json(200, { status: 'ok' })


### PR DESCRIPTION
## Motivation
Lock the analytics origin so it only accepts traffic from the Akamai edge, and give it a stable custom domain for Akamai to front — mirroring the MCP setup.

## What
- **Origin lock:** the Lambda validates an `X-Edge-Auth` header (constant-time) against `EDGE_AUTH_SECRET`. Empty secret disables the check (local/pre-edge). Health stays open; missing/wrong header → 403.
- **Custom domain:** ACM certificate + API Gateway custom domain + Route53 alias for `analytics.dev.eufemia.tech-03.net` (the Akamai origin).
