### PR TITLE
fix(Modal): correct dialogTitle fallback casing and docs

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
+++ b/packages/dnb-eufemia/src/components/modal/ModalDocs.ts
@@ -112,7 +112,7 @@ export const ModalProperties: PropertiesTableProps = {
     status: 'deprecated',
   },
   dialogTitle: {
-    doc: 'The aria label of the dialog when no labelledBy and no title is given. Defaults to `Vindu`.',
+    doc: 'The `aria-label` used for the dialog when neither `title` nor `labelledBy` is given. Prefer a meaningful `title` or `labelledBy` for accessibility; this is only a generic fallback. Defaults to a localized string (`Separat vindu` for `nb-NO`).',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1530,7 +1530,7 @@ describe('Modal component', () => {
       document
         .querySelector('.dnb-modal__content')
         .getAttribute('aria-label')
-    ).toContain('Vindu')
+    ).toBe('Separat vindu')
 
     rerender(<Modal {...props} title="now there is a title" />)
     expect(

--- a/packages/dnb-eufemia/src/components/modal/types.ts
+++ b/packages/dnb-eufemia/src/components/modal/types.ts
@@ -205,7 +205,7 @@ export type ModalContentProps = {
   title?: ReactNode
 
   /**
-   * The aria label of the dialog when no labelledBy and no title is given. Defaults to `Vindu`.
+   * The `aria-label` used for the dialog when neither `title` nor `labelledBy` is given. Prefer a meaningful `title` or `labelledBy` for accessibility; this is only a generic fallback. Defaults to a localized string (`Separat vindu` for `nb-NO`).
    */
   dialogTitle?: string
 

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -549,7 +549,7 @@ describe('Wizard.Container', () => {
         </StrictMode>
       )
 
-      expect(screen.getAllByText('Separat Vindu')).toHaveLength(2)
+      expect(screen.getAllByText('Separat vindu')).toHaveLength(2)
       expect(screen.getByText('Hjelpetekst')).toBeInTheDocument()
 
       expect(output()).toHaveTextContent('Step 1')

--- a/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/shared/locales/nb-NO.ts
@@ -90,7 +90,7 @@ export default {
       indicatorLabel: 'Henter data ...',
     },
     Modal: {
-      dialogTitle: 'Separat Vindu',
+      dialogTitle: 'Separat vindu',
       closeTitle: 'Lukk',
     },
     Dialog: {


### PR DESCRIPTION
## Motivation

Follow-up from a review of generic fallback copy in Eufemia. `Modal.dialogTitle` is the `aria-label` applied to a `Modal` / `Dialog` / `Drawer` only when neither `title` nor `labelledBy` is provided. Two small correctness issues:

1. **Casing inconsistency (nb-NO).** `nb-NO` used title-case **"Separat Vindu"**, while `da-DK` ("Separat vindue") and `sv-SE` ("Separat fönster") use sentence case. Aligned nb-NO to **"Separat vindu"** (correct Bokmål sentence case).
2. **Incorrect documentation.** The `dialogTitle` doc (in both `ModalDocs` and the `ModalContentProps` JSDoc) claimed it *"Defaults to `Vindu`"* — but the actual fallback is the localized string (e.g. "Separat vindu"). Corrected the text and added guidance that a meaningful `title` or `labelledBy` is preferred for accessibility, since `dialogTitle` is only a generic fallback.

No visual impact: `dialogTitle` is an `aria-label`, not rendered text. Only two tests that used the fallback string as a value assertion were updated.

## Deliberately out of scope

The more substantive accessibility improvement would be to **warn in development when a dialog opens with no accessible name** (no `title` / `labelledBy` / `aria-label`) — the industry norm (react-aria, Radix) and consistent with the existing "A Dialog or Drawer needs an h1…" warning. It's left out here because an always-on warning fires for the many intentionally title-less modals in the test suite (one test asserts `warn` is called exactly once), so it needs its own change with test updates. Happy to follow up if the team wants it.
