### PR TITLE
feat(MCP): expose metadata and clarify tool routing

### DIFF
--- a/packages/dnb-eufemia/src/mcp/README.md
+++ b/packages/dnb-eufemia/src/mcp/README.md
@@ -30,7 +30,8 @@ yarn add --dev @modelcontextprotocol/node @modelcontextprotocol/server-legacy ex
 
 The server exposes these tools:
 
-- `docs_entry` - Returns docs/llm.md (AI entrypoint).
+- `docs_guide` - Returns a concise tool-routing and version guide.
+- `docs_entry` - Returns the complete docs/llm.md link index (large; use only for exhaustive discovery).
 - `docs_meta` - Returns the Eufemia version, generation time and source commit for the served documentation.
 - `docs_index` - Returns a JSON list of all markdown docs.
 - `docs_list` - List docs with optional prefix filter.

--- a/packages/dnb-eufemia/src/mcp/README.md
+++ b/packages/dnb-eufemia/src/mcp/README.md
@@ -30,8 +30,7 @@ yarn add --dev @modelcontextprotocol/node @modelcontextprotocol/server-legacy ex
 
 The server exposes these tools:
 
-- `docs_guide` - Returns a concise tool-routing and version guide.
-- `docs_entry` - Returns the complete docs/llm.md link index (large; use only for exhaustive discovery).
+- `docs_entry` - Returns docs/llm.md (AI entrypoint).
 - `docs_meta` - Returns the Eufemia version, generation time and source commit for the served documentation.
 - `docs_index` - Returns a JSON list of all markdown docs.
 - `docs_list` - List docs with optional prefix filter.

--- a/packages/dnb-eufemia/src/mcp/README.md
+++ b/packages/dnb-eufemia/src/mcp/README.md
@@ -30,7 +30,7 @@ yarn add --dev @modelcontextprotocol/node @modelcontextprotocol/server-legacy ex
 
 The server exposes these tools:
 
-- `docs_entry` - Returns docs/llm.md (AI entrypoint).
+- `docs_entry` - Returns the complete docs/llm.md link index (large; use only for exhaustive discovery).
 - `docs_meta` - Returns the Eufemia version, generation time and source commit for the served documentation.
 - `docs_index` - Returns a JSON list of all markdown docs.
 - `docs_list` - List docs with optional prefix filter.

--- a/packages/dnb-eufemia/src/mcp/README.md
+++ b/packages/dnb-eufemia/src/mcp/README.md
@@ -31,6 +31,7 @@ yarn add --dev @modelcontextprotocol/node @modelcontextprotocol/server-legacy ex
 The server exposes these tools:
 
 - `docs_entry` - Returns docs/llm.md (AI entrypoint).
+- `docs_meta` - Returns the Eufemia version, generation time and source commit for the served documentation.
 - `docs_index` - Returns a JSON list of all markdown docs.
 - `docs_list` - List docs with optional prefix filter.
 - `docs_read` - Read a docs file by path.

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -186,6 +186,31 @@ describe('docs_entry', () => {
   })
 })
 
+describe('docs_guide', () => {
+  let docsRoot: string
+  let cleanup: () => void
+
+  beforeAll(() => {
+    const fixture = createDocsFixture()
+    docsRoot = fixture.docsRoot
+    cleanup = fixture.cleanup
+  })
+
+  afterAll(() => cleanup())
+
+  it('returns concise tool routing and version context', async () => {
+    const tools = createDocsTools({ docsRoot })
+    const result = await tools.docsGuide({})
+    const text = getText(result)
+
+    expect(text).toContain('Eufemia 11.10.1')
+    expect(text).toContain('component_props')
+    expect(text).toContain('docs_search')
+    expect(text).toContain('docs_entry')
+    expect(Buffer.byteLength(text)).toBeLessThan(2_000)
+  })
+})
+
 describe('docs_meta', () => {
   let docsRoot: string
   let cleanup: () => void

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -30,6 +30,15 @@ function createDocsFixture(): DocsFixture {
   )
 
   fs.writeFileSync(
+    path.join(docsRoot, '_meta.json'),
+    JSON.stringify({
+      eufemiaVersion: '11.10.1',
+      generatedAt: '2026-08-19T10:00:00.000Z',
+      commit: 'abc123',
+    })
+  )
+
+  fs.writeFileSync(
     path.join(componentsDir, 'button.md'),
     [
       '---',
@@ -174,6 +183,30 @@ describe('docs_entry', () => {
     const tools = createDocsTools({ docsRoot })
     const result = await tools.docsEntry({})
     expect(getText(result)).toContain('Eufemia Docs')
+  })
+})
+
+describe('docs_meta', () => {
+  let docsRoot: string
+  let cleanup: () => void
+
+  beforeAll(() => {
+    const fixture = createDocsFixture()
+    docsRoot = fixture.docsRoot
+    cleanup = fixture.cleanup
+  })
+
+  afterAll(() => cleanup())
+
+  it('returns the documentation metadata', async () => {
+    const tools = createDocsTools({ docsRoot })
+    const result = await tools.docsMeta({})
+
+    expect(JSON.parse(getText(result))).toEqual({
+      eufemiaVersion: '11.10.1',
+      generatedAt: '2026-08-19T10:00:00.000Z',
+      commit: 'abc123',
+    })
   })
 })
 

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -186,31 +186,6 @@ describe('docs_entry', () => {
   })
 })
 
-describe('docs_guide', () => {
-  let docsRoot: string
-  let cleanup: () => void
-
-  beforeAll(() => {
-    const fixture = createDocsFixture()
-    docsRoot = fixture.docsRoot
-    cleanup = fixture.cleanup
-  })
-
-  afterAll(() => cleanup())
-
-  it('returns concise tool routing and version context', async () => {
-    const tools = createDocsTools({ docsRoot })
-    const result = await tools.docsGuide({})
-    const text = getText(result)
-
-    expect(text).toContain('Eufemia 11.10.1')
-    expect(text).toContain('component_props')
-    expect(text).toContain('docs_search')
-    expect(text).toContain('docs_entry')
-    expect(Buffer.byteLength(text)).toBeLessThan(2_000)
-  })
-})
-
 describe('docs_meta', () => {
   let docsRoot: string
   let cleanup: () => void

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
@@ -243,7 +243,6 @@ describe('mcp-http-server', () => {
       expect(toolNames).toEqual(
         expect.arrayContaining([
           'docs_entry',
-          'docs_guide',
           'docs_meta',
           'docs_index',
           'docs_list',

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
@@ -237,9 +237,16 @@ describe('mcp-http-server', () => {
 
       const listEvent = await readSseEvent(listRes)
       const listJson = JSON.parse(listEvent.data ?? '{}') as {
-        result?: { tools?: Array<{ name: string }> }
+        result?: {
+          tools?: Array<{
+            name: string
+            title?: string
+            description?: string
+          }>
+        }
       }
-      const toolNames = (listJson.result?.tools ?? []).map((t) => t.name)
+      const tools = listJson.result?.tools ?? []
+      const toolNames = tools.map((tool) => tool.name)
       expect(toolNames).toEqual(
         expect.arrayContaining([
           'docs_entry',
@@ -254,6 +261,16 @@ describe('mcp-http-server', () => {
           'component_props',
         ])
       )
+
+      expect(
+        tools.find(({ name }) => name === 'docs_entry')
+      ).toMatchObject({
+        title: 'Full docs entry index',
+        description: expect.stringContaining('large exhaustive payload'),
+      })
+      expect(
+        tools.find(({ name }) => name === 'docs_search')?.description
+      ).not.toContain('docs entry')
     })
   })
 

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
@@ -243,6 +243,7 @@ describe('mcp-http-server', () => {
       expect(toolNames).toEqual(
         expect.arrayContaining([
           'docs_entry',
+          'docs_guide',
           'docs_meta',
           'docs_index',
           'docs_list',

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-http-server.test.ts
@@ -243,6 +243,7 @@ describe('mcp-http-server', () => {
       expect(toolNames).toEqual(
         expect.arrayContaining([
           'docs_entry',
+          'docs_meta',
           'docs_index',
           'docs_list',
           'docs_read',

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -657,6 +657,7 @@ type EmptyInputType = z.infer<typeof EmptyInput>
 
 type DocsToolHandlers = {
   docsEntry: (_input: EmptyInputType) => Promise<ToolResult>
+  docsMeta: (_input: EmptyInputType) => Promise<ToolResult>
   docsIndex: (_input: EmptyInputType) => Promise<ToolResult>
   docsList: (input: DocsListInputType) => Promise<ToolResult>
   docsRead: (input: DocsReadInputType) => Promise<ToolResult>
@@ -733,6 +734,11 @@ export function createDocsTools(
       return makeTextResult('llm.md not found in docs root.')
     }
     return makeTextResult(text)
+  }
+
+  const docsMeta = async (_input: EmptyInputType): Promise<ToolResult> => {
+    const meta = await readDocsMeta(context.source)
+    return makeTextResult(JSON.stringify(meta, null, 2))
   }
 
   const docsIndex = async (
@@ -945,6 +951,7 @@ export function createDocsTools(
 
   return {
     docsEntry,
+    docsMeta,
     docsIndex,
     docsList,
     docsRead,
@@ -1007,6 +1014,17 @@ export function registerDocsTools(
       inputSchema: EmptyInput.shape,
     },
     (input) => tools.docsEntry(input)
+  )
+
+  server.registerTool(
+    'docs_meta',
+    {
+      title: 'Docs metadata',
+      description:
+        'Return metadata for the documentation served by this MCP instance, including the Eufemia version, generation time, and source commit. Use this before relying on version-specific guidance or comparing the served documentation with an installed Eufemia package.',
+      inputSchema: EmptyInput.shape,
+    },
+    (input) => tools.docsMeta(input)
   )
 
   server.registerTool(

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -657,6 +657,7 @@ type EmptyInputType = z.infer<typeof EmptyInput>
 
 type DocsToolHandlers = {
   docsEntry: (_input: EmptyInputType) => Promise<ToolResult>
+  docsGuide: (_input: EmptyInputType) => Promise<ToolResult>
   docsMeta: (_input: EmptyInputType) => Promise<ToolResult>
   docsIndex: (_input: EmptyInputType) => Promise<ToolResult>
   docsList: (input: DocsListInputType) => Promise<ToolResult>
@@ -734,6 +735,13 @@ export function createDocsTools(
       return makeTextResult('llm.md not found in docs root.')
     }
     return makeTextResult(text)
+  }
+
+  const docsGuide = async (
+    _input: EmptyInputType
+  ): Promise<ToolResult> => {
+    const meta = await readDocsMeta(context.source)
+    return makeTextResult(renderDocsGuide(meta))
   }
 
   const docsMeta = async (_input: EmptyInputType): Promise<ToolResult> => {
@@ -951,6 +959,7 @@ export function createDocsTools(
 
   return {
     docsEntry,
+    docsGuide,
     docsMeta,
     docsIndex,
     docsList,
@@ -971,6 +980,30 @@ export type DocsMeta = {
   eufemiaVersion: string
   generatedAt: string
   commit: string
+}
+
+export function renderDocsGuide(meta: DocsMeta): string {
+  const source = meta.commit ? ` from commit ${meta.commit}` : ''
+  const generated = meta.generatedAt
+    ? `, generated ${meta.generatedAt}`
+    : ''
+
+  return `# Eufemia MCP guide
+
+This server provides Eufemia ${meta.eufemiaVersion}${generated}${source}.
+
+Use targeted tools instead of loading the complete documentation index:
+
+- Known component API: call \`component_props\`.
+- Component behavior or examples: call \`component_doc\`.
+- Uncertain component name: call \`component_find\` first.
+- Concept or use-case lookup: call \`docs_search\`, then \`docs_read\` for the relevant result.
+- Enumerate one documentation area: call \`docs_list\` with a prefix.
+- Machine-readable version and provenance: call \`docs_meta\`.
+- Complete path inventory: call \`docs_index\` only when exhaustive enumeration is required.
+- Full \`llm.md\` index: call \`docs_entry\` only when its exhaustive link index is explicitly needed; it is a large payload, not a normal lookup step.
+
+Start broad implementation work by reading \`/uilib/usage/first-steps/quick-reference.md\` with \`docs_read\`. Read component and topic documentation before producing code. Use the documentation exactly as provided and do not infer missing APIs or behavior.`
 }
 
 export function createServerInfo(eufemiaVersion?: string): {
@@ -1008,12 +1041,23 @@ export function registerDocsTools(
   server.registerTool(
     'docs_entry',
     {
-      title: 'Docs entry',
+      title: 'Full docs entry index',
       description:
-        'IMPORTANT! Primary entrypoint to the Eufemia documentation. Before implementing any Eufemia-based features or examples, call mcp_eufemia_docs_entry to understand the docs structure, and learn how to use the other MCP tools correctly; then use mcp_eufemia_docs_search and mcp_eufemia_docs_read to fetch relevant documentation. Make sure you have located and carefully read the relevant getting started or first-steps documentation before you implement any examples or code snippets based on these docs. Always follow these guidelines when using the documentation: use the documentation exactly as provided; gather all required information from the documentation before using it as a reference; and do not make assumptions or infer missing details unless the documentation or user explicitly instructs you to do so.',
+        'Return the complete llm.md documentation link index. This is a large exhaustive payload, not a normal lookup or onboarding step. Prefer docs_guide for concise tool routing, component_find/component_props for component APIs, docs_search/docs_read for topics, and docs_list for one documentation area. Use docs_entry only when the full cross-document index is explicitly required.',
       inputSchema: EmptyInput.shape,
     },
     (input) => tools.docsEntry(input)
+  )
+
+  server.registerTool(
+    'docs_guide',
+    {
+      title: 'Docs tool guide',
+      description:
+        'Return a concise Eufemia MCP tool-routing guide with documentation version context. Use this once when you need to learn which targeted tool to call. It avoids the large exhaustive payload returned by docs_entry.',
+      inputSchema: EmptyInput.shape,
+    },
+    (input) => tools.docsGuide(input)
   )
 
   server.registerTool(

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -657,7 +657,6 @@ type EmptyInputType = z.infer<typeof EmptyInput>
 
 type DocsToolHandlers = {
   docsEntry: (_input: EmptyInputType) => Promise<ToolResult>
-  docsGuide: (_input: EmptyInputType) => Promise<ToolResult>
   docsMeta: (_input: EmptyInputType) => Promise<ToolResult>
   docsIndex: (_input: EmptyInputType) => Promise<ToolResult>
   docsList: (input: DocsListInputType) => Promise<ToolResult>
@@ -735,13 +734,6 @@ export function createDocsTools(
       return makeTextResult('llm.md not found in docs root.')
     }
     return makeTextResult(text)
-  }
-
-  const docsGuide = async (
-    _input: EmptyInputType
-  ): Promise<ToolResult> => {
-    const meta = await readDocsMeta(context.source)
-    return makeTextResult(renderDocsGuide(meta))
   }
 
   const docsMeta = async (_input: EmptyInputType): Promise<ToolResult> => {
@@ -959,7 +951,6 @@ export function createDocsTools(
 
   return {
     docsEntry,
-    docsGuide,
     docsMeta,
     docsIndex,
     docsList,
@@ -980,30 +971,6 @@ export type DocsMeta = {
   eufemiaVersion: string
   generatedAt: string
   commit: string
-}
-
-export function renderDocsGuide(meta: DocsMeta): string {
-  const source = meta.commit ? ` from commit ${meta.commit}` : ''
-  const generated = meta.generatedAt
-    ? `, generated ${meta.generatedAt}`
-    : ''
-
-  return `# Eufemia MCP guide
-
-This server provides Eufemia ${meta.eufemiaVersion}${generated}${source}.
-
-Use targeted tools instead of loading the complete documentation index:
-
-- Known component API: call \`component_props\`.
-- Component behavior or examples: call \`component_doc\`.
-- Uncertain component name: call \`component_find\` first.
-- Concept or use-case lookup: call \`docs_search\`, then \`docs_read\` for the relevant result.
-- Enumerate one documentation area: call \`docs_list\` with a prefix.
-- Machine-readable version and provenance: call \`docs_meta\`.
-- Complete path inventory: call \`docs_index\` only when exhaustive enumeration is required.
-- Full \`llm.md\` index: call \`docs_entry\` only when its exhaustive link index is explicitly needed; it is a large payload, not a normal lookup step.
-
-Start broad implementation work by reading \`/uilib/usage/first-steps/quick-reference.md\` with \`docs_read\`. Read component and topic documentation before producing code. Use the documentation exactly as provided and do not infer missing APIs or behavior.`
 }
 
 export function createServerInfo(eufemiaVersion?: string): {
@@ -1041,23 +1008,12 @@ export function registerDocsTools(
   server.registerTool(
     'docs_entry',
     {
-      title: 'Full docs entry index',
+      title: 'Docs entry',
       description:
-        'Return the complete llm.md documentation link index. This is a large exhaustive payload, not a normal lookup or onboarding step. Prefer docs_guide for concise tool routing, component_find/component_props for component APIs, docs_search/docs_read for topics, and docs_list for one documentation area. Use docs_entry only when the full cross-document index is explicitly required.',
+        'IMPORTANT! Primary entrypoint to the Eufemia documentation. Before implementing any Eufemia-based features or examples, call mcp_eufemia_docs_entry to understand the docs structure, and learn how to use the other MCP tools correctly; then use mcp_eufemia_docs_search and mcp_eufemia_docs_read to fetch relevant documentation. Make sure you have located and carefully read the relevant getting started or first-steps documentation before you implement any examples or code snippets based on these docs. Always follow these guidelines when using the documentation: use the documentation exactly as provided; gather all required information from the documentation before using it as a reference; and do not make assumptions or infer missing details unless the documentation or user explicitly instructs you to do so.',
       inputSchema: EmptyInput.shape,
     },
     (input) => tools.docsEntry(input)
-  )
-
-  server.registerTool(
-    'docs_guide',
-    {
-      title: 'Docs tool guide',
-      description:
-        'Return a concise Eufemia MCP tool-routing guide with documentation version context. Use this once when you need to learn which targeted tool to call. It avoids the large exhaustive payload returned by docs_entry.',
-      inputSchema: EmptyInput.shape,
-    },
-    (input) => tools.docsGuide(input)
   )
 
   server.registerTool(

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -1008,9 +1008,9 @@ export function registerDocsTools(
   server.registerTool(
     'docs_entry',
     {
-      title: 'Docs entry',
+      title: 'Full docs entry index',
       description:
-        'IMPORTANT! Primary entrypoint to the Eufemia documentation. Before implementing any Eufemia-based features or examples, call mcp_eufemia_docs_entry to understand the docs structure, and learn how to use the other MCP tools correctly; then use mcp_eufemia_docs_search and mcp_eufemia_docs_read to fetch relevant documentation. Make sure you have located and carefully read the relevant getting started or first-steps documentation before you implement any examples or code snippets based on these docs. Always follow these guidelines when using the documentation: use the documentation exactly as provided; gather all required information from the documentation before using it as a reference; and do not make assumptions or infer missing details unless the documentation or user explicitly instructs you to do so.',
+        'Return the complete llm.md documentation link index. This is a large exhaustive payload, not a normal onboarding or lookup step. Use it only when the full documentation structure is explicitly required. For routine work, prefer component_find/component_props for component APIs, component_doc for component guidance and examples, docs_search followed by docs_read for conceptual topics, or docs_list for one documentation area.',
       inputSchema: EmptyInput.shape,
     },
     (input) => tools.docsEntry(input)
@@ -1065,7 +1065,7 @@ export function registerDocsTools(
     {
       title: 'Search docs',
       description:
-        'Search across all markdown and MDX documentation using a free-text query, returning a JSON array of ranked matches with relevance scores and text snippets. Use this when you know what you are looking for conceptually (for example a component, feature, or concept name), but you do not know the exact file path yet. Prefer this after you have called the docs entry tool so you understand how the docs are structured. In particular, use this to find and read the appropriate getting started or first-steps documentation before you rely on any specific examples or code snippets.',
+        'Search across all markdown and MDX documentation using a free-text query, returning a JSON array of ranked matches with relevance scores and text snippets. Use this when you know what you are looking for conceptually (for example a component, feature, or concept name), but you do not know the exact file path yet. Read the relevant result with docs_read before relying on its guidance or examples. Add a prefix when you know the documentation area to reduce unrelated results.',
       inputSchema: DocsSearchInput.shape,
     },
     (input) => tools.docsSearch(input)

--- a/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
+++ b/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
@@ -91,6 +91,7 @@ describe('lambda-handler stateless transport lifecycle', () => {
     // The full tool set is served identically with no state shared between
     // invocations.
     expect(firstTools).toContain('docs_entry')
+    expect(firstTools).toContain('docs_guide')
     expect(firstTools).toContain('component_props')
     expect(secondTools).toEqual(firstTools)
   })

--- a/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
+++ b/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
@@ -91,7 +91,6 @@ describe('lambda-handler stateless transport lifecycle', () => {
     // The full tool set is served identically with no state shared between
     // invocations.
     expect(firstTools).toContain('docs_entry')
-    expect(firstTools).toContain('docs_guide')
     expect(firstTools).toContain('component_props')
     expect(secondTools).toEqual(firstTools)
   })


### PR DESCRIPTION
Exposes authoritative documentation version, generation time, and source commit through docs_meta. Also clarifies the existing MCP tool descriptions: docs_entry is a large exhaustive index for explicit full-structure discovery, while normal component and topic work should use the targeted component, search, read, and list tools.