### PR TITLE
docs: clarify supported theme color schemes

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -99,6 +99,16 @@ Use the `colorScheme` prop on the [Theme](/uilib/usage/customisation/theming/the
 
 When set to `"auto"`, it follows the user's system color preference unless overridden by a parent theme or application setting. It uses the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme) media query to detect the system preference.
 
+Dark color schemes are currently available for the DNB and Sbanken themes.
+Carnegie and Eiendom are light-only themes. Setting `colorScheme="dark"` does
+not add dark mode support to a theme without a corresponding dark token
+stylesheet.
+
+This is separate from a dark surface. A light-only theme can still place
+content on a bounded dark background by using `surface="dark"`, which switches
+components to their `ondark` tokens without changing the application's color
+scheme.
+
 Dark mode tokens are not included in the default theme import. You need to import them separately:
 
 ```tsx

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -99,10 +99,9 @@ Use the `colorScheme` prop on the [Theme](/uilib/usage/customisation/theming/the
 
 When set to `"auto"`, it follows the user's system color preference unless overridden by a parent theme or application setting. It uses the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme) media query to detect the system preference.
 
-Dark color schemes are currently available for the DNB and Sbanken themes.
-Carnegie and Eiendom are light-only themes. Setting `colorScheme="dark"` does
-not add dark mode support to a theme without a corresponding dark token
-stylesheet.
+Dark color schemes are currently available for the DNB, Sbanken and Eiendom
+themes. Carnegie is light-only. Setting `colorScheme="dark"` does not add dark
+mode support to a theme without a corresponding dark token stylesheet.
 
 This is separate from a dark surface. A light-only theme can still place
 content on a bounded dark background by using `surface="dark"`, which switches
@@ -117,6 +116,9 @@ import '@dnb/eufemia/style/themes/ui/ui-theme-dark-mode.min.css' // Use --isolat
 
 // Sbanken theme
 import '@dnb/eufemia/style/themes/sbanken/sbanken-theme-dark-mode.min.css'
+
+// Eiendom theme
+import '@dnb/eufemia/style/themes/eiendom/eiendom-theme-dark-mode.min.css'
 ```
 
 For Tailwind, dark tokens are in a separate file per theme:


### PR DESCRIPTION
Clarifies the distinction between a supported dark color scheme and content rendered on a dark surface. This makes the Carnegie and Eiendom support boundary explicit so consumers and documentation tools do not infer unsupported dark themes from the shared `colorScheme` API or `ondark` tokens.