### PR TITLE
chore(security): add least-privilege permissions to icons-lib workflow

### DIFF
--- a/.github/workflows/icons-lib.yml
+++ b/.github/workflows/icons-lib.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'icon*/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Motivation

`icons-lib.yml` was the only workflow without a `permissions:` block, so its `GITHUB_TOKEN` inherited the repository default (potentially `write-all`) and was available to every step, including `Setup dependencies` (`yarn install`). This mirrors the gap #9035 closed for codeql/e2e/dev.

## What

- Add top-level `permissions: contents: read`.

`contents: read` is sufficient — the `Commit icons and updated snapshots` step authenticates its push with the `GH_TOKEN` PAT via `http.extraheader` (added in #9034), not `GITHUB_TOKEN`. `GITHUB_TOKEN` is only used by the checkout to clone, so no write access is needed. This is tighter than the `contents: write` upper bound; happy to bump it to `write` if a safety margin is preferred.
