### PR TITLE
chore(security): disable credential persistence in CodeQL checkout

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
## Motivation

The CodeQL `Git checkout` was the only checkout in the repo not setting `persist-credentials: false`, so the `GITHUB_TOKEN` stayed in the local `.git/config`. The `autobuild` step then runs build commands with that token available.

## What

- Set `persist-credentials: false` on the CodeQL checkout, matching every other workflow.

No step in the job pushes or fetches over the remote, and the repo has no submodules, so nothing depends on the persisted credential.
