### PR TITLE
refactor(ToggleButton): use CSS gap in Group

### DIFF
--- a/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/ToggleButtonGroup.tsx
@@ -268,6 +268,7 @@ function ToggleButtonGroup(ownProps: ToggleButtonGroupProps) {
           role={variant === 'radio' ? 'radiogroup' : 'group'}
         >
           <Flex.Container
+            layoutEngine="css"
             direction={
               vertical || labelDirection === 'vertical'
                 ? 'vertical'

--- a/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
+++ b/packages/dnb-eufemia/src/components/toggle-button/__tests__/ToggleButtonGroup.test.tsx
@@ -25,7 +25,7 @@ describe('ToggleButton group component', () => {
     const flexElement = element.querySelector('.dnb-flex-container')
 
     expect(flexElement).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-x-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-x-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
 
@@ -36,7 +36,7 @@ describe('ToggleButton group component', () => {
     )
 
     expect(flexElement).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
   })
@@ -508,11 +508,11 @@ describe('ToggleButton group component', () => {
         '.dnb-toggle-button-group .dnb-flex-container'
       )
     ).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
     expect(document.querySelector('.dnb-flex-container')).toHaveClass(
-      'dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
+      'dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-flex-start dnb-flex-container--spacing-small dnb-flex-container--wrap dnb-flex-container--divider-space',
       { exact: true }
     )
   })


### PR DESCRIPTION
Moves the internal ToggleButton.Group layout to native CSS gap while preserving its existing API and visual layout. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.