### PR TITLE
chore(mcp): require edge secret and lock healthz behind the edge check

### DIFF
--- a/tools/mcp-lambda/infra/main.tf
+++ b/tools/mcp-lambda/infra/main.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "mcp" {
     variables = {
       NODE_OPTIONS = "--enable-source-maps"
 
-      # Optional shared secret sent as the X-Edge-Auth header; empty disables the check.
+      # Shared secret for the X-Edge-Auth origin check (injected by Akamai).
       EDGE_AUTH_SECRET = var.edge_auth_secret
     }
   }

--- a/tools/mcp-lambda/infra/variables.tf
+++ b/tools/mcp-lambda/infra/variables.tf
@@ -33,7 +33,11 @@ variable "domain_name" {
 
 variable "edge_auth_secret" {
   type        = string
-  description = "Optional shared secret for the X-Edge-Auth header; empty disables the check."
-  default     = ""
+  description = "Shared secret for the X-Edge-Auth header injected by Akamai."
   sensitive   = true
+
+  validation {
+    condition     = length(var.edge_auth_secret) > 0
+    error_message = "edge_auth_secret must be a non-empty value."
+  }
 }

--- a/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
+++ b/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
@@ -118,6 +118,7 @@ describe('lambda-handler health check', () => {
     // server.js (imported transitively by the handler) resolves the docs root
     // at module load; point it at the temp docs so the import succeeds.
     process.env.EUFEMIA_DOCS_ROOT = docsRoot
+    delete process.env.EDGE_AUTH_SECRET
   })
 
   afterAll(async () => {
@@ -372,16 +373,26 @@ describe('lambda-handler origin auth (X-Edge-Auth)', () => {
     expect(result.statusCode).not.toBe(403)
   })
 
-  it('keeps GET /healthz open even when the secret is set', async () => {
+  it('requires the edge header for /healthz when the secret is set', async () => {
     process.env.EDGE_AUTH_SECRET = secret
     const { handler } = await import('../transports/lambda-handler.js')
 
-    const result = (await handler({
+    const missing = (await handler({
       rawPath: '/healthz',
       requestContext: { http: { method: 'GET' } },
       headers: {},
-    } as Parameters<typeof handler>[0])) as { statusCode: number }
+    } as unknown as Parameters<typeof handler>[0])) as {
+      statusCode: number
+    }
+    expect(missing.statusCode).toBe(403)
 
-    expect(result.statusCode).toBe(200)
+    const withHeader = (await handler({
+      rawPath: '/healthz',
+      requestContext: { http: { method: 'GET' } },
+      headers: { 'x-edge-auth': secret },
+    } as unknown as Parameters<typeof handler>[0])) as {
+      statusCode: number
+    }
+    expect(withHeader.statusCode).toBe(200)
   })
 })

--- a/tools/mcp-lambda/src/transports/lambda-handler.ts
+++ b/tools/mcp-lambda/src/transports/lambda-handler.ts
@@ -64,7 +64,6 @@ function toWebRequest(event: APIGatewayProxyEventV2): Request {
 }
 
 // Verifies the X-Edge-Auth header against the configured secret.
-// No secret set = check disabled (local and pre-edge environments).
 function isEdgeAuthorized(event: APIGatewayProxyEventV2): boolean {
   const expected = process.env.EDGE_AUTH_SECRET
   if (!expected) {
@@ -103,6 +102,18 @@ async function toApiGatewayResult(
 export async function handler(
   event: APIGatewayProxyEventV2
 ): Promise<APIGatewayProxyResultV2> {
+  if (!isEdgeAuthorized(event)) {
+    return {
+      statusCode: 403,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Forbidden' },
+        id: null,
+      }),
+    }
+  }
+
   // Cheap health check for uptime monitoring: answer without spinning up the
   // MCP transport or touching the docs source.
   if (
@@ -113,19 +124,6 @@ export async function handler(
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status: 'ok' }),
-    }
-  }
-
-  // Enforced after /healthz so health probes stay open.
-  if (!isEdgeAuthorized(event)) {
-    return {
-      statusCode: 403,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        error: { code: -32001, message: 'Forbidden' },
-        id: null,
-      }),
     }
   }
 


### PR DESCRIPTION
## Motivation
Harden the MCP origin lock to match the analytics service (cloned from this code, hardened in review on #9014).

## What
- Require a non-empty `edge_auth_secret` (no default + validation), so a deploy cannot skip the origin lock.
- Move `/healthz` behind the `X-Edge-Auth` check (Akamai still probes it with the header injected).
- Drop the fail-open comment from a public file.
