### PR TITLE
chore(visual-regression): surface the diff report in the run summary and host it

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -177,6 +177,85 @@ jobs:
           path: |
             ./packages/dnb-eufemia/visual-diff-report/**
 
-      - name: Run visual tests info
+      # The visual diff report is a self-contained folder (index.html +
+      # images/). Only proceed when it actually exists (a non-screenshot
+      # failure produces none), and detect whether Cloudflare credentials are
+      # available so the deploy is skipped gracefully on forked PRs (no
+      # secrets) or when the token is not configured. The secret comparison
+      # yields only a boolean; the secret value itself is never emitted.
+      - name: Detect report hosting capability
+        id: report_host
         if: failure()
-        run: echo '\n\n👉 Download the diff files as a ZIP file. \nIt is called "visual-test-artifact" and you find it in the test "Summary" under "Artifacts".\n\n\n'
+        run: |
+          if [ -f packages/dnb-eufemia/visual-diff-report/report.json ]; then
+            echo "has_report=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_report=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "enabled=${{ secrets.CLOUDFLARE_API_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy visual report to Cloudflare Pages
+        id: report_deploy
+        if: failure() && steps.report_host.outputs.has_report == 'true' && steps.report_host.outputs.enabled == 'true'
+        # Best-effort: a hosting hiccup must not add a red step to a run that
+        # already failed on the real visual regression.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          # Extract the deployment URL from wrangler's stdout. Uses POSIX
+          # [[:space:]] (not \s) because this job runs on macOS, whose BSD sed
+          # does not support \s.
+          OUTPUT="$(yarn workspace dnb-design-system-portal wrangler pages deploy \
+            "$GITHUB_WORKSPACE/packages/dnb-eufemia/visual-diff-report" \
+            --project-name eufemia \
+            --branch "vr-$BRANCH" \
+            --commit-dirty=true)"
+
+          echo "$OUTPUT"
+
+          ALIAS_URL="$(echo "$OUTPUT" | sed -nE 's/.*Deployment alias URL:[[:space:]]*(https:\/\/[^ ]+).*/\1/p')"
+          DEPLOYMENT_URL="$(echo "$OUTPUT" | sed -nE 's/.*Take a peek over at[[:space:]]*(https:\/\/[^ ]+).*/\1/p')"
+
+          # Prefer the immutable per-deployment URL so each run's summary keeps
+          # pointing at its own report; the branch alias always moves to the
+          # latest deploy. Fall back to the alias if the unique URL is absent.
+          echo "report_url=${DEPLOYMENT_URL:-$ALIAS_URL}" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Passed via env (not inlined into the script) so an untrusted PR
+          # branch name cannot inject shell commands into the run step.
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+
+      # Render the failed screenshots directly on the run's Summary page. When
+      # the report was hosted, each row embeds a diff thumbnail linking to the
+      # full-size image; otherwise the list still points to the artifact. The
+      # Markdown is built by a small, unit-tested Node module.
+      - name: Publish visual report to job summary
+        if: failure() && steps.report_host.outputs.has_report == 'true'
+        # Best-effort: rendering the summary must not add a red step to an
+        # already-failed run.
+        continue-on-error: true
+        env:
+          REPORT_URL: ${{ steps.report_deploy.outputs.report_url }}
+        run: |
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types \
+            packages/dnb-eufemia/scripts/tools/visualReport/summaryCli.ts \
+            packages/dnb-eufemia/visual-diff-report/report.json >> "$GITHUB_STEP_SUMMARY"
+
+      # Print clickable links in the failing job's log so you can jump
+      # straight to the hosted report (or the run summary) without hunting.
+      # GitHub linkifies bare URLs in step logs.
+      - name: Run visual tests info
+        if: failure() && steps.report_host.outputs.has_report == 'true'
+        env:
+          REPORT_URL: ${{ steps.report_deploy.outputs.report_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo '👉 Visual regression failed — where to see why:'
+          if [ -n "${REPORT_URL}" ]; then
+            echo "   • Hosted report (before / after / diff): ${REPORT_URL}"
+          fi
+          echo "   • Run summary (failed-test table + artifact): ${RUN_URL}"
+          echo "   • Offline: download the 'visual-test-artifact' ZIP from the run summary."

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/make-and-run-tests.mdx
@@ -221,7 +221,7 @@ you can find a report entry (`index.html`), that lists all of the failed tests h
 
 You may check out the CI/CLI logs for more details.
 
-**GitHub Actions:** If visual screenshot test is failing on the CI, you can navigate to the test "Summary" where you can find "Artifacts". There you can download the **visual-test-artifact** zip file, containing the visual diff files as well as the report entry inside `/visual-diff-report`.
+**GitHub Actions:** When a visual screenshot test fails on the CI, the failed screenshots are listed directly on the run's "Summary" page. When report hosting is available, each row links to a hosted before/after/diff view, so no download is needed. The same report is also attached as the **visual-test-artifact** zip file (containing `/visual-diff-report` with `index.html` and the diff images) for offline inspection.
 
 ## Support SCSS snapshot test
 

--- a/packages/dnb-eufemia/scripts/tools/visualReport/__tests__/renderSummary.test.ts
+++ b/packages/dnb-eufemia/scripts/tools/visualReport/__tests__/renderSummary.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  renderVisualReportSummary,
+  type VisualReportFailure,
+} from '../renderSummary'
+
+const makeFailure = (
+  overrides: Partial<VisualReportFailure> = {}
+): VisualReportFailure => ({
+  title: 'Table > has to match active state',
+  testFilePath: 'src/components/table/Table.test.ts',
+  lineNumber: 42,
+  dataVisualTestId: 'table-active',
+  message: 'Screenshot mismatch: 100 px differ (1.5%).',
+  images: {
+    expected: 'images/0-table-active.snap.expected.png',
+    actual: 'images/0-table-active.actual.actual.png',
+    diff: 'images/0-table-active.diff.diff.png',
+  },
+  ...overrides,
+})
+
+describe('renderVisualReportSummary', () => {
+  it('renders a heading and the failure count', () => {
+    const md = renderVisualReportSummary({ failures: [makeFailure()] })
+
+    expect(md).toContain('## Visual regression report')
+    expect(md).toContain(
+      '**1** screenshot differs from the committed baseline.'
+    )
+  })
+
+  it('pluralises the count and verb for several failures', () => {
+    const md = renderVisualReportSummary({
+      failures: [makeFailure(), makeFailure()],
+    })
+
+    expect(md).toContain(
+      '**2** screenshots differ from the committed baseline.'
+    )
+  })
+
+  it('links to the hosted report and embeds a diff thumbnail when a URL is given', () => {
+    const md = renderVisualReportSummary(
+      { failures: [makeFailure()] },
+      'https://vr-branch.eufemia.pages.dev/'
+    )
+
+    // trailing slash is normalised away
+    expect(md).toContain(
+      '[Open the full interactive report](https://vr-branch.eufemia.pages.dev)'
+    )
+    expect(md).toContain(
+      '<img src="https://vr-branch.eufemia.pages.dev/images/0-table-active.diff.diff.png" width="220"'
+    )
+    expect(md).toContain('| Test | Location | Diff |')
+    expect(md).toContain('src/components/table/Table.test.ts:42')
+  })
+
+  it('falls back to the artifact note and no thumbnails without a URL', () => {
+    const md = renderVisualReportSummary({ failures: [makeFailure()] })
+
+    expect(md).toContain('**visual-test-artifact**')
+    expect(md).not.toContain('<img')
+    // diff column shows a dash placeholder
+    expect(md).toMatch(/\|\s*—\s*\|/)
+  })
+
+  it('uses the actual image when no diff image exists', () => {
+    const failure = makeFailure({
+      images: {
+        expected: 'images/0-x.expected.png',
+        actual: 'images/0-x.actual.actual.png',
+        diff: null,
+      },
+    })
+    const md = renderVisualReportSummary(
+      { failures: [failure] },
+      'https://host'
+    )
+
+    expect(md).toContain('https://host/images/0-x.actual.actual.png')
+  })
+
+  it('omits the table when there are no failures', () => {
+    const md = renderVisualReportSummary({ failures: [] })
+
+    expect(md).toContain('**0** screenshots differ')
+    expect(md).not.toContain('| Test | Location | Diff |')
+  })
+
+  it('escapes HTML-significant characters in text cells', () => {
+    const failure = makeFailure({
+      title: 'Field <script> & "friends"',
+      message: 'a | b < c',
+      dataVisualTestId: 'id-<x>',
+    })
+    const md = renderVisualReportSummary({ failures: [failure] })
+
+    expect(md).toContain('Field &lt;script&gt; &amp; "friends"')
+    expect(md).toContain('a \\| b &lt; c')
+    expect(md).toContain('data-visual-test="id-&lt;x&gt;"')
+    expect(md).not.toContain('<script>')
+  })
+
+  it('escapes backslashes before pipe-escaping so a cell cannot break the table', () => {
+    const md = renderVisualReportSummary({
+      failures: [makeFailure({ title: 'a\\|b', message: 'c\\d' })],
+    })
+
+    // A literal "\|" must become "\\" + "\|" so the pipe stays escaped and
+    // does not introduce a new table column.
+    expect(md).toContain('a' + '\\\\' + '\\|' + 'b')
+    expect(md).toContain('c' + '\\\\' + 'd')
+  })
+
+  it('escapes double quotes in image URLs to prevent attribute breakout', () => {
+    const failure = makeFailure({
+      images: {
+        expected: null,
+        actual: null,
+        diff: 'images/0-a"onerror=alert(1).diff.png',
+      },
+    })
+    const md = renderVisualReportSummary(
+      { failures: [failure] },
+      'https://host'
+    )
+
+    expect(md).not.toContain('"onerror=alert(1)')
+    expect(md).toContain('&quot;onerror=alert(1)')
+  })
+
+  it('caps the table and notes the overflow, pointing to the hosted report', () => {
+    const failures = [makeFailure(), makeFailure(), makeFailure()]
+    const md = renderVisualReportSummary({ failures }, 'https://host', 2)
+
+    const rowCount = (md.match(/\| <strong>/g) || []).length
+    expect(rowCount).toBe(2)
+    expect(md).toContain('**3** screenshots differ')
+    expect(md).toContain(
+      'Showing the first 2 of 3 failures — see the full report for the remaining 1.'
+    )
+  })
+
+  it('points the overflow note to the artifact when not hosted', () => {
+    const failures = [makeFailure(), makeFailure(), makeFailure()]
+    const md = renderVisualReportSummary({ failures }, '', 2)
+
+    expect(md).toContain(
+      'see the **visual-test-artifact** for the remaining 1.'
+    )
+  })
+})

--- a/packages/dnb-eufemia/scripts/tools/visualReport/renderSummary.ts
+++ b/packages/dnb-eufemia/scripts/tools/visualReport/renderSummary.ts
@@ -1,0 +1,143 @@
+/**
+ * Renders the GitHub Actions job-summary Markdown for a failed visual
+ * regression run.
+ *
+ * Pure and dependency-free so it can be unit-tested and run standalone
+ * in CI (see `summaryCli.ts`). The manifest shape mirrors the
+ * `report.json` written by `screenshotReporter.ts`.
+ */
+
+export type VisualReportImages = {
+  expected: string | null
+  actual: string | null
+  diff: string | null
+}
+
+export type VisualReportFailure = {
+  title: string
+  testFilePath: string
+  lineNumber: number | null
+  dataVisualTestId: string | null
+  message: string
+  images: VisualReportImages
+}
+
+export type VisualReportManifest = {
+  failures: VisualReportFailure[]
+}
+
+// Escape text placed into Markdown table cells / inline HTML text.
+const escapeText = (value: unknown): string =>
+  String(value ?? '')
+    // Escape backslashes first so the `\|` escape added below cannot be
+    // corrupted by a pre-existing backslash (which would leave a bare `|`
+    // that breaks the table).
+    .replace(/\\/g, '\\\\')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, ' ')
+    .trim()
+
+// Escape a value placed inside a double-quoted HTML attribute so a crafted
+// test name (which can flow into an image file name) cannot break out of the
+// attribute.
+const escapeAttr = (value: unknown): string =>
+  String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
+const thumbnail = (
+  reportUrl: string,
+  relativePath: string | null,
+  altText: string
+): string => {
+  if (!reportUrl || !relativePath) {
+    return ''
+  }
+  const url = escapeAttr(`${reportUrl}/${relativePath}`)
+  return `<a href="${url}"><img src="${url}" width="220" alt="${escapeAttr(altText)}" /></a>`
+}
+
+// Cap table rows so the summary stays well under GitHub's 1 MiB per-step
+// limit when a broad change fails hundreds of screenshots. The full set is
+// always available in the hosted report / artifact.
+const DEFAULT_MAX_SUMMARY_ROWS = 100
+
+export const renderVisualReportSummary = (
+  manifest: VisualReportManifest,
+  reportUrl = '',
+  maxRows = DEFAULT_MAX_SUMMARY_ROWS
+): string => {
+  const failures = Array.isArray(manifest?.failures)
+    ? manifest.failures
+    : []
+  const normalizedUrl = reportUrl.replace(/\/+$/, '')
+  const lines: string[] = []
+
+  lines.push('## Visual regression report', '')
+  lines.push(
+    `**${failures.length}** screenshot${failures.length === 1 ? '' : 's'} ` +
+      `differ${failures.length === 1 ? 's' : ''} from the committed baseline.`,
+    ''
+  )
+
+  if (normalizedUrl) {
+    lines.push(
+      `🔗 **[Open the full interactive report](${normalizedUrl})** — before / after / diff for every failure.`,
+      ''
+    )
+  } else {
+    lines.push(
+      '_Images are in the **visual-test-artifact** below (report hosting was unavailable for this run)._',
+      ''
+    )
+  }
+
+  if (failures.length) {
+    const shown = failures.slice(0, Math.max(0, maxRows))
+
+    lines.push('| Test | Location | Diff |', '| --- | --- | --- |')
+
+    for (const failure of shown) {
+      const id = failure.dataVisualTestId
+        ? `<br><code>data-visual-test="${escapeText(failure.dataVisualTestId)}"</code>`
+        : ''
+      const testCell = `<strong>${escapeText(failure.title)}</strong>${id}<br>${escapeText(failure.message)}`
+      const location = `<code>${escapeText(failure.testFilePath)}${failure.lineNumber ? ':' + failure.lineNumber : ''}</code>`
+      const images = failure.images || {
+        expected: null,
+        actual: null,
+        diff: null,
+      }
+      const diffCell =
+        thumbnail(normalizedUrl, images.diff, `${failure.title} diff`) ||
+        thumbnail(
+          normalizedUrl,
+          images.actual,
+          `${failure.title} actual`
+        ) ||
+        '—'
+
+      lines.push(`| ${testCell} | ${location} | ${diffCell} |`)
+    }
+
+    lines.push('')
+
+    if (failures.length > shown.length) {
+      const remaining = failures.length - shown.length
+      const where = normalizedUrl
+        ? 'the full report'
+        : 'the **visual-test-artifact**'
+      lines.push(
+        `_Showing the first ${shown.length} of ${failures.length} failures — see ${where} for the remaining ${remaining}._`,
+        ''
+      )
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/packages/dnb-eufemia/scripts/tools/visualReport/summaryCli.ts
+++ b/packages/dnb-eufemia/scripts/tools/visualReport/summaryCli.ts
@@ -1,0 +1,39 @@
+/**
+ * CLI wrapper around `renderVisualReportSummary`.
+ *
+ * Reads the `report.json` written by the screenshot reporter and prints
+ * the job-summary Markdown to stdout, so CI can append it to
+ * `$GITHUB_STEP_SUMMARY`. Diagnostics go to stderr to keep stdout clean.
+ *
+ * Usage: node summaryCli.ts [path/to/report.json]
+ * Env:   REPORT_URL - base URL of the hosted report (optional)
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { renderVisualReportSummary } from './renderSummary.ts'
+
+const manifestPath = path.resolve(
+  process.argv[2] || 'visual-diff-report/report.json'
+)
+
+if (!fs.existsSync(manifestPath)) {
+  console.error(
+    `No visual-diff report found at ${manifestPath}; nothing to summarise.`
+  )
+  process.exit(0)
+}
+
+try {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+  process.stdout.write(
+    renderVisualReportSummary(manifest, process.env.REPORT_URL ?? '') +
+      '\n'
+  )
+} catch (error) {
+  console.error(
+    `Failed to build the visual report summary: ${(error as Error).message}`
+  )
+  process.exit(0)
+}

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildReportManifest,
+  reportImageName,
+  type ResolvedFailure,
+} from '../screenshotReporter'
+
+const makeFailure = (
+  overrides: Partial<ResolvedFailure> = {}
+): ResolvedFailure => ({
+  testFilePath:
+    '/repo/packages/dnb-eufemia/src/components/table/Table.test.ts',
+  relativeTestFilePath: 'src/components/table/Table.test.ts',
+  fullName: 'Table > has to match active state',
+  snapshotPath: '/snapshots/table-active.snap.png',
+  diffPath: '/tmp/table-active.diff.png',
+  actualPath: '/tmp/table-active.actual.png',
+  expectedImagePath: '/snapshots/table-active.snap.png',
+  dataVisualTestId: 'table-active',
+  lineNumber: 42,
+  message: 'Screenshot mismatch: 100 px differ (1.5%).',
+  ...overrides,
+})
+
+describe('reportImageName', () => {
+  it('prefixes the index and strips the .png extension and directory', () => {
+    expect(reportImageName(3, '/a/b/table-active.snap.png', 'diff')).toBe(
+      '3-table-active.snap.diff.png'
+    )
+  })
+})
+
+describe('buildReportManifest', () => {
+  const existsAll = () => true
+
+  it('maps each genuine failure to a summary row', () => {
+    const failure = makeFailure()
+    const manifest = buildReportManifest([failure], [failure], existsAll)
+
+    expect(manifest.failureCount).toBe(1)
+    expect(manifest.failures[0]).toMatchObject({
+      title: 'Table > has to match active state',
+      testFilePath: 'src/components/table/Table.test.ts',
+      lineNumber: 42,
+      dataVisualTestId: 'table-active',
+      message: 'Screenshot mismatch: 100 px differ (1.5%).',
+    })
+  })
+
+  it('references the images the HTML writer copied for that index', () => {
+    const failure = makeFailure()
+    const { images } = buildReportManifest([failure], [failure], existsAll)
+      .failures[0]
+
+    expect(images).toEqual({
+      expected: 'images/0-table-active.snap.expected.png',
+      actual: 'images/0-table-active.actual.actual.png',
+      diff: 'images/0-table-active.diff.diff.png',
+    })
+  })
+
+  it('uses the last index when a snapshot is retried', () => {
+    const attempt1 = makeFailure()
+    const attempt2 = makeFailure()
+
+    // allFailures holds both attempts; the deduped genuine failure is the
+    // last one, so its images must reference index 1 (the last copy).
+    const { images } = buildReportManifest(
+      [attempt1, attempt2],
+      [attempt2],
+      existsAll
+    ).failures[0]
+
+    expect(images.diff).toBe('images/1-table-active.diff.diff.png')
+  })
+
+  it('emits null for images whose source file is missing', () => {
+    const failure = makeFailure()
+    const { images } = buildReportManifest(
+      [failure],
+      [failure],
+      () => false
+    ).failures[0]
+
+    expect(images).toEqual({ expected: null, actual: null, diff: null })
+  })
+
+  it('emits null for image kinds the record does not carry', () => {
+    const failure = makeFailure({ diffPath: null, actualPath: null })
+    const { images } = buildReportManifest([failure], [failure], existsAll)
+      .failures[0]
+
+    expect(images.diff).toBeNull()
+    expect(images.actual).toBeNull()
+    expect(images.expected).toBe('images/0-table-active.snap.expected.png')
+  })
+
+  it('strips ANSI codes and collapses newlines in the message', () => {
+    const failure = makeFailure({
+      message:
+        '\u001B[33mScreenshot dimensions differ:\nreference 1x2\u001B[0m',
+    })
+    const { message } = buildReportManifest(
+      [failure],
+      [failure],
+      existsAll
+    ).failures[0]
+
+    expect(message).toBe('Screenshot dimensions differ: reference 1x2')
+  })
+})

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildReportManifest,
+  escapeHtml,
+  renderHtml,
   reportImageName,
   type ResolvedFailure,
 } from '../screenshotReporter'
@@ -110,5 +112,67 @@ describe('buildReportManifest', () => {
     ).failures[0]
 
     expect(message).toBe('Screenshot dimensions differ: reference 1x2')
+  })
+})
+
+describe('escapeHtml', () => {
+  it('escapes HTML-significant characters', () => {
+    expect(escapeHtml(`<img src=x onerror="alert(1)">&'`)).toBe(
+      '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;&amp;&#39;'
+    )
+  })
+})
+
+describe('renderHtml', () => {
+  // A failure with no on-disk images so renderHtml does no filesystem work.
+  const imagelessFailure = (
+    overrides: Partial<ResolvedFailure> = {}
+  ): ResolvedFailure =>
+    makeFailure({
+      expectedImagePath: null,
+      actualPath: null,
+      diffPath: null,
+      ...overrides,
+    })
+
+  const xss = '"><img src=x onerror=alert(1)>'
+
+  it('escapes every untrusted value so it cannot become markup', () => {
+    const html = renderHtml(
+      [
+        imagelessFailure({
+          fullName: xss,
+          testFilePath: xss,
+          relativeTestFilePath: xss,
+          dataVisualTestId: xss,
+          message: xss,
+        }),
+      ],
+      '/tmp/does-not-exist'
+    )
+
+    expect(html).not.toContain('<img src=x onerror=alert(1)>')
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;')
+    expect(html).toContain('data-clipboard-text="&quot;&gt;&lt;img')
+  })
+
+  it('does not emit an inline onclick handler', () => {
+    const html = renderHtml(
+      [imagelessFailure({ dataVisualTestId: 'table-active' })],
+      '/tmp/does-not-exist'
+    )
+
+    expect(html).not.toContain('onclick=')
+    expect(html).toContain('data-clipboard-text="table-active"')
+  })
+
+  it('escapes the failure message but keeps newlines as <br />', () => {
+    const html = renderHtml(
+      [imagelessFailure({ message: 'line<one>\nline&two' })],
+      '/tmp/does-not-exist'
+    )
+
+    expect(html).toContain('line&lt;one&gt;<br />line&amp;two')
+    expect(html).not.toContain('line<one>')
   })
 })

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
@@ -24,7 +24,7 @@ import { drainFailures, type ScreenshotFailureRecord } from './failures'
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_SEQUENCE = /\u001B\[[0-?]*[ -/]*[@-~]/g
 
-type ResolvedFailure = {
+export type ResolvedFailure = {
   relativeTestFilePath: string
   expectedImagePath: string | null
   dataVisualTestId: string | null
@@ -83,6 +83,17 @@ const resolveFailures = (
 }
 
 /**
+ * Build the deterministic file name for a copied report image.
+ * Shared by the HTML writer and the JSON manifest so the two never
+ * drift: the manifest can reference the exact files the HTML copied.
+ */
+export const reportImageName = (
+  index: number,
+  srcPath: string,
+  suffix: string
+) => `${index}-${path.basename(srcPath, '.png')}.${suffix}.png`
+
+/**
  * Copy a source image into the report's `images/` subfolder,
  * returning the local relative path for use inside the HTML.
  * The filename is prefixed with an index to keep the listing
@@ -98,8 +109,7 @@ const copyImageToReport = (
   if (!fs.existsSync(imagesDir)) {
     fs.mkdirSync(imagesDir, { recursive: true })
   }
-  const baseName = path.basename(srcPath, '.png')
-  const destName = `${index}-${baseName}.${suffix}.png`
+  const destName = reportImageName(index, srcPath, suffix)
   const destPath = path.join(imagesDir, destName)
   fs.copyFileSync(srcPath, destPath)
   return `images/${destName}`
@@ -267,6 +277,78 @@ const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
     `
 }
 
+export type ReportManifestImages = {
+  expected: string | null
+  actual: string | null
+  diff: string | null
+}
+
+export type ReportManifestFailure = {
+  title: string
+  testFilePath: string
+  lineNumber: number | null
+  dataVisualTestId: string | null
+  message: string
+  images: ReportManifestImages
+}
+
+export type ReportManifest = {
+  failureCount: number
+  failures: ReportManifestFailure[]
+}
+
+const toPlainMessage = (message: string) =>
+  message
+    .replace(ANSI_ESCAPE_SEQUENCE, '')
+    .replace(/\s*\n\s*/g, ' ')
+    .trim()
+
+/**
+ * Structured, machine-readable sibling of the HTML report. CI reads
+ * this to build a job-summary table and to turn the relative image
+ * paths into absolute URLs once the report is hosted. The image paths
+ * match the files the HTML writer copied (same `reportImageName`), so
+ * the two never drift.
+ */
+export const buildReportManifest = (
+  allFailures: ResolvedFailure[],
+  genuineFailures: ResolvedFailure[],
+  exists: (filePath: string) => boolean = fs.existsSync
+): ReportManifest => {
+  const lastIndexBySnapshot = new Map<string, number>()
+  allFailures.forEach((failure, index) => {
+    lastIndexBySnapshot.set(failure.snapshotPath, index)
+  })
+
+  const relImage = (
+    index: number,
+    srcPath: string | null,
+    suffix: string
+  ): string | null =>
+    srcPath && exists(srcPath)
+      ? `images/${reportImageName(index, srcPath, suffix)}`
+      : null
+
+  return {
+    failureCount: genuineFailures.length,
+    failures: genuineFailures.map((failure) => {
+      const index = lastIndexBySnapshot.get(failure.snapshotPath) ?? 0
+      return {
+        title: failure.fullName,
+        testFilePath: failure.relativeTestFilePath,
+        lineNumber: failure.lineNumber,
+        dataVisualTestId: failure.dataVisualTestId,
+        message: toPlainMessage(failure.message),
+        images: {
+          expected: relImage(index, failure.expectedImagePath, 'expected'),
+          actual: relImage(index, failure.actualPath, 'actual'),
+          diff: relImage(index, failure.diffPath, 'diff'),
+        },
+      }
+    }),
+  }
+}
+
 /**
  * Collect the fullNames of tests whose final result is 'failed'.
  * Tests that failed on an early attempt but passed on retry are
@@ -363,6 +445,15 @@ export default class ScreenshotReporter implements Reporter {
       fs.mkdirSync(reportDir, { recursive: true })
     }
     fs.writeFileSync(htmlFilePath, renderHtml(allFailures, reportDir))
+
+    fs.writeFileSync(
+      path.join(reportDir, 'report.json'),
+      JSON.stringify(
+        buildReportManifest(allFailures, genuineFailures),
+        null,
+        2
+      )
+    )
   }
 }
 

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
@@ -31,8 +31,22 @@ export type ResolvedFailure = {
   lineNumber: number | null
 } & ScreenshotFailureRecord
 
+// Escape a value for safe use in HTML text or double/single-quoted
+// attributes. The report is published to a public URL, so every
+// test-derived value must be escaped before it is interpolated.
+export const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
 const formatMessage = (message: string) =>
-  message.replace(ANSI_ESCAPE_SEQUENCE, '').replace(/\n/g, '<br />')
+  escapeHtml(message.replace(ANSI_ESCAPE_SEQUENCE, '')).replace(
+    /\n/g,
+    '<br />'
+  )
 
 const extractTestMetadata = (
   testFilePath: string,
@@ -115,7 +129,10 @@ const copyImageToReport = (
   return `images/${destName}`
 }
 
-const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
+export const renderHtml = (
+  failures: ResolvedFailure[],
+  reportDir: string
+) => {
   // Track how many times each test appears so we can label retries.
   const attemptByName = new Map<string, number>()
   const uniqueTests = new Set<string>()
@@ -139,8 +156,8 @@ const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
         figures.push(`
             <figure class="screenshot-figure">
               <figcaption>Expected</figcaption>
-              <a class="diff" target="_blank" href="${rel}">
-                <img src="${rel}" alt="Expected screenshot" />
+              <a class="diff" target="_blank" href="${escapeHtml(rel)}">
+                <img src="${escapeHtml(rel)}" alt="Expected screenshot" />
               </a>
             </figure>`)
       }
@@ -150,8 +167,8 @@ const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
         figures.push(`
             <figure class="screenshot-figure">
               <figcaption>Actual</figcaption>
-              <a class="diff" target="_blank" href="${rel}">
-                <img src="${rel}" alt="Actual screenshot" />
+              <a class="diff" target="_blank" href="${escapeHtml(rel)}">
+                <img src="${escapeHtml(rel)}" alt="Actual screenshot" />
               </a>
             </figure>`)
       }
@@ -161,8 +178,8 @@ const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
         figures.push(`
             <figure class="screenshot-figure">
               <figcaption>Diff</figcaption>
-              <a class="diff" target="_blank" href="${rel}">
-                <img src="${rel}" alt="Shows the visual difference" />
+              <a class="diff" target="_blank" href="${escapeHtml(rel)}">
+                <img src="${escapeHtml(rel)}" alt="Shows the visual difference" />
               </a>
             </figure>`)
       }
@@ -174,15 +191,15 @@ const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
         : ''
 
       const visualTestIdHtml = f.dataVisualTestId
-        ? `<p><b><code class="copy-id" onclick="navigator.clipboard.writeText('${f.dataVisualTestId}').then(() => { this.classList.add('copied'); setTimeout(() => this.classList.remove('copied'), 1000) })">data-visual-test="${f.dataVisualTestId}"</code></b></p>`
+        ? `<p><b><code class="copy-id" data-clipboard-text="${escapeHtml(f.dataVisualTestId)}">data-visual-test="${escapeHtml(f.dataVisualTestId)}"</code></b></p>`
         : ''
 
       return `
             <li>
               <dl>
-                <dt>${f.fullName}${retryLabel}</dt>
+                <dt>${escapeHtml(f.fullName)}${retryLabel}</dt>
                 <dd>
-                  <p><a href="vscode://file${f.testFilePath}${f.lineNumber ? ':' + f.lineNumber : ''}"><code>${f.relativeTestFilePath}${f.lineNumber ? ':' + f.lineNumber : ''}</code></a></p>
+                  <p><a href="vscode://file${escapeHtml(f.testFilePath)}${f.lineNumber ? ':' + f.lineNumber : ''}"><code>${escapeHtml(f.relativeTestFilePath)}${f.lineNumber ? ':' + f.lineNumber : ''}</code></a></p>
                   ${visualTestIdHtml}
                   <p>${formatMessage(f.message)}</p>
                   ${image}
@@ -270,6 +287,23 @@ const renderHtml = (failures: ResolvedFailure[], reportDir: string) => {
         <li>Failed Tests: <b>${uniqueTests.size}</b></li>
         ${items}
       </ol>
+
+      <script>
+        document.addEventListener('click', function (event) {
+          var el = event.target.closest('.copy-id')
+          if (!el) {
+            return
+          }
+          navigator.clipboard
+            .writeText(el.getAttribute('data-clipboard-text'))
+            .then(function () {
+              el.classList.add('copied')
+              setTimeout(function () {
+                el.classList.remove('copied')
+              }, 1000)
+            })
+        })
+      </script>
 
     </body>
 


### PR DESCRIPTION
## Why

When a visual screenshot test fails on CI, contributors have to open the run, find the **visual-test-artifact**, download the ZIP, unzip it and open `index.html` locally just to see _which_ screenshots differ and _why_. That friction makes triage slow.

## What

Make the existing diff report available without leaving the browser:

- **Run summary table** — the failed screenshots are now rendered directly on the GitHub Actions run **Summary** page (test name, `file:line`, `data-visual-test` id and the diff message).
- **Hosted report** — on failure the self-contained report is deployed to Cloudflare Pages (reusing the same credentials/project as the branch preview deploy), and each summary row embeds a diff thumbnail linking to the full before/after/diff view.
- **Graceful fallback** — when hosting is unavailable (e.g. a forked PR without secrets), the summary still lists the failures and points to the downloadable artifact, which is unchanged.

The reporter now writes a small structured `report.json` next to `index.html` (image paths kept in sync with the HTML via a shared helper) that the workflow reads to build the summary.

No new repository secrets or permissions are required.
