### PR TITLE
chore(Autocomplete): correct stale default for title prop

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -179,7 +179,7 @@ export type AutocompleteProps = {
    */
   mode?: AutocompleteMode
   /**
-   * Give a title to let the user know what they have to do. Defaults to `Skriv og få alternativer`.
+   * Give a title to let the user know what they have to do. Defaults to `Skriv og velg`.
    */
   title?: AutocompleteTitle
   /**

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -17,7 +17,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     status: 'optional',
   },
   title: {
-    doc: 'Give a title to let the user know what they have to do. Defaults to `Skriv og få alternativer`.',
+    doc: 'Give a title to let the user know what they have to do. Defaults to `Skriv og velg`.',
     type: 'React.ReactNode',
     status: 'optional',
   },


### PR DESCRIPTION
## Motivation

`Autocomplete`'s `title` prop was documented as `Defaults to \`Skriv og få alternativer\``, but the actual default is the localized value **`Skriv og velg`** (`Autocomplete.title`). The `title` prop resolves via `getTranslation`, and the input placeholder even falls back to it (`placeholder || title`).

The string "Skriv og få alternativer" was **orphaned** — it existed only in these two doc locations (JSDoc + `AutocompleteDocs`) and nowhere in the locales, defaults, or tests. This is the same doc-drift class as the recent Modal `dialogTitle` "Vindu" correction (#9067).

Doc-only change — no behavior, locale, or test impact.
