### PR TITLE
feat(List): support even striped rows

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/demos.mdx
@@ -66,7 +66,7 @@ Use the `separated` property on `List.Container` to add row gap between list ite
 
 ### Striped rows
 
-Use the `striped` property on `List.Container` to apply alternating row background colors.
+Use the `striped` property on `List.Container` to apply alternating row background colors. Set it to `even` to leave the first item uncolored and start the striping on the second item.
 
 <Examples.StripedRows />
 

--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -24,10 +24,10 @@ export type ListContainerProps = {
   variant?: ListVariant
   separated?: boolean
   /**
-   * When `true`, applies alternating row background colors to the list items.
+   * Applies alternating row background colors to the list items. Use `true` or `odd` to color odd items, or `even` to color even items.
    * Default: `false`
    */
-  striped?: boolean
+  striped?: boolean | 'odd' | 'even'
   skeleton?: SkeletonShow
   disabled?: boolean
 } & FlexProps
@@ -106,6 +106,7 @@ function ListContainer(props: ListContainerProps) {
         variant && `dnb-list--variant-${variant}`,
         separated && 'dnb-list--separated',
         striped && 'dnb-list--striped',
+        striped === 'even' && 'dnb-list--striped-even',
         className
       )}
       {...rest}

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -7,8 +7,8 @@ export const ContainerProperties: PropertiesTableProps = {
     status: 'optional',
   },
   striped: {
-    doc: 'When `true`, applies alternating row background colors to the list items.',
-    type: 'boolean',
+    doc: 'Applies alternating row background colors to the list items. Use `true` or `odd` to color odd items, or `even` to color even items.',
+    type: ['boolean', '"odd"', '"even"'],
     defaultValue: 'false',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -66,13 +66,17 @@ describe('List Container', () => {
     expect(element.classList).toContain('dnb-list--separated')
   })
 
-  it('adds striped modifier class when striped is true', () => {
-    render(<Container striped>Content</Container>)
+  it.each([true, 'odd'] as const)(
+    'adds striped modifier class when striped is %s',
+    (striped) => {
+      render(<Container striped={striped}>Content</Container>)
 
-    const element = document.querySelector('.dnb-list')
+      const element = document.querySelector('.dnb-list')
 
-    expect(element.classList).toContain('dnb-list--striped')
-  })
+      expect(element.classList).toContain('dnb-list--striped')
+      expect(element.classList).not.toContain('dnb-list--striped-even')
+    }
+  )
 
   it('adds even modifier class when striped is even', () => {
     render(<Container striped="even">Content</Container>)

--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -74,6 +74,15 @@ describe('List Container', () => {
     expect(element.classList).toContain('dnb-list--striped')
   })
 
+  it('adds even modifier class when striped is even', () => {
+    render(<Container striped="even">Content</Container>)
+
+    const element = document.querySelector('.dnb-list')
+
+    expect(element.classList).toContain('dnb-list--striped')
+    expect(element.classList).toContain('dnb-list--striped-even')
+  })
+
   it('does not add striped class when striped is false or omitted', () => {
     const { rerender } = render(<Container>Content</Container>)
 

--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -461,7 +461,9 @@
 
     list-style: none;
 
-    &.dnb-list--striped > .dnb-list__item:nth-of-type(odd) {
+    &.dnb-list--striped:not(.dnb-list--striped-even)
+      > .dnb-list__item:nth-of-type(odd),
+    &.dnb-list--striped-even > .dnb-list__item:nth-of-type(even) {
       --list-item-background-color: var(
         --token-color-background-neutral-subtle
       );


### PR DESCRIPTION
Allows striped lists next to neutral backgrounds to start with an uncolored item, avoiding adjacent subtle background rows. Existing `striped` behavior remains unchanged, while `striped="even"` shifts the pattern to even items.

Motivation: https://dnb.enterprise.slack.com/archives/CMXABCHEY/p1786975403794129?thread_ts=1786365892.411519&channel=CMXABCHEY&message_ts=1786975403.794129