### PR TITLE
refactor(Upload): use CSS gap in info layout

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadInfo.tsx
@@ -58,9 +58,9 @@ const UploadInfo = () => {
     displayFilesAmountLimitItem
 
   return (
-    <Flex.Stack gap="small">
+    <Flex.Stack layoutEngine="css" gap="small">
       {(title || text) && (
-        <Flex.Stack gap="xx-small">
+        <Flex.Stack layoutEngine="css" gap="xx-small">
           {title && <Lead space="0">{title}</Lead>}
 
           {text && <P className="dnb-upload__text">{text}</P>}

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.test.tsx
@@ -127,6 +127,24 @@ describe('Upload', () => {
     expect(screen.getByText('My custom content')).toBeInTheDocument()
   })
 
+  it('uses the CSS gap layout engine for upload information', () => {
+    render(<Upload {...defaultProps}>My custom content</Upload>)
+
+    const layouts = document.querySelectorAll(
+      '.dnb-upload .dnb-flex-container'
+    )
+
+    expect(layouts).toHaveLength(2)
+    expect(layouts[0]).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-small'
+    )
+    expect(layouts[1]).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-xx-small'
+    )
+  })
+
   describe('Text', () => {
     it('renders the title', () => {
       render(<Upload {...defaultProps} />)


### PR DESCRIPTION
Moves the internal upload information stacks to native CSS gap while preserving custom content and the existing visual layout. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.