### PR TITLE
fix(Field.MultiSelection): add accessible name to the search field

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -723,6 +723,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   const searchContent = (
     <MultiSelectionSearch
       show={showSearchField}
+      label={translation.searchLabel}
       placeholder={translation.searchPlaceholder}
       value={searchValue}
       disabled={disabled}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSearch.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSearch.tsx
@@ -2,6 +2,7 @@ import { Input } from '../../../../components'
 
 export type MultiSelectionSearchProps = {
   show: boolean
+  label: string
   placeholder: string
   value: string
   disabled?: boolean
@@ -10,6 +11,7 @@ export type MultiSelectionSearchProps = {
 
 export function MultiSelectionSearch({
   show,
+  label,
   placeholder,
   value,
   disabled,
@@ -22,7 +24,8 @@ export function MultiSelectionSearch({
   return (
     <Input
       type="search"
-      label={false}
+      label={label}
+      labelSrOnly
       icon="loupe"
       iconPosition="left"
       placeholder={placeholder}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -942,6 +942,28 @@ describe('MultiSelection', () => {
       )
     })
 
+    it('gives the search input an accessible name', async () => {
+      const data = [
+        { value: 'option1', title: 'Option 1' },
+        { value: 'option2', title: 'Option 2' },
+      ]
+
+      const { container } = render(
+        <Field.MultiSelection
+          variant="inline"
+          label="Select options"
+          data={data}
+          showSearchField
+        />
+      )
+
+      expect(
+        screen.getByRole('searchbox', { name: 'Søk' })
+      ).toBeInTheDocument()
+
+      expect(await axeComponent(container)).toHaveNoViolations()
+    })
+
     it('filters on description text', async () => {
       const data = [
         {
@@ -2610,9 +2632,11 @@ describe('MultiSelection', () => {
         '.dnb-forms-field-multi-selection__item'
       )
       expect(items).toHaveLength(1)
-      expect(document.querySelector('.dnb-form-label')).toHaveTextContent(
-        'Banana'
-      )
+      expect(
+        document.querySelector(
+          '.dnb-forms-field-multi-selection__item .dnb-form-label'
+        )
+      ).toHaveTextContent('Banana')
     })
 
     it('does not render a popover', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
@@ -115,6 +115,7 @@ export default {
       placeholder: 'Vælg en eller flere',
       selectAll: 'Vælg alle',
       searchPlaceholder: 'Søg...',
+      searchLabel: 'Søg',
       noOptions: 'Ingen muligheder',
       confirmButton: 'Bekræft ({count} valgt)',
       cancelButton: 'Annuller',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -113,6 +113,7 @@ export default {
       placeholder: 'Select one or more',
       selectAll: 'Select all',
       searchPlaceholder: 'Search...',
+      searchLabel: 'Search',
       noOptions: 'No options',
       confirmButton: 'Confirm ({count} selected)',
       cancelButton: 'Cancel',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -114,6 +114,7 @@ export default {
       placeholder: 'Velg en eller flere',
       selectAll: 'Velg alle',
       searchPlaceholder: 'Søk...',
+      searchLabel: 'Søk',
       noOptions: 'Ingen alternativer',
       confirmButton: 'Bekreft ({count} valgt)',
       cancelButton: 'Avbryt',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -115,6 +115,7 @@ export default {
       placeholder: 'Välj en eller flera',
       selectAll: 'Välj alla',
       searchPlaceholder: 'Sök...',
+      searchLabel: 'Sök',
       noOptions: 'Inga alternativ',
       confirmButton: 'Bekräfta ({count} valda)',
       cancelButton: 'Avbryt',


### PR DESCRIPTION
This was found while reviewing #9081 (real-browser axe run against the preview build): the violation is present on the existing inline demo too, so it is pre-existing and independent of that PR's `maxHeight` feature.

## Why the placeholder does not already cover this

A reasonable question is "the search field already has a placeholder — isn't that read by screen readers?" It is not, and the distinction matters:

- A **native HTML `placeholder`** attribute *is* used as a last-resort fallback in the accessible-name computation (HTML-AAM / accname). If Eufemia emitted one, the field would technically have a name.
- But Eufemia's `Input` does **not** emit a native `placeholder`. It sets **`aria-placeholder`** on the input and renders the visible placeholder text as a separate decorative `<span>` (not linked via `aria-labelledby`/`aria-describedby`). `aria-placeholder` is a *hint* and is explicitly **excluded** from the accessible-name computation.

So the search input had **no accessible name at all** (no `<label>`, no `aria-label`, no `aria-labelledby`, only `aria-placeholder`), which is a WCAG 4.1.2 (Name, Role, Value) failure and the critical axe `label` violation.

### Verified against the base commit

Rendering the pre-fix component and inspecting the emitted input:

```
<input ... id="id-ra" aria-placeholder="Søk..." type="search" ...>
```

- native `placeholder`: none · `aria-label`: none · `aria-labelledby`: none · `<label for>`: none
- querying the searchbox *by* the placeholder text as its name → not found (placeholder is not the name)
- axe → **1 critical `label` violation** ("Form elements must have labels")

With this PR a visually-hidden `<label for>` is added, the field's accessible name becomes `Søk`, and axe reports **0** violations. No visual change.
