### PR TITLE
feat(Card): support opting into CSS gap with `layoutEngine: 'css'`

### DIFF
--- a/packages/dnb-eufemia/src/components/card/CardDocs.ts
+++ b/packages/dnb-eufemia/src/components/card/CardDocs.ts
@@ -1,6 +1,12 @@
 import type { PropertiesTableProps } from '../../shared/types'
 
 export const CardProperties: PropertiesTableProps = {
+  layoutEngine: {
+    doc: 'Select the internal Flex layout engine. Defaults to `css`. Use `legacy` as a temporary compatibility fallback for custom integrations that depend on the previous wrapper-based layout.',
+    type: [`'css'`, `'legacy'`],
+    defaultValue: `'css'`,
+    status: 'optional',
+  },
   outset: {
     doc: 'Whether or not to break out (using negative margins) on larger screens. Defaults to `false`.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/card/CardDocs.ts
+++ b/packages/dnb-eufemia/src/components/card/CardDocs.ts
@@ -2,9 +2,9 @@ import type { PropertiesTableProps } from '../../shared/types'
 
 export const CardProperties: PropertiesTableProps = {
   layoutEngine: {
-    doc: 'Select the internal Flex layout engine. Defaults to `css`. Use `legacy` as a temporary compatibility fallback for custom integrations that depend on the previous wrapper-based layout.',
+    doc: 'Select the internal Flex layout engine. Defaults to `legacy` for backwards compatibility. Use `css` to opt in to native CSS gap.',
     type: [`'css'`, `'legacy'`],
-    defaultValue: `'css'`,
+    defaultValue: `'legacy'`,
     status: 'optional',
   },
   outset: {

--- a/packages/dnb-eufemia/src/components/card/CardInner.tsx
+++ b/packages/dnb-eufemia/src/components/card/CardInner.tsx
@@ -57,6 +57,7 @@ function Card(props: CardProps) {
     align,
     divider = 'space',
     rowGap,
+    layoutEngine = 'css',
     responsive = !nestedContext?.isNested,
     filled,
     outset,
@@ -119,6 +120,7 @@ function Card(props: CardProps) {
     <Flex.Item alignSelf={alignSelf} {...params} element={element}>
       <CardContext value={{ ...nestedContext, isNested: true }}>
         <Flex.Container
+          layoutEngine={layoutEngine}
           direction={direction ?? 'vertical'}
           divider={divider}
           alignSelf={alignSelf}

--- a/packages/dnb-eufemia/src/components/card/CardInner.tsx
+++ b/packages/dnb-eufemia/src/components/card/CardInner.tsx
@@ -57,7 +57,7 @@ function Card(props: CardProps) {
     align,
     divider = 'space',
     rowGap,
-    layoutEngine = 'css',
+    layoutEngine = 'legacy',
     responsive = !nestedContext?.isNested,
     filled,
     outset,

--- a/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
+++ b/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
@@ -6,26 +6,26 @@ import Card from '../../card/Card'
 import { P } from '../../../elements'
 
 describe('Card', () => {
-  it('uses the CSS gap layout engine by default', () => {
+  it('uses the legacy layout engine by default', () => {
     render(
       <Card>
         <P>Paragraph</P>
       </Card>
     )
 
-    expect(document.querySelector('.dnb-flex-container')).toHaveClass(
+    expect(document.querySelector('.dnb-flex-container')).not.toHaveClass(
       'dnb-flex-container--css-gap'
     )
   })
 
-  it('supports opting into the legacy layout engine', () => {
+  it('supports opting into the CSS gap layout engine', () => {
     render(
-      <Card layoutEngine="legacy">
+      <Card layoutEngine="css">
         <P>Paragraph</P>
       </Card>
     )
 
-    expect(document.querySelector('.dnb-flex-container')).not.toHaveClass(
+    expect(document.querySelector('.dnb-flex-container')).toHaveClass(
       'dnb-flex-container--css-gap'
     )
   })
@@ -164,9 +164,12 @@ describe('Card', () => {
     expect(children.length).toBe(2)
 
     expect(children[0].tagName).toBe('P')
-    expect(children[0]).toHaveClass('dnb-p')
+    expect(children[0]).toHaveClass(
+      'dnb-p dnb-space__top--zero dnb-space__bottom--zero'
+    )
+
     expect(children[1].tagName).toBe('P')
-    expect(children[1]).toHaveClass('dnb-p')
+    expect(children[1]).toHaveClass('dnb-space__top--medium')
   })
 
   it('should have correct classes when "stack" is set', () => {
@@ -232,13 +235,21 @@ describe('Card', () => {
 
     expect(container).toHaveClass('dnb-flex-container--divider-line')
 
-    expect(children.length).toBe(2)
+    expect(children.length).toBe(3)
 
     expect(children[0].tagName).toBe('P')
-    expect(children[0]).toHaveClass('dnb-p')
-    expect(children[1].tagName).toBe('P')
-    expect(children[1]).toHaveClass('dnb-p')
-    expect(container.querySelector('hr')).toBeNull()
+    expect(children[0]).toHaveClass(
+      'dnb-p dnb-space__top--zero dnb-space__bottom--zero'
+    )
+    expect(children[1].tagName).toBe('HR')
+    expect(children[1]).toHaveClass(
+      'dnb-flex-container__hr dnb-space__top--medium dnb-space__left--zero dnb-space__bottom--zero dnb-space__right--zero dnb-hr'
+    )
+
+    expect(children[2].tagName).toBe('P')
+    expect(children[2]).toHaveClass(
+      'dnb-p dnb-space__top--medium dnb-space__bottom--zero'
+    )
   })
 
   it('should change direction', () => {
@@ -305,9 +316,14 @@ describe('Card', () => {
 
     expect(children.length).toBe(3)
 
-    expect(children[0]).toHaveClass('dnb-p')
-    expect(children[1]).toHaveClass('dnb-p')
-    expect(children[2]).toHaveClass('dnb-p')
+    expect(children[0]).toHaveClass('dnb-space__top--zero')
+    expect(children[0]).toHaveClass('dnb-space__bottom--zero')
+
+    expect(children[1]).toHaveClass('dnb-space__top--small')
+    expect(children[1]).toHaveClass('dnb-space__bottom--zero')
+
+    expect(children[2]).toHaveClass('dnb-space__top--small')
+    expect(children[2]).toHaveClass('dnb-space__bottom--zero')
 
     rerender(
       <Card gap="large">
@@ -319,9 +335,14 @@ describe('Card', () => {
 
     expect(container).toHaveClass('dnb-flex-container--spacing-large')
 
-    expect(children[0]).toHaveClass('dnb-p')
-    expect(children[1]).toHaveClass('dnb-p')
-    expect(children[2]).toHaveClass('dnb-p')
+    expect(children[0]).toHaveClass('dnb-space__top--zero')
+    expect(children[0]).toHaveClass('dnb-space__bottom--zero')
+
+    expect(children[1]).toHaveClass('dnb-space__top--large')
+    expect(children[1]).toHaveClass('dnb-space__bottom--zero')
+
+    expect(children[2]).toHaveClass('dnb-space__top--large')
+    expect(children[2]).toHaveClass('dnb-space__bottom--zero')
   })
 
   it('gets valid ref element', () => {

--- a/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
+++ b/packages/dnb-eufemia/src/components/card/__tests__/Card.test.tsx
@@ -6,6 +6,30 @@ import Card from '../../card/Card'
 import { P } from '../../../elements'
 
 describe('Card', () => {
+  it('uses the CSS gap layout engine by default', () => {
+    render(
+      <Card>
+        <P>Paragraph</P>
+      </Card>
+    )
+
+    expect(document.querySelector('.dnb-flex-container')).toHaveClass(
+      'dnb-flex-container--css-gap'
+    )
+  })
+
+  it('supports opting into the legacy layout engine', () => {
+    render(
+      <Card layoutEngine="legacy">
+        <P>Paragraph</P>
+      </Card>
+    )
+
+    expect(document.querySelector('.dnb-flex-container')).not.toHaveClass(
+      'dnb-flex-container--css-gap'
+    )
+  })
+
   it('should support legacy and CSS gap ScrollView roots', () => {
     const css = loadScss(require.resolve('../style/dnb-card.scss'))
 
@@ -140,12 +164,9 @@ describe('Card', () => {
     expect(children.length).toBe(2)
 
     expect(children[0].tagName).toBe('P')
-    expect(children[0]).toHaveClass(
-      'dnb-p dnb-space__top--zero dnb-space__bottom--zero'
-    )
-
+    expect(children[0]).toHaveClass('dnb-p')
     expect(children[1].tagName).toBe('P')
-    expect(children[1]).toHaveClass('dnb-space__top--medium')
+    expect(children[1]).toHaveClass('dnb-p')
   })
 
   it('should have correct classes when "stack" is set', () => {
@@ -211,21 +232,13 @@ describe('Card', () => {
 
     expect(container).toHaveClass('dnb-flex-container--divider-line')
 
-    expect(children.length).toBe(3)
+    expect(children.length).toBe(2)
 
     expect(children[0].tagName).toBe('P')
-    expect(children[0]).toHaveClass(
-      'dnb-p dnb-space__top--zero dnb-space__bottom--zero'
-    )
-    expect(children[1].tagName).toBe('HR')
-    expect(children[1]).toHaveClass(
-      'dnb-flex-container__hr dnb-space__top--medium dnb-space__left--zero dnb-space__bottom--zero dnb-space__right--zero dnb-hr'
-    )
-
-    expect(children[2].tagName).toBe('P')
-    expect(children[2]).toHaveClass(
-      'dnb-p dnb-space__top--medium dnb-space__bottom--zero'
-    )
+    expect(children[0]).toHaveClass('dnb-p')
+    expect(children[1].tagName).toBe('P')
+    expect(children[1]).toHaveClass('dnb-p')
+    expect(container.querySelector('hr')).toBeNull()
   })
 
   it('should change direction', () => {
@@ -292,14 +305,9 @@ describe('Card', () => {
 
     expect(children.length).toBe(3)
 
-    expect(children[0]).toHaveClass('dnb-space__top--zero')
-    expect(children[0]).toHaveClass('dnb-space__bottom--zero')
-
-    expect(children[1]).toHaveClass('dnb-space__top--small')
-    expect(children[1]).toHaveClass('dnb-space__bottom--zero')
-
-    expect(children[2]).toHaveClass('dnb-space__top--small')
-    expect(children[2]).toHaveClass('dnb-space__bottom--zero')
+    expect(children[0]).toHaveClass('dnb-p')
+    expect(children[1]).toHaveClass('dnb-p')
+    expect(children[2]).toHaveClass('dnb-p')
 
     rerender(
       <Card gap="large">
@@ -311,14 +319,9 @@ describe('Card', () => {
 
     expect(container).toHaveClass('dnb-flex-container--spacing-large')
 
-    expect(children[0]).toHaveClass('dnb-space__top--zero')
-    expect(children[0]).toHaveClass('dnb-space__bottom--zero')
-
-    expect(children[1]).toHaveClass('dnb-space__top--large')
-    expect(children[1]).toHaveClass('dnb-space__bottom--zero')
-
-    expect(children[2]).toHaveClass('dnb-space__top--large')
-    expect(children[2]).toHaveClass('dnb-space__bottom--zero')
+    expect(children[0]).toHaveClass('dnb-p')
+    expect(children[1]).toHaveClass('dnb-p')
+    expect(children[2]).toHaveClass('dnb-p')
   })
 
   it('gets valid ref element', () => {


### PR DESCRIPTION
Passes the `layoutEngine` prop through to Card’s internal Flex container so consumers can opt into native CSS gap.

Card keeps the legacy engine by default because it accepts arbitrary children, and changing their wrapper, spacing, and intrinsic sizing behavior would break existing layouts. Controlled Card usages can migrate explicitly ahead of the next major version.