### PR TITLE
refactor(List): use CSS gap in Container

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/Examples.tsx
@@ -1001,12 +1001,9 @@ export const CustomItemComponent = () => {
   return (
     <ComponentBox>
       {() => {
-        // Mark the component so List.Container treats it as a list item
-        // instead of wrapping it in an extra element.
         const CustomListItem = (props) => {
           return <List.Item.Action {...props} />
         }
-        CustomListItem._supportsSpacingProps = true
 
         return (
           <List.Container>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -92,11 +92,7 @@ render(
 
 ## Custom item components
 
-`List.Container` applies spacing to each direct child by checking it for a `_supportsSpacingProps` marker. The built-in items (`List.Item.Basic`, `List.Item.Action`, `List.Item.Accordion`) set it, so they render directly as `<li>` children of the list.
-
-If you extract a row into your own component, the container can't tell it is a list item and wraps it in an extra element. This makes each row its own group, so every row gets top and bottom rounding instead of only the first and last row of the list.
-
-Set `_supportsSpacingProps = true` on your component to opt in, and forward the props to the underlying item so spacing (such as the `separated` variant gap) still applies:
+`List.Container` uses CSS gap and leaves its React children unchanged. If you extract a row into your own component, render a `List.Item` from its root so the resulting `<li>` remains a direct child of the list. No marker or spacing-prop forwarding is needed:
 
 <Examples.CustomItemComponent />
 

--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -42,6 +42,7 @@ function ListContainer(props: ListContainerProps) {
     striped = false,
     skeleton,
     disabled,
+    layoutEngine = 'css',
     wrapChildrenInSpace = false,
     ...rest
   } = props
@@ -97,6 +98,7 @@ function ListContainer(props: ListContainerProps) {
   const listContent = (
     <FlexContainer
       element="ul"
+      layoutEngine={layoutEngine}
       rowGap={separated ? 'small' : false}
       wrap={false}
       wrapChildrenInSpace={wrapChildrenInSpace}

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -1,6 +1,12 @@
 import type { PropertiesTableProps } from '../../shared/types'
 
 export const ContainerProperties: PropertiesTableProps = {
+  layoutEngine: {
+    doc: 'Select the internal Flex layout engine. Defaults to `css`. Use `legacy` only as a temporary compatibility fallback while migrating an existing custom list integration.',
+    type: [`'css'`, `'legacy'`],
+    defaultValue: `'css'`,
+    status: 'optional',
+  },
   separated: {
     doc: 'When `true`, adds row gap between items so each row keeps its own outline and border radius instead of running edge-to-edge.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/Container.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import type { ListContainerProps } from '../Container'
 import Container from '../Container'
@@ -24,6 +25,62 @@ describe('List Container', () => {
     const element = document.querySelector('.dnb-list')
 
     expect(element.tagName).toBe('UL')
+  })
+
+  it('uses the CSS gap layout engine by default', () => {
+    render(
+      <Container separated>
+        <ItemContent>Item 1</ItemContent>
+        <ItemContent>Item 2</ItemContent>
+      </Container>
+    )
+
+    const list = document.querySelector('.dnb-list')
+    const items = Array.from(list.children)
+
+    expect(list).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-small'
+    )
+    expect(items).toHaveLength(2)
+    expect(items.every((item) => item.tagName === 'LI')).toBe(true)
+    expect(items[0]).not.toHaveClass('dnb-space__top--zero')
+    expect(items[1]).not.toHaveClass('dnb-space__top--small')
+  })
+
+  it('keeps the legacy layout engine available as an escape hatch', () => {
+    render(
+      <Container separated layoutEngine="legacy">
+        <ItemContent>Item 1</ItemContent>
+        <ItemContent>Item 2</ItemContent>
+      </Container>
+    )
+
+    const list = document.querySelector('.dnb-list')
+    const items = Array.from(list.children)
+
+    expect(list).not.toHaveClass('dnb-flex-container--css-gap')
+    expect(items[0]).toHaveClass('dnb-space__top--zero')
+    expect(items[1]).toHaveClass('dnb-space__top--small')
+  })
+
+  it('renders custom item component roots directly without a marker', () => {
+    const CustomItem = ({ children }: { children: ReactNode }) => (
+      <ItemContent>{children}</ItemContent>
+    )
+
+    render(
+      <Container separated>
+        <CustomItem>Item 1</CustomItem>
+        <CustomItem>Item 2</CustomItem>
+      </Container>
+    )
+
+    const list = document.querySelector('.dnb-list')
+    const items = Array.from(list.children)
+
+    expect(items).toHaveLength(2)
+    expect(items.every((item) => item.tagName === 'LI')).toBe(true)
   })
 
   it('merges custom className', () => {
@@ -138,9 +195,9 @@ describe('List Container', () => {
 
     expect(children).toHaveLength(2)
     expect(children[0].tagName).toBe('LI')
-    expect(children[0]).toHaveClass('dnb-space__top--zero')
     expect(children[1].tagName).toBe('LI')
-    expect(children[1]).toHaveClass('dnb-space__top--small')
+    expect(children[0]).not.toHaveClass('dnb-space__top--zero')
+    expect(children[1]).not.toHaveClass('dnb-space__top--small')
     expect(list.querySelector(':scope > div')).toBeNull()
   })
 


### PR DESCRIPTION
## Summary

Move List.Container to the new CSS gap engine while preserving its existing DOM structure and visual layout. This removes the need for custom list item components to expose the internal _supportsSpacingProps marker, while retaining an explicit legacy escape hatch for compatibility.

Preview: https://codex-refactor-list-css-gap.eufemia-e25.pages.dev/uilib/components/list/demos#separated-lists
Builds on #8942.
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1785921129466409