### PR TITLE
chore(visual-regression): only show genuinely-failed tests in the diff report

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
@@ -176,6 +176,22 @@ describe('renderHtml', () => {
     expect(html).toContain('line&lt;one&gt;<br />line&amp;two')
     expect(html).not.toContain('line<one>')
   })
+
+  it('does not label multiple snapshots of the same test as retries', () => {
+    const html = renderHtml(
+      [
+        imagelessFailure({ dataVisualTestId: 'button-primary' }),
+        imagelessFailure({ dataVisualTestId: 'button-secondary' }),
+      ],
+      '/tmp/does-not-exist'
+    )
+
+    expect(html).not.toContain('retry')
+    expect(html).toContain('data-visual-test="button-primary"')
+    expect(html).toContain('data-visual-test="button-secondary"')
+    // Both rows belong to one test, so it is counted once.
+    expect(html).toContain('Failed Tests: <b>1</b>')
+  })
 })
 
 describe('ScreenshotReporter.onTestRunEnd', () => {

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
@@ -1,14 +1,19 @@
 // @vitest-environment node
 
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
-import {
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ScreenshotReporter, {
   buildReportManifest,
   escapeHtml,
   renderHtml,
   reportImageName,
   type ResolvedFailure,
 } from '../screenshotReporter'
+import { drainFailures, recordFailure } from '../failures'
 
 const makeFailure = (
   overrides: Partial<ResolvedFailure> = {}
@@ -40,7 +45,7 @@ describe('buildReportManifest', () => {
 
   it('maps each genuine failure to a summary row', () => {
     const failure = makeFailure()
-    const manifest = buildReportManifest([failure], [failure], existsAll)
+    const manifest = buildReportManifest([failure], existsAll)
 
     expect(manifest.failureCount).toBe(1)
     expect(manifest.failures[0]).toMatchObject({
@@ -54,7 +59,7 @@ describe('buildReportManifest', () => {
 
   it('references the images the HTML writer copied for that index', () => {
     const failure = makeFailure()
-    const { images } = buildReportManifest([failure], [failure], existsAll)
+    const { images } = buildReportManifest([failure], existsAll)
       .failures[0]
 
     expect(images).toEqual({
@@ -64,35 +69,34 @@ describe('buildReportManifest', () => {
     })
   })
 
-  it('uses the last index when a snapshot is retried', () => {
-    const attempt1 = makeFailure()
-    const attempt2 = makeFailure()
+  it('indexes images by position in the failure list', () => {
+    const first = makeFailure()
+    const second = makeFailure({
+      snapshotPath: '/snapshots/other.snap.png',
+      diffPath: '/tmp/other.diff.png',
+    })
 
-    // allFailures holds both attempts; the deduped genuine failure is the
-    // last one, so its images must reference index 1 (the last copy).
-    const { images } = buildReportManifest(
-      [attempt1, attempt2],
-      [attempt2],
-      existsAll
-    ).failures[0]
+    const manifest = buildReportManifest([first, second], existsAll)
 
-    expect(images.diff).toBe('images/1-table-active.diff.diff.png')
+    expect(manifest.failures[0].images.diff).toBe(
+      'images/0-table-active.diff.diff.png'
+    )
+    expect(manifest.failures[1].images.diff).toBe(
+      'images/1-other.diff.diff.png'
+    )
   })
 
   it('emits null for images whose source file is missing', () => {
     const failure = makeFailure()
-    const { images } = buildReportManifest(
-      [failure],
-      [failure],
-      () => false
-    ).failures[0]
+    const { images } = buildReportManifest([failure], () => false)
+      .failures[0]
 
     expect(images).toEqual({ expected: null, actual: null, diff: null })
   })
 
   it('emits null for image kinds the record does not carry', () => {
     const failure = makeFailure({ diffPath: null, actualPath: null })
-    const { images } = buildReportManifest([failure], [failure], existsAll)
+    const { images } = buildReportManifest([failure], existsAll)
       .failures[0]
 
     expect(images.diff).toBeNull()
@@ -105,11 +109,8 @@ describe('buildReportManifest', () => {
       message:
         '\u001B[33mScreenshot dimensions differ:\nreference 1x2\u001B[0m',
     })
-    const { message } = buildReportManifest(
-      [failure],
-      [failure],
-      existsAll
-    ).failures[0]
+    const { message } = buildReportManifest([failure], existsAll)
+      .failures[0]
 
     expect(message).toBe('Screenshot dimensions differ: reference 1x2')
   })
@@ -174,5 +175,80 @@ describe('renderHtml', () => {
 
     expect(html).toContain('line&lt;one&gt;<br />line&amp;two')
     expect(html).not.toContain('line<one>')
+  })
+})
+
+describe('ScreenshotReporter.onTestRunEnd', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    drainFailures()
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vr-report-'))
+    // process.chdir is unsupported in vitest workers, so point the
+    // reporter at the temp dir by stubbing the cwd it reads.
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    drainFailures()
+  })
+
+  it('reports only genuinely-failed tests, excluding flaky retries', () => {
+    recordFailure({
+      testFilePath: '/tmp/fake.test.ts',
+      fullName: 'Flaky > recovers on retry',
+      snapshotPath: '/tmp/missing-flaky.snap.png',
+      diffPath: null,
+      actualPath: null,
+      message: 'Screenshot mismatch: 10 px differ (0.1%).',
+    })
+    recordFailure({
+      testFilePath: '/tmp/fake.test.ts',
+      fullName: 'Genuine > stays broken',
+      snapshotPath: '/tmp/missing-genuine.snap.png',
+      diffPath: null,
+      actualPath: null,
+      message: 'Screenshot mismatch: 999 px differ (9%).',
+    })
+
+    // The flaky test passed on retry; only the genuine one is still failed.
+    const modules = [
+      {
+        children: [
+          {
+            type: 'test',
+            fullName: 'Flaky > recovers on retry',
+            result: () => ({ state: 'passed' }),
+          },
+          {
+            type: 'test',
+            fullName: 'Genuine > stays broken',
+            result: () => ({ state: 'failed' }),
+          },
+        ],
+      },
+    ] as never
+
+    new ScreenshotReporter().onTestRunEnd(modules, [], 'failed' as never)
+
+    const reportDir = path.join(tmpDir, 'visual-diff-report')
+    const html = fs.readFileSync(
+      path.join(reportDir, 'index.html'),
+      'utf-8'
+    )
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(reportDir, 'report.json'), 'utf-8')
+    )
+
+    expect(html).toContain('Genuine &gt; stays broken')
+    expect(html).toContain('Failed Tests: <b>1</b>')
+    expect(html).not.toContain('Flaky')
+
+    expect(manifest.failureCount).toBe(1)
+    expect(
+      manifest.failures.map((failure: { title: string }) => failure.title)
+    ).toEqual(['Genuine > stays broken'])
   })
 })

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
@@ -251,4 +251,33 @@ describe('ScreenshotReporter.onTestRunEnd', () => {
       manifest.failures.map((failure: { title: string }) => failure.title)
     ).toEqual(['Genuine > stays broken'])
   })
+
+  it('writes no report when every failure passed on retry', () => {
+    recordFailure({
+      testFilePath: '/tmp/fake.test.ts',
+      fullName: 'Flaky > recovers on retry',
+      snapshotPath: '/tmp/missing-flaky.snap.png',
+      diffPath: null,
+      actualPath: null,
+      message: 'Screenshot mismatch: 10 px differ (0.1%).',
+    })
+
+    const modules = [
+      {
+        children: [
+          {
+            type: 'test',
+            fullName: 'Flaky > recovers on retry',
+            result: () => ({ state: 'passed' }),
+          },
+        ],
+      },
+    ] as never
+
+    new ScreenshotReporter().onTestRunEnd(modules, [], 'failed' as never)
+
+    expect(fs.existsSync(path.join(tmpDir, 'visual-diff-report'))).toBe(
+      false
+    )
+  })
 })

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
@@ -340,20 +340,15 @@ const toPlainMessage = (message: string) =>
 /**
  * Structured, machine-readable sibling of the HTML report. CI reads
  * this to build a job-summary table and to turn the relative image
- * paths into absolute URLs once the report is hosted. The image paths
- * match the files the HTML writer copied (same `reportImageName`), so
- * the two never drift.
+ * paths into absolute URLs once the report is hosted. It renders the
+ * same failures as the HTML report, in the same order, so the image
+ * index (and thus each `reportImageName`) matches the files the HTML
+ * writer copied.
  */
 export const buildReportManifest = (
-  allFailures: ResolvedFailure[],
-  genuineFailures: ResolvedFailure[],
+  failures: ResolvedFailure[],
   exists: (filePath: string) => boolean = fs.existsSync
 ): ReportManifest => {
-  const lastIndexBySnapshot = new Map<string, number>()
-  allFailures.forEach((failure, index) => {
-    lastIndexBySnapshot.set(failure.snapshotPath, index)
-  })
-
   const relImage = (
     index: number,
     srcPath: string | null,
@@ -364,22 +359,19 @@ export const buildReportManifest = (
       : null
 
   return {
-    failureCount: genuineFailures.length,
-    failures: genuineFailures.map((failure) => {
-      const index = lastIndexBySnapshot.get(failure.snapshotPath) ?? 0
-      return {
-        title: failure.fullName,
-        testFilePath: failure.relativeTestFilePath,
-        lineNumber: failure.lineNumber,
-        dataVisualTestId: failure.dataVisualTestId,
-        message: toPlainMessage(failure.message),
-        images: {
-          expected: relImage(index, failure.expectedImagePath, 'expected'),
-          actual: relImage(index, failure.actualPath, 'actual'),
-          diff: relImage(index, failure.diffPath, 'diff'),
-        },
-      }
-    }),
+    failureCount: failures.length,
+    failures: failures.map((failure, index) => ({
+      title: failure.fullName,
+      testFilePath: failure.relativeTestFilePath,
+      lineNumber: failure.lineNumber,
+      dataVisualTestId: failure.dataVisualTestId,
+      message: toPlainMessage(failure.message),
+      images: {
+        expected: relImage(index, failure.expectedImagePath, 'expected'),
+        actual: relImage(index, failure.actualPath, 'actual'),
+        diff: relImage(index, failure.diffPath, 'diff'),
+      },
+    })),
   }
 }
 
@@ -443,11 +435,15 @@ export default class ScreenshotReporter implements Reporter {
       new Map(filteredRecords.map((r) => [r.snapshotPath, r])).values()
     )
 
-    // Always resolve all records for the HTML report (shows retried
-    // diffs as informational), but only print CLI warnings for
-    // genuine failures.
-    const allFailures = resolveFailures(records)
+    // Report only genuinely-failed tests. A test that passed on a
+    // retry has its diff/actual images deleted by the passing attempt,
+    // so including its stale record would render a misleading
+    // "expected only" entry. Deduping also collapses retry duplicates.
     const genuineFailures = resolveFailures(deduped)
+
+    if (genuineFailures.length === 0) {
+      return
+    }
 
     const cwd = process.cwd()
     const reportDir = path.join(cwd, 'visual-diff-report')
@@ -478,15 +474,11 @@ export default class ScreenshotReporter implements Reporter {
     if (!fs.existsSync(reportDir)) {
       fs.mkdirSync(reportDir, { recursive: true })
     }
-    fs.writeFileSync(htmlFilePath, renderHtml(allFailures, reportDir))
+    fs.writeFileSync(htmlFilePath, renderHtml(genuineFailures, reportDir))
 
     fs.writeFileSync(
       path.join(reportDir, 'report.json'),
-      JSON.stringify(
-        buildReportManifest(allFailures, genuineFailures),
-        null,
-        2
-      )
+      JSON.stringify(buildReportManifest(genuineFailures), null, 2)
     )
   }
 }

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
@@ -133,17 +133,15 @@ export const renderHtml = (
   failures: ResolvedFailure[],
   reportDir: string
 ) => {
-  // Track how many times each test appears so we can label retries.
-  const attemptByName = new Map<string, number>()
+  // Count distinct tests for the summary. A single test can emit
+  // several snapshots (one per data-visual-test), so the same name
+  // may legitimately appear on more than one row.
   const uniqueTests = new Set<string>()
 
   const items = failures
     .map((f, i) => {
-      const attempt = (attemptByName.get(f.fullName) ?? 0) + 1
-      attemptByName.set(f.fullName, attempt)
       uniqueTests.add(f.fullName)
 
-      const retryLabel = attempt > 1 ? ` (retry #${attempt - 1})` : ''
       const figures: string[] = []
 
       if (f.expectedImagePath && fs.existsSync(f.expectedImagePath)) {
@@ -184,8 +182,6 @@ export const renderHtml = (
             </figure>`)
       }
 
-      void i
-
       const image = figures.length
         ? `<div class="screenshot-row">${figures.join('\n')}</div>`
         : ''
@@ -197,7 +193,7 @@ export const renderHtml = (
       return `
             <li>
               <dl>
-                <dt>${escapeHtml(f.fullName)}${retryLabel}</dt>
+                <dt>${escapeHtml(f.fullName)}</dt>
                 <dd>
                   <p><a href="vscode://file${escapeHtml(f.testFilePath)}${f.lineNumber ? ':' + f.lineNumber : ''}"><code>${escapeHtml(f.relativeTestFilePath)}${f.lineNumber ? ':' + f.lineNumber : ''}</code></a></p>
                   ${visualTestIdHtml}


### PR DESCRIPTION
Render the diff report from the deduped, finally-failed records only, so flaky-passed tests and retry duplicates no longer appear as misleading "expected only" rows.
