### PR TITLE
chore(Portal): deploy production only from release

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,6 @@ on:
       - '!experiments/**'
       - '!dependabot/**'
       - '!release'
-      - '!portal'
       - '!beta'
       - '!alpha'
   pull_request:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,7 +10,6 @@ on:
       - '!experiments/**'
   pull_request:
     branches:
-      - 'portal'
       - 'release'
       - 'beta'
       - 'alpha'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,12 +9,10 @@ on:
       - '!wip/**'
       - '!experiments/**'
       - '!release'
-      - '!portal'
       - '!beta'
       - '!alpha'
   pull_request:
     branches:
-      - 'portal'
       - 'release'
       - 'beta'
       - 'alpha'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          fetch-depth: 2
+          # The portal footer falls back to the latest reachable stable tag
+          # when a portal-only deployment does not produce an npm version.
+          fetch-depth: 0
 
       - name: Setup dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'release'
-      - 'portal'
       - 'beta'
       - 'alpha'
       - 'next'
@@ -58,21 +57,18 @@ jobs:
         run: yarn workspace @dnb/eufemia prebuild:ci
 
       - name: Build portal
-        if: (github.ref == 'refs/heads/release' ||
-          github.ref == 'refs/heads/portal')
+        if: github.ref == 'refs/heads/release'
         run: yarn workspace dnb-design-system-portal build:ci
 
       - name: Push Algolia search index
-        if: (github.ref == 'refs/heads/release' ||
-          github.ref == 'refs/heads/portal')
+        if: github.ref == 'refs/heads/release'
         run: yarn workspace dnb-design-system-portal build:algolia
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
 
       - name: Upload portal artifact
-        if: (github.ref == 'refs/heads/release' ||
-          github.ref == 'refs/heads/portal')
+        if: github.ref == 'refs/heads/release'
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: ./packages/dnb-design-system-portal/public
@@ -92,8 +88,7 @@ jobs:
   deploy-portal:
     name: Deploy portal to GitHub Pages
     needs: action
-    if: (github.ref == 'refs/heads/release' ||
-      github.ref == 'refs/heads/portal')
+    if: github.ref == 'refs/heads/release'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -9,12 +9,10 @@ on:
       - '!wip/**'
       - '!experiments/**'
       - '!release'
-      - '!portal'
       - '!beta'
       - '!alpha'
   pull_request:
     branches:
-      - 'portal'
       - 'release'
       - 'beta'
       - 'alpha'

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs-extra')
 const path = require('path')
+const { execFile } = require('child_process')
 const { isCI } = require('repo-utils')
 const {
   getNextReleaseVersion,
@@ -24,6 +25,11 @@ const init = async () => {
 }
 
 exports.init = init
+
+const resolveReleaseVersion = (nextVersion, latestTag) =>
+  nextVersion || latestTag?.replace(/^v(?=\d)/, '') || 'Not released'
+
+exports.resolveReleaseVersion = resolveReleaseVersion
 
 // run only if the script was executed from command line
 if (
@@ -55,7 +61,9 @@ async function createReleaseNewVersion() {
   try {
     const file = path.resolve(__dirname, '../package.json')
     const packageJson = await fs.readJson(file)
-    const version = (await getNextReleaseVersion()) || 'Not released'
+    const nextVersion = await getNextReleaseVersion()
+    const latestTag = nextVersion ? null : await getLatestReleaseTag()
+    const version = resolveReleaseVersion(nextVersion, latestTag)
     packageJson.releaseVersion = version
 
     // Update the extracted version of package.json with the build version
@@ -65,6 +73,27 @@ async function createReleaseNewVersion() {
   } catch (e) {
     console.warn(`Failed to create new release version! \n${e.message}`)
   }
+}
+
+async function getLatestReleaseTag() {
+  const repoRoot = path.resolve(__dirname, '../../..')
+  const tags = await new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      ['tag', '--merged', 'HEAD', '--sort=-version:refname'],
+      { cwd: repoRoot },
+      (error, stdout) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve(stdout)
+      }
+    )
+  })
+
+  return tags.split('\n').find((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
 }
 
 async function createNewChangelogVersion() {

--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
@@ -25,8 +25,7 @@ The steps, from code changes to production builds, are:
    and releases a new NPM version when the included commits require one.
 
 The production Portal is always built from `origin/release`, which is the single
-source of truth for the currently deployed Portal and package version. The
-legacy `origin/portal` branch is not a deployment source.
+source of truth for the currently deployed Portal and package version.
 
 Changes whose commits do not trigger semantic-release, such as `docs` and
 `chore`, can be promoted to `origin/release` for a Portal-only deployment. Use a

--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
@@ -36,6 +36,9 @@ a Portal-only deployment because it may include unrelated unreleased changes.
 If the Portal change depends on unreleased package code, include it in the next
 regular release instead.
 
+The Portal footer keeps the latest published package version for a Portal-only
+deployment. `Portal update` shows when that Portal build was created.
+
 ### How to make releases
 
 Make sure you only make _Pull Request_ from `origin/main` into `origin/release` when you release the latest stable version.

--- a/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/deploy.mdx
@@ -21,7 +21,21 @@ The steps, from code changes to production builds, are:
 1. After the _Pull Request_ gets approved by one of the authorized [maintainers](https://github.com/dnbexperience/eufemia/graphs/contributors),
 1. You can merge your _Pull Request_.
 1. A maintainer will create a _Pull Request_ into one of the release branches (`next`, `alpha`, `beta` or `release`).
-1. After a release _Pull Request_ got merged, the CI Server will deploy the Portal and release a new version to NPM.
+1. After a release _Pull Request_ got merged, the CI Server deploys the Portal
+   and releases a new NPM version when the included commits require one.
+
+The production Portal is always built from `origin/release`, which is the single
+source of truth for the currently deployed Portal and package version. The
+legacy `origin/portal` branch is not a deployment source.
+
+Changes whose commits do not trigger semantic-release, such as `docs` and
+`chore`, can be promoted to `origin/release` for a Portal-only deployment. Use a
+separate Pull Request based on the latest `origin/release`, include only the
+approved Portal commits, and verify that the Pull Request contains no change
+that would publish a new package version. Do not merge all of `origin/main` for
+a Portal-only deployment because it may include unrelated unreleased changes.
+If the Portal change depends on unreleased package code, include it in the next
+regular release instead.
 
 ### How to make releases
 

--- a/packages/dnb-design-system-portal/vite/__tests__/version-script.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/version-script.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { resolveReleaseVersion } = require('../../scripts/version')
+
+describe('portal version script', () => {
+  it('uses the latest package tag for a portal-only deployment', () => {
+    expect(resolveReleaseVersion(null, 'v11.11.0')).toBe('11.11.0')
+  })
+
+  it('uses the upcoming package version for a regular release', () => {
+    expect(resolveReleaseVersion('11.12.0', 'v11.11.0')).toBe('11.12.0')
+  })
+
+  it('reports when no package version can be resolved', () => {
+    expect(resolveReleaseVersion(null, undefined)).toBe('Not released')
+  })
+})

--- a/packages/dnb-design-system-portal/vite/prod/push-algolia.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/push-algolia.mjs
@@ -84,7 +84,7 @@ function getIndexName() {
     return 'beta_eufemia_docs'
   }
 
-  if (process.env.CI && /^(release|portal)$/.test(branch)) {
+  if (process.env.CI && branch === 'release') {
     return 'prod_eufemia_docs'
   }
 


### PR DESCRIPTION
Makes the `release` branch the single source of truth for the production portal and its search index.

Documents a narrow portal-only promotion path so urgent content can be deployed from the current released version without bringing unrelated, unreleased changes from `main`. Portal-only deployments keep the latest published package version in the footer, while Portal update reflects the new portal build time.

Preview: [Open the release workflow guidance](https://ci-deploy-portal-from-releas.eufemia-e25.pages.dev/contribute/deploy/#release-gitflow)