### PR TITLE
refactor(Form.Section): use CSS gap in content containers

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -130,7 +130,7 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
           className={clsx('dnb-forms-section-edit-block', className)}
           {...restProps}
         >
-          <Flex.Stack>
+          <Flex.Stack layoutEngine="css">
             {title && <Lead size="basis">{title}</Lead>}
             {children}
             {hasToolbar ? null : (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -130,7 +130,10 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
           className={clsx('dnb-forms-section-edit-block', className)}
           {...restProps}
         >
-          <Flex.Stack layoutEngine="css">
+          <Flex.Stack
+            layoutEngine="css"
+            className="dnb-forms-section-block__content"
+          >
             {title && <Lead size="basis">{title}</Lead>}
             {children}
             {hasToolbar ? null : (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
@@ -19,7 +19,10 @@ describe('EditContainer', () => {
       document.querySelector(
         '.dnb-forms-section-edit-block .dnb-flex-stack'
       )
-    ).toHaveClass('dnb-flex-container--css-gap')
+    ).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-forms-section-block__content'
+    )
   })
 
   it('should throw when preventUncommittedChanges is used without a section path', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditContainer.test.tsx
@@ -6,6 +6,22 @@ import Toolbar from '../../Toolbar'
 const nb = nbNO['nb-NO']
 
 describe('EditContainer', () => {
+  it('uses the CSS gap layout engine by default', () => {
+    render(
+      <Form.Section>
+        <Form.Section.EditContainer>
+          Edit Content
+        </Form.Section.EditContainer>
+      </Form.Section>
+    )
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-section-edit-block .dnb-flex-stack'
+      )
+    ).toHaveClass('dnb-flex-container--css-gap')
+  })
+
   it('should throw when preventUncommittedChanges is used without a section path', () => {
     expect(() =>
       render(

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainer.tsx
@@ -41,7 +41,10 @@ function ViewContainer(props: FormSectionViewContainerAllProps) {
       className={clsx('dnb-forms-section-view-block', className)}
       {...restProps}
     >
-      <Flex.Stack layoutEngine="css">
+      <Flex.Stack
+        layoutEngine="css"
+        className="dnb-forms-section-block__content"
+      >
         {title && <Lead size="basis">{title}</Lead>}
         {children}
         {showDefaultToolbar ? (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/ViewContainer.tsx
@@ -41,7 +41,7 @@ function ViewContainer(props: FormSectionViewContainerAllProps) {
       className={clsx('dnb-forms-section-view-block', className)}
       {...restProps}
     >
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         {title && <Lead size="basis">{title}</Lead>}
         {children}
         {showDefaultToolbar ? (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/ViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/ViewContainer.test.tsx
@@ -8,6 +8,20 @@ import Toolbar from '../../Toolbar'
 const nb = nbNO['nb-NO'].SectionViewContainer
 
 describe('ViewContainer', () => {
+  it('uses the CSS gap layout engine by default', () => {
+    render(
+      <SectionContainerContext value={{ containerMode: 'view' }}>
+        <ViewContainer>content</ViewContainer>
+      </SectionContainerContext>
+    )
+
+    expect(
+      document.querySelector(
+        '.dnb-forms-section-view-block .dnb-flex-stack'
+      )
+    ).toHaveClass('dnb-flex-container--css-gap')
+  })
+
   it('renders content and without errors', () => {
     const { rerender } = render(
       <SectionContainerContext value={{ containerMode: 'edit' }}>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/ViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/ViewContainer/__tests__/ViewContainer.test.tsx
@@ -19,7 +19,10 @@ describe('ViewContainer', () => {
       document.querySelector(
         '.dnb-forms-section-view-block .dnb-flex-stack'
       )
-    ).toHaveClass('dnb-flex-container--css-gap')
+    ).toHaveClass(
+      'dnb-flex-container--css-gap',
+      'dnb-forms-section-block__content'
+    )
   })
 
   it('renders content and without errors', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/style/dnb-form-section.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/style/dnb-form-section.scss
@@ -28,6 +28,16 @@
       }
     }
 
+    &__content.dnb-flex-container--css-gap {
+      > :not(.dnb-space--has-block-start):not([class*='dnb-space__top']) {
+        margin-block-start: 0;
+      }
+
+      > :not(.dnb-space--has-block-end):not([class*='dnb-space__bottom']) {
+        margin-block-end: 0;
+      }
+    }
+
     &--variant-basic {
       --border-color: transparent;
       --block-outline-color: transparent;


### PR DESCRIPTION
Moves the internal ViewContainer and EditContainer content stacks to native CSS gap without changing the public Form.Section API. This reduces reliance on generated legacy spacing wrappers ahead of the legacy Flex engine removal.