### PR TITLE
chore(visual-regression): resolve report metadata from Vitest task location

### DIFF
--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotEngine.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotEngine.test.ts
@@ -116,6 +116,30 @@ describe('buildUrl', () => {
   })
 })
 
+describe('visualTestIdFromSelector', () => {
+  const { visualTestIdFromSelector } = _testing
+
+  it('extracts the id from a data-visual-test selector', () => {
+    expect(
+      visualTestIdFromSelector('[data-visual-test="button-primary"]')
+    ).toBe('button-primary')
+  })
+
+  it('extracts the id from a compound selector', () => {
+    expect(
+      visualTestIdFromSelector(
+        '[data-visual-test="drawer-list"] .dnb-drawer-list__list'
+      )
+    ).toBe('drawer-list')
+  })
+
+  it('returns null when there is no data-visual-test id', () => {
+    expect(visualTestIdFromSelector('.dnb-button')).toBeNull()
+    expect(visualTestIdFromSelector(null)).toBeNull()
+    expect(visualTestIdFromSelector(undefined)).toBeNull()
+  })
+})
+
 describe('applyScreenshotColorScheme', () => {
   afterEach(() => {
     vi.unstubAllGlobals()

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/__tests__/screenshotReporter.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ScreenshotReporter, {
   buildReportManifest,
+  collectTestLocations,
   escapeHtml,
   renderHtml,
   reportImageName,
@@ -295,5 +296,105 @@ describe('ScreenshotReporter.onTestRunEnd', () => {
     expect(fs.existsSync(path.join(tmpDir, 'visual-diff-report'))).toBe(
       false
     )
+  })
+
+  it('uses each test location and recorded id for duplicate titles', () => {
+    recordFailure({
+      testFilePath: '/tmp/dup.test.ts',
+      fullName: 'Group A > has to match default',
+      snapshotPath: '/tmp/missing-a.snap.png',
+      diffPath: null,
+      actualPath: null,
+      message: 'Screenshot mismatch: 1 px differ (0.1%).',
+      dataVisualTestId: 'group-a-default',
+    })
+    recordFailure({
+      testFilePath: '/tmp/dup.test.ts',
+      fullName: 'Group B > has to match default',
+      snapshotPath: '/tmp/missing-b.snap.png',
+      diffPath: null,
+      actualPath: null,
+      message: 'Screenshot mismatch: 2 px differ (0.2%).',
+      dataVisualTestId: 'group-b-default',
+    })
+
+    const modules = [
+      {
+        children: [
+          {
+            type: 'test',
+            fullName: 'Group A > has to match default',
+            location: { line: 41, column: 3 },
+            result: () => ({ state: 'failed' }),
+          },
+          {
+            type: 'test',
+            fullName: 'Group B > has to match default',
+            location: { line: 57, column: 3 },
+            result: () => ({ state: 'failed' }),
+          },
+        ],
+      },
+    ] as never
+
+    new ScreenshotReporter().onTestRunEnd(modules, [], 'failed' as never)
+
+    const html = fs.readFileSync(
+      path.join(tmpDir, 'visual-diff-report', 'index.html'),
+      'utf-8'
+    )
+
+    // Same title in different describes -> each links to its own line.
+    expect(html).toContain('vscode://file/tmp/dup.test.ts:41')
+    expect(html).toContain('vscode://file/tmp/dup.test.ts:57')
+    // The id comes straight from the recorded selector, not a grep.
+    expect(html).toContain('data-visual-test="group-a-default"')
+    expect(html).toContain('data-visual-test="group-b-default"')
+  })
+})
+
+describe('collectTestLocations', () => {
+  const testNode = (fullName: string, line: number | undefined) =>
+    ({
+      type: 'test',
+      fullName,
+      location: line === undefined ? undefined : { line, column: 3 },
+    }) as never
+  const suiteNode = (children: unknown[]) =>
+    ({ type: 'suite', children }) as never
+  const moduleNode = (children: unknown[]) => ({ children }) as never
+
+  it('maps nested tests to their declared line', () => {
+    const locations = collectTestLocations([
+      moduleNode([
+        suiteNode([
+          testNode('Button > primary', 12),
+          testNode('Button > secondary', 20),
+        ]),
+      ]),
+    ])
+
+    expect(locations.get('Button > primary')).toBe(12)
+    expect(locations.get('Button > secondary')).toBe(20)
+  })
+
+  it('resolves duplicate titles across describes to distinct lines', () => {
+    const locations = collectTestLocations([
+      moduleNode([
+        testNode('Group A > has to match', 41),
+        testNode('Group B > has to match', 57),
+      ]),
+    ])
+
+    expect(locations.get('Group A > has to match')).toBe(41)
+    expect(locations.get('Group B > has to match')).toBe(57)
+  })
+
+  it('omits tests without a location', () => {
+    const locations = collectTestLocations([
+      moduleNode([testNode('No location', undefined)]),
+    ])
+
+    expect(locations.has('No location')).toBe(false)
   })
 })

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/commands/screenshotEngine.ts
@@ -1657,6 +1657,18 @@ async function performScreenshot(
 
 // ── snapshot pipeline ────────────────────────────────────────────────
 
+/**
+ * Parse the `data-visual-test` id from a screenshot selector such as
+ * `[data-visual-test="button-primary"]`. Recorded with each failure so
+ * the reporter shows it without re-parsing the test source.
+ */
+const visualTestIdFromSelector = (
+  selector: string | null | undefined
+): string | null => {
+  const match = selector?.match(/data-visual-test="([^"]+)"/)
+  return match ? match[1] : null
+}
+
 async function diffAndPersist(
   payload: MakeScreenshotPayload,
   actualBytes: Buffer
@@ -1696,6 +1708,7 @@ async function diffAndPersist(
       actualPath: payload.actualPath,
       message: `Screenshot dimensions differ: reference ${refWidth}x${refHeight}, actual ${actWidth}x${actHeight}.`,
       htmlDumpPath: payload.htmlDumpPath,
+      dataVisualTestId: visualTestIdFromSelector(payload.selector),
     })
 
     // Help V8 reclaim memory before return
@@ -1740,6 +1753,7 @@ async function diffAndPersist(
       actualPath: payload.actualPath,
       message: `Screenshot mismatch: ${diffPixels} px differ (${(ratio * 100).toFixed(3)}%).`,
       htmlDumpPath: payload.htmlDumpPath,
+      dataVisualTestId: visualTestIdFromSelector(payload.selector),
     })
 
     // Help V8 reclaim memory before return
@@ -1839,6 +1853,7 @@ export const makeScreenshot = defineBrowserCommand<
 
 export const _testing = {
   buildUrl,
+  visualTestIdFromSelector,
   applyScreenshotColorScheme,
   sessions,
   browserSlots,

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/failures.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/failures.ts
@@ -22,6 +22,10 @@ export type ScreenshotFailureRecord = {
   diffPath: string | null
   actualPath: string | null
   message: string
+  // The data-visual-test id parsed from the screenshot selector,
+  // recorded so the reporter can show it without re-reading the
+  // test source.
+  dataVisualTestId?: string | null
   // Optional path to a side-by-side dump of the DOM HTML (saved
   // alongside the actual/diff PNGs). Lets contributors tell at a
   // glance whether a screenshot diff is a real visual regression or

--- a/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
+++ b/packages/dnb-eufemia/src/core/vitest-screenshots/screenshotReporter.ts
@@ -48,52 +48,20 @@ const formatMessage = (message: string) =>
     '<br />'
   )
 
-const extractTestMetadata = (
-  testFilePath: string,
-  title: string
-): { dataVisualTestId: string | null; lineNumber: number | null } => {
-  try {
-    const content = fs.readFileSync(testFilePath, 'utf-8')
-    const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const idx = content.search(new RegExp(escaped))
-    if (idx === -1) {
-      return { dataVisualTestId: null, lineNumber: null }
-    }
-    const lineNumber = content.substring(0, idx).split('\n').length
-    const window = content.substring(idx, idx + 2000)
-    const m = window.match(/data-visual-test="([^"]+)"/)
-    return {
-      dataVisualTestId: m ? m[1] : null,
-      lineNumber,
-    }
-  } catch {
-    return { dataVisualTestId: null, lineNumber: null }
-  }
-}
-
-const lastSegmentOf = (fullName: string) =>
-  (fullName.split(' > ').pop() ?? '').trim()
-
 const resolveFailures = (
-  records: ScreenshotFailureRecord[]
+  records: ScreenshotFailureRecord[],
+  lineByFullName: Map<string, number>
 ): ResolvedFailure[] => {
   const cwd = process.cwd()
-  return records.map((record) => {
-    const relativeTestFilePath = path.relative(cwd, record.testFilePath)
-    const meta = extractTestMetadata(
-      record.testFilePath,
-      lastSegmentOf(record.fullName)
-    )
-    return {
-      ...record,
-      relativeTestFilePath,
-      expectedImagePath: fs.existsSync(record.snapshotPath)
-        ? record.snapshotPath
-        : null,
-      dataVisualTestId: meta.dataVisualTestId,
-      lineNumber: meta.lineNumber,
-    }
-  })
+  return records.map((record) => ({
+    ...record,
+    relativeTestFilePath: path.relative(cwd, record.testFilePath),
+    expectedImagePath: fs.existsSync(record.snapshotPath)
+      ? record.snapshotPath
+      : null,
+    dataVisualTestId: record.dataVisualTestId ?? null,
+    lineNumber: lineByFullName.get(record.fullName) ?? null,
+  }))
 }
 
 /**
@@ -402,6 +370,39 @@ const collectFinallyFailedNames = (
   return names
 }
 
+/**
+ * Map each test's fullName to the line where it is declared, taken
+ * from Vitest's task location (requires `includeTaskLocation`). Tests
+ * that share a title across describe blocks have distinct fullNames,
+ * so each resolves to its own line.
+ */
+export const collectTestLocations = (
+  modules: ReadonlyArray<TestModule>
+): Map<string, number> => {
+  const lines = new Map<string, number>()
+
+  const visit = (node: TestSuite | TestCase) => {
+    if (node.type === 'test') {
+      const line = node.location?.line
+      if (typeof line === 'number') {
+        lines.set(node.fullName, line)
+      }
+    } else if (node.type === 'suite') {
+      for (const child of Array.from(node.children)) {
+        visit(child)
+      }
+    }
+  }
+
+  for (const mod of modules) {
+    for (const child of Array.from(mod.children)) {
+      visit(child)
+    }
+  }
+
+  return lines
+}
+
 export default class ScreenshotReporter implements Reporter {
   // We don't read TestModule data here; the engine already has the
   // failure records it needs. This callback exists just to fire at the
@@ -435,7 +436,10 @@ export default class ScreenshotReporter implements Reporter {
     // retry has its diff/actual images deleted by the passing attempt,
     // so including its stale record would render a misleading
     // "expected only" entry. Deduping also collapses retry duplicates.
-    const genuineFailures = resolveFailures(deduped)
+    const genuineFailures = resolveFailures(
+      deduped,
+      collectTestLocations(modules)
+    )
 
     if (genuineFailures.length === 0) {
       return

--- a/packages/dnb-eufemia/vitest.config.screenshots.ts
+++ b/packages/dnb-eufemia/vitest.config.screenshots.ts
@@ -27,6 +27,12 @@ export default defineConfig({
     include: process.env.SCREENSHOT_INCLUDE
       ? process.env.SCREENSHOT_INCLUDE.split(',')
       : ['src/**/*.screenshot.test.{ts,tsx}'],
+
+    // Populate TestCase.location so the screenshot reporter can build
+    // accurate file:line deep links, even for tests that share a title
+    // across describe blocks.
+    includeTaskLocation: true,
+
     reporters: [
       new SummaryOnlyReporter(),
       new LiveReporter(),


### PR DESCRIPTION
Take the report file:line links from Vitest `TestCase.location` and the `data-visual-test` id from the screenshot selector, replacing the source-file grep. Fixes the wrong line/id when tests share a title across describe blocks.
