### PR TITLE
refactor(HelpButton): use CSS gap in inline content

### DIFF
--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -319,11 +319,15 @@ function HelpButtonInlineContentComponent(
       >
         <Flex.Vertical layoutEngine="css" gap="x-small">
           {title && (
-            <P weight="medium" element="div">
+            <P weight="medium" element="div" bottom={0}>
               {title}
             </P>
           )}
-          {content && <P element="div">{content}</P>}
+          {content && (
+            <P element="div" bottom={0}>
+              {content}
+            </P>
+          )}
         </Flex.Vertical>
         {children}
       </Section>

--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -317,7 +317,7 @@ function HelpButtonInlineContentComponent(
         }
         {...rest}
       >
-        <Flex.Vertical gap="x-small">
+        <Flex.Vertical layoutEngine="css" gap="x-small">
           {title && (
             <P weight="medium" element="div">
               {title}

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -20,7 +20,7 @@ describe('HelpButtonInline', () => {
     ).toBeInTheDocument()
   })
 
-  it('uses the CSS gap layout engine for inline content', () => {
+  it('uses CSS gap without adding paragraph margins', () => {
     render(
       <HelpButtonInline
         help={{
@@ -39,6 +39,12 @@ describe('HelpButtonInline', () => {
       'dnb-flex-container--css-gap',
       'dnb-flex-container--spacing-x-small'
     )
+
+    const paragraphs = content.querySelectorAll('.dnb-p')
+    expect(paragraphs).toHaveLength(2)
+    paragraphs.forEach((paragraph) => {
+      expect(paragraph).toHaveClass('dnb-space__bottom--zero')
+    })
   })
 
   it('should toggle open state when clicked', async () => {

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -20,6 +20,27 @@ describe('HelpButtonInline', () => {
     ).toBeInTheDocument()
   })
 
+  it('uses the CSS gap layout engine for inline content', () => {
+    render(
+      <HelpButtonInline
+        help={{
+          open: true,
+          title: 'Help title',
+          content: 'Help content',
+        }}
+      />
+    )
+
+    const content = document.querySelector(
+      '.dnb-help-button__content .dnb-flex-container'
+    )
+
+    expect(content).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-x-small'
+    )
+  })
+
   it('should toggle open state when clicked', async () => {
     render(<HelpButtonInline help={{ title: 'Help title' }} />)
 


### PR DESCRIPTION
Moves the internal inline-help content layout to native CSS gap while preserving the existing public API and visual spacing. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.