### PR TITLE
chore(Slider): quote nb-NO default for add/subtract title props

### DIFF
--- a/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
+++ b/packages/dnb-eufemia/src/components/slider/SliderDocs.ts
@@ -52,12 +52,12 @@ export const SliderProperties: PropertiesTableProps = {
     status: 'optional',
   },
   subtractTitle: {
-    doc: 'Give the subtract button a title for accessibility reasons. Defaults to `Decrease (%s)`.',
+    doc: 'Give the subtract button a title for accessibility reasons. Defaults to `Reduser (%s)`.',
     type: 'string',
     status: 'optional',
   },
   addTitle: {
-    doc: 'Give the add button a title for accessibility reasons. Defaults to `Increase (%s)`.',
+    doc: 'Give the add button a title for accessibility reasons. Defaults to `Øk (%s)`.',
     type: 'string',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/slider/types.ts
+++ b/packages/dnb-eufemia/src/components/slider/types.ts
@@ -71,12 +71,12 @@ export type SliderProps = {
   thumbTitle?: string
 
   /**
-   * Give the add button a title for accessibility reasons. Defaults to `Increase (%s)`.
+   * Give the add button a title for accessibility reasons. Defaults to `Øk (%s)`.
    */
   addTitle?: string
 
   /**
-   * Give the subtract button a title for accessibility reasons. Defaults to `Decrease (%s)`.
+   * Give the subtract button a title for accessibility reasons. Defaults to `Reduser (%s)`.
    */
   subtractTitle?: string
 


### PR DESCRIPTION
## Motivation

`Slider`'s `addTitle` and `subtractTitle` docs quoted the en-GB values (`Increase (%s)` / `Decrease (%s)`), but the actual default is the localized value from nb-NO (Eufemia's default locale): **`Øk (%s)`** / **`Reduser (%s)`**.

Most component docs (Pagination, GlobalStatus, Autocomplete, …) quote the nb-NO default; this aligns Slider with that convention and makes the documented default accurate. Doc-only — no behavior, locale, or test impact.
