### PR TITLE
chore(StepIndicator): fix stepTitle documented default (missing colon)

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -62,7 +62,7 @@ export type StepIndicatorProps = Omit<
      */
     overviewTitle?: string
     /**
-     * Label for `<StepIndicatorTriggerButton />` and screen reader text for `<StepIndicatorItem />`. Must contain `%step` and `%count` to interpolate `currentStep` and `stepCount` into the text. Defaults to `Step %step of %count`.
+     * Label for `<StepIndicatorTriggerButton />` and screen reader text for `<StepIndicatorItem />`. Must contain `%step` and `%count` to interpolate `currentStep` and `stepCount` into the text. Defaults to `Step %step of %count:`.
      */
     stepTitle?: string
     /**

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -22,7 +22,7 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     status: 'optional',
   },
   stepTitle: {
-    doc: 'Label for `<StepIndicatorTriggerButton />` and screen reader text for `<StepIndicatorItem />`. Must contain `%step` and `%count` to interpolate `currentStep` and `stepCount` into the text. Defaults to `Step %step of %count`.',
+    doc: 'Label for `<StepIndicatorTriggerButton />` and screen reader text for `<StepIndicatorItem />`. Must contain `%step` and `%count` to interpolate `currentStep` and `stepCount` into the text. Defaults to `Step %step of %count:`.',
     type: 'string',
     status: 'optional',
   },


### PR DESCRIPTION
## Motivation

The `StepIndicator.stepTitle` doc quoted `Defaults to \`Step %step of %count\``, but the actual default value ends with a colon: **`Step %step of %count:`** (matching the `stepTitle` locale value). Corrected the JSDoc and `StepIndicatorDocs` to include it. Doc-only — no behavior, locale, or test impact.
