### PR TITLE
refactor(Stat.Inline): use CSS gap by default

### DIFF
--- a/packages/dnb-eufemia/src/components/stat/Inline.tsx
+++ b/packages/dnb-eufemia/src/components/stat/Inline.tsx
@@ -20,6 +20,7 @@ function Inline({
   className = null,
   gap = 'x-small',
   align = 'center',
+  layoutEngine = 'css',
   skeleton = null,
   ...rest
 }: InlineProps) {
@@ -40,6 +41,7 @@ function Inline({
         <Flex.Horizontal
           {...rest}
           {...attributes}
+          layoutEngine={layoutEngine}
           gap={gap}
           align={align}
           className={clsx(

--- a/packages/dnb-eufemia/src/components/stat/InlineDocs.ts
+++ b/packages/dnb-eufemia/src/components/stat/InlineDocs.ts
@@ -1,6 +1,12 @@
 import type { PropertiesTableProps } from '../../shared/types'
 
 export const InlineProperties: PropertiesTableProps = {
+  layoutEngine: {
+    doc: 'Select the internal Flex layout engine. Defaults to `css`. Use `legacy` as a temporary compatibility fallback for custom integrations that depend on the previous wrapper-based layout.',
+    type: [`'css'`, `'legacy'`],
+    defaultValue: `'css'`,
+    status: 'optional',
+  },
   children: {
     doc: 'Inline layout container for content elements, typically `Stat.Trend` and `Stat.Info`.',
     type: ['React.ReactNode'],

--- a/packages/dnb-eufemia/src/components/stat/__tests__/Inline.test.tsx
+++ b/packages/dnb-eufemia/src/components/stat/__tests__/Inline.test.tsx
@@ -38,6 +38,32 @@ describe('Stat.Inline', () => {
     )
   })
 
+  it('uses the CSS gap layout engine by default', () => {
+    render(
+      <Stat.Inline>
+        <Stat.Trend>+1.2%</Stat.Trend>
+        <Stat.Info>(additional information)</Stat.Info>
+      </Stat.Inline>
+    )
+
+    expect(document.querySelector('.dnb-stat__inline')).toHaveClass(
+      'dnb-flex-container--css-gap'
+    )
+  })
+
+  it('supports opting into the legacy layout engine', () => {
+    render(
+      <Stat.Inline layoutEngine="legacy">
+        <Stat.Trend>+1.2%</Stat.Trend>
+        <Stat.Info>(additional information)</Stat.Info>
+      </Stat.Inline>
+    )
+
+    expect(document.querySelector('.dnb-stat__inline')).not.toHaveClass(
+      'dnb-flex-container--css-gap'
+    )
+  })
+
   it('supports overrides', () => {
     render(
       <Stat.Inline align="baseline" gap="small">


### PR DESCRIPTION
Moves the Stat.Inline layout to native CSS gap while retaining layoutEngine=legacy as a compatibility fallback for custom integrations. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.