### PR TITLE
fix(Modal): use sentence case for en-GB dialogTitle

### DIFF
--- a/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
+++ b/packages/dnb-eufemia/src/components/dialog/__tests__/Dialog.test.tsx
@@ -165,7 +165,7 @@ describe('Dialog', () => {
     )
 
     expect(document.querySelector('.dnb-dialog__title').textContent).toBe(
-      'Dialog Window'
+      'Dialog window'
     )
   })
 
@@ -189,7 +189,7 @@ describe('Dialog', () => {
     })
 
     expect(document.body.querySelector('.dnb-tooltip').textContent).toBe(
-      'Dialog Window'
+      'Dialog window'
     )
   })
 

--- a/packages/dnb-eufemia/src/shared/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/shared/locales/en-GB.ts
@@ -91,7 +91,7 @@ export default {
       indicatorLabel: 'Getting data ...',
     },
     Modal: {
-      dialogTitle: 'Dialog Window',
+      dialogTitle: 'Dialog window',
       closeTitle: 'Close',
     },
     Dialog: {


### PR DESCRIPTION
## Motivation

The en-GB `Modal.dialogTitle` used title case **"Dialog Window"**, while `da-DK` ("Separat vindue") and `sv-SE` ("Separat fönster") use sentence case. Aligned en-GB to **"Dialog window"** for consistency.

This complements #9067, which applies the same sentence-case correction to `nb-NO` ("Separat Vindu" → "Separat vindu"). `dialogTitle` is the dialog's `aria-label` fallback (used only when neither `title` nor `labelledBy` is given), so there is no visual impact; two Dialog tests that assert the resolved string were updated.
