### PR TITLE
chore(mcp): add legacy Cloudflare endpoint deprecation proxy

### DIFF
--- a/.github/workflows/mcp-legacy-proxy-deploy.yml
+++ b/.github/workflows/mcp-legacy-proxy-deploy.yml
@@ -1,0 +1,85 @@
+name: MCP legacy proxy deploy
+
+# Deploys the legacy Cloudflare Worker that keeps the old MCP URL
+# (eufemia-mcp.eufemia.workers.dev) working during migration. Runs on merges to
+# main that touch the proxy, and can be dispatched manually to flip MODE
+# (proxy -> redirect -> gone) without a code change.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/mcp-legacy-proxy/**'
+      - '.github/workflows/mcp-legacy-proxy-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'MODE override (proxy | redirect | gone). Empty = use wrangler.toml.'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}
+
+      # The Cloudflare credentials are scoped to the deploy step that uses them.
+      - name: Skip if Cloudflare credentials are missing
+        id: gate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "Cloudflare credentials are not set; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy Worker
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Passed via env (not inlined) so the dispatch input cannot inject
+          # shell commands into the run step.
+          MODE: ${{ github.event.inputs.mode }}
+          REF_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          EXTRA=()
+          if [ -n "${MODE:-}" ]; then
+            case "${MODE}" in
+              proxy | redirect | gone) EXTRA+=(--var "MODE:${MODE}") ;;
+              *)
+                echo "Invalid MODE '${MODE}' (expected proxy | redirect | gone)" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          yarn workspace @dnb/eufemia-mcp-legacy-proxy exec wrangler deploy \
+            --message "${REF_SHA} via GitHub Actions" \
+            "${EXTRA[@]}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -103,7 +103,9 @@ jobs:
           restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-eslint-eufemia-
 
       - name: Run lint
-        run: yarn workspace @dnb/eufemia lint:ci
+        run: |
+          yarn workspace @dnb/eufemia lint:ci
+          yarn workspace @dnb/eufemia-mcp-legacy-proxy lint
 
   lint-portal:
     name: Run portal lint
@@ -173,6 +175,7 @@ jobs:
           yarn workspace dnb-design-system-portal test:types
           yarn workspace eufemia-css-optimizer test:types
           yarn workspace eufemia-llm-metadata test:types
+          yarn workspace @dnb/eufemia-mcp-legacy-proxy typecheck
 
   test:
     name: Run tests
@@ -200,6 +203,7 @@ jobs:
           yarn workspace eufemia-css-optimizer test
           yarn workspace markdown-tables-utils test
           yarn workspace eufemia-llm-metadata test
+          yarn workspace @dnb/eufemia-mcp-legacy-proxy test
 
   deps:
     name: Run dependency checks

--- a/tools/mcp-legacy-proxy/README.md
+++ b/tools/mcp-legacy-proxy/README.md
@@ -49,20 +49,22 @@ yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy
 Phase the endpoint down without editing code:
 
 ```bash
-wrangler deploy --var MODE:redirect   # step to 308
-wrangler deploy --var MODE:gone       # final 410
+yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy --var MODE:redirect
+yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy --var MODE:gone
 ```
 
 ## Rollback
 
 - Revert `MODE` (e.g. `gone` → `redirect` → `proxy`) and re-deploy, **or**
-- `wrangler rollback` to the previous deployed version.
+- Run `yarn workspace @dnb/eufemia-mcp-legacy-proxy exec wrangler rollback`.
 
 ## Migration plan
 
 1. Deploy in `proxy` mode; announce the new URL and sunset date.
-2. Monitor legacy traffic (Worker logs: `wrangler tail`) — each request logs
-   `{ method, client, status }` only; no credentials or bodies are recorded.
+2. Monitor legacy traffic with
+   `yarn workspace @dnb/eufemia-mcp-legacy-proxy exec wrangler tail` — each
+   request logs `{ method, client, status }` only; no credentials or bodies are
+   recorded.
 3. When legacy traffic is low, switch to `redirect` (`308`).
 4. After the final support period, switch to `gone` (`410`).
 

--- a/tools/mcp-legacy-proxy/README.md
+++ b/tools/mcp-legacy-proxy/README.md
@@ -1,0 +1,70 @@
+# Eufemia MCP legacy proxy (Cloudflare Worker)
+
+Deprecation compatibility layer for the **old** Cloudflare-hosted MCP endpoint.
+
+- **Deprecated:** `https://eufemia-mcp.eufemia.workers.dev/mcp`
+- **Current:** `https://server.eufemia.dnb.no/mcp/web`
+
+Existing users may still have the old URL configured. This Worker keeps that URL
+working during the migration window and makes the new URL visible to both
+clients (via headers / redirect) and agents (via the MCP `initialize`
+instructions and JSON-RPC error messages).
+
+The new server is stateless, POST-only, unauthenticated, and returns JSON (not
+SSE), so this proxy is deliberately small.
+
+## Behaviour (`MODE`)
+
+The endpoint is phased down by changing the `MODE` var — no code change needed:
+
+| `MODE`     | Response                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`    | Forward `POST` to the new endpoint, add deprecation headers, inject a migration notice into the `initialize` instructions. **Default.** |
+| `redirect` | `308 Permanent Redirect` to the new endpoint (+ JSON-RPC error body for clients that don't follow redirects).                           |
+| `gone`     | `410 Gone` with a migration message.                                                                                                    |
+
+Every response carries `Deprecation` (RFC 9745), `Sunset` (RFC 8594), and
+`Link: <…>; rel="successor-version"`.
+
+## Develop
+
+```bash
+yarn workspace @dnb/eufemia-mcp-legacy-proxy dev        # local worker
+yarn workspace @dnb/eufemia-mcp-legacy-proxy test       # unit tests
+yarn workspace @dnb/eufemia-mcp-legacy-proxy typecheck
+```
+
+## Deploy
+
+Requires Cloudflare credentials for the account that owns the
+`eufemia-mcp.eufemia.workers.dev` hostname (`wrangler login`, or
+`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`). The Worker `name` is
+`eufemia-mcp`, so with the `eufemia` account subdomain it serves the original
+`eufemia-mcp.eufemia.workers.dev` URL.
+
+```bash
+yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy
+```
+
+Phase the endpoint down without editing code:
+
+```bash
+wrangler deploy --var MODE:redirect   # step to 308
+wrangler deploy --var MODE:gone       # final 410
+```
+
+## Rollback
+
+- Revert `MODE` (e.g. `gone` → `redirect` → `proxy`) and re-deploy, **or**
+- `wrangler rollback` to the previous deployed version.
+
+## Migration plan
+
+1. Deploy in `proxy` mode; announce the new URL and sunset date.
+2. Monitor legacy traffic (Worker logs: `wrangler tail`) — each request logs
+   `{ method, client, status }` only; no credentials or bodies are recorded.
+3. When legacy traffic is low, switch to `redirect` (`308`).
+4. After the final support period, switch to `gone` (`410`).
+
+Update the `SUNSET` / `DEPRECATION_DATE` vars in [`wrangler.toml`](./wrangler.toml)
+once the dates are agreed.

--- a/tools/mcp-legacy-proxy/README.md
+++ b/tools/mcp-legacy-proxy/README.md
@@ -36,19 +36,19 @@ yarn workspace @dnb/eufemia-mcp-legacy-proxy typecheck
 
 ## Deploy
 
-Requires Cloudflare credentials for the account that owns the
-`eufemia-mcp.eufemia.workers.dev` hostname (`wrangler login`, or
-`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`). The Worker `name` is
-`eufemia-mcp`, so with the `eufemia` account subdomain it serves the original
-`eufemia-mcp.eufemia.workers.dev` URL.
+Merges to `main` that touch this workspace auto-deploy via
+[`mcp-legacy-proxy-deploy.yml`](../../.github/workflows/mcp-legacy-proxy-deploy.yml),
+using the repo's `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets. The
+Worker `name` is `eufemia-mcp`, so with the `eufemia` account subdomain it serves
+the original `eufemia-mcp.eufemia.workers.dev` URL.
+
+Phase the endpoint down without a code change by dispatching the workflow with a
+`mode` input (`proxy` | `redirect` | `gone`) from the Actions tab.
+
+To deploy manually (needs `wrangler login` or the Cloudflare env vars):
 
 ```bash
 yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy
-```
-
-Phase the endpoint down without editing code:
-
-```bash
 yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy --var MODE:redirect
 yarn workspace @dnb/eufemia-mcp-legacy-proxy deploy --var MODE:gone
 ```

--- a/tools/mcp-legacy-proxy/eslint.config.mjs
+++ b/tools/mcp-legacy-proxy/eslint.config.mjs
@@ -1,0 +1,2 @@
+import parentConfig from 'dnb-design-system-portal/eslint.config.mjs'
+export default [...parentConfig]

--- a/tools/mcp-legacy-proxy/package.json
+++ b/tools/mcp-legacy-proxy/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@dnb/eufemia-mcp-legacy-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Deprecation compatibility proxy for the legacy Cloudflare-hosted Eufemia MCP endpoint",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts'"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "4.20260617.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.10",
+    "wrangler": "4.102.0"
+  }
+}

--- a/tools/mcp-legacy-proxy/src/index.test.ts
+++ b/tools/mcp-legacy-proxy/src/index.test.ts
@@ -87,6 +87,33 @@ describe('proxy mode', () => {
     expect(body.result.instructions).toContain(TARGET)
   })
 
+  it('drops the upstream Content-Length when the body is rewritten', async () => {
+    const upstreamBody = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: '2025-06-18',
+        serverInfo: { name: 'eufemia', version: '0.0.0' },
+      },
+    })
+    fetchMock.mockResolvedValue(
+      new Response(upstreamBody, {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': String(upstreamBody.length),
+        },
+      })
+    )
+
+    const res = await worker.fetch(initializeRequest(), proxyEnv)
+
+    // A stale Content-Length would truncate the injected notice.
+    expect(res.headers.get('content-length')).toBeNull()
+    const body = (await res.json()) as any
+    expect(body.result.instructions).toContain(TARGET)
+  })
+
   it('passes non-initialize responses through unchanged', async () => {
     const toolResult = {
       jsonrpc: '2.0',

--- a/tools/mcp-legacy-proxy/src/index.test.ts
+++ b/tools/mcp-legacy-proxy/src/index.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import worker, { type Env } from './index'
+
+const TARGET = 'https://server.eufemia.dnb.no/mcp/web'
+
+const initializeRequest = () =>
+  new Request('https://eufemia-mcp.eufemia.workers.dev/mcp', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      authorization: 'Bearer secret-should-not-be-forwarded',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { clientInfo: { name: 'test-client', version: '1.0' } },
+    }),
+  })
+
+const initializeResult = (instructions?: string) =>
+  new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: '2025-06-18',
+        serverInfo: { name: 'eufemia', version: '0.0.0' },
+        ...(instructions ? { instructions } : {}),
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+
+const proxyEnv: Env = { MODE: 'proxy', TARGET_URL: TARGET }
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('proxy mode', () => {
+  it('forwards POST to the new endpoint and adds deprecation headers', async () => {
+    fetchMock.mockResolvedValue(initializeResult())
+
+    const res = await worker.fetch(initializeRequest(), proxyEnv)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(TARGET)
+    expect(init.method).toBe('POST')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Deprecation')).toBeTruthy()
+    expect(res.headers.get('Sunset')).toBeTruthy()
+    expect(res.headers.get('Link')).toContain(
+      `<${TARGET}>; rel="successor-version"`
+    )
+  })
+
+  it('injects the migration notice into the initialize instructions', async () => {
+    fetchMock.mockResolvedValue(initializeResult())
+
+    const res = await worker.fetch(initializeRequest(), proxyEnv)
+    const body = (await res.json()) as any
+
+    expect(body.result.instructions).toContain(TARGET)
+    expect(body.result.instructions).toContain('deprecated')
+  })
+
+  it('appends to existing instructions instead of overwriting them', async () => {
+    fetchMock.mockResolvedValue(initializeResult('Existing guidance.'))
+
+    const res = await worker.fetch(initializeRequest(), proxyEnv)
+    const body = (await res.json()) as any
+
+    expect(body.result.instructions).toContain('Existing guidance.')
+    expect(body.result.instructions).toContain(TARGET)
+  })
+
+  it('passes non-initialize responses through unchanged', async () => {
+    const toolResult = {
+      jsonrpc: '2.0',
+      id: 2,
+      result: { content: [{ type: 'text', text: 'hello' }] },
+    }
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(toolResult), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+
+    const req = new Request(
+      'https://eufemia-mcp.eufemia.workers.dev/mcp',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+        }),
+      }
+    )
+    const res = await worker.fetch(req, proxyEnv)
+    const body = (await res.json()) as any
+
+    expect(body).toEqual(toolResult)
+  })
+
+  it('does not forward sensitive headers upstream', async () => {
+    fetchMock.mockResolvedValue(initializeResult())
+
+    await worker.fetch(initializeRequest(), proxyEnv)
+
+    const forwarded = fetchMock.mock.calls[0][1].headers as Headers
+    expect(forwarded.get('authorization')).toBeNull()
+    expect(forwarded.get('content-type')).toBe('application/json')
+  })
+
+  it('streams SSE responses through without buffering', async () => {
+    const sse = new Response('event: message\ndata: {}\n\n', {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })
+    fetchMock.mockResolvedValue(sse)
+
+    const res = await worker.fetch(initializeRequest(), proxyEnv)
+
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+    expect(res.headers.get('Deprecation')).toBeTruthy()
+    expect(await res.text()).toContain('data: {}')
+  })
+
+  it('returns 405 with Allow for non-POST methods', async () => {
+    const req = new Request(
+      'https://eufemia-mcp.eufemia.workers.dev/mcp',
+      {
+        method: 'GET',
+      }
+    )
+    const res = await worker.fetch(req, proxyEnv)
+
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST, OPTIONS')
+    expect(fetchMock).not.toHaveBeenCalled()
+    const body = (await res.json()) as any
+    expect(body.error.message).toContain(TARGET)
+  })
+
+  it('returns a JSON-RPC error when the upstream is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'))
+
+    const res = await worker.fetch(initializeRequest(), proxyEnv)
+
+    expect(res.status).toBe(502)
+    const body = (await res.json()) as any
+    expect(body.error.message).toContain(TARGET)
+  })
+
+  it('logs only method, client name, and status', async () => {
+    const logSpy = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined)
+    fetchMock.mockResolvedValue(initializeResult())
+
+    await worker.fetch(initializeRequest(), proxyEnv)
+
+    const logged = JSON.parse(logSpy.mock.calls[0][0] as string)
+    expect(logged).toEqual({
+      event: 'legacy_mcp_request',
+      method: 'POST',
+      client: 'test-client',
+      status: 200,
+    })
+    // The raw request body / credentials must never be logged.
+    const all = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(all).not.toContain('secret-should-not-be-forwarded')
+  })
+})
+
+describe('redirect mode', () => {
+  // Clients that follow redirects use Location; clients that do not read the body.
+  it('returns 308 with Location and a JSON-RPC error body naming the new URL', async () => {
+    const res = await worker.fetch(initializeRequest(), {
+      MODE: 'redirect',
+      TARGET_URL: TARGET,
+    })
+
+    expect(res.status).toBe(308)
+    expect(res.headers.get('Location')).toBe(TARGET)
+    expect(res.headers.get('Deprecation')).toBeTruthy()
+    const body = (await res.json()) as any
+    expect(body.error.message).toContain(TARGET)
+  })
+})
+
+describe('gone mode', () => {
+  it('returns 410 with a JSON-RPC error naming the new URL', async () => {
+    const res = await worker.fetch(initializeRequest(), {
+      MODE: 'gone',
+      TARGET_URL: TARGET,
+    })
+
+    expect(res.status).toBe(410)
+    const body = (await res.json()) as any
+    expect(body.error.message).toContain(TARGET)
+  })
+})
+
+describe('OPTIONS preflight', () => {
+  it('responds 204 with CORS and deprecation headers', async () => {
+    const req = new Request(
+      'https://eufemia-mcp.eufemia.workers.dev/mcp',
+      {
+        method: 'OPTIONS',
+      }
+    )
+    const res = await worker.fetch(req, proxyEnv)
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain(
+      'POST'
+    )
+    expect(res.headers.get('Deprecation')).toBeTruthy()
+  })
+})

--- a/tools/mcp-legacy-proxy/src/index.ts
+++ b/tools/mcp-legacy-proxy/src/index.ts
@@ -1,0 +1,241 @@
+/**
+ * Deprecation compatibility proxy for the legacy Cloudflare-hosted Eufemia MCP
+ * endpoint (`eufemia-mcp.eufemia.workers.dev/mcp`).
+ *
+ * The MCP server moved to `https://server.eufemia.dnb.no/mcp/web`. This Worker
+ * keeps the old URL working during the migration window and surfaces the new
+ * URL to both clients and agents. Behaviour is controlled by the `MODE` var so
+ * the endpoint can be phased down without code changes:
+ *
+ *   - `proxy`    (default) — forward the request to the new endpoint, add
+ *                deprecation headers, and inject a migration notice into the
+ *                MCP `initialize` response `instructions`.
+ *   - `redirect` — respond `308 Permanent Redirect` to the new endpoint.
+ *   - `gone`     — respond `410 Gone` with a migration message.
+ *
+ * The new server is stateless, POST-only, and returns JSON (not SSE), so this
+ * proxy stays intentionally small. It never forwards host-specific or sensitive
+ * headers, and logs only method, client name, and status — never credentials or
+ * request contents.
+ */
+
+export interface Env {
+  /** `proxy` (default) | `redirect` | `gone` */
+  MODE?: string
+  /** Successor endpoint the legacy URL points at. */
+  TARGET_URL?: string
+  /** RFC 8594 Sunset date (IMF-fixdate). */
+  SUNSET?: string
+  /** RFC 9745 Deprecation date (structured-field sf-date, e.g. `@1786924800`). */
+  DEPRECATION_DATE?: string
+}
+
+const DEFAULT_TARGET = 'https://server.eufemia.dnb.no/mcp/web'
+
+// The endpoint moved on 2026-08-17; RFC 9745 sf-date (seconds since epoch).
+const DEFAULT_DEPRECATION = '@1786924800'
+
+// Provisional — replace once the sunset date is formally agreed.
+const DEFAULT_SUNSET = 'Sun, 15 Nov 2026 00:00:00 GMT'
+
+const MIGRATION_NOTICE =
+  'This MCP server URL is deprecated. Update your configuration to https://server.eufemia.dnb.no/mcp/web.'
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const mode = env.MODE ?? 'proxy'
+    const target = env.TARGET_URL ?? DEFAULT_TARGET
+
+    if (request.method === 'OPTIONS') {
+      return decorate(new Response(null, { status: 204 }), env)
+    }
+
+    if (mode === 'gone') {
+      log(request.method, undefined, 410)
+      return decorate(
+        jsonRpcResponse(410, movedMessage(target), target),
+        env
+      )
+    }
+
+    if (mode === 'redirect') {
+      log(request.method, undefined, 308)
+      const res = jsonRpcResponse(308, movedMessage(target), target)
+      res.headers.set('Location', target)
+      return decorate(res, env)
+    }
+
+    // proxy mode
+    if (request.method !== 'POST') {
+      log(request.method, undefined, 405)
+      const res = jsonRpcResponse(405, movedMessage(target), target)
+      res.headers.set('Allow', 'POST, OPTIONS')
+      return decorate(res, env)
+    }
+
+    const bodyText = await request.text()
+    const clientName = extractClientName(bodyText)
+
+    let upstream: Response
+    try {
+      upstream = await fetch(target, {
+        method: 'POST',
+        headers: buildUpstreamHeaders(request.headers),
+        body: bodyText,
+      })
+    } catch {
+      log(request.method, clientName, 502)
+      return decorate(
+        jsonRpcResponse(
+          502,
+          `The new Eufemia MCP endpoint is temporarily unreachable. New endpoint: ${target}`,
+          target
+        ),
+        env
+      )
+    }
+
+    log(request.method, clientName, upstream.status)
+
+    const contentType = upstream.headers.get('content-type') ?? ''
+
+    // Stream SSE straight through without buffering.
+    if (contentType.includes('text/event-stream')) {
+      return decorate(upstream, env)
+    }
+
+    const text = await upstream.text()
+    const body = injectMigrationNotice(text, contentType)
+    return decorate(
+      new Response(body, {
+        status: upstream.status,
+        headers: upstream.headers,
+      }),
+      env
+    )
+  },
+}
+
+/** Copy only the request headers the upstream server needs. */
+function buildUpstreamHeaders(source: Headers): Headers {
+  const headers = new Headers()
+  for (const name of [
+    'content-type',
+    'accept',
+    'mcp-session-id',
+    'mcp-protocol-version',
+  ]) {
+    const value = source.get(name)
+    if (value) {
+      headers.set(name, value)
+    }
+  }
+  return headers
+}
+
+/** Add deprecation signalling and CORS to any outgoing response. */
+function decorate(response: Response, env: Env): Response {
+  const headers = new Headers(response.headers)
+
+  headers.set('Deprecation', env.DEPRECATION_DATE ?? DEFAULT_DEPRECATION)
+  headers.set('Sunset', env.SUNSET ?? DEFAULT_SUNSET)
+  headers.append(
+    'Link',
+    `<${env.TARGET_URL ?? DEFAULT_TARGET}>; rel="successor-version"`
+  )
+
+  headers.set('Access-Control-Allow-Origin', '*')
+  headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  headers.set(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version'
+  )
+  headers.set(
+    'Access-Control-Expose-Headers',
+    'Deprecation, Sunset, Link, Mcp-Session-Id, Mcp-Protocol-Version'
+  )
+
+  return new Response(response.body, { status: response.status, headers })
+}
+
+/**
+ * Add the migration notice to an MCP `initialize` response so clients that show
+ * server `instructions` surface it. Any other response passes through untouched.
+ */
+function injectMigrationNotice(text: string, contentType: string): string {
+  if (!contentType.includes('application/json')) {
+    return text
+  }
+
+  try {
+    const json = JSON.parse(text)
+    if (json?.result?.serverInfo) {
+      const existing =
+        typeof json.result.instructions === 'string'
+          ? json.result.instructions
+          : ''
+      json.result.instructions = existing
+        ? `${existing}\n\n${MIGRATION_NOTICE}`
+        : MIGRATION_NOTICE
+      return JSON.stringify(json)
+    }
+  } catch {
+    // Not JSON we can safely rewrite; pass through unchanged.
+  }
+
+  return text
+}
+
+/** Extract only `clientInfo.name` from an `initialize` request, for logging. */
+function extractClientName(bodyText: string): string | undefined {
+  try {
+    const parsed = JSON.parse(bodyText)
+    const messages = Array.isArray(parsed) ? parsed : [parsed]
+    for (const message of messages) {
+      if (message?.method === 'initialize') {
+        const name = message?.params?.clientInfo?.name
+        if (typeof name === 'string') {
+          return name
+        }
+      }
+    }
+  } catch {
+    // Non-JSON or unparsable body; nothing to extract.
+  }
+  return undefined
+}
+
+function log(
+  method: string,
+  client: string | undefined,
+  status: number
+): void {
+  console.log(
+    JSON.stringify({
+      event: 'legacy_mcp_request',
+      method,
+      client: client ?? 'unknown',
+      status,
+    })
+  )
+}
+
+function movedMessage(target: string): string {
+  return `This MCP endpoint has moved. Use ${target} instead.`
+}
+
+function jsonRpcResponse(
+  status: number,
+  message: string,
+  _target: string
+): Response {
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: null,
+    error: { code: -32000, message },
+  })
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}

--- a/tools/mcp-legacy-proxy/src/index.ts
+++ b/tools/mcp-legacy-proxy/src/index.ts
@@ -137,6 +137,11 @@ function buildUpstreamHeaders(source: Headers): Headers {
 function decorate(response: Response, env: Env): Response {
   const headers = new Headers(response.headers)
 
+  // The body may have been rewritten (notice injection) or re-emitted from a
+  // decoded string, so let the runtime recompute length/encoding.
+  headers.delete('content-length')
+  headers.delete('content-encoding')
+
   headers.set('Deprecation', env.DEPRECATION_DATE ?? DEFAULT_DEPRECATION)
   headers.set('Sunset', env.SUNSET ?? DEFAULT_SUNSET)
   headers.append(

--- a/tools/mcp-legacy-proxy/src/index.ts
+++ b/tools/mcp-legacy-proxy/src/index.ts
@@ -19,7 +19,7 @@
  * request contents.
  */
 
-export interface Env {
+export type Env = {
   /** `proxy` (default) | `redirect` | `gone` */
   MODE?: string
   /** Successor endpoint the legacy URL points at. */

--- a/tools/mcp-legacy-proxy/tsconfig.json
+++ b/tools/mcp-legacy-proxy/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tools/mcp-legacy-proxy/wrangler.toml
+++ b/tools/mcp-legacy-proxy/wrangler.toml
@@ -1,0 +1,15 @@
+name = "eufemia-mcp"
+main = "src/index.ts"
+compatibility_date = "2026-08-01"
+workers_dev = true
+
+# Phase the endpoint down by changing MODE and re-deploying (or
+# `wrangler deploy --var MODE:redirect`):
+#   proxy    -> forward to the new endpoint (default, safest)
+#   redirect -> 308 Permanent Redirect to the new endpoint
+#   gone     -> 410 Gone
+[vars]
+MODE = "proxy"
+TARGET_URL = "https://server.eufemia.dnb.no/mcp/web"
+SUNSET = "Sun, 15 Nov 2026 00:00:00 GMT"
+DEPRECATION_DATE = "@1786924800"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,6 +2049,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workers-types@npm:4.20260617.1":
+  version: 4.20260617.1
+  resolution: "@cloudflare/workers-types@npm:4.20260617.1"
+  checksum: 10/a55488e0ea4018d4fbb34e9735cf12437323b51f179c468cb0714edef5ddbb7ae1b84c86bbe596b7ba52686294e65eddaaf8521fe6ab8a2172cad318dd01a501
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -2735,6 +2742,17 @@ __metadata:
   checksum: 10/688148ec74ebb8af023dd75e99af918929f80e365bf221de65769b733523cb4e1f454275bd325f84cff2af8f6f79c88be3c757eae176547b14f59ee68c15f716
   languageName: node
   linkType: hard
+
+"@dnb/eufemia-mcp-legacy-proxy@workspace:tools/mcp-legacy-proxy":
+  version: 0.0.0-use.local
+  resolution: "@dnb/eufemia-mcp-legacy-proxy@workspace:tools/mcp-legacy-proxy"
+  dependencies:
+    "@cloudflare/workers-types": "npm:4.20260617.1"
+    typescript: "npm:5.9.3"
+    vitest: "npm:4.1.10"
+    wrangler: "npm:4.102.0"
+  languageName: unknown
+  linkType: soft
 
 "@dnb/eufemia-mcp@workspace:tools/mcp-lambda":
   version: 0.0.0-use.local


### PR DESCRIPTION
Motivation: https://dnb-asa.atlassian.net/browse/EDS-955

The MCP server moved from `https://eufemia-mcp.eufemia.workers.dev/mcp` to `https://server.eufemia.dnb.no/mcp/web`, but some users still have the old URL configured. This keeps the old URL working so they migrate without their MCP clients breaking.

It adds a small Cloudflare Worker at the old URL that forwards to the new endpoint, adds deprecation headers (`Deprecation`, `Sunset`, `Link; rel="successor-version"`), and injects a migration notice into the MCP `initialize` instructions. A `MODE` var lets us later switch to `308` then `410` without code changes.

Not deployed yet — needs Cloudflare credentials.