### PR TITLE
refactor(Radio): use CSS gap in Group

### DIFF
--- a/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
+++ b/packages/dnb-eufemia/src/components/radio/RadioGroup.tsx
@@ -237,6 +237,7 @@ function RadioGroup(ownProps: RadioGroupProps) {
           role="radiogroup"
         >
           <Flex.Container
+            layoutEngine="css"
             direction={
               vertical || labelDirection === 'vertical'
                 ? 'vertical'

--- a/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/radio/__tests__/RadioGroup.test.tsx
@@ -126,11 +126,11 @@ describe('Radio group component', () => {
     expect(
       document.querySelector('.dnb-radio-group .dnb-flex-container')
     ).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
     expect(document.querySelector('.dnb-flex-container')).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
   })
@@ -146,7 +146,7 @@ describe('Radio group component', () => {
     const flexElement = element.querySelector('.dnb-flex-container')
 
     expect(flexElement).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-x-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-x-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
 
@@ -157,7 +157,7 @@ describe('Radio group component', () => {
     )
 
     expect(flexElement).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
   })


### PR DESCRIPTION
Moves the internal Radio.Group layout to native CSS gap while preserving its existing API and visual layout. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.