### PR TITLE
refactor(Filter): use CSS gap in Selection

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/FilterSelection.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterSelection.tsx
@@ -67,14 +67,17 @@ function FilterSelection({
       filterKey={filterKey}
       defaultOpen={defaultOpen}
     >
-      <Flex.Vertical gap="small">
+      <Flex.Vertical layoutEngine="css" gap="small">
         {options.map((option) => (
-          <Checkbox
-            key={option.value}
-            label={option.label}
-            checked={currentValue.includes(option.value)}
-            onChange={({ checked }) => handleChange(option.value, checked)}
-          />
+          <Flex.Item key={option.value}>
+            <Checkbox
+              label={option.label}
+              checked={currentValue.includes(option.value)}
+              onChange={({ checked }) =>
+                handleChange(option.value, checked)
+              }
+            />
+          </Flex.Item>
         ))}
       </Flex.Vertical>
     </FilterItem>

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterSelection.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterSelection.test.tsx
@@ -30,6 +30,35 @@ describe('Filter.Selection', () => {
     expect(checkboxes).toHaveLength(2)
   })
 
+  it('uses the CSS gap layout engine for the options', () => {
+    render(
+      <FilterRoot>
+        <FilterSelection
+          label="Type"
+          filterKey="type"
+          data={options}
+          defaultOpen
+        />
+      </FilterRoot>
+    )
+
+    const optionsContainer = document.querySelector(
+      '.dnb-flex-container--direction-vertical'
+    )
+
+    expect(optionsContainer).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-small'
+    )
+    expect(optionsContainer.children).toHaveLength(2)
+    expect(
+      optionsContainer.querySelectorAll(':scope > .dnb-flex-item')
+    ).toHaveLength(2)
+    expect(
+      optionsContainer.querySelector(':scope > .dnb-space__top--small')
+    ).toBeNull()
+  })
+
   it('sets individual filter entries when checkboxes are checked', () => {
     function FilterState() {
       const ctx = useFilterContext()


### PR DESCRIPTION
## Summary

Move the internal Filter.Selection checkbox layout to the CSS gap engine while preserving the existing option wrappers and visual geometry.

Builds on #8942.