### PR TITLE
chore(mcp-legacy-proxy): silence per-request logs in unit tests

### DIFF
--- a/tools/mcp-legacy-proxy/src/index.test.ts
+++ b/tools/mcp-legacy-proxy/src/index.test.ts
@@ -41,6 +41,8 @@ let fetchMock: ReturnType<typeof vi.fn>
 beforeEach(() => {
   fetchMock = vi.fn()
   vi.stubGlobal('fetch', fetchMock)
+  // The worker logs one structured line per request; silence it in tests.
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
 })
 
 afterEach(() => {
@@ -196,9 +198,7 @@ describe('proxy mode', () => {
   })
 
   it('logs only method, client name, and status', async () => {
-    const logSpy = vi
-      .spyOn(console, 'log')
-      .mockImplementation(() => undefined)
+    const logSpy = vi.mocked(console.log)
     fetchMock.mockResolvedValue(initializeResult())
 
     await worker.fetch(initializeRequest(), proxyEnv)


### PR DESCRIPTION
Motivation: https://github.com/dnbexperience/eufemia/actions/runs/32245779395/job/96046085651#step:4:1072

The proxy Worker emits one structured log line per request via `console.log`, which is intentional for production (Cloudflare Worker logs). During `yarn test`, vitest surfaces every one of those lines as `stdout` output, cluttering the test and CI logs.

Silence the request log in the test `beforeEach` and reuse that spy in the dedicated logging assertion, so the logging behaviour stays fully covered while the noise is gone.