### PR TITLE
chore: replace peaceiris/actions-gh-pages with official actions/deploy-pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
   issues: write # Required for semantic-release to comment on issues
   pull-requests: write # Required for semantic-release to comment on PRs
   id-token: write # Required for npm provenance
+  pages: write # Required for GitHub Pages deployment
 
 env:
   GH_EMAIL: ${{ secrets.GH_EMAIL }}
@@ -70,13 +71,17 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
 
+      - name: Upload portal artifact
+        if: (github.ref == 'refs/heads/release' ||
+          github.ref == 'refs/heads/portal')
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: ./packages/dnb-design-system-portal/public
+
       - name: Deploy portal
         if: (github.ref == 'refs/heads/release' ||
           github.ref == 'refs/heads/portal')
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
-        with:
-          personal_token: ${{ secrets.GH_TOKEN }}
-          publish_dir: ./packages/dnb-design-system-portal/public
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
       - name: Postbuild Library
         run: yarn workspace @dnb/eufemia postbuild:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ permissions:
   issues: write # Required for semantic-release to comment on issues
   pull-requests: write # Required for semantic-release to comment on PRs
   id-token: write # Required for npm provenance
-  pages: write # Required for GitHub Pages deployment
 
 env:
   GH_EMAIL: ${{ secrets.GH_EMAIL }}
@@ -78,11 +77,6 @@ jobs:
         with:
           path: ./packages/dnb-design-system-portal/public
 
-      - name: Deploy portal
-        if: (github.ref == 'refs/heads/release' ||
-          github.ref == 'refs/heads/portal')
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
-
       - name: Postbuild Library
         run: yarn workspace @dnb/eufemia postbuild:ci
 
@@ -94,3 +88,32 @@ jobs:
           github.ref == 'refs/heads/next' ||
           endsWith(github.ref, '.x'))
         run: yarn workspace @dnb/eufemia publish:ci
+
+  deploy-portal:
+    name: Deploy portal to GitHub Pages
+    needs: action
+    if: (github.ref == 'refs/heads/release' ||
+      github.ref == 'refs/heads/portal')
+
+    runs-on: ubuntu-latest
+
+    # Scoped to the minimum the deploy needs (the release job keeps the
+    # broader permissions it requires for semantic-release).
+    permissions:
+      pages: write # Required to deploy to GitHub Pages
+      id-token: write # Required for OIDC verification of the deployment
+
+    # Serialize Pages deployments and never cancel one mid-flight, so a
+    # deployment is not left half-finished (per actions/deploy-pages guidance).
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy portal
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
Replaces the third-party `peaceiris/actions-gh-pages` (single-maintainer community action that receives a PAT) with the official `actions/upload-pages-artifact` + `actions/deploy-pages`.

**What changes:**
- Portal deploy no longer needs `GH_TOKEN` (PAT) — the official action uses the workflow's `GITHUB_TOKEN` with OIDC
- One fewer third-party action in the supply chain
- Both new actions are SHA-pinned (v4)
- `CNAME` file (`eufemia.dnb.no`) is already in `static/` and included in the build output — custom domain is preserved

**Required manual step before merging:**
In repo Settings → Pages → Source, change from **"Deploy from a branch"** to **"GitHub Actions"**. Without this, the `deploy-pages` action will fail with a permissions error.

**Rollback:** If anything goes wrong, revert the source to "Deploy from a branch" (gh-pages) in Settings and revert this PR.
