### PR TITLE
feat(visual-regression): generate a diff image when screenshot sizes differ

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/diffAndPersist.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/diffAndPersist.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { PNG } from 'pngjs'
+
+// defineBrowserCommand isn't available outside browser mode; make it a
+// passthrough so the engine module can be imported in a node test.
+vi.mock('@vitest/browser-playwright', () => ({
+  defineBrowserCommand: vi.fn(
+    <T extends unknown[]>(fn: (...args: T) => unknown) => fn
+  ),
+}))
+
+// Capture failure records so we can assert a diff path is reported.
+vi.mock('../failures', () => ({
+  recordFailure: vi.fn(),
+  recordNavigation: vi.fn(),
+}))
+
+import {
+  _testing,
+  type MakeScreenshotPayload,
+} from '../commands/screenshotEngine'
+import { recordFailure } from '../failures'
+
+const { diffAndPersist } = _testing
+
+const solidPngBytes = (
+  width: number,
+  height: number,
+  [r, g, b, a]: [number, number, number, number] = [255, 255, 255, 255]
+): Buffer => {
+  const png = new PNG({ width, height })
+  for (let i = 0; i < width * height; i++) {
+    png.data[i * 4] = r
+    png.data[i * 4 + 1] = g
+    png.data[i * 4 + 2] = b
+    png.data[i * 4 + 3] = a
+  }
+  return PNG.sync.write(png)
+}
+
+let tmpDir: string
+
+const makePayload = (): MakeScreenshotPayload =>
+  ({
+    testFilePath: '/repo/src/Example.screenshot.test.tsx',
+    fullName: 'Example > renders',
+    snapshotPath: path.join(tmpDir, 'snapshot.snap.png'),
+    diffPath: path.join(tmpDir, 'snapshot.diff.png'),
+    actualPath: path.join(tmpDir, 'snapshot.actual.png'),
+    htmlDumpPath: path.join(tmpDir, 'snapshot.html'),
+    allowedMismatchedPixelRatio: 0,
+    update: false,
+  }) as unknown as MakeScreenshotPayload
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eufemia-diff-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('diffAndPersist', () => {
+  // The reported real-world scenario: a Field help/info-message expands
+  // the component so the actual screenshot is taller than the baseline.
+  it('writes a diff image and reports its path when dimensions differ', async () => {
+    const payload = makePayload()
+    fs.writeFileSync(payload.snapshotPath, solidPngBytes(8, 8))
+    const actualBytes = solidPngBytes(8, 16)
+
+    const result = await diffAndPersist(payload, actualBytes)
+
+    expect(result.status).toBe('size-mismatch')
+    if (result.status !== 'size-mismatch') {
+      throw new Error('expected a size-mismatch result')
+    }
+    expect(result.reference).toEqual({ width: 8, height: 8 })
+    expect(result.actual).toEqual({ width: 8, height: 16 })
+    expect(result.diffPath).toBe(payload.diffPath)
+
+    // The diff image is actually written to disk (previously it was not).
+    expect(fs.existsSync(payload.diffPath)).toBe(true)
+    expect(fs.existsSync(payload.actualPath)).toBe(true)
+
+    const diffPng = PNG.sync.read(fs.readFileSync(payload.diffPath))
+    expect(diffPng.width).toBe(8)
+    expect(diffPng.height).toBe(16)
+    // A pixel in the added band is highlighted.
+    const i = (12 * diffPng.width + 4) * 4
+    expect([
+      diffPng.data[i],
+      diffPng.data[i + 1],
+      diffPng.data[i + 2],
+      diffPng.data[i + 3],
+    ]).toEqual([255, 0, 0, 255])
+
+    expect(recordFailure).toHaveBeenCalledTimes(1)
+    const record = vi.mocked(recordFailure).mock.calls[0][0]
+    expect(record.diffPath).toBe(payload.diffPath)
+    expect(record.message).toContain('dimensions differ')
+  })
+
+  it('does not write a diff for an identical equal-size screenshot', async () => {
+    const payload = makePayload()
+    const bytes = solidPngBytes(8, 8)
+    fs.writeFileSync(payload.snapshotPath, bytes)
+
+    const result = await diffAndPersist(payload, bytes)
+
+    expect(result.status).toBe('match')
+    expect(fs.existsSync(payload.diffPath)).toBe(false)
+    expect(fs.existsSync(payload.actualPath)).toBe(false)
+    expect(recordFailure).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/imageDiff.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/imageDiff.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest'
+import { PNG } from 'pngjs'
+
+import { copyImageRegion, diffImages } from '../commands/imageDiff'
+
+// blazediff paints differing pixels with its default diff color (red).
+const RED: [number, number, number, number] = [255, 0, 0, 255]
+const WHITE: [number, number, number, number] = [255, 255, 255, 255]
+
+const solid = (
+  width: number,
+  height: number,
+  [r, g, b, a]: [number, number, number, number] = WHITE
+): PNG => {
+  const png = new PNG({ width, height })
+  for (let i = 0; i < width * height; i++) {
+    png.data[i * 4] = r
+    png.data[i * 4 + 1] = g
+    png.data[i * 4 + 2] = b
+    png.data[i * 4 + 3] = a
+  }
+  return png
+}
+
+const fillRect = (
+  png: PNG,
+  x0: number,
+  y0: number,
+  w: number,
+  h: number,
+  [r, g, b, a]: [number, number, number, number]
+) => {
+  for (let y = y0; y < y0 + h; y++) {
+    for (let x = x0; x < x0 + w; x++) {
+      const i = (y * png.width + x) * 4
+      png.data[i] = r
+      png.data[i + 1] = g
+      png.data[i + 2] = b
+      png.data[i + 3] = a
+    }
+  }
+}
+
+const pixelAt = (
+  png: PNG,
+  x: number,
+  y: number
+): [number, number, number, number] => {
+  const i = (y * png.width + x) * 4
+  return [png.data[i], png.data[i + 1], png.data[i + 2], png.data[i + 3]]
+}
+
+describe('copyImageRegion', () => {
+  it('pads a smaller image into the top-left and leaves the rest transparent', () => {
+    const source = solid(2, 2, [10, 20, 30, 40])
+    const padded = copyImageRegion(source.data, 2, 2, 4, 4)
+
+    expect(padded.length).toBe(4 * 4 * 4)
+    // Top-left pixel copied from the source.
+    expect([padded[0], padded[1], padded[2], padded[3]]).toEqual([
+      10, 20, 30, 40,
+    ])
+    // Second source row lands on the padded row stride, not the source one.
+    const secondRow = (1 * 4 + 0) * 4
+    expect([
+      padded[secondRow],
+      padded[secondRow + 1],
+      padded[secondRow + 2],
+      padded[secondRow + 3],
+    ]).toEqual([10, 20, 30, 40])
+    // A pixel outside the source stays transparent.
+    const outside = (0 * 4 + 2) * 4
+    expect([
+      padded[outside],
+      padded[outside + 1],
+      padded[outside + 2],
+      padded[outside + 3],
+    ]).toEqual([0, 0, 0, 0])
+  })
+
+  it('crops a larger image down to the target region', () => {
+    const source = solid(4, 4, [1, 2, 3, 255])
+    const cropped = copyImageRegion(source.data, 4, 4, 2, 2)
+
+    expect(cropped.length).toBe(2 * 2 * 4)
+    const last = (1 * 2 + 1) * 4
+    expect([
+      cropped[last],
+      cropped[last + 1],
+      cropped[last + 2],
+      cropped[last + 3],
+    ]).toEqual([1, 2, 3, 255])
+  })
+})
+
+describe('diffImages', () => {
+  it('reports no difference for identical equal-size images', () => {
+    const { diff, diffPixels, sizeMismatch, width, height } = diffImages(
+      solid(8, 8),
+      solid(8, 8)
+    )
+
+    expect(sizeMismatch).toBe(false)
+    expect(diffPixels).toBe(0)
+    expect(width).toBe(8)
+    expect(height).toBe(8)
+    expect(diff.width).toBe(8)
+    expect(diff.height).toBe(8)
+  })
+
+  it('detects content differences for equal-size images', () => {
+    const actual = solid(8, 8)
+    fillRect(actual, 0, 0, 4, 4, RED)
+
+    const { diffPixels, sizeMismatch } = diffImages(solid(8, 8), actual)
+
+    expect(sizeMismatch).toBe(false)
+    expect(diffPixels).toBe(16)
+  })
+
+  // The reported real-world scenario: a Field help/info-message expands
+  // the component so the actual screenshot is taller than the baseline.
+  it('produces a union-sized diff and highlights the added band when the actual is taller', () => {
+    const { diff, diffPixels, sizeMismatch, width, height } = diffImages(
+      solid(8, 8),
+      solid(8, 16)
+    )
+
+    expect(sizeMismatch).toBe(true)
+    expect(width).toBe(8)
+    expect(height).toBe(16)
+    expect(diff.width).toBe(8)
+    expect(diff.height).toBe(16)
+    // The extra band (present only in the taller actual) is highlighted.
+    expect(diffPixels).toBe(64)
+    expect(pixelAt(diff, 4, 12)).toEqual(RED)
+    // The overlapping region is unchanged, so it is not highlighted.
+    expect(pixelAt(diff, 4, 4)).not.toEqual(RED)
+  })
+
+  it('produces a union-sized diff and highlights the added band when the actual is wider', () => {
+    const { diff, diffPixels, sizeMismatch, width, height } = diffImages(
+      solid(8, 8),
+      solid(16, 8)
+    )
+
+    expect(sizeMismatch).toBe(true)
+    expect(width).toBe(16)
+    expect(height).toBe(8)
+    expect(diffPixels).toBe(64)
+    expect(pixelAt(diff, 12, 4)).toEqual(RED)
+    expect(pixelAt(diff, 4, 4)).not.toEqual(RED)
+  })
+
+  it('highlights both the size delta and content changes in the overlap', () => {
+    const actual = solid(8, 16)
+    fillRect(actual, 0, 0, 4, 4, RED)
+
+    const { diff, diffPixels, sizeMismatch } = diffImages(
+      solid(8, 8),
+      actual
+    )
+
+    expect(sizeMismatch).toBe(true)
+    // 16 changed pixels in the overlap + 64 for the added band.
+    expect(diffPixels).toBe(80)
+    expect(pixelAt(diff, 2, 2)).toEqual(RED) // content change
+    expect(pixelAt(diff, 4, 12)).toEqual(RED) // added band
+    expect(pixelAt(diff, 6, 6)).not.toEqual(RED) // unchanged overlap
+  })
+
+  it('handles a reference larger than the actual (removed region)', () => {
+    const { diff, diffPixels, sizeMismatch, width, height } = diffImages(
+      solid(8, 16),
+      solid(8, 8)
+    )
+
+    expect(sizeMismatch).toBe(true)
+    expect(width).toBe(8)
+    expect(height).toBe(16)
+    expect(diffPixels).toBe(64)
+    // The region present only in the reference is highlighted.
+    expect(pixelAt(diff, 4, 12)).toEqual(RED)
+  })
+})

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/commands/imageDiff.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/commands/imageDiff.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared image-diff helper used by the screenshot engine and the
+ * `matchImageSnapshot` command.
+ *
+ * blazediff can only compare two buffers of identical dimensions. When
+ * a screenshot changes size, both images are padded onto a common union
+ * canvas (max width × max height) so the comparison still runs and the
+ * added/removed region is highlighted in the diff — instead of
+ * producing no diff image at all.
+ */
+
+import blazediff from '@blazediff/core'
+import { PNG } from 'pngjs'
+
+// 1% per-pixel color difference tolerance.
+const DEFAULT_THRESHOLD = 0.01
+
+export type ImageDiffResult = {
+  diff: PNG
+  diffPixels: number
+  totalPixels: number
+  width: number
+  height: number
+  sizeMismatch: boolean
+}
+
+/**
+ * Copy the top-left `targetWidth × targetHeight` region of an RGBA image
+ * into a fresh, contiguous buffer. Pixels outside the source image are
+ * left transparent (zero-filled); blazediff reports those as a
+ * difference against the opaque screenshot content, so padded areas show
+ * up in the diff. Handles the differing row stride between the source
+ * and the target.
+ */
+export const copyImageRegion = (
+  sourceData: Buffer,
+  sourceWidth: number,
+  sourceHeight: number,
+  targetWidth: number,
+  targetHeight: number
+): Buffer => {
+  const dest = Buffer.alloc(targetWidth * targetHeight * 4)
+  const copyWidth = Math.min(sourceWidth, targetWidth)
+  const copyHeight = Math.min(sourceHeight, targetHeight)
+  const sourceStride = sourceWidth * 4
+  const targetStride = targetWidth * 4
+  const rowBytes = copyWidth * 4
+
+  for (let y = 0; y < copyHeight; y++) {
+    sourceData.copy(
+      dest,
+      y * targetStride,
+      y * sourceStride,
+      y * sourceStride + rowBytes
+    )
+  }
+
+  return dest
+}
+
+/**
+ * Compare two decoded PNGs and produce a diff image. When the images
+ * differ in size, both are padded onto a union canvas first so the diff
+ * always renders (the size delta shows as a highlighted band).
+ */
+export const diffImages = (
+  reference: PNG,
+  actual: PNG,
+  options: { threshold?: number } = {}
+): ImageDiffResult => {
+  const sizeMismatch =
+    reference.width !== actual.width || reference.height !== actual.height
+  const width = Math.max(reference.width, actual.width)
+  const height = Math.max(reference.height, actual.height)
+
+  const referenceData = sizeMismatch
+    ? copyImageRegion(
+        reference.data,
+        reference.width,
+        reference.height,
+        width,
+        height
+      )
+    : reference.data
+  const actualData = sizeMismatch
+    ? copyImageRegion(
+        actual.data,
+        actual.width,
+        actual.height,
+        width,
+        height
+      )
+    : actual.data
+
+  const diff = new PNG({ width, height })
+  const diffPixels = blazediff(
+    referenceData,
+    actualData,
+    diff.data,
+    width,
+    height,
+    { threshold: options.threshold ?? DEFAULT_THRESHOLD }
+  )
+  const totalPixels = width * height
+
+  return { diff, diffPixels, totalPixels, width, height, sizeMismatch }
+}

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/commands/loadImage.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/commands/loadImage.ts
@@ -11,11 +11,11 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { defineBrowserCommand } from '@vitest/browser-playwright'
-import blazediff from '@blazediff/core'
 import { PNG } from 'pngjs'
 
 import type { MakeScreenshotResult } from './screenshotEngine'
 import { recordFailure } from '../failures'
+import { diffImages } from './imageDiff'
 
 export type LoadImagePayload = {
   imagePath: string
@@ -84,49 +84,18 @@ export const matchImageSnapshot = defineBrowserCommand<
   const referencePng = PNG.sync.read(reference)
   const actualPng = PNG.sync.read(actualBytes)
 
-  if (
-    referencePng.width !== actualPng.width ||
-    referencePng.height !== actualPng.height
-  ) {
-    await writeFile(payload.actualPath, actualBytes)
-    recordFailure({
-      testFilePath: payload.testFilePath,
-      fullName: payload.fullName,
-      snapshotPath: payload.snapshotPath,
-      diffPath: null,
-      actualPath: payload.actualPath,
-      message: `Image dimensions differ: reference ${referencePng.width}x${referencePng.height}, actual ${actualPng.width}x${actualPng.height}.`,
-    })
-    return {
-      status: 'size-mismatch',
-      reference: {
-        width: referencePng.width,
-        height: referencePng.height,
-      },
-      actual: {
-        width: actualPng.width,
-        height: actualPng.height,
-      },
-      actualPath: payload.actualPath,
-    }
-  }
-
-  const diff = new PNG({
-    width: referencePng.width,
-    height: referencePng.height,
-  })
-  const diffPixels = blazediff(
-    referencePng.data,
-    actualPng.data,
-    diff.data,
-    referencePng.width,
-    referencePng.height,
-    { threshold: 0.01 } // 1% per-pixel color difference tolerance
+  // When the dimensions differ blazediff cannot compare the buffers
+  // directly, so `diffImages` pads both onto a union canvas so a diff
+  // image is still produced (the size delta is highlighted).
+  const { diff, diffPixels, totalPixels, sizeMismatch } = diffImages(
+    referencePng,
+    actualPng
   )
-  const total = referencePng.width * referencePng.height
-  const ratio = total === 0 ? 0 : diffPixels / total
+  const ratio = totalPixels === 0 ? 0 : diffPixels / totalPixels
 
-  if (ratio > payload.allowedMismatchedPixelRatio) {
+  // A size mismatch always fails; equal-size images fail only when the
+  // differing-pixel ratio exceeds the allowed threshold.
+  if (sizeMismatch || ratio > payload.allowedMismatchedPixelRatio) {
     await writeFile(payload.actualPath, actualBytes)
     await writeFile(payload.diffPath, PNG.sync.write(diff))
     recordFailure({
@@ -135,8 +104,25 @@ export const matchImageSnapshot = defineBrowserCommand<
       snapshotPath: payload.snapshotPath,
       diffPath: payload.diffPath,
       actualPath: payload.actualPath,
-      message: `Image mismatch: ${diffPixels} px differ (${(ratio * 100).toFixed(3)}%).`,
+      message: sizeMismatch
+        ? `Image dimensions differ: reference ${referencePng.width}x${referencePng.height}, actual ${actualPng.width}x${actualPng.height}.`
+        : `Image mismatch: ${diffPixels} px differ (${(ratio * 100).toFixed(3)}%).`,
     })
+    if (sizeMismatch) {
+      return {
+        status: 'size-mismatch',
+        reference: {
+          width: referencePng.width,
+          height: referencePng.height,
+        },
+        actual: {
+          width: actualPng.width,
+          height: actualPng.height,
+        },
+        diffPath: payload.diffPath,
+        actualPath: payload.actualPath,
+      }
+    }
     return {
       status: 'mismatch',
       diffPixels,

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
@@ -12,7 +12,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { defineBrowserCommand } from '@vitest/browser-playwright'
-import blazediff from '@blazediff/core'
 import { PNG } from 'pngjs'
 import type {
   Browser,
@@ -27,6 +26,7 @@ import {
 } from '../pageResetStrategy'
 import { clearBrowserStorages } from '../storageReset'
 import { recordFailure, recordNavigation } from '../failures'
+import { diffImages, type ImageDiffResult } from './imageDiff'
 
 // ── shared types ─────────────────────────────────────────────────────
 
@@ -99,6 +99,7 @@ export type MakeScreenshotResult =
       status: 'size-mismatch'
       reference: { width: number; height: number }
       actual: { width: number; height: number }
+      diffPath: string
       actualPath: string
     }
 
@@ -1682,47 +1683,21 @@ async function diffAndPersist(
   const actWidth = actualPng.width
   const actHeight = actualPng.height
 
-  if (refWidth !== actWidth || refHeight !== actHeight) {
-    await writeFile(payload.actualPath, actualBytes)
-    recordFailure({
-      testFilePath: payload.testFilePath,
-      fullName: payload.fullName,
-      snapshotPath: payload.snapshotPath,
-      diffPath: null,
-      actualPath: payload.actualPath,
-      message: `Screenshot dimensions differ: reference ${refWidth}x${refHeight}, actual ${actWidth}x${actHeight}.`,
-      htmlDumpPath: payload.htmlDumpPath,
-    })
-
-    // Help V8 reclaim memory before return
-    // eslint-disable-next-line no-useless-assignment
-    referencePng = null
-    // eslint-disable-next-line no-useless-assignment
-    actualPng = null
-
-    return {
-      status: 'size-mismatch',
-      reference: { width: refWidth, height: refHeight },
-      actual: { width: actWidth, height: actHeight },
-      actualPath: payload.actualPath,
-    }
-  }
-
-  let diff: PNG | null = new PNG({ width: refWidth, height: refHeight })
-
-  const diffPixels = blazediff(
-    referencePng.data,
-    actualPng.data,
-    diff.data,
-    refWidth,
-    refHeight,
-    { threshold: 0.01 } // 1% per-pixel color difference tolerance
+  // When the dimensions differ blazediff cannot compare the buffers
+  // directly, so `diffImages` pads both onto a union canvas — the
+  // added/removed region is highlighted in the diff instead of
+  // producing no diff image at all.
+  let diffResult: ImageDiffResult | null = diffImages(
+    referencePng,
+    actualPng
   )
-
-  const totalPixels = refWidth * refHeight
+  let diff: PNG | null = diffResult.diff
+  const { diffPixels, totalPixels, sizeMismatch } = diffResult
   const ratio = totalPixels === 0 ? 0 : diffPixels / totalPixels
 
-  if (ratio > payload.allowedMismatchedPixelRatio) {
+  // A size mismatch always fails; equal-size shots fail only when the
+  // differing-pixel ratio exceeds the allowed threshold.
+  if (sizeMismatch || ratio > payload.allowedMismatchedPixelRatio) {
     await writeFile(payload.actualPath, actualBytes)
     await writeFile(payload.diffPath, PNG.sync.write(diff))
     recordFailure({
@@ -1731,7 +1706,9 @@ async function diffAndPersist(
       snapshotPath: payload.snapshotPath,
       diffPath: payload.diffPath,
       actualPath: payload.actualPath,
-      message: `Screenshot mismatch: ${diffPixels} px differ (${(ratio * 100).toFixed(3)}%).`,
+      message: sizeMismatch
+        ? `Screenshot dimensions differ: reference ${refWidth}x${refHeight}, actual ${actWidth}x${actHeight}.`
+        : `Screenshot mismatch: ${diffPixels} px differ (${(ratio * 100).toFixed(3)}%).`,
       htmlDumpPath: payload.htmlDumpPath,
     })
 
@@ -1742,6 +1719,18 @@ async function diffAndPersist(
     actualPng = null
     // eslint-disable-next-line no-useless-assignment
     diff = null
+    // eslint-disable-next-line no-useless-assignment
+    diffResult = null
+
+    if (sizeMismatch) {
+      return {
+        status: 'size-mismatch',
+        reference: { width: refWidth, height: refHeight },
+        actual: { width: actWidth, height: actHeight },
+        diffPath: payload.diffPath,
+        actualPath: payload.actualPath,
+      }
+    }
 
     return {
       status: 'mismatch',
@@ -1761,6 +1750,8 @@ async function diffAndPersist(
   actualPng = null
   // eslint-disable-next-line no-useless-assignment
   diff = null
+  // eslint-disable-next-line no-useless-assignment
+  diffResult = null
 
   await removeIfExists(payload.diffPath)
   await removeIfExists(payload.actualPath)
@@ -1833,6 +1824,7 @@ export const makeScreenshot = defineBrowserCommand<
 export const _testing = {
   buildUrl,
   applyScreenshotColorScheme,
+  diffAndPersist,
   sessions,
   browserSlots,
   sessionToSlot,

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/setupVitestScreenshots.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/setupVitestScreenshots.ts
@@ -334,7 +334,7 @@ export const makeScreenshot = async (
 
     case 'size-mismatch':
       throw new Error(
-        `Screenshot dimensions differ: reference ${result.reference.width}x${result.reference.height}, actual ${result.actual.width}x${result.actual.height}. Saved actual to ${result.actualPath}.`
+        `Screenshot dimensions differ: reference ${result.reference.width}x${result.reference.height}, actual ${result.actual.width}x${result.actual.height}. Diff at ${result.diffPath}, actual at ${result.actualPath}.`
       )
 
     case 'mismatch':


### PR DESCRIPTION
When a component's screenshot changes size — for example a Field help/info message that expands the component's height — the visual-regression runner saved only the **actual** and **expected** images and no diff, because the diff library (blazediff) cannot compare buffers of different dimensions. Reviewers then had to compare two full screenshots by eye to find what changed.

This pads both images onto a shared union canvas (max width × max height) so a diff is always produced; the added or removed region is highlighted like any other change. The shared padding/diff logic now lives in `imageDiff.ts`, reused by the screenshot engine and the `loadImage` command.

A rendered real-world example (a taller `FieldBlock` with an expanded info message) is on the `example/visual-regression-size-mismatch-diff` branch under `examples/visual-regression-size-mismatch/`.
