### PR TITLE
feat(Plugins): expose review rule metadata

### DIFF
--- a/packages/dnb-eufemia/src/plugins/__tests__/review-rules.test.ts
+++ b/packages/dnb-eufemia/src/plugins/__tests__/review-rules.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+
+import eslintPlugin from '../eslint.js'
+import reviewRules from '../review-rules.js'
+import stylelintPlugin from '../stylelint.js'
+
+const stylelintPluginWithMetadata =
+  stylelintPlugin as typeof stylelintPlugin & {
+    reviewRules: typeof reviewRules
+  }
+
+describe('review rule metadata', () => {
+  it('is shared by the ESLint and Stylelint plugins', () => {
+    expect(eslintPlugin.reviewRules).toEqual(reviewRules)
+    expect(stylelintPluginWithMetadata.reviewRules).toEqual(reviewRules)
+  })
+
+  it('distinguishes warning metadata from automatic fixes', () => {
+    expect(
+      reviewRules['eufemia/no-deprecated-color-variables']
+    ).toMatchObject({
+      category: 'deprecation',
+      fixable: false,
+      level: 'warning',
+      tools: ['eslint', 'stylelint'],
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/plugins/eslint/index.js
+++ b/packages/dnb-eufemia/src/plugins/eslint/index.js
@@ -1,6 +1,8 @@
 const noDeprecatedColorVariables = require('./rules/no-deprecated-color-variables.js')
+const reviewRules = require('../review-rules.js')
 
 const eslintPlugin = {
+  reviewRules,
   rules: {
     'no-deprecated-color-variables': noDeprecatedColorVariables,
   },

--- a/packages/dnb-eufemia/src/plugins/eslint/rules/no-deprecated-color-variables.js
+++ b/packages/dnb-eufemia/src/plugins/eslint/rules/no-deprecated-color-variables.js
@@ -1,6 +1,7 @@
 const COLOR_VARIABLE_REGEX = /--color-[a-z0-9-]+/g
-const DESIGN_TOKENS_GUIDE_URL =
-  'https://eufemia.dnb.no/uilib/usage/customisation/theming/design-tokens/guide/'
+const reviewRule = require('../../review-rules.js')[
+  'eufemia/no-deprecated-color-variables'
+]
 
 const reportMatches = (context, node, text) => {
   if (typeof text !== 'string') {
@@ -29,9 +30,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Warn when deprecated --color-* CSS variables are used in JavaScript and TypeScript code',
-      url: DESIGN_TOKENS_GUIDE_URL,
+      description: reviewRule.description,
+      url: reviewRule.documentation,
     },
     messages: {
       deprecatedColorVariable:

--- a/packages/dnb-eufemia/src/plugins/review-rules.js
+++ b/packages/dnb-eufemia/src/plugins/review-rules.js
@@ -1,0 +1,16 @@
+const DESIGN_TOKENS_GUIDE_URL =
+  'https://eufemia.dnb.no/uilib/usage/customisation/theming/design-tokens/guide/'
+
+const reviewRules = {
+  'eufemia/no-deprecated-color-variables': {
+    category: 'deprecation',
+    description:
+      'Warn when deprecated --color-* CSS variables are used instead of design tokens.',
+    documentation: DESIGN_TOKENS_GUIDE_URL,
+    fixable: false,
+    level: 'warning',
+    tools: ['eslint', 'stylelint'],
+  },
+}
+
+module.exports = reviewRules

--- a/packages/dnb-eufemia/src/plugins/stylelint/index.js
+++ b/packages/dnb-eufemia/src/plugins/stylelint/index.js
@@ -2,6 +2,7 @@ const noDeprecatedColorVariables = require('./rules/no-deprecated-color-variable
 const tokenNamePolicy = require('./rules/token-name-policy.cjs')
 const noUnusedUse = require('./rules/no-unused-use.cjs')
 const noUndefinedCustomProperty = require('./rules/no-undefined-custom-property.cjs')
+const reviewRules = require('../review-rules.js')
 
 const pluginPack = [
   noDeprecatedColorVariables,
@@ -10,6 +11,7 @@ const pluginPack = [
   noUndefinedCustomProperty,
 ]
 
+pluginPack.reviewRules = reviewRules
 pluginPack.recommended = {
   plugins: pluginPack,
   rules: {

--- a/packages/dnb-eufemia/src/plugins/stylelint/rules/no-deprecated-color-variables.js
+++ b/packages/dnb-eufemia/src/plugins/stylelint/rules/no-deprecated-color-variables.js
@@ -2,8 +2,7 @@ const stylelint = require('stylelint')
 
 const RULE_NAME = 'eufemia/no-deprecated-color-variables'
 const COLOR_VARIABLE_REGEX = /--color-[a-z0-9-]+/g
-const DESIGN_TOKENS_GUIDE_URL =
-  'https://eufemia.dnb.no/uilib/usage/customisation/theming/design-tokens/guide/'
+const reviewRule = require('../../review-rules.js')[RULE_NAME]
 
 const messages = stylelint.utils.ruleMessages(RULE_NAME, {
   rejected: (variable) =>
@@ -11,7 +10,7 @@ const messages = stylelint.utils.ruleMessages(RULE_NAME, {
 })
 
 const meta = {
-  url: DESIGN_TOKENS_GUIDE_URL,
+  url: reviewRule.documentation,
 }
 
 const reportMatches = ({ node, result, value }) => {


### PR DESCRIPTION
Makes Eufemia's first cross-tool review rule machine-readable and shared by the public ESLint and Stylelint plugins. Consumers can distinguish a deprecation warning from an autofixable requirement and link recommendations back to Eufemia-owned documentation.