### PR TITLE
docs: add missing events pages for Card and Field.Indeterminate

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/card.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/card.mdx
@@ -10,6 +10,8 @@ tabs:
     key: '/demos'
   - title: Properties
     key: '/properties'
+  - title: Events
+    key: '/events'
 theme: ['sbanken', 'carnegie']
 ---
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/card/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/card/events.mdx
@@ -1,0 +1,10 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { CardActionEvents } from '@dnb/eufemia/src/components/card/CardDocs'
+
+## `Card.Action` events
+
+<PropertiesTable props={CardActionEvents} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Indeterminate.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Indeterminate.mdx
@@ -12,6 +12,8 @@ tabs:
     key: '/demos'
   - title: Properties
     key: '/properties'
+  - title: Events
+    key: '/events'
 breadcrumb:
   - text: Forms
     href: /uilib/extensions/forms/

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Indeterminate/events.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/Indeterminate/events.mdx
@@ -1,0 +1,17 @@
+---
+showTabs: true
+---
+
+import PropertiesTable from 'dnb-design-system-portal/src/shared/parts/PropertiesTable'
+import { FieldEvents } from '@dnb/eufemia/src/extensions/forms/Field/FieldDocs'
+import { IndeterminateEvents } from '@dnb/eufemia/src/extensions/forms/Field/Indeterminate/IndeterminateDocs'
+
+## Events
+
+### Field-specific events
+
+<PropertiesTable props={IndeterminateEvents} />
+
+### General events
+
+<PropertiesTable props={FieldEvents} />

--- a/packages/dnb-eufemia/src/components/card/CardDocs.ts
+++ b/packages/dnb-eufemia/src/components/card/CardDocs.ts
@@ -121,11 +121,6 @@ export const CardActionProperties: PropertiesTableProps = {
     type: ['string', 'React.Element'],
     status: 'optional',
   },
-  onClick: {
-    doc: 'Click handler. When used without `href`/`to`, renders a button-like wrapper with keyboard support (Enter/Space).',
-    type: 'function',
-    status: 'optional',
-  },
   children: {
     doc: 'Contents of the Card inside the action wrapper.',
     type: 'React.ReactNode',
@@ -134,6 +129,14 @@ export const CardActionProperties: PropertiesTableProps = {
   'Card properties': {
     doc: 'All [Card](/uilib/components/card/properties) properties are supported.',
     type: 'Various',
+    status: 'optional',
+  },
+}
+
+export const CardActionEvents: PropertiesTableProps = {
+  onClick: {
+    doc: 'Click handler. When used without `href`/`to`, renders a button-like wrapper with keyboard support (Enter/Space).',
+    type: 'function',
     status: 'optional',
   },
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/IndeterminateDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Indeterminate/IndeterminateDocs.ts
@@ -28,3 +28,11 @@ export const IndeterminateProperties: PropertiesTableProps = {
   textOff: undefined,
   variant: undefined,
 }
+
+export const IndeterminateEvents: PropertiesTableProps = {
+  onClick: {
+    doc: 'Will be called on click.',
+    type: '(value: unknown, { event: ClickEvent, preventDefault: () => void }) => void',
+    status: 'optional',
+  },
+}


### PR DESCRIPTION
Some documented components expose public event handlers but were missing a dedicated **Events** documentation tab, so those events were either buried under Properties or not surfaced at all.

- **Card** — `Card.Action`'s `onClick` was documented as a property. Moved it to a new events page to match the library convention where `onClick` is documented as an event (e.g. `Button`, `Field.Boolean`).
- **Field.Indeterminate** — a checkbox field that emits field events (`onChange`, `onClick`, `onFocus`, `onBlur`), but unlike its sibling fields it had no events page.

A full scan of the portal (components, elements, forms, layout) confirmed these were the only documented items exposing public events without an events page; everything else already has one or intentionally hides the Events tab.
