### PR TITLE
chore(Autocomplete): complete showOptionsSr documented default

### DIFF
--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -203,7 +203,7 @@ export type AutocompleteProps = {
    */
   indicatorLabel?: AutocompleteIndicatorLabel
   /**
-   * Only for screen readers. Title of the button to show the suggestions / options. It is always present and when activating, it opens the DrawerList and sets the focus on it. Defaults to `Bla gjennom alternativer`.
+   * Only for screen readers. Title of the button to show the suggestions / options. It is always present and when activating, it opens the DrawerList and sets the focus on it. Defaults to `Bla gjennom alternativer, lukk med esc knappen`.
    */
   showOptionsSr?: string
   /**

--- a/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
+++ b/packages/dnb-eufemia/src/components/autocomplete/AutocompleteDocs.ts
@@ -132,7 +132,7 @@ export const AutocompleteProperties: PropertiesTableProps = {
     status: 'optional',
   },
   showOptionsSr: {
-    doc: 'Only for screen readers. Title of the button to show the suggestions / options. It is always present and when activating, it opens the DrawerList and sets the focus on it. Defaults to `Bla gjennom alternativer`.',
+    doc: 'Only for screen readers. Title of the button to show the suggestions / options. It is always present and when activating, it opens the DrawerList and sets the focus on it. Defaults to `Bla gjennom alternativer, lukk med esc knappen`.',
     type: 'string',
     status: 'optional',
   },


### PR DESCRIPTION
## Motivation

`Autocomplete.showOptionsSr` documented its default as `Bla gjennom alternativer`, but the actual locale value is the full string **`Bla gjennom alternativer, lukk med esc knappen`**. Completed the JSDoc and `AutocompleteDocs` to match. Doc-only — no behavior, locale, or test impact (the Autocomplete test already asserts the full value).
