### PR TITLE
fix(Field.MultiSelection): scroll the focused option into view

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -636,12 +636,6 @@ function MultiSelection(props: FieldMultiSelectionProps) {
             : navigable[(index - 1 + navigable.length) % navigable.length]
 
       next?.focus()
-
-      if (next !== searchInput) {
-        next
-          ?.closest('.dnb-forms-field-multi-selection__item')
-          ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-      }
     },
     [disabled, getCheckboxes, getSearchInput]
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback } from 'react'
-import type { ReactNode, MouseEvent } from 'react'
+import type { ReactNode, MouseEvent, FocusEvent } from 'react'
 import { clsx } from 'clsx'
 import { Checkbox } from '../../../../components'
 import ScrollView from '../../../../components/scroll-view/ScrollView'
@@ -90,6 +90,23 @@ export function MultiSelectionItemList({
     [disabled, onToggleItem, onToggleParent]
   )
 
+  // Keep the focused option visible while navigating the list. Each checkbox's
+  // focusable input is an oversized, absolutely-positioned hit-area, so the
+  // browser treats it as already on-screen and never scrolls the list to a
+  // focused row below the fold — leaving keyboard focus invisible (WCAG 2.4.7),
+  // most visibly when Tabbing. Scrolling the row on focus fixes this uniformly
+  // for Tab, arrow keys and programmatic focus, in both the inline and popover
+  // variants. `block: 'nearest'` scrolls only when the row is not already in
+  // view. Focus bubbles from the checkbox up to this list.
+  const handleItemFocus = useCallback(
+    (event: FocusEvent<HTMLUListElement>) => {
+      ;(event.target as HTMLElement | null)
+        ?.closest('.dnb-forms-field-multi-selection__item')
+        ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    },
+    []
+  )
+
   const renderItems = (
     items: MultiSelectionItem[],
     depth = 0,
@@ -161,7 +178,10 @@ export function MultiSelectionItemList({
 
   return (
     <ScrollView className={clsx('dnb-forms-field-multi-selection__items')}>
-      <ul className="dnb-forms-field-multi-selection__list">
+      <ul
+        className="dnb-forms-field-multi-selection__list"
+        onFocus={handleItemFocus}
+      >
         {showSelectAll && selectableFilteredFlat.length > 0 && (
           <li className="dnb-forms-field-multi-selection__item dnb-forms-field-multi-selection__item--select-all">
             <Checkbox

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
@@ -102,7 +102,9 @@ export function MultiSelectionItemList({
     (event: FocusEvent<HTMLUListElement>) => {
       ;(event.target as HTMLElement | null)
         ?.closest('.dnb-forms-field-multi-selection__item')
-        ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        // Optional call: jsdom and older browsers may not implement
+        // scrollIntoView.
+        ?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
     },
     []
   )

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -805,11 +805,46 @@ describe('MultiSelection', () => {
     ) as HTMLElement
 
     firstCheckbox.focus()
+    // Focusing already scrolls the row into view; clear so the assertions
+    // below capture only the ArrowDown navigation.
+    scrollIntoViewMock.mockClear()
     fireEvent.keyDown(firstCheckbox, { key: 'ArrowDown' })
 
     expect(document.activeElement).toBe(secondCheckbox)
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
     expect(scrollIntoViewMock.mock.instances[0]).toBe(secondItem)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'nearest',
+    })
+  })
+
+  it('scrolls a focused option into view when reached via Tab (inline)', () => {
+    const data = [
+      { value: 'option1', title: 'Option 1' },
+      { value: 'option2', title: 'Option 2' },
+      { value: 'option3', title: 'Option 3' },
+    ]
+
+    render(
+      <Field.MultiSelection variant="inline" label="Options" data={data} />
+    )
+
+    const checkboxes = document.querySelectorAll(
+      '.dnb-forms-field-multi-selection__items .dnb-checkbox__input'
+    )
+    const lastCheckbox = checkboxes[checkboxes.length - 1] as HTMLElement
+    const lastItem = lastCheckbox.closest(
+      '.dnb-forms-field-multi-selection__item'
+    ) as HTMLElement
+
+    scrollIntoViewMock.mockClear()
+
+    // Tab lands focus directly on the checkbox (no arrow-key handler runs).
+    lastCheckbox.focus()
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
+    expect(scrollIntoViewMock.mock.instances[0]).toBe(lastItem)
     expect(scrollIntoViewMock).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'nearest',


### PR DESCRIPTION
## Problem

In `Field.MultiSelection`, tabbing through the options moved keyboard focus to checkboxes that stayed **scrolled out of view** — the focus indicator was off-screen (WCAG 2.4.7 Focus Visible).

**Root cause:** each checkbox's focusable `<input>` is an oversized (~2000×2000px), absolutely-positioned hit-area. The browser's native "scroll focused element into view" sees that huge box as already on-screen, so it never scrolls the list to reveal the focused row.

This affected **both variants**: the popover list (scrolls via CSS `max-height`) and the inline list (scrolls when a `maxHeight` is set). Verified in a real browser against the preview build.

## Fix

Scroll the focused row into view on `focus` in the shared list component (`MultiSelectionItemList`). Because it keys off the `focus` event, it covers **Tab, arrow keys and programmatic focus** uniformly, in both variants. `block: 'nearest'` only scrolls when the row isn't already visible, and the search field (which lives outside the list) never triggers it.

The popover's arrow-key handler previously did this manually for arrow keys only; that call is now redundant and removed, leaving a single code path.

## Tests

- New test: focusing an option directly (as Tab does) scrolls its row into view — in the **inline** variant, which had no scroll-on-navigation before.
- Existing arrow-key navigation test updated (focus now drives the scroll); still asserts the row scrolls with `{ behavior: 'smooth', block: 'nearest' }`.
- The existing "does not scroll when focus moves to the search input" test still passes.
- Full `MultiSelection` suite green (79); ESLint and type-check clean.

_Note:_ the component has visual-regression (screenshot) tests; this changes only scroll-on-focus behaviour, no static layout, so no snapshot changes are expected.