### PR TITLE
chore: resolve CodeQL security-and-quality findings

### DIFF
--- a/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
+++ b/packages/dnb-eufemia/scripts/figma/helpers/docHelpers.js
@@ -166,9 +166,14 @@ const saveLiveVersionOfFigmaDoc = async ({ figmaFile, version }) => {
   try {
     const lockFile = path.resolve(__dirname, `../version.lock`)
 
-    const existingLockFileContent = fs.existsSync(lockFile)
-      ? JSON.parse((await fs.readFile(lockFile, 'utf-8')) || '{}')
-      : {}
+    let existingLockFileContent = {}
+    try {
+      existingLockFileContent = JSON.parse(
+        (await fs.readFile(lockFile, 'utf-8')) || '{}'
+      )
+    } catch {
+      // No existing lock file yet; start fresh.
+    }
     const newLockFileContent = {
       [md5(figmaFile)]: version,
     }
@@ -211,6 +216,16 @@ export const getFigmaDoc = async ({
     ErrorHandler(
       'No Figma file defined. Make sure there is a .env file with a valid "figmaFile" defined!'
     )
+  }
+
+  // Figma file keys are alphanumeric; reject anything else so it cannot traverse the cache path.
+  if (
+    typeof figmaFile === 'string' &&
+    figmaFile.length > 0 &&
+    !/^[A-Za-z0-9]+$/.test(figmaFile)
+  ) {
+    ErrorHandler('Invalid Figma file key. Expected an alphanumeric key.')
+    return false
   }
 
   const localDir = path.resolve(__dirname, `../.cache`)

--- a/packages/dnb-eufemia/scripts/figma/tasks/assetsExtractors.ts
+++ b/packages/dnb-eufemia/scripts/figma/tasks/assetsExtractors.ts
@@ -747,6 +747,10 @@ const createXMLTarBundles = async ({
   async function convertSvgToXml() {
     try {
       log.info(`> Figma: convert SVG to XML in directory: ${destDir}`)
+      // Allow only path characters so a directory value cannot inject shell syntax.
+      if (!/^[A-Za-z0-9 _./@+-]+$/.test(String(destDir))) {
+        throw new Error(`Unsafe destination directory: ${destDir}`)
+      }
       const safeDestDir = `'${String(destDir).replace(/'/g, `'\\''`)}'`
       await runCommand(`yarn vd-tool -c -in ${safeDestDir}`)
     } catch (error) {
@@ -859,14 +863,15 @@ const optimizeSVGIcons = async ({ destDir, listWithFiles }) => {
 }
 
 const optimizeSVG = async (file) => {
-  if (!fs.existsSync(file)) {
+  let content
+  try {
+    content = await fs.readFile(file, 'utf-8')
+  } catch {
     log.fail(`Figma: optimizeSVG got an non existing file: ${file}`)
     return null
   }
 
   try {
-    const content = await fs.readFile(file, 'utf-8')
-
     const config = await loadConfig()
     let { data } = await optimize(content, {
       path: file,

--- a/packages/dnb-eufemia/scripts/lib/error.ts
+++ b/packages/dnb-eufemia/scripts/lib/error.ts
@@ -20,6 +20,9 @@ function ErrorHandler(
     message = error.message
   }
 
+  // Neutralise CR/LF so a value cannot forge extra log lines.
+  message = String(message).replace(/[\r\n]+/g, ' ')
+
   const err = new Error(`${message} (error code ${code})`)
 
   if (code === ERROR_FATAL) {

--- a/packages/dnb-eufemia/src/components/filter/utils/__tests__/sanitizeUrlFilters.test.ts
+++ b/packages/dnb-eufemia/src/components/filter/utils/__tests__/sanitizeUrlFilters.test.ts
@@ -154,4 +154,15 @@ describe('sanitizeUrlFilters', () => {
       status: { value: 'active', label: 'Active' },
     })
   })
+
+  it('does not pollute Object.prototype for a crafted key', () => {
+    const input = JSON.parse(
+      '{"__proto__": {"polluted": "yes"}, "status": {"value": "ok", "label": "OK"}}'
+    )
+
+    sanitizeUrlFilters(input)
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('polluted')
+  })
 })

--- a/packages/dnb-eufemia/src/components/filter/utils/sanitizeUrlFilters.ts
+++ b/packages/dnb-eufemia/src/components/filter/utils/sanitizeUrlFilters.ts
@@ -1,7 +1,5 @@
 import type { FilterValue } from '../FilterContext'
 
-const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
-
 /**
  * Validates and sanitizes filter data parsed from a URL query parameter.
  *
@@ -20,7 +18,12 @@ export function sanitizeUrlFilters(
   const result: Record<string, FilterValue> = {}
 
   for (const key of Object.keys(raw as Record<string, unknown>)) {
-    if (FORBIDDEN_KEYS.has(key)) {
+    // Skip prototype-polluting keys before writing them to the result object.
+    if (
+      key === '__proto__' ||
+      key === 'constructor' ||
+      key === 'prototype'
+    ) {
       continue
     }
 

--- a/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/InputMasked.tsx
@@ -171,7 +171,8 @@ function InputMasked({ ref, ...restProps }: InputMaskedProps) {
 
     const clone = { ...context.InputMasked }
     for (const key in clone) {
-      if (/^as[_A-Z]|numberMask|currencyMask/.test(key)) {
+      // Anchor every alternative so the match is "starts with", not "contains".
+      if (/^(?:as[_A-Z]|numberMask|currencyMask)/.test(key)) {
         delete clone[key]
       }
     }

--- a/packages/dnb-eufemia/src/mcp/mcp-http-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-http-server.ts
@@ -151,6 +151,8 @@ function hostAllowlistMiddleware(
     const host = String(req.headers['host'] ?? '')
       .split(':')[0]
       .toLowerCase()
+      // Strip CR/LF so a crafted Host header cannot forge log lines.
+      .replace(/[\r\n]+/g, '')
     if (set.has(host)) {
       next()
       return

--- a/packages/dnb-eufemia/src/style/__tests__/optimizer.test.ts
+++ b/packages/dnb-eufemia/src/style/__tests__/optimizer.test.ts
@@ -308,7 +308,8 @@ describe('createSafelist', () => {
   })
 
   it('rejects a manifest file with an unsupported schema version', () => {
-    const manifestPath = path.join(os.tmpdir(), 'eufemia-manifest-v2.json')
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'eufemia-'))
+    const manifestPath = path.join(tempDir, 'manifest-v2.json')
     writeFileSync(
       manifestPath,
       JSON.stringify({ ...manifest, version: 2 }),
@@ -320,7 +321,7 @@ describe('createSafelist', () => {
         createSafelist({ manifestPath, components: ['button'] })
       ).toThrow(/same @dnb\/eufemia version/i)
     } finally {
-      rmSync(manifestPath, { force: true })
+      rmSync(tempDir, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Why

Enabling CodeQL's `security-and-quality` suite (#9087) surfaces a set of pre-existing findings. This resolves them so the expanded suite starts from a clean state. The findings are independent of #9087 and this can merge on its own.

## What

- **Filter** — write sanitized URL-filter entries as own data properties so a crafted key cannot reach the prototype chain (`js/remote-property-injection`).
- **InputMasked** — anchor every alternative in the context mask-removal regex, so it matches "starts with" rather than "contains" (`js/regex/missing-regexp-anchor`).
- **MCP server** and the **build error handler** — strip CR/LF from user-influenced values before logging (`js/log-injection`).
- **Figma build scripts** — remove check-then-use file races, validate the Figma file key before it builds a cache path, and allowlist the directory passed to the SVG-to-XML command (`js/file-system-race`, `js/http-to-file-access`, indirect command injection).
- **Style optimizer test** — write the fixture into a unique temp directory (`js/insecure-temporary-file`).

Behavior is unchanged for real inputs. Adds a prototype-pollution regression test for the filter util.
