### PR TITLE
chore(security): scope icons-lib workflow secrets to least privilege

### DIFF
--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -9,13 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  GH_EMAIL: ${{ secrets.GH_EMAIL }}
-  GH_NAME: ${{ secrets.GH_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-  FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
+# No job-wide `env:` on purpose: secrets are scoped to the individual steps that
+# use them, so `yarn install` and the build steps never receive credentials.
 
 jobs:
   process-icons:
@@ -54,6 +49,9 @@ jobs:
 
       - name: Icons fetch and prebuild
         run: yarn workspace @dnb/eufemia prebuild:figma:ci
+        env:
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_ICONS_FILE: ${{ secrets.FIGMA_ICONS_FILE }}
 
       - name: Prebuild Library
         run: yarn workspace @dnb/eufemia build:prebuild
@@ -79,3 +77,7 @@ jobs:
       - name: Commit icons and updated snapshots
         if: success()
         run: yarn workspace @dnb/eufemia icons:commit
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_NAME: ${{ secrets.GH_NAME }}
+          GH_EMAIL: ${{ secrets.GH_EMAIL }}


### PR DESCRIPTION
## Motivation

`icons-lib.yml` defined `GH_TOKEN`, `GH_NAME`, `GH_EMAIL`, `FIGMA_TOKEN`, `FIGMA_ICONS_FILE` and `NPM_TOKEN` in a workflow-level `env:` block, so every step received all credentials — including `Setup dependencies` (`yarn install`), which runs dependency lifecycle scripts. A compromised dependency could read those secrets during install. `NPM_TOKEN` was not used by any step.

## What

- Remove the workflow-level `env:` block.
- Scope `FIGMA_TOKEN`/`FIGMA_ICONS_FILE` to the icons fetch step and `GH_TOKEN`/`GH_NAME`/`GH_EMAIL` to the commit step — the only steps that consume them.
- Drop the unused `NPM_TOKEN`.

Mirrors the least-privilege pattern already applied to the other workflows in #9000.
