### PR TITLE
fix(renderWithFormatting): prevent polynomial ReDoS in link parsing

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/renderWithFormatting.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/renderWithFormatting.test.tsx
@@ -320,4 +320,32 @@ describe('renderWithFormatting', () => {
     expect(a).toBeTruthy()
     expect(a.getAttribute('href')).toBeNull()
   })
+
+  it('does not exhibit catastrophic backtracking on unmatched markers', () => {
+    // A long run of unmatched "[" previously made the marker fast-path run in
+    // O(n^2) time (polynomial ReDoS).
+    const input = '['.repeat(100000)
+
+    const start = performance.now()
+    const result = renderWithFormatting(input)
+    const elapsed = performance.now() - start
+
+    expect(result).toBe(input)
+    expect(elapsed).toBeLessThan(1000)
+  })
+
+  it('does not exhibit catastrophic backtracking on unbalanced link delimiters', () => {
+    // Long runs of unmatched "[" and "(" previously made the inline link matcher
+    // run in O(n^2) time (polynomial ReDoS).
+    const input = '**bold** ' + '[a]('.repeat(100000)
+
+    const start = performance.now()
+    const nodes = renderWithFormatting(input)
+    const elapsed = performance.now() - start
+
+    expect(elapsed).toBeLessThan(1000)
+
+    const { container } = renderNode(nodes)
+    expect(container.querySelector('strong')?.textContent).toBe('bold')
+  })
 })

--- a/packages/dnb-eufemia/src/shared/renderWithFormatting.tsx
+++ b/packages/dnb-eufemia/src/shared/renderWithFormatting.tsx
@@ -35,7 +35,7 @@ export default function renderWithFormatting(
   // Fast-path: if text is a plain string without any formatting markers, return it directly
   if (typeof text === 'string') {
     const HAS_MARKERS_RE =
-      /(`[^`]+`|\[[^\]]+\]\([^)\s]+\)|\bhttps?:\/\/[^\s<>()]+|\*\*[^*]+\*\*|_[^_]+_)/
+      /(`[^`]+`|\[[^[\]]+\]\([^)\s[]+\)|\bhttps?:\/\/[^\s<>()]+|\*\*[^*]+\*\*|_[^_]+_)/
     const hasFormatting =
       (br && text.includes(br)) || HAS_MARKERS_RE.test(text)
     if (!hasFormatting) {
@@ -69,8 +69,9 @@ function withFormatting(
     <Fragment key={`c-${k()}`}>{code(m[0].slice(1, -1))}</Fragment>,
   ])
 
-  // [label](href) — recursive formatting inside the label, but avoid nested links
-  const linkRe = /\[([^\]]+)\]\(([^)\s]+)\)/g
+  // [label](href) — recursive formatting inside the label, but avoid nested links.
+  // Content classes exclude "[" so unbalanced brackets fail fast (prevents ReDoS).
+  const linkRe = /\[([^[\]]+)\]\(([^)\s[]+)\)/g
   nodes = replaceInStrings(nodes, linkRe, (m, { k }) => {
     const [, label, href] = m
     const children = withFormatting(label, {


### PR DESCRIPTION
`renderWithFormatting` renders markdown-like text (links, bold, code) and is a publicly exported shared helper used by translations and Forms field labels. Its inline link matcher and the marker fast-path used content classes that did not exclude the opening `[` delimiter, so long runs of unbalanced brackets triggered O(n²) backtracking — a denial-of-service risk when formatting untrusted or interpolated strings.

Excluding `[` from the link/URL content classes makes matching fail fast on unbalanced brackets and stay linear, while preserving the existing output (including URLs that contain parentheses).

Found while scanning for the same class of issue as #9075.
