### PR TITLE
refactor(Iterate.Array): use CSS gap by default

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/Array.tsx
@@ -429,7 +429,9 @@ function ArrayComponent(props: IterateArrayProps) {
       'dnb-forms-section', // To support containers
       props?.className
     ),
-    ...pickFlexContainerProps(props as FlexContainerProps),
+    ...pickFlexContainerProps(props as FlexContainerProps, {
+      layoutEngine: 'css',
+    }),
     ...pickSpacingProps(props),
     id: props?.id,
     ref: containerRef,

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/ArrayDocs.ts
@@ -2,6 +2,12 @@ import type { PropertiesTableProps } from '../../../../shared/types'
 import { DataValueWritePropsProperties } from '../../hooks/DataValueWritePropsDocs'
 
 export const ArrayProperties: PropertiesTableProps = {
+  layoutEngine: {
+    doc: 'Select the internal Flex layout engine. Defaults to `css`. Use `legacy` as a temporary compatibility fallback for custom integrations that depend on the previous wrapper-based layout.',
+    type: [`'css'`, `'legacy'`],
+    defaultValue: `'css'`,
+    status: 'optional',
+  },
   value: {
     doc: 'The data to iterate over. Alternative you can use the `path` property.',
     type: 'array',

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/Array/__tests__/Array.test.tsx
@@ -47,6 +47,32 @@ describe('Iterate.Array', () => {
     })
   })
 
+  describe('layout engine', () => {
+    it('uses the CSS gap layout engine by default', () => {
+      render(
+        <Iterate.Array value={['one', 'two']}>
+          <Field.String itemPath="/" />
+        </Iterate.Array>
+      )
+
+      expect(document.querySelector('.dnb-forms-iterate')).toHaveClass(
+        'dnb-flex-container--css-gap'
+      )
+    })
+
+    it('supports opting into the legacy layout engine', () => {
+      render(
+        <Iterate.Array layoutEngine="legacy" value={['one', 'two']}>
+          <Field.String itemPath="/" />
+        </Iterate.Array>
+      )
+
+      expect(document.querySelector('.dnb-forms-iterate')).not.toHaveClass(
+        'dnb-flex-container--css-gap'
+      )
+    })
+  })
+
   describe('with primitive elements', () => {
     it('should distribute values and receive callbacks', async () => {
       const onChange = vi.fn()

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/__tests__/ItemNo.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/ItemNo/__tests__/ItemNo.test.tsx
@@ -36,10 +36,10 @@ describe('Iterate.ItemNo', () => {
     )
     expect(document.querySelector('section')).toMatchInlineSnapshot(`
       <section
-        class="dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--align-self-stretch dnb-flex-container--spacing-medium dnb-flex-container--wrap dnb-flex-container--divider-space dnb-flex-stack dnb-forms-iterate dnb-forms-section"
+        class="dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--align-self-stretch dnb-flex-container--spacing-medium dnb-flex-container--wrap dnb-flex-container--divider-space dnb-flex-stack dnb-forms-iterate dnb-forms-section"
       >
         <div
-          class="dnb-space dnb-space__top--zero dnb-space__bottom--zero dnb-flex-item dnb-forms-iterate__element"
+          class="dnb-space dnb-flex-item dnb-forms-iterate__element"
           tabindex="-1"
         >
           <b>
@@ -64,10 +64,10 @@ describe('Iterate.ItemNo', () => {
     expect(document.querySelector('strong').textContent).toBe('ready')
     expect(document.querySelector('section')).toMatchInlineSnapshot(`
       <section
-        class="dnb-space dnb-flex-container dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--align-self-stretch dnb-flex-container--spacing-medium dnb-flex-container--wrap dnb-flex-container--divider-space dnb-flex-stack dnb-forms-iterate dnb-forms-section"
+        class="dnb-space dnb-flex-container dnb-flex-container--css-gap dnb-flex-container--direction-vertical dnb-flex-container--justify-flex-start dnb-flex-container--align-stretch dnb-flex-container--align-self-stretch dnb-flex-container--spacing-medium dnb-flex-container--wrap dnb-flex-container--divider-space dnb-flex-stack dnb-forms-iterate dnb-forms-section"
       >
         <div
-          class="dnb-space dnb-space__top--zero dnb-space__bottom--zero dnb-flex-item dnb-forms-iterate__element"
+          class="dnb-space dnb-flex-item dnb-forms-iterate__element"
           tabindex="-1"
         >
           Item no. 

--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/style/dnb-iterate.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/style/dnb-iterate.scss
@@ -1,6 +1,28 @@
 // More styles are in "dnb-form-section.scss"
 
 .dnb-forms-iterate {
+  &.dnb-flex-container--css-gap:has(
+      > .dnb-forms-iterate__element ~ .dnb-forms-iterate__element
+    ) {
+    --block-gap: var(--horizontal-gap);
+  }
+
+  &.dnb-flex-container--css-gap:has(
+      > .dnb-forms-iterate__element > .dnb-forms-section-block
+    ) {
+    row-gap: 0;
+  }
+
+  &.dnb-flex-container--css-gap.dnb-flex-container--divider-line:has(
+      > .dnb-forms-iterate__element ~ .dnb-forms-iterate__element
+    ) {
+    row-gap: var(--horizontal-gap);
+
+    &::after {
+      transform: translateY(calc(var(--horizontal-gap) / -2));
+    }
+  }
+
   &__element {
     outline: none; // Because of JavaScript focus management (tabIndex)
   }


### PR DESCRIPTION
Moves the internal Iterate.Array stack to native CSS gap while retaining layoutEngine=legacy as a compatibility fallback for custom integrations. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.