### PR TITLE
chore(analytics): deploy on code changes not the release

### DIFF
--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -7,20 +7,21 @@ name: Analytics Lambda
 # repository where OIDC federation handles AWS authentication.
 #
 # Triggers:
-# - `release` branch and `v*` / `v*.*.*` tags — deploys automatically.
-# - Any branch under the `analytics/` prefix (e.g. `analytics/new-field`).
-# - `workflow_dispatch` — manual deploy from the Actions tab.
+# - Push to `main` that touches `tools/analytics/**` (or this workflow) — deploys automatically.
+# - `workflow_dispatch` — manual deploy from the Actions tab (any branch).
+#
+# Analytics is self-contained (no Eufemia docs dependency), so it deploys on its
+# own code changes rather than on every Eufemia release like the MCP server.
 #
 # See tools/analytics/README.md for deploy details.
 
 on:
   push:
     branches:
-      - release
-      - 'analytics/**'
-    tags:
-      - 'v*'
-      - 'v*.*.*'
+      - main
+    paths:
+      - 'tools/analytics/**'
+      - '.github/workflows/analytics-lambda.yml'
   workflow_dispatch:
 
 permissions:

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -73,7 +73,7 @@ public GitHub (.github/workflows/analytics-lambda.yml)
           → OIDC assume role → terraform apply
 ```
 
-- **Triggers** (`analytics-lambda.yml`): the `release` branch, any `analytics/**` branch, `v*` tags, or manual `workflow_dispatch`.
+- **Triggers** (`analytics-lambda.yml`): a push to `main` touching `tools/analytics/**` (or the workflow), or a manual `workflow_dispatch` from any branch. Analytics deploys on its own code changes, not on every Eufemia release (it has no Eufemia docs dependency, unlike the MCP server).
 - The public workflow copies `ghe-deploy-workflow.yml` onto the GHE `deploy` branch, so the deploy job is self-installing — no manual workflow setup in the GHE repo.
 - On forks and PRs without deploy credentials, the build-and-push step is skipped (tests still run).
 


### PR DESCRIPTION
## Motivation
Analytics is self-contained — no Eufemia docs dependency, unlike the MCP server — so it should deploy when its own code changes, not on the release train.

## What
- Deploy on push to `main` touching `tools/analytics/**` (or this workflow), plus manual `workflow_dispatch` from any branch.
- Drop the `release` branch, `v*` tags, and `analytics/**` triggers.
