### PR TITLE
chore: remove GITHUB_TOKEN from visual-regression workflow-level env

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -30,9 +30,9 @@ permissions:
   pull-requests: read
 
 env:
-  # Only non-secret build flags and the ephemeral, permission-scoped
-  # GITHUB_TOKEN remain here; the public Algolia config is scoped to the build.
-  GITHUB_TOKEN: ${{ github.token }}
+  # Only non-secret build flags remain here; the public Algolia config is
+  # scoped to the build step. actions/github-script receives the token
+  # automatically — no env var needed.
   RUN_POST_BUILD: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}
   RUN_VISUAL_TEST: ${{ !startsWith(github.ref, 'refs/heads/icon') }}
   PLAYWRIGHT_SCREENSHOT_WORKERS: 100%


### PR DESCRIPTION
`GITHUB_TOKEN` was set in the workflow-level `env:` block, injecting it into every step — including `yarn install`, which runs dependency lifecycle scripts. No step actually references the env var; `actions/github-script` receives the token automatically through the built-in `github` object.

Removing the workflow-level declaration limits token exposure to only the steps that need it.
