### PR TITLE
chore(Fragments): align import section with standard docs pattern

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/fragments.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/fragments.mdx
@@ -12,9 +12,7 @@ import ListFragments from 'dnb-design-system-portal/src/shared/parts/ListFragmen
 
 ## Import
 
-You import them like so:
-
-```jsx
+```tsx
 import { DrawerList, TextCounter } from '@dnb/eufemia/fragments'
 ```
 


### PR DESCRIPTION
The [Fragments](https://eufemia.dnb.no/uilib/components/fragments) docs page introduced its import example with the sentence "You import them like so:" and used a `jsx` code fence. Every other component, element and field doc goes straight from the `## Import` heading to a `tsx` code block with no intro prose.

This removes the extra sentence and switches the fence to `tsx` so the Fragments Import section matches the standard pattern used across the rest of the documentation.
