### PR TITLE
fix(Theme): prevent polynomial ReDoS in query parsing

### DIFF
--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -238,10 +238,9 @@ export function getTheme(defaultTheme: ThemeNames = 'ui'): ThemeState {
     const data = window.localStorage.getItem(STORAGE_KEY)
     const theme = JSON.parse(data?.startsWith('{') ? data : '{}')
 
-    const regex = /.*eufemia-theme=([^&]*).*/
-    const query = window.location.search
     const fromQuery =
-      (regex.test(query) && query?.replace(regex, '$1')) || null
+      new URLSearchParams(window.location.search).get('eufemia-theme') ||
+      null
 
     const name = (fromQuery || theme?.name || defaultTheme) as ThemeNames
 

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -628,6 +628,21 @@ describe('Portals', () => {
       window.history.replaceState({}, '', '/')
     })
 
+    it('does not exhibit catastrophic backtracking on a long query string', () => {
+      // A long query without the marker previously made the ".*eufemia-theme..."
+      // matcher run in O(n^2) time (polynomial ReDoS).
+      window.history.replaceState({}, '', '?' + 'a'.repeat(100000))
+
+      const start = performance.now()
+      const result = getTheme()
+      const elapsed = performance.now() - start
+
+      window.history.replaceState({}, '', '/')
+
+      expect(result).toEqual({ name: 'ui' })
+      expect(elapsed).toBeLessThan(1000)
+    })
+
     it('persists theme state to localStorage', () => {
       setTheme({ name: 'eiendom', colorScheme: 'dark' })
 


### PR DESCRIPTION
`getTheme` reads the optional `?eufemia-theme=<name>` override from `window.location.search`, which is attacker-influenceable. It used a `/.*eufemia-theme=([^&]*).*/` regex whose leading and trailing `.*` cause O(n²) backtracking on a long query string that lacks the marker — a denial-of-service risk at app startup.

Replace it with `URLSearchParams`, which is linear and also decodes the value correctly. Behavior is otherwise unchanged (the existing query-override test still passes).

Found while scanning for the same class of issue as #9075.
