### PR TITLE
chore(AI): add portal content contribution skill

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx
@@ -40,7 +40,11 @@ If you are working on a single component update, you can use a decoration and a 
 - `fix(ExampleComponent): an example fix message`
 - `feat(ExampleComponent): this is a new feature`
 
-You can also use the following decorators – but keep in mind, they won't be included in the [releases change log](https://github.com/dnbexperience/eufemia/releases):
+You can also use the following decorators. `docs`, `design`, `style`, `deps`,
+`refactor`, `perf`, and `test` are included in the
+[release notes](https://github.com/dnbexperience/eufemia/releases) when another
+change triggers a release. `chore` and `build` are not included. None of these
+decorators triggers a release on its own:
 
 - `chore:`
 - `design:`

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
@@ -26,6 +26,8 @@ working with Eufemia:
   documented rules.
 - **`eufemia-migrate`** — plan and validate upgrades using current release
   documentation.
+- **`eufemia-portal-content`** — help non-technical contributors edit portal
+  content and create small pull requests with direct page previews.
 
 The skills provide workflows and tell the agent which Eufemia documentation to
 retrieve. Component APIs, tokens, theme support, and other version-sensitive
@@ -55,7 +57,7 @@ RAIWork marketplace plugin bundles the same skills and does not require
 also prohibited, an administrator must pre-provision one of the supported skill
 directories or the user must use an approved marketplace distribution.
 
-The command asks where to install the five skills. Select one or more supported
+The command asks where to install the six skills. Select one or more supported
 project locations:
 
 - **Claude Code and GitHub Copilot:** `.claude/skills`

--- a/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
+++ b/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
@@ -15,12 +15,13 @@
     {
       "id": 2,
       "prompt": "This Eufemia portal correction is urgent and must be live tomorrow. Put every current main change into the production branch so we can deploy it immediately.",
-      "expected_output": "A safe portal-only promotion that keeps authoring on main, uses release as the production source, carries over only the approved content, verifies that npm will not be released, and excludes unrelated main changes.",
+      "expected_output": "A safe two-PR workflow where the main PR receives the full content review and AI prepares a linked chore(Portal) promotion PR whose patch matches exactly for a quick deployment-gate review.",
       "assertions": [
         "The response records the desired deadline and asks for a short reason for the urgency",
-        "The response uses release as the production deployment source",
-        "The release pull request contains only approved content compatible with the currently released portal",
-        "The response verifies semantic-release behavior and requires explicit permission before merging"
+        "Selecting portal-only once authorizes AI to prepare both pull requests without another release request",
+        "The promotion uses a chore(Portal) title and every release commit since the latest npm tag is checked as non-release-triggering",
+        "The promotion has the same affected paths and resulting content patch as the approved main change with no extras",
+        "The response distinguishes the full main review from the short release deployment gate, requires a squash merge for the promotion, and requires explicit permission before either merge"
       ]
     }
   ]

--- a/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
+++ b/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "eufemia-portal-content",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I am a designer and need AI to clarify one paragraph on the Eufemia portal, create an easy-to-review pull request, and give reviewers a direct preview of the changed section.",
+      "expected_output": "A non-technical workflow that asks about release importance, makes one focused content change from main, and creates a pull request whose description links to the verified page and anchor on the stable branch preview.",
+      "assertions": [
+        "The response asks whether the change can wait for the regular deployment or needs a portal-only deployment",
+        "The content pull request targets main and remains limited to one independently reviewable outcome",
+        "The final pull request description contains a verified branch-preview link to the affected route and anchor",
+        "The response chooses docs(Portal) or chore(Portal) from the requested release-note visibility"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "This Eufemia portal correction is urgent and must be live tomorrow. Put every current main change into the old portal branch so we can deploy it immediately.",
+      "expected_output": "A safe portal-only promotion that keeps authoring on main, uses release as the production source, carries over only the approved content, verifies that npm will not be released, and refuses the legacy portal branch and unrelated main changes.",
+      "assertions": [
+        "The response records the desired deadline and asks for a short reason for the urgency",
+        "The response does not target or deploy from the legacy portal branch",
+        "The release pull request contains only approved content compatible with the currently released portal",
+        "The response verifies semantic-release behavior and requires explicit permission before merging"
+      ]
+    }
+  ]
+}

--- a/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
+++ b/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
@@ -14,11 +14,11 @@
     },
     {
       "id": 2,
-      "prompt": "This Eufemia portal correction is urgent and must be live tomorrow. Put every current main change into the old portal branch so we can deploy it immediately.",
-      "expected_output": "A safe portal-only promotion that keeps authoring on main, uses release as the production source, carries over only the approved content, verifies that npm will not be released, and refuses the legacy portal branch and unrelated main changes.",
+      "prompt": "This Eufemia portal correction is urgent and must be live tomorrow. Put every current main change into the production branch so we can deploy it immediately.",
+      "expected_output": "A safe portal-only promotion that keeps authoring on main, uses release as the production source, carries over only the approved content, verifies that npm will not be released, and excludes unrelated main changes.",
       "assertions": [
         "The response records the desired deadline and asks for a short reason for the urgency",
-        "The response does not target or deploy from the legacy portal branch",
+        "The response uses release as the production deployment source",
         "The release pull request contains only approved content compatible with the currently released portal",
         "The response verifies semantic-release behavior and requires explicit permission before merging"
       ]

--- a/packages/dnb-eufemia/agent-skills-evals/trigger-cases.json
+++ b/packages/dnb-eufemia/agent-skills-evals/trigger-cases.json
@@ -41,6 +41,14 @@
       "expected_skill": "eufemia-migrate"
     },
     {
+      "prompt": "Update this Eufemia portal paragraph for me and create a small pull request with a direct page preview.",
+      "expected_skill": "eufemia-portal-content"
+    },
+    {
+      "prompt": "I am a designer. Please publish an urgent editorial correction to the Eufemia portal without making me manage Git or GitHub.",
+      "expected_skill": "eufemia-portal-content"
+    },
+    {
       "prompt": "Optimize this SQL query and propose a database index.",
       "expected_skill": null
     },

--- a/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
+++ b/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: eufemia-portal-content
+description: Edit content in the official Eufemia portal and deliver small, reviewable pull requests with working page previews. Use when a non-technical contributor asks AI to change portal copy, guidance, or other editorial content.
+compatibility: Requires the Eufemia repository and permission to create GitHub pull requests.
+metadata:
+  owner: dnbexperience/eufemia
+  manifest-version: '1'
+---
+
+# Edit Eufemia Portal Content
+
+Handle the repository and GitHub workflow for the contributor. Use plain
+language, show the proposed result, and do not require them to choose branches,
+commands, files, or validation steps.
+
+1. Read the repository instructions and inspect the current page and nearby
+   content before proposing an edit. Verify technical claims against the source
+   or current Eufemia documentation.
+2. Before changing files, ask how important and time-sensitive the change is:
+   can it wait for the next regular portal deployment, or does it need a
+   portal-only deployment? For an urgent change, also ask for the desired
+   deadline and a short reason that maintainers can evaluate.
+3. Fetch current refs and create the content branch from `origin/main`. `main`
+   is the source for new work; `release` is the exact source deployed to the
+   production portal. Do not base new work on or target the legacy `portal`
+   branch.
+4. Keep one independently understandable content outcome per pull request.
+   Split changes that cover different topics, audiences, navigation areas, or
+   reviewer decisions. Keep tightly coupled edits together when separating them
+   would make either preview incomplete or misleading. If the work grows while
+   editing, stop expanding the current pull request and propose the remaining
+   sequence.
+5. Preserve the page's MDX structure, imports, links, terminology, tone, and
+   heading hierarchy. Do not turn an editorial request into component, API, or
+   layout work without explaining the additional scope and receiving approval.
+6. Format changed files with the workspace tools, run focused checks, inspect
+   the complete diff, and verify the affected route and anchor. Add or update
+   tests only when behavior rather than prose changes.
+7. Choose the pull request title from the contributor's release-note intent:
+   - Use `docs(Portal): ...` when the change should be listed under
+     Documentation in the next Eufemia release notes.
+   - Use `chore(Portal): ...` when it should not be listed.
+     Confirm the choice in plain language. Neither type should publish a package
+     version by itself, but verify the current semantic-release configuration
+     before promising release behavior.
+8. Open the pull request against `main` with a short motivation-focused
+   description. After the preview workflow finishes, read its stable Branch
+   Preview URL, append the affected page path and anchor, verify that exact link,
+   and update the description. Include a short release-priority line. Do not list
+   changed files or validation steps. A suitable shape is:
+
+   ```markdown
+   Explains the problem and why the content change matters.
+
+   Preview: [Open the changed section](https://<branch-preview>/<route>/#<anchor>)
+
+   Release priority: Regular, or portal-only by <date> because <reason>.
+   ```
+
+9. Report the pull request, the verified preview link, the release-note choice,
+   and any remaining reviewer decision in plain language. Never merge the pull
+   request without explicit permission.
+
+## Portal-only deployment
+
+An urgent portal deployment is a separate promotion after the content pull
+request is approved and merged to `main`. It does not change how content is
+authored.
+
+1. Require explicit permission before preparing or merging a promotion.
+2. Create a branch from the latest `origin/release` and bring over only the
+   approved content commit or commits. Open a separate pull request to
+   `release`.
+3. Verify that the promotion contains only the intended portal content, works
+   with the currently released portal, and contains no commit that would trigger
+   an npm release. If it depends on unreleased code or conflicts substantially,
+   stop and recommend the regular release path.
+4. Verify the release pull request's own portal preview. Merging it deploys the
+   production portal from `release`; semantic-release should skip npm publishing
+   when no release-triggering commits are present.
+
+Do not copy all of `main` into `release` for an urgent content change. That can
+silently include unrelated features and fixes.

--- a/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
+++ b/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
@@ -23,8 +23,7 @@ commands, files, or validation steps.
    can evaluate.
 3. Fetch current refs and create the content branch from `origin/main`. `main`
    is the source for new work; `release` is the exact source deployed to the
-   production portal. Do not base new work on or target the legacy `portal`
-   branch.
+   production portal.
 4. Keep one independently understandable content outcome per pull request.
    Split changes that cover different topics, audiences, navigation areas, or
    reviewer decisions. Keep tightly coupled edits together when separating them

--- a/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
+++ b/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
@@ -16,10 +16,11 @@ commands, files, or validation steps.
 1. Read the repository instructions and inspect the current page and nearby
    content before proposing an edit. Verify technical claims against the source
    or current Eufemia documentation.
-2. Before changing files, ask how important and time-sensitive the change is:
-   can it wait for the next regular portal deployment, or does it need a
-   portal-only deployment? For an urgent change, also ask for the desired
-   deadline and a short reason that maintainers can evaluate.
+2. Before changing files, ask two plain-language questions: whether the change
+   should appear in the next release notes, and whether it can wait for the next
+   regular portal deployment or needs a portal-only deployment. For an urgent
+   change, also ask for the desired deadline and a short reason that maintainers
+   can evaluate.
 3. Fetch current refs and create the content branch from `origin/main`. `main`
    is the source for new work; `release` is the exact source deployed to the
    production portal. Do not base new work on or target the legacy `portal`

--- a/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
+++ b/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
@@ -63,21 +63,59 @@ commands, files, or validation steps.
 
 ## Portal-only deployment
 
-An urgent portal deployment is a separate promotion after the content pull
-request is approved and merged to `main`. It does not change how content is
-authored.
+Treat the contributor's portal-only selection as authorization to prepare the
+promotion pull request. Do not ask them to request the promotion again. It does
+not authorize either merge.
 
-1. Require explicit permission before preparing or merging a promotion.
+1. Before preparing the promotion, fetch current refs, identify the latest npm
+   version tag reachable from `origin/release`, and confirm no release is
+   running. Inspect every commit after that tag together with the proposed
+   promotion using the current semantic-release rules. Continue only when none
+   would trigger an npm release. Earlier portal-only `chore` commits after the
+   tag are safe; a pending `feat`, `fix`, or other release-triggering commit is
+   not. Wait for the regular release to finish in that case, then fetch and
+   check again.
 2. Create a branch from the latest `origin/release` and bring over only the
-   approved content commit or commits. Open a separate pull request to
-   `release`.
-3. Verify that the promotion contains only the intended portal content, works
-   with the currently released portal, and contains no commit that would trigger
-   an npm release. If it depends on unreleased code or conflicts substantially,
-   stop and recommend the regular release path.
-4. Verify the release pull request's own portal preview. Merging it deploys the
-   production portal from `release`; semantic-release should skip npm publishing
-   when no release-triggering commits are present.
+   content commit or commits from the source pull request. Open a separate pull
+   request to `release` titled `chore(Portal): promote ...` so the deployment
+   commit is not repeated in later release notes.
+3. For an ASAP request, prepare this promotion pull request as a draft as soon
+   as the content diff is stable. After the content pull request is merged to
+   `main`, update or recreate the promotion from the latest `origin/release` and
+   complete the checks below. For other portal-only requests, prepare it after
+   the merge to `main`.
+4. Compare the promotion with the final approved content change. The affected
+   paths and resulting content patch must match, with no extra changes. Commit
+   hashes and commit messages may differ because the branches have different
+   histories. If the patches do not match, update the promotion and require the
+   mismatch to be reviewed.
+5. Verify that the promoted content works with the currently released portal,
+   that no included commit would trigger an npm release, and that the promotion
+   pull request has its own working portal preview. If the content depends on
+   unreleased code or conflicts substantially, stop and recommend the regular
+   release path.
+6. Link the original content pull request from the promotion description and
+   state that the affected paths and resulting content were verified as an
+   exact match with no extras. Require the maintainer to squash-merge it so
+   `release` receives one `chore(Portal)` deployment commit. Merging the
+   promotion deploys the production portal from `release`; semantic-release
+   should skip npm publishing when the preflight above passes.
+
+The review responsibilities are different:
+
+- The designer verifies the content once, using the content pull request's
+  preview.
+- The maintainer performs the full content review on the pull request to
+  `main`.
+- The maintainer treats the pull request to `release` as a short deployment
+  gate: confirm that the source pull request is merged, the target is `release`,
+  the patch matches with no extras, the preview works, and the npm-release
+  preflight passes. Then squash-merge it. The maintainer does not create this
+  pull request or repeat the editorial review.
+
+If the agent cannot remain active until the first pull request is merged, state
+that the maintainer must resume the task afterward; do not imply that background
+automation exists.
 
 Do not copy all of `main` into `release` for an urgent content change. That can
 silently include unrelated features and fixes.

--- a/packages/dnb-eufemia/agent-skills/manifest.json
+++ b/packages/dnb-eufemia/agent-skills/manifest.json
@@ -63,6 +63,12 @@
         "component_find",
         "component_props"
       ]
+    },
+    {
+      "name": "eufemia-portal-content",
+      "description": "Edit content in the official Eufemia portal and deliver small, reviewable pull requests with working page previews. Use when a non-technical contributor asks AI to change portal copy, guidance, or other editorial content.",
+      "path": "eufemia-portal-content/SKILL.md",
+      "requiredTools": []
     }
   ]
 }

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -692,7 +692,7 @@ describe('agent skills', () => {
     const manifest = fs.readJsonSync(
       path.join(skillsRoot, 'manifest.json')
     )
-    expect(manifest.skills).toHaveLength(5)
+    expect(manifest.skills).toHaveLength(6)
 
     for (const skill of manifest.skills) {
       expect(fs.existsSync(path.join(skillsRoot, skill.path))).toBe(true)

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
@@ -216,7 +216,7 @@ describe('package.json', () => {
     try {
       expect(run('--version').trim()).toBe('0.0.0-development')
       expect(run('skills', 'install', '--target', target)).toContain(
-        'Installed 5 Eufemia skills'
+        'Installed 6 Eufemia skills'
       )
       expect(run('skills', 'check', '--target', target)).toContain(
         'Eufemia agent skills are current'
@@ -225,7 +225,7 @@ describe('package.json', () => {
         fs.existsSync(path.join(target, 'eufemia-components', 'SKILL.md'))
       ).toBe(true)
       expect(run('skills', 'uninstall', '--target', target)).toContain(
-        'Removed 5 Eufemia skill files'
+        'Removed 6 Eufemia skill files'
       )
 
       const interactiveResult = spawnSync(

--- a/packages/dnb-eufemia/src/cli/__tests__/agentSkills.test.ts
+++ b/packages/dnb-eufemia/src/cli/__tests__/agentSkills.test.ts
@@ -41,16 +41,23 @@ describe('Eufemia agent skills', () => {
       'eufemia-accessibility',
       'eufemia-review',
       'eufemia-migrate',
+      'eufemia-portal-content',
     ])
     expect(manifest.optionalTools).toEqual([])
-    expect(files.size).toBe(5)
+    expect(files.size).toBe(6)
     expect(
-      manifest.skills.every(
-        ({ requiredTools }) =>
-          requiredTools.includes('docs_meta') &&
-          !requiredTools.includes('docs_entry')
-      )
+      manifest.skills
+        .filter(({ name }) => name !== 'eufemia-portal-content')
+        .every(
+          ({ requiredTools }) =>
+            requiredTools.includes('docs_meta') &&
+            !requiredTools.includes('docs_entry')
+        )
     ).toBe(true)
+    expect(
+      manifest.skills.find(({ name }) => name === 'eufemia-portal-content')
+        ?.requiredTools
+    ).toEqual([])
     expect(
       manifest.skills.find(({ name }) => name === 'eufemia-review')
         ?.requiredTools
@@ -100,7 +107,7 @@ describe('Eufemia agent skills', () => {
       packageVersion,
     })
 
-    expect(installed).toHaveLength(5)
+    expect(installed).toHaveLength(6)
     await expect(
       fs.readFile(
         path.join(targetRoot, 'eufemia-components', 'SKILL.md'),
@@ -265,7 +272,7 @@ describe('Eufemia agent skills', () => {
 
     expect(output).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('Installed 5 Eufemia skills'),
+        expect.stringContaining('Installed 6 Eufemia skills'),
         expect.stringContaining('Eufemia agent skills are current'),
       ])
     )
@@ -456,7 +463,7 @@ describe('Eufemia agent skills', () => {
       })
     ).resolves.toBe(0)
 
-    expect(output).toHaveLength(5)
+    expect(output).toHaveLength(6)
     expect(output[0]).toMatch(
       /^1\. eufemia-components\n {3}Find and apply current Eufemia component APIs\.[\s\S]+\n$/
     )
@@ -465,7 +472,10 @@ describe('Eufemia agent skills', () => {
       '\n\n2. eufemia-compose\n   Compose '
     )
     expect(output[4]).toMatch(/^5\. eufemia-migrate\n {3}Migrate /)
-    expect(output[4]).not.toMatch(/\n$/)
+    expect(output[5]).toMatch(
+      /^6\. eufemia-portal-content\n {3}Edit content /
+    )
+    expect(output[5]).not.toMatch(/\n$/)
   })
 
   it('shows the package version through the main CLI', async () => {

--- a/tools/eufemia-raiwork-plugin/README.md
+++ b/tools/eufemia-raiwork-plugin/README.md
@@ -243,7 +243,7 @@ After publication:
 
 1. Install the plugin in a clean RAIWork profile.
 2. Enable the `eufemia` MCP server during consent.
-3. Confirm all five skills are discoverable.
+3. Confirm all six skills are discoverable.
 4. Confirm the MCP tools can be listed and called.
 5. Run the canonical trigger and non-trigger prompts from
    `packages/dnb-eufemia/agent-skills-evals/trigger-cases.json`.

--- a/tools/eufemia-raiwork-plugin/__tests__/bundle.test.ts
+++ b/tools/eufemia-raiwork-plugin/__tests__/bundle.test.ts
@@ -32,8 +32,8 @@ describe('Eufemia RAIWork plugin', () => {
 
     expect(report).toMatchObject({
       bundleRoot: paths.outputRoot,
-      fileCount: 9,
-      skillCount: 5,
+      fileCount: 10,
+      skillCount: 6,
     })
     expect(report.totalBytes).toBeLessThan(50 * 1024 * 1024)
 
@@ -61,7 +61,7 @@ describe('Eufemia RAIWork plugin', () => {
         scripts: [],
       },
     })
-    expect(manifest.contents.skills).toHaveLength(5)
+    expect(manifest.contents.skills).toHaveLength(6)
   })
 
   it('changes only skill frontmatter', async () => {

--- a/tools/eufemia-raiwork-plugin/assets/PLUGIN_README.md
+++ b/tools/eufemia-raiwork-plugin/assets/PLUGIN_README.md
@@ -40,9 +40,10 @@ installation is prohibited, limit work to documentation and planning.
 ## Scope
 
 This plugin owns generic Eufemia components, themes, accessibility guidance,
-review rules, and migrations. Product-specific authentication, providers,
-deployment, and business workflows remain with product or platform tooling.
-Generic visual-exploration skills can support ideation, but they do not define
-production DNB design-system APIs or compliance requirements.
+review rules, migrations, and contributions to the official Eufemia Portal.
+Product-specific authentication, providers, deployment, and business workflows
+remain with product or platform tooling. Generic visual-exploration skills can
+support ideation, but they do not define production DNB design-system APIs or
+compliance requirements.
 
 More documentation: [eufemia.dnb.no](https://eufemia.dnb.no)

--- a/tools/eufemia-raiwork-plugin/assets/PLUGIN_README.md
+++ b/tools/eufemia-raiwork-plugin/assets/PLUGIN_README.md
@@ -5,13 +5,14 @@ frontends.
 
 ## Included skills
 
-| Skill                   | Use it for                                                                |
-| ----------------------- | ------------------------------------------------------------------------- |
-| `eufemia-components`    | Find components and verify current props, events, forms, and layout APIs. |
-| `eufemia-compose`       | Compose complete pages and features from Eufemia primitives and guidance. |
-| `eufemia-accessibility` | Apply Eufemia-specific accessibility guidance and verification.           |
-| `eufemia-review`        | Review code against supported APIs, deprecations, and documented rules.   |
-| `eufemia-migrate`       | Plan and validate Eufemia upgrades using current release documentation.   |
+| Skill                    | Use it for                                                                |
+| ------------------------ | ------------------------------------------------------------------------- |
+| `eufemia-components`     | Find components and verify current props, events, forms, and layout APIs. |
+| `eufemia-compose`        | Compose complete pages and features from Eufemia primitives and guidance. |
+| `eufemia-accessibility`  | Apply Eufemia-specific accessibility guidance and verification.           |
+| `eufemia-review`         | Review code against supported APIs, deprecations, and documented rules.   |
+| `eufemia-migrate`        | Plan and validate Eufemia upgrades using current release documentation.   |
+| `eufemia-portal-content` | Edit Portal content and create small pull requests with page previews.    |
 
 ## Enable the MCP server
 

--- a/tools/eufemia-raiwork-plugin/plugin.config.json
+++ b/tools/eufemia-raiwork-plugin/plugin.config.json
@@ -4,7 +4,7 @@
     "name": "dnb-eufemia-web",
     "version": "0.1.0",
     "title": "Eufemia Web",
-    "description": "Official Eufemia skills and MCP documentation for building, reviewing, and migrating DNB web frontends with current component APIs, themes, accessibility guidance, and design-system rules.",
+    "description": "Official Eufemia skills and MCP documentation for building, reviewing, and migrating DNB web frontends and contributing Portal content.",
     "license": "Apache-2.0 with Commons Clause",
     "homepage": "https://eufemia.dnb.no",
     "tags": [

--- a/tools/eufemia-raiwork-plugin/plugin.config.json
+++ b/tools/eufemia-raiwork-plugin/plugin.config.json
@@ -42,6 +42,10 @@
     "eufemia-migrate": {
       "title": "Migrate Eufemia",
       "tags": ["eufemia", "migration", "upgrade", "codemods"]
+    },
+    "eufemia-portal-content": {
+      "title": "Edit Eufemia Portal Content",
+      "tags": ["eufemia", "documentation", "content", "github"]
     }
   }
 }


### PR DESCRIPTION
Makes portal content updates approachable for designers by packaging a workflow that handles repository details, keeps changes reviewable, asks about deployment urgency, and verifies a direct preview of the affected section. It also aligns the contributor guide with the release-note behavior the skill depends on.

Depends on #9096 for the release-only production deployment path.

Preview: [Open the Agent Skills section](https://docs-eufemia-portal-content.eufemia-e25.pages.dev/uilib/usage/first-steps/tools/#agent-skills)

Release priority: Regular.