### PR TITLE
chore: add explicit permissions to codeql-analysis, e2e, and dev workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,10 @@ on:
   schedule:
     - cron: '44 3 * * 5'
 
+permissions:
+  contents: read
+  security-events: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -52,6 +56,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,6 +17,9 @@ on:
       - 'next'
     types: [opened]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,9 @@ on:
       - 'next'
     types: [opened]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Three workflows (`codeql-analysis.yml`, `e2e.yml`, `dev.yml`) had no `permissions:` block, so `GITHUB_TOKEN` inherited the repository default — which may be broader than needed.

This adds explicit least-privilege permissions to each:

- **codeql-analysis**: `contents: read` + `security-events: write` (the minimum for CodeQL scanning). Also adds `persist-credentials: false` to the checkout step to match every other workflow.
- **e2e**: `contents: read`
- **dev**: `contents: read`
