### PR TITLE
chore(Anchor): sanitize javascript: hrefs in InlineLink

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -20,6 +20,7 @@ import Context from '../../shared/Context'
 import { extendPropsWithContext } from '../../shared/component-helper'
 import useId from '../../shared/helpers/useId'
 import { getOffsetTop } from '../../shared/helpers'
+import { isDangerousHref } from '../../shared/helpers/isDangerousHref'
 import IconPrimary from '../icon-primary/IconPrimary'
 import Tooltip from '../tooltip/Tooltip'
 import { launch as LaunchIcon } from '../../icons'
@@ -319,33 +320,6 @@ export function pickIcon(icon, className?: string) {
 export const opensNewTab = (target: string, href: string): boolean =>
   target === '_blank' && !/^(mailto|tel|sms)/.test(href)
 
-/**
- * Returns true when the given href uses a script-executing protocol
- * (`javascript:` or `vbscript:`). Browsers ignore leading control characters
- * and whitespace (including tabs and newlines) when resolving the scheme, so
- * those are stripped before testing to catch obfuscated values such as
- * `java\tscript:alert(1)`.
- *
- * Only script-executing protocols are blocked. `data:` and `blob:` URLs are
- * intentionally left untouched: they have legitimate uses (such as download
- * links and inline media), and modern browsers already block top-level `data:`
- * navigation triggered by a link click.
- */
-export function isDangerousHref(href: unknown): boolean {
-  if (typeof href !== 'string') {
-    return false
-  }
-
-  // Remove characters that browsers ignore when resolving a URL scheme
-  // (C0 controls, space, DEL and C1 controls) so obfuscated values such as
-  // "java\tscript:" are still detected.
-  let normalized = ''
-  for (const char of href) {
-    const code = char.charCodeAt(0)
-    if (code > 0x20 && code !== 0x7f && !(code >= 0x80 && code <= 0xa0)) {
-      normalized += char
-    }
-  }
-
-  return /^(javascript|vbscript):/i.test(normalized)
-}
+// Re-exported from the shared helper so importing it does not pull the whole
+// Anchor module (and its dependency chain) into lightweight consumers.
+export { isDangerousHref }

--- a/packages/dnb-eufemia/src/shared/__tests__/renderWithFormatting.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/renderWithFormatting.test.tsx
@@ -303,4 +303,21 @@ describe('renderWithFormatting', () => {
       </form>
     `)
   })
+
+  it('strips javascript: hrefs from inline links', () => {
+    const text = 'Click [here](javascript:alert(1))'
+    renderNode(renderWithFormatting(text))
+    const a = document.querySelector('a') as HTMLAnchorElement
+    expect(a).toBeTruthy()
+    expect(a.textContent).toBe('here')
+    expect(a.getAttribute('href')).toBeNull()
+  })
+
+  it('strips obfuscated javascript: hrefs from inline links', () => {
+    const text = 'Click [xss](JAVASCRIPT:alert(1))'
+    renderNode(renderWithFormatting(text))
+    const a = document.querySelector('a') as HTMLAnchorElement
+    expect(a).toBeTruthy()
+    expect(a.getAttribute('href')).toBeNull()
+  })
 })

--- a/packages/dnb-eufemia/src/shared/helpers/isDangerousHref.ts
+++ b/packages/dnb-eufemia/src/shared/helpers/isDangerousHref.ts
@@ -1,0 +1,30 @@
+/**
+ * Returns true when the given href uses a script-executing protocol
+ * (`javascript:` or `vbscript:`). Browsers ignore leading control characters
+ * and whitespace (including tabs and newlines) when resolving the scheme, so
+ * those are stripped before testing to catch obfuscated values such as
+ * `java\tscript:alert(1)`.
+ *
+ * Only script-executing protocols are blocked. `data:` and `blob:` URLs are
+ * intentionally left untouched: they have legitimate uses (such as download
+ * links and inline media), and modern browsers already block top-level `data:`
+ * navigation triggered by a link click.
+ */
+export function isDangerousHref(href: unknown): boolean {
+  if (typeof href !== 'string') {
+    return false
+  }
+
+  // Remove characters that browsers ignore when resolving a URL scheme
+  // (C0 controls, space, DEL and C1 controls) so obfuscated values such as
+  // "java\tscript:" are still detected.
+  let normalized = ''
+  for (const char of href) {
+    const code = char.charCodeAt(0)
+    if (code > 0x20 && code !== 0x7f && !(code >= 0x80 && code <= 0xa0)) {
+      normalized += char
+    }
+  }
+
+  return /^(javascript|vbscript):/i.test(normalized)
+}

--- a/packages/dnb-eufemia/src/shared/internal/InlineLink.tsx
+++ b/packages/dnb-eufemia/src/shared/internal/InlineLink.tsx
@@ -1,5 +1,5 @@
 import type { AnchorHTMLAttributes } from 'react'
-import { isDangerousHref } from '../../components/anchor/Anchor'
+import { isDangerousHref } from '../helpers/isDangerousHref'
 
 type InlineLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 

--- a/packages/dnb-eufemia/src/shared/internal/InlineLink.tsx
+++ b/packages/dnb-eufemia/src/shared/internal/InlineLink.tsx
@@ -1,9 +1,12 @@
 import type { AnchorHTMLAttributes } from 'react'
+import { isDangerousHref } from '../../components/anchor/Anchor'
+
 type InlineLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export default function InlineLink({
   className,
   children,
+  href,
   ...rest
 }: InlineLinkProps) {
   const hasNode = typeof children !== 'string'
@@ -17,7 +20,11 @@ export default function InlineLink({
     .join(' ')
 
   return (
-    <a className={classes} {...rest}>
+    <a
+      className={classes}
+      href={isDangerousHref(href) ? undefined : href}
+      {...rest}
+    >
       {children}
     </a>
   )


### PR DESCRIPTION
`InlineLink` renders a plain `<a>` without the `isDangerousHref()` check that `Anchor` applies. Since `renderWithFormatting` parses `[label](href)` from translation strings and passes extracted hrefs to `InlineLink`, a consumer supplying custom translations containing `javascript:` URLs could trigger script execution.

This applies the same `isDangerousHref` guard used by `Anchor`: the href is stripped when it matches `javascript:` or `vbscript:` (including case-insensitive and obfuscated forms with control characters).

Two regression tests are added to `renderWithFormatting.test.tsx`.
