### PR TITLE
chore: fail closed when EDGE_AUTH_SECRET is unset

### DIFF
--- a/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
+++ b/tools/mcp-lambda/src/__tests__/lambda-handler.test.ts
@@ -118,11 +118,12 @@ describe('lambda-handler health check', () => {
     // server.js (imported transitively by the handler) resolves the docs root
     // at module load; point it at the temp docs so the import succeeds.
     process.env.EUFEMIA_DOCS_ROOT = docsRoot
-    delete process.env.EDGE_AUTH_SECRET
+    process.env.EDGE_AUTH_SECRET = 'test-health-secret'
   })
 
   afterAll(async () => {
     delete process.env.EUFEMIA_DOCS_ROOT
+    delete process.env.EDGE_AUTH_SECRET
     await fs.rm(docsRoot, { recursive: true, force: true })
   })
 
@@ -132,7 +133,7 @@ describe('lambda-handler health check', () => {
     const event = {
       rawPath: '/healthz',
       requestContext: { http: { method: 'GET' } },
-      headers: {},
+      headers: { 'x-edge-auth': 'test-health-secret' },
     } as unknown as Parameters<typeof handler>[0]
 
     const result = await handler(event)
@@ -148,15 +149,18 @@ describe('lambda-handler health check', () => {
 })
 
 describe('lambda-handler protocol versions', () => {
+  const secret = 'test-protocol-secret'
   let docsRoot: string
 
   beforeAll(async () => {
     docsRoot = await createTempDocs()
     process.env.EUFEMIA_DOCS_ROOT = docsRoot
+    process.env.EDGE_AUTH_SECRET = secret
   })
 
   afterAll(async () => {
     delete process.env.EUFEMIA_DOCS_ROOT
+    delete process.env.EDGE_AUTH_SECRET
     await fs.rm(docsRoot, { recursive: true, force: true })
   })
 
@@ -175,6 +179,7 @@ describe('lambda-handler protocol versions', () => {
       headers: {
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream',
+        'x-edge-auth': secret,
         ...headers,
       },
       body: JSON.stringify(body),
@@ -250,29 +255,34 @@ describe('lambda-handler protocol versions', () => {
 })
 
 describe('lambda-handler error handling', () => {
+  const secret = 'test-error-secret'
   let docsRoot: string
 
   beforeAll(async () => {
     docsRoot = await createTempDocs()
     process.env.EUFEMIA_DOCS_ROOT = docsRoot
+    process.env.EDGE_AUTH_SECRET = secret
   })
 
   afterAll(async () => {
     delete process.env.EUFEMIA_DOCS_ROOT
+    delete process.env.EDGE_AUTH_SECRET
     await fs.rm(docsRoot, { recursive: true, force: true })
   })
 
   it('returns a 500 JSON-RPC error when request processing throws', async () => {
     const { handler } = await import('../transports/lambda-handler.js')
 
-    // A POST event without `headers` makes toWebRequest throw inside the
-    // handler's try/catch, exercising the 500 fallback.
+    // An event with valid auth but a rawPath that makes the URL constructor
+    // inside toWebRequest throw, exercising the 500 fallback.
     const event = {
-      rawPath: '/mcp',
+      rawPath: '//[invalid',
       requestContext: {
-        domainName: 'example.test',
+        domainName: '',
         http: { method: 'POST' },
       },
+      headers: { 'x-edge-auth': secret },
+      body: '{',
     } as unknown as Parameters<typeof handler>[0]
 
     const errorSpy = vi
@@ -362,7 +372,7 @@ describe('lambda-handler origin auth (X-Edge-Auth)', () => {
     expect(result.statusCode).not.toBe(403)
   })
 
-  it('is a no-op when the secret is unset', async () => {
+  it('rejects with 403 when the secret is unset (fail-closed)', async () => {
     delete process.env.EDGE_AUTH_SECRET
     const { handler } = await import('../transports/lambda-handler.js')
 
@@ -370,7 +380,7 @@ describe('lambda-handler origin auth (X-Edge-Auth)', () => {
       mcpEvent({}) as Parameters<typeof handler>[0]
     )) as { statusCode: number }
 
-    expect(result.statusCode).not.toBe(403)
+    expect(result.statusCode).toBe(403)
   })
 
   it('requires the edge header for /healthz when the secret is set', async () => {

--- a/tools/mcp-lambda/src/transports/lambda-handler.ts
+++ b/tools/mcp-lambda/src/transports/lambda-handler.ts
@@ -67,7 +67,11 @@ function toWebRequest(event: APIGatewayProxyEventV2): Request {
 function isEdgeAuthorized(event: APIGatewayProxyEventV2): boolean {
   const expected = process.env.EDGE_AUTH_SECRET
   if (!expected) {
-    return true
+    // Fail closed: reject all requests when the secret is not configured.
+    console.error(
+      '[eufemia] EDGE_AUTH_SECRET is not set — rejecting request'
+    )
+    return false
   }
 
   const provided = event.headers['x-edge-auth']


### PR DESCRIPTION
`isEdgeAuthorized()` in the Lambda handler returned `true` when `EDGE_AUTH_SECRET` was not set, silently disabling authentication. If the env var were accidentally removed from the Lambda config, the entire endpoint would become publicly accessible with no indication.

This inverts the default: a missing secret now rejects all requests with 403 and logs an error to CloudWatch. Terraform validates the variable at plan time, but the runtime should not fail open if the config drifts.

All existing tests updated to pass `EDGE_AUTH_SECRET` and the auth header where needed. The "is a no-op when unset" test is replaced with a "rejects with 403 when unset (fail-closed)" assertion.
