### PR TITLE
refactor(Form.InfoOverlay): use CSS gap

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/InfoOverlay.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/InfoOverlay.tsx
@@ -127,7 +127,7 @@ function InfoOverlay(props: FormInfoOverlayProps) {
         innerSpace={{ top: 'large', bottom: 'xx-large' }}
         {...restProps}
       >
-        <Flex.Stack gap="large">
+        <Flex.Stack layoutEngine="css" gap="large">
           <MainHeading>{title ?? tr.title}</MainHeading>
           <P>{description ?? tr.description}</P>
           <Button
@@ -149,7 +149,7 @@ function InfoOverlay(props: FormInfoOverlayProps) {
         innerSpace={{ top: 'large', bottom: 'xx-large' }}
         {...restProps}
       >
-        <Flex.Stack gap="large">
+        <Flex.Stack layoutEngine="css" gap="large">
           <MainHeading>{title ?? tr.title}</MainHeading>
           <HeightAnimation>
             <P>
@@ -158,7 +158,7 @@ function InfoOverlay(props: FormInfoOverlayProps) {
                 : (description ?? tr.description)}
             </P>
           </HeightAnimation>
-          <Flex.Horizontal>
+          <Flex.Horizontal layoutEngine="css">
             <Button variant="secondary" onClick={onCancelHandler}>
               {cancelButton ?? tr.cancelButton}
             </Button>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/__tests__/InfoOverlay.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/InfoOverlay/__tests__/InfoOverlay.test.tsx
@@ -37,6 +37,21 @@ describe('Form.InfoOverlay', () => {
     expect(anchor).toHaveAttribute('href', '/')
   })
 
+  it('uses the CSS gap layout engine for success content', () => {
+    render(
+      <Form.InfoOverlay content="success">
+        fallback content
+      </Form.InfoOverlay>
+    )
+
+    expect(
+      document.querySelector('.dnb-forms-info-overlay .dnb-flex-container')
+    ).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-large'
+    )
+  })
+
   it('should render error with correct text', async () => {
     const nb = nbNO['nb-NO'].InfoOverlayError
     const formId = {}
@@ -63,6 +78,26 @@ describe('Form.InfoOverlay', () => {
     const [backButton, retryButton] = Array.from(buttons)
     expect(backButton).toHaveTextContent(nb.cancelButton)
     expect(retryButton).toHaveTextContent(nb.retryButton)
+  })
+
+  it('uses the CSS gap layout engine for error content', () => {
+    render(
+      <Form.InfoOverlay content="error">fallback content</Form.InfoOverlay>
+    )
+
+    const content = document.querySelector(
+      '.dnb-forms-info-overlay .dnb-flex-container--direction-vertical'
+    )
+
+    expect(content).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-large'
+    )
+    expect(
+      content.querySelector(
+        ':scope > .dnb-flex-container--direction-horizontal'
+      )
+    ).toHaveClass('dnb-flex-container--css-gap')
   })
 
   it('should accept custom buttonHref', () => {


### PR DESCRIPTION
Moves the internal success, error, and action layouts to native CSS gap while preserving the existing public API and visual spacing. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.