### PR TITLE
refactor(Field.MultiSelection): use CSS gap in selected items header

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSelectedTags.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSelectedTags.tsx
@@ -64,6 +64,7 @@ export function MultiSelectionSelectedTags({
     <Fragment>
       {isCollapsible && (
         <Flex.Horizontal
+          layoutEngine="css"
           className="dnb-forms-field-multi-selection__selected-items-header"
           justify="space-between"
           align="center"

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -1689,6 +1689,33 @@ describe('MultiSelection', () => {
       )
     })
 
+    it('uses the CSS gap layout engine for the selected items header', async () => {
+      const data = Array.from({ length: 25 }, (_, i) => ({
+        value: `option${i + 1}`,
+        title: `Option ${i + 1}`,
+      }))
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection
+            data={data}
+            showSelectedTags
+            value={data.slice(0, 22).map((item) => item.value)}
+          />
+        </Provider>
+      )
+
+      fireEvent.click(document.querySelector('button'))
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-multi-selection__selected-items-header'
+          )
+        ).toHaveClass('dnb-flex-container--css-gap')
+      })
+    })
+
     it('shows tags by default when total items exceed threshold', async () => {
       const data = Array.from({ length: 25 }, (_, i) => ({
         value: `option${i + 1}`,


### PR DESCRIPTION
Moves the internal selected-items header to native CSS gap while preserving the existing public API and visual layout. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.