### PR TITLE
chore(ci): run the CodeQL security-and-quality query suite

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,10 +64,9 @@ jobs:
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+          # Run the security-and-quality suite so CI also flags code-quality
+          # issues such as polynomial ReDoS, not only the default security queries.
+          queries: security-and-quality
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
## Why

CodeQL currently runs the default, security-only query suite. Several recent PRs manually fixed polynomial ReDoS issues (#9075, #9078, #9079, #9080) — exactly the class of finding CodeQL's `security-and-quality` suite detects automatically.

Running that suite lets CI flag these (and other code-quality issues) on every PR, instead of relying on manual review to catch them.
