### PR TITLE
chore(Tabs): remove redundant white background from max-width example

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
@@ -231,7 +231,6 @@ export const TabsExampleMaxWidth = () => (
     {() => {
       const MaxWidthWrapper = styled.div`
         max-width: 30rem;
-        background: var(--color-white);
       `
 
       function TabsMaxWidth() {


### PR DESCRIPTION
The max-width example for `Tabs` set an explicit `background: var(--color-white)` on its wrapper. This is redundant for demonstrating the max-width behavior and makes the example render inconsistently against themed backgrounds. Removing it keeps the example focused on what it is meant to show.
