### PR TITLE
refactor(Wizard.Step): use CSS gap by default

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/Step.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/Step.tsx
@@ -69,6 +69,7 @@ function Step(props: WizardStepProps): JSX.Element {
     keepInDOM: keepInDOMProp,
     prerenderFieldProps,
     children,
+    layoutEngine = 'css',
     ...restProps
   } = props
 
@@ -194,6 +195,7 @@ function Step(props: WizardStepProps): JSX.Element {
   const childrenWithFlex = (
     <WizardStepContext value={{ index }}>
       <Flex.Stack
+        layoutEngine={layoutEngine}
         className={clsx('dnb-forms-step', className)}
         element="section"
         aria-label={ariaLabel}

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/StepDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/StepDocs.ts
@@ -1,6 +1,12 @@
 import type { PropertiesTableProps } from '../../../../shared/types'
 
 export const StepProperties: PropertiesTableProps = {
+  layoutEngine: {
+    doc: 'Select the internal Flex layout engine. Defaults to `css`. Use `legacy` as a temporary compatibility fallback for custom integrations that depend on the previous wrapper-based layout.',
+    type: [`'css'`, `'legacy'`],
+    defaultValue: `'css'`,
+    status: 'optional',
+  },
   title: {
     doc: 'A unique title of the step.',
     type: 'React.ReactNode',

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/__tests__/Step.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Step/__tests__/Step.test.tsx
@@ -60,6 +60,22 @@ describe('Step', () => {
     expect(stepElement.tagName).toBe('SECTION')
   })
 
+  it('uses the CSS gap layout engine by default', () => {
+    render(<Wizard.Step>Step Content</Wizard.Step>)
+
+    expect(document.querySelector('.dnb-forms-step')).toHaveClass(
+      'dnb-flex-container--css-gap'
+    )
+  })
+
+  it('supports opting into the legacy layout engine', () => {
+    render(<Wizard.Step layoutEngine="legacy">Step Content</Wizard.Step>)
+
+    expect(document.querySelector('.dnb-forms-step')).not.toHaveClass(
+      'dnb-flex-container--css-gap'
+    )
+  })
+
   it('should have tabIndex of -1', () => {
     render(
       <WizardContext value={{}}>

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/style/dnb-wizard-layout.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/style/dnb-wizard-layout.scss
@@ -17,6 +17,22 @@
 
     .dnb-forms-step {
       outline: none;
+
+      &.dnb-flex-container--css-gap {
+        > .dnb-forms-section-block,
+        > .dnb-form-status:not(:first-child) {
+          margin-block-start: calc(var(--horizontal-gap) * -1);
+        }
+
+        > .dnb-card + .dnb-forms-button-row,
+        > .dnb-card + .dnb-button--primary {
+          margin-block-start: 0;
+        }
+
+        > .dnb-forms-section-block + .dnb-forms-button-row {
+          margin-block-start: calc(1rem - var(--horizontal-gap));
+        }
+      }
     }
 
     .dnb-forms-step > .appear-fx,


### PR DESCRIPTION
Moves the Wizard.Step layout to native CSS gap while retaining layoutEngine=legacy as a compatibility fallback for custom integrations. This reduces reliance on the legacy Flex layout engine ahead of its removal in the next major version.