### PR TITLE
refactor(Filter): use CSS gap in toolbar and active filters

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/FilterActiveFilters.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterActiveFilters.tsx
@@ -90,6 +90,7 @@ function FilterActiveFilters({
           {isCollapsible ? (
             <>
               <Flex.Horizontal
+                layoutEngine="css"
                 className="dnb-filter__active-filters__header"
                 justify="space-between"
                 align="center"
@@ -121,6 +122,7 @@ function FilterActiveFilters({
           ) : (
             <>
               <Flex.Horizontal
+                layoutEngine="css"
                 className="dnb-filter__active-filters__header"
                 justify="space-between"
                 align="center"

--- a/packages/dnb-eufemia/src/components/filter/FilterToolbar.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterToolbar.tsx
@@ -26,6 +26,7 @@ function FilterToolbarActions({
 }: FilterToolbarActionsProps) {
   return (
     <Flex.Horizontal
+      layoutEngine="css"
       gap="small"
       align="center"
       className={clsx('dnb-filter__toolbar-actions', className)}

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterActiveFilters.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterActiveFilters.test.tsx
@@ -351,6 +351,21 @@ describe('Filter.ActiveFilters collapsible', () => {
     expect(clearButton).toBeInTheDocument()
   })
 
+  it('uses the CSS gap layout engine for the header', () => {
+    render(
+      <FilterRoot>
+        <SetManyFilters count={2} />
+        <FilterActiveFilters />
+      </FilterRoot>
+    )
+
+    fireEvent.click(document.querySelector('[data-testid="set-many"]'))
+
+    expect(
+      document.querySelector('.dnb-filter__active-filters__header')
+    ).toHaveClass('dnb-flex-container--css-gap')
+  })
+
   it('clears all filters when clear all is clicked without collapsibleThreshold', () => {
     function FilterState() {
       const ctx = useFilterContext()

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterHeader.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterHeader.test.tsx
@@ -36,6 +36,25 @@ describe('Filter.Header', () => {
 })
 
 describe('Filter.Toolbar.Actions', () => {
+  it('uses the CSS gap layout engine', () => {
+    render(
+      <FilterRoot>
+        <FilterToolbar>
+          <FilterToolbar.Actions>
+            <button>Action</button>
+          </FilterToolbar.Actions>
+        </FilterToolbar>
+      </FilterRoot>
+    )
+
+    expect(
+      document.querySelector('.dnb-filter__toolbar-actions')
+    ).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-flex-container--spacing-small'
+    )
+  })
+
   it('renders children', () => {
     render(
       <FilterRoot>


### PR DESCRIPTION
Moves the internal toolbar actions and active-filter headers to native CSS gap while preserving the existing public API and visual layout. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.