### PR TITLE
chore: stop embedding PAT in git remote URL

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/commitToBranch.js
+++ b/packages/dnb-eufemia/scripts/prebuild/commitToBranch.js
@@ -17,7 +17,6 @@ try {
 const log = ora()
 
 const config = {
-  remote: `https://${process.env.GH_TOKEN}@github.com/dnbexperience/eufemia.git`,
   user: {
     name: process.env.GH_NAME,
     email: process.env.GH_EMAIL,
@@ -35,12 +34,21 @@ const getRepo = async () => {
   const pathToRepo = path.resolve(__dirname, '../../../../')
   const repo = simpleGit(pathToRepo)
 
-  // update the origin to use a token
-  // cause CI has normally no write access to the repo
-  if (isCI && config.remote) {
-    await repo.removeRemote('origin')
-    await repo.addRemote('origin', config.remote)
-    log.info('Added new remote to origin')
+  // Authenticate via http.extraheader instead of embedding the PAT in
+  // the remote URL — keeps the token out of .git/config and error output.
+  if (isCI && process.env.GH_TOKEN) {
+    const authHeader = Buffer.from(
+      `x-access-token:${process.env.GH_TOKEN}`
+    ).toString('base64')
+
+    repo.env({
+      ...process.env,
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+      GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${authHeader}`,
+    })
+
+    log.info('Configured git auth via extraheader')
   }
 
   return repo


### PR DESCRIPTION
The `commitToBranch.js` script embeds the `GH_TOKEN` PAT directly in the git remote URL (`https://<token>@github.com/...`). This persists the token in `.git/config` on disk and can leak it in git error output or verbose logs.

This replaces it with the safer `http.extraheader` pattern — the same approach already used in the analytics-lambda and mcp-lambda deploy workflows. The token is passed via `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_0` / `GIT_CONFIG_VALUE_0` environment variables, so it never touches `.git/config` and is scoped to the `simple-git` child process.
