### PR TITLE
fix(input-masked): prevent polynomial ReDoS in numeric value cleanup

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -522,7 +522,10 @@ function stripAffixes(
  * If the mask is a numeric mask (has maskParams), strip prefix/suffix from the value.
  * Otherwise return the value unchanged.
  */
-function cleanNumericValue(value: string, rawMask: TextMaskMask): string {
+export function cleanNumericValue(
+  value: string,
+  rawMask: TextMaskMask
+): string {
   if (
     typeof rawMask === 'object' &&
     rawMask !== null &&
@@ -536,7 +539,12 @@ function cleanNumericValue(value: string, rawMask: TextMaskMask): string {
     // 5.4 can re-parse the value. Otherwise it drops the number and resets the
     // caret. Digits, decimal/thousand separators and the minus sign are kept.
     if (mp.suffix) {
-      return result.replace(/[^\d.,·-]+$/, '')
+      // Linear scan instead of /[^\d.,·-]+$/ to avoid super-linear backtracking.
+      let end = result.length
+      while (end > 0 && !/[\d.,·-]/.test(result[end - 1])) {
+        end--
+      }
+      return result.slice(0, end)
     }
 
     return result

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/TextMask.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/TextMask.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
-import TextMask from '../TextMask'
+import TextMask, { cleanNumericValue } from '../TextMask'
+import type { TextMaskMask } from '../TextMask'
 import { maskitoTransform, maskitoUpdateElement } from '@maskito/core'
 
 vi.mock('@maskito/react', () => ({
@@ -89,5 +90,28 @@ describe('TextMask', () => {
     render(<TextMask mask={[/\d/]} value={null} />)
 
     expect(maskitoUpdateElementMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('cleanNumericValue', () => {
+  const numericMask = {
+    maskParams: { suffix: ' kroner' },
+  } as unknown as TextMaskMask
+
+  it('drops a mismatched dynamic suffix', () => {
+    expect(cleanNumericValue('1 krone', numericMask)).toBe('1')
+  })
+
+  it('does not exhibit catastrophic backtracking on long non-numeric input', () => {
+    // The equivalent /[^\d.,·-]+$/ ran in O(n^2) time on a long non-numeric run
+    // ending in a digit (polynomial ReDoS).
+    const input = 'a'.repeat(100000) + '1'
+
+    const start = performance.now()
+    const result = cleanNumericValue(input, numericMask)
+    const elapsed = performance.now() - start
+
+    expect(result).toBe(input)
+    expect(elapsed).toBeLessThan(1000)
   })
 })


### PR DESCRIPTION
When a currency field uses a dynamic suffix (e.g. `krone` vs `kroner`), `cleanNumericValue` strips the mismatched trailing text before re-parsing. It did so with `/[^\d.,·-]+$/`, which backtracks in O(n²) time on a long non-numeric value ending in a digit — a denial-of-service risk when a long string value is fed to a masked numeric field.

Replace the regex with a linear trailing-character scan. Behavior is unchanged (the existing `Field.Currency` dynamic-suffix tests still pass). The helper is now exported so the behavior can be unit-tested directly.

Found while scanning for the same class of issue as #9075.
