### PR TITLE
chore(Analytics): fail closed when auth secrets are unset

### DIFF
--- a/tools/analytics/__tests__/http.test.ts
+++ b/tools/analytics/__tests__/http.test.ts
@@ -16,9 +16,9 @@ describe('isAuthorized', () => {
     }
   })
 
-  it('allows any request when API_TOKEN is not set', () => {
-    expect(isAuthorized(undefined)).toBe(true)
-    expect(isAuthorized({})).toBe(true)
+  it('rejects any request when API_TOKEN is not set (fail-closed)', () => {
+    expect(isAuthorized(undefined)).toBe(false)
+    expect(isAuthorized({})).toBe(false)
   })
 
   it('accepts a matching bearer token', () => {
@@ -65,9 +65,9 @@ describe('isEdgeAuthorized', () => {
     }
   })
 
-  it('allows any request when EDGE_AUTH_SECRET is not set', () => {
-    expect(isEdgeAuthorized(undefined)).toBe(true)
-    expect(isEdgeAuthorized({})).toBe(true)
+  it('rejects any request when EDGE_AUTH_SECRET is not set (fail-closed)', () => {
+    expect(isEdgeAuthorized(undefined)).toBe(false)
+    expect(isEdgeAuthorized({})).toBe(false)
   })
 
   it('accepts a matching X-Edge-Auth header', () => {

--- a/tools/analytics/__tests__/index.test.ts
+++ b/tools/analytics/__tests__/index.test.ts
@@ -25,11 +25,18 @@ function event(
     isBase64Encoded?: boolean
     headers?: Record<string, string | undefined>
     query?: Record<string, string | undefined>
+    // Injected by default so requests pass the edge lock; pass null to omit it.
+    edgeAuth?: string | null
   } = {}
 ): APIGatewayProxyEventV2 {
+  const edgeHeader =
+    opts.edgeAuth === null
+      ? {}
+      : { 'x-edge-auth': opts.edgeAuth ?? 'edge-secret' }
+
   return {
     rawPath: path,
-    headers: opts.headers ?? {},
+    headers: { ...edgeHeader, ...(opts.headers ?? {}) },
     queryStringParameters: opts.query,
     requestContext: { http: { method } },
     body: opts.body,
@@ -48,10 +55,12 @@ describe('handler', () => {
     storeRecord.mockReset()
     retrieveRecords.mockReset()
     process.env.API_TOKEN = 'secret'
+    process.env.EDGE_AUTH_SECRET = 'edge-secret'
   })
 
   afterEach(() => {
     delete process.env.API_TOKEN
+    delete process.env.EDGE_AUTH_SECRET
   })
 
   it('serves /healthz without auth', async () => {
@@ -194,7 +203,9 @@ describe('handler origin auth (X-Edge-Auth)', () => {
   })
 
   it('requires the edge header for /healthz when the edge secret is set', async () => {
-    const missing = await invoke(event('GET', '/healthz'))
+    const missing = await invoke(
+      event('GET', '/healthz', { edgeAuth: null })
+    )
     expect(missing.statusCode).toBe(403)
 
     const withHeader = await invoke(
@@ -207,7 +218,11 @@ describe('handler origin auth (X-Edge-Auth)', () => {
 
   it('rejects with 403 when the edge header is missing', async () => {
     const res = await invoke(
-      event('POST', '/records', { body: '{}', headers: auth })
+      event('POST', '/records', {
+        body: '{}',
+        headers: auth,
+        edgeAuth: null,
+      })
     )
 
     expect(res.statusCode).toBe(403)

--- a/tools/analytics/src/lambda/http.ts
+++ b/tools/analytics/src/lambda/http.ts
@@ -13,6 +13,20 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB)
 }
 
+// Logs a message at most once per process, so a misconfiguration surfaces in
+// CloudWatch without repeating on every request.
+const warned = new Set<string>()
+
+function warnOnce(message: string): void {
+  if (warned.has(message)) {
+    return
+  }
+
+  warned.add(message)
+  // eslint-disable-next-line no-console -- server-side logging to CloudWatch
+  console.error(message)
+}
+
 /** Build a JSON HTTP response for API Gateway (HTTP API / payload v2). */
 export function json(
   statusCode: number,
@@ -36,8 +50,7 @@ export function isAuthorized(
 
   if (!expected) {
     // Fail closed: reject all requests when the token is not configured.
-    // eslint-disable-next-line no-console -- server-side logging to CloudWatch
-    console.error('[eufemia] API_TOKEN is not set — rejecting request')
+    warnOnce('[eufemia] API_TOKEN is not set — rejecting request')
     return false
   }
 
@@ -62,10 +75,7 @@ export function isEdgeAuthorized(
 
   if (!expected) {
     // Fail closed: reject all requests when the secret is not configured.
-    // eslint-disable-next-line no-console -- server-side logging to CloudWatch
-    console.error(
-      '[eufemia] EDGE_AUTH_SECRET is not set — rejecting request'
-    )
+    warnOnce('[eufemia] EDGE_AUTH_SECRET is not set — rejecting request')
     return false
   }
 

--- a/tools/analytics/src/lambda/http.ts
+++ b/tools/analytics/src/lambda/http.ts
@@ -35,7 +35,10 @@ export function isAuthorized(
   const expected = process.env.API_TOKEN
 
   if (!expected) {
-    return true
+    // Fail closed: reject all requests when the token is not configured.
+    // eslint-disable-next-line no-console -- server-side logging to CloudWatch
+    console.error('[eufemia] API_TOKEN is not set — rejecting request')
+    return false
   }
 
   const header = headers?.authorization ?? headers?.Authorization ?? ''
@@ -58,7 +61,12 @@ export function isEdgeAuthorized(
   const expected = process.env.EDGE_AUTH_SECRET
 
   if (!expected) {
-    return true
+    // Fail closed: reject all requests when the secret is not configured.
+    // eslint-disable-next-line no-console -- server-side logging to CloudWatch
+    console.error(
+      '[eufemia] EDGE_AUTH_SECRET is not set — rejecting request'
+    )
+    return false
   }
 
   const provided = headers?.['x-edge-auth'] ?? headers?.['X-Edge-Auth']


### PR DESCRIPTION
Both auth checks in the analytics Lambda — the `API_TOKEN` bearer check and the `EDGE_AUTH_SECRET` origin lock — previously treated an unset secret as "check disabled" and returned `true`. This inverts that default so a missing secret is rejected and logged (once per process) instead.

Terraform already validates both variables as non-empty at plan time; this aligns the runtime behavior so the checks stay effective if configuration ever drifts.

Mirrors the hardening applied to the MCP Lambda in #9039.