### PR TITLE
docs(Heading): import from package root in element docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/heading/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/heading/info.mdx
@@ -5,7 +5,7 @@ showTabs: true
 ## Import
 
 ```tsx
-import { Heading } from '@dnb/eufemia/components'
+import { Heading } from '@dnb/eufemia'
 import { H1, H2, H3, H4, H5, H6 } from '@dnb/eufemia/elements'
 ```
 


### PR DESCRIPTION
The [Heading element](https://eufemia.dnb.no/uilib/elements/heading) doc imported `Heading` from `@dnb/eufemia/components`. The canonical [Heading component](https://eufemia.dnb.no/uilib/components/heading) doc and every other component doc import from the root `@dnb/eufemia`.

`Heading` is exported from the package root, so this aligns the element doc's Import section with the standard convention. Follow-up to #9088.
