### PR TITLE
chore(markdown-tables-utils): prevent polynomial ReDoS in table parsing

### DIFF
--- a/tools/markdown-tables-utils/src/__tests__/markdownTablesUtils.test.ts
+++ b/tools/markdown-tables-utils/src/__tests__/markdownTablesUtils.test.ts
@@ -48,4 +48,37 @@ describe('markdownTablesUtils', () => {
       ],
     ])
   })
+
+  test('does not exhibit catastrophic backtracking on malformed separator rows', () => {
+    // A near-separator with a large trailing whitespace run previously made the
+    // separator matcher run in O(n^2) time (polynomial ReDoS).
+    const md = ['a | b', '-|-' + ' '.repeat(100000) + 'x'].join('\n')
+
+    const start = performance.now()
+    const tables = extractMarkdownTables(md)
+    const elapsed = performance.now() - start
+
+    expect(tables).toEqual([])
+    expect(elapsed).toBeLessThan(1000)
+  })
+
+  test('does not exhibit catastrophic backtracking on unmatched link delimiters', () => {
+    // Long runs of unmatched "[" and "(" previously made the inline link matcher
+    // run in O(n^2) time (polynomial ReDoS).
+    const openBrackets = '['.repeat(100000)
+    const openLinks = '[a]('.repeat(100000)
+    const md = [
+      '| h1 | h2 |',
+      '| --- | --- |',
+      `| ${openBrackets} | ${openLinks} |`,
+    ].join('\n')
+
+    const start = performance.now()
+    const tables = extractMarkdownTables(md)
+    const elapsed = performance.now() - start
+
+    expect(tables).toHaveLength(1)
+    expect(tables[0][1]).toEqual([openBrackets, openLinks])
+    expect(elapsed).toBeLessThan(1000)
+  })
 })

--- a/tools/markdown-tables-utils/src/markdownTablesUtils.ts
+++ b/tools/markdown-tables-utils/src/markdownTablesUtils.ts
@@ -42,9 +42,14 @@ export function extractMarkdownTables(md) {
 }
 
 function isTableSeparator(line) {
-  // Simplified pattern to prevent ReDoS - match table separator rows
-  // Pattern: optional leading pipe, then one or more cells with dashes/colons, optional trailing pipe
-  return /^\s*\|?\s*(:?-+:?\s*\|)+\s*:?-+:?\s*\|?\s*$/.test(line)
+  // Split on pipes instead of matching with a single regex: the previous pattern
+  // had ambiguous, adjacent whitespace quantifiers that allowed polynomial ReDoS.
+  const inner = line.trim().replace(/^\|/, '').replace(/\|$/, '')
+  const cells = inner.split('|')
+  if (cells.length < 2) {
+    return false
+  }
+  return cells.every((cell) => /^:?-+:?$/.test(cell.trim()))
 }
 
 function splitTableRow(line) {
@@ -92,8 +97,9 @@ function renderMarkdownInline(input) {
   }
 
   let out = input
-  // Use non-greedy quantifiers to prevent ReDoS
-  out = out.replace(/\[([^\]]+?)\]\(([^)]+?)\)/g, '<a href="$2">$1</a>')
+  // Exclude the opening delimiters from the link/url content so a match fails
+  // fast on unbalanced brackets, keeping the matcher linear (prevents ReDoS).
+  out = out.replace(/\[([^[\]]+?)\]\(([^()]+?)\)/g, '<a href="$2">$1</a>')
   out = out.replace(/`([^`]+?)`/g, '<code>$1</code>')
   out = out.replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
   out = out.replace(/__([^_]+?)__/g, '<strong>$1</strong>')


### PR DESCRIPTION
Motivation:
- https://github.com/dnbexperience/eufemia/security/code-scanning/58
- https://github.com/dnbexperience/eufemia/security/code-scanning/59

Two CodeQL `js/polynomial-redos` alerts flagged the shared markdown table helpers. The table-separator matcher and the inline link matcher could run in O(n²) time on crafted input, which is a denial-of-service risk when parsing untrusted markdown.

The separator check now splits on pipes instead of relying on a single regex with ambiguous, adjacent whitespace quantifiers, and the inline link matcher excludes the opening `[`/`(` delimiters from its content classes so it fails fast on unbalanced brackets. Both keep matching linear while preserving the existing output.
