### PR TITLE
fix(Upload): wrap long file names when a file click handler is set

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
@@ -47,6 +47,7 @@ const UploadFileButton = (props: UploadFileButtonProps) => {
       size="small"
       icon={false}
       variant="tertiary"
+      wrap
       onClick={onClick}
       {...useSpacing(props, {})}
     >

--- a/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListLink.test.tsx
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/UploadFileListLink.test.tsx
@@ -85,6 +85,13 @@ describe('UploadFileListLink', () => {
       expect(screen.queryByText(fileName)).toBeInTheDocument()
     })
 
+    it('wraps long file names', () => {
+      render(<UploadFileLink {...defaultProps} onClick={vi.fn()} />)
+
+      const element = document.querySelector('.dnb-button')
+      expect(element).toHaveClass('dnb-button--wrap')
+    })
+
     it('executes onClick event when button is clicked', () => {
       const onClick = vi.fn()
 


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1787646719543479


Reprod of issue: https://stackblitz.com/edit/eufemia-starter-qryf6arm?file=src%2FApp.tsx

Screenshot of issue:

<img width="556" height="77" alt="image" src="https://github.com/user-attachments/assets/63cdd661-aa77-4e76-b8a0-8dcd4260a588" />



Screenshot of fix from reprod of issue (I only manually applied `dnb-button--wrap` to button):

<img width="551" height="195" alt="Screenshot 2026-08-25 at 10 49 45" src="https://github.com/user-attachments/assets/53f2adf1-edc9-44fa-bb3e-95f475d6d6d8" />


