### PR TITLE
fix(StepIndicator): use sentence case for en-GB overviewTitle

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -58,7 +58,7 @@ export type StepIndicatorProps = Omit<
      */
     data: StepIndicatorData
     /**
-     * The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`. Defaults to `Steps Overview`.
+     * The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`. Defaults to `Steps overview`.
      */
     overviewTitle?: string
     /**

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -17,7 +17,7 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     status: 'optional',
   },
   overviewTitle: {
-    doc: 'The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`. Defaults to `Steps Overview`.',
+    doc: 'The title shown inside the `<StepIndicatorModal />` supplemental screen reader text for the `<StepIndicatorTriggerButton />`. Defaults to `Steps overview`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -133,7 +133,7 @@ export default {
       nextButtonTitle: 'Next tab',
     },
     StepIndicator: {
-      overviewTitle: 'Steps Overview',
+      overviewTitle: 'Steps overview',
       stepTitle: 'Step %step of %count:',
     },
     Slider: {


### PR DESCRIPTION
## Motivation

The en-GB `StepIndicator.overviewTitle` used title case **"Steps Overview"**, which is inconsistent with the sentence-case convention used throughout the locale (e.g. "Show options", "Upload documents", "Next page"). The Norwegian/Danish/Swedish values are single words, so this was the only multi-word one and stood out.

Aligned it to **"Steps overview"** and updated the two places that document the default (`StepIndicatorProps` JSDoc and `StepIndicatorDocs`). The value is used as the trigger's `aria-label`, so there is no visual impact.
