### PR TITLE
refactor(Forms): use CSS gap in container toolbars

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
@@ -36,7 +36,7 @@ export default function Toolbar(props: FormSectionToolbarProps) {
       <Hr space={0} />
 
       <ToolbarContext value={{ setShowError, onEdit, onDone, onCancel }}>
-        <Flex.Horizontal top="x-small" gap="large">
+        <Flex.Horizontal layoutEngine="css" top="x-small" gap="large">
           {children}
         </Flex.Horizontal>
       </ToolbarContext>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/__tests__/Toolbar.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/__tests__/Toolbar.test.tsx
@@ -19,6 +19,23 @@ describe('Toolbar', () => {
     ).toHaveClass('dnb-space__top--large')
   })
 
+  it('uses the CSS gap layout engine', () => {
+    render(
+      <SectionContainerContext value={{}}>
+        <Toolbar>content</Toolbar>
+      </SectionContainerContext>
+    )
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-section-toolbar > .dnb-flex-container'
+      )
+    ).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-large'
+    )
+  })
+
   it('has buttons/tools by default', () => {
     render(
       <SectionContainerContext value={{}}>

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/PushContainer.tsx
@@ -453,7 +453,7 @@ function NewContainer({
   const toolbar = (
     <Toolbar>
       <IterateItemContext value={newItemContextProps}>
-        <Flex.Horizontal gap="large">
+        <Flex.Horizontal layoutEngine="css" gap="large">
           <DoneButton text={createButton} />
           {showOpenButton && <CancelButton onClick={cancelHandler} />}
           {(preventUncommittedChanges || showResetButton) && (

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -19,6 +19,24 @@ import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
 describe('PushContainer', () => {
+  it('uses the CSS gap layout engine for its actions', () => {
+    render(
+      <Form.Handler>
+        <Iterate.PushContainer path="/entries">
+          <Field.String itemPath="/name" />
+        </Iterate.PushContainer>
+      </Form.Handler>
+    )
+
+    const layouts = document.querySelectorAll(
+      '.dnb-forms-iterate-toolbar .dnb-flex-container'
+    )
+
+    expect(layouts).toHaveLength(2)
+    expect(layouts[0]).toHaveClass('dnb-flex-container--css-gap')
+    expect(layouts[1]).toHaveClass('dnb-flex-container--css-gap')
+  })
+
   it('should add a new entry to the array', async () => {
     const onChange = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/Toolbar.tsx
@@ -63,6 +63,7 @@ export default function Toolbar({
 
       <ToolbarContext value={{ setShowError }}>
         <Flex.Horizontal
+          layoutEngine="css"
           top={toolbarVariant === 'custom' ? false : 'x-small'}
           gap="large"
         >

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/__tests__/Toolbar.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Toolbar/__tests__/Toolbar.test.tsx
@@ -20,6 +20,19 @@ describe('Toolbar', () => {
     ).toHaveClass('dnb-space__top--large')
   })
 
+  it('uses the CSS gap layout engine', () => {
+    render(<Toolbar>content</Toolbar>)
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-iterate-toolbar > .dnb-flex-container'
+      )
+    ).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-large'
+    )
+  })
+
   it('should render Hr by default', () => {
     render(<Toolbar>content</Toolbar>)
 


### PR DESCRIPTION
Moves the internal Iterate and Form.Section toolbar layouts to native CSS gap while preserving their existing public APIs and visuals. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.