### PR TITLE
chore: standardize "re-use" to "reuse" spelling

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -69,7 +69,7 @@ Theming file names ending with `-ui` will be packed into the global theming pack
 
 ### SCSS utilities
 
-Use the same SCSS setup as all the other components. You may re-use all the [helper classes](/uilib/helpers/classes):
+Use the same SCSS setup as all the other components. You may reuse all the [helper classes](/uilib/helpers/classes):
 
 - `./packages/dnb-eufemia/src/style/core/utilities.scss`
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/principles.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/principles.mdx
@@ -12,7 +12,7 @@ The purposes of Eufemia are:
 1. To establish a shared vocabulary and an open platform for designers and developers.
 1. To ensure consistency and adherence to the look and feel of DNB digital products.
 1. To provide principles and guidelines for designers and developers.
-1. To encourage re-use of code and design resources.
+1. To encourage reuse of code and design resources.
 1. To exist as a single source of truth.
 
 ## Introduction

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/error-messages/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/error-messages/info.mdx
@@ -79,7 +79,7 @@ import { Field } from '@dnb/eufemia/extensions/forms'
 render(<Field.PhoneNumber error={new Error('Custom message')} />)
 ```
 
-When it comes to re-using existing translations, you can also use the `FormError` object to display error messages.
+When it comes to reusing existing translations, you can also use the `FormError` object to display error messages.
 
 You can provide either an existing translation key, such as:
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/create-component/useFieldProps/info.mdx
@@ -220,7 +220,7 @@ const { error, hasError } = useFieldProps({
 })
 ```
 
-To re-use existing `errorMessages`, you can use the `FormError` constructor as well:
+To reuse existing `errorMessages`, you can use the `FormError` constructor as well:
 
 ```ts
 import { FormError } from '@dnb/eufemia/extensions/forms'

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/media-queries.mdx
@@ -301,7 +301,7 @@ import { defaultBreakpoints } from '@dnb/eufemia/shared/MediaQueryUtils'
 
 ## SCSS mixins
 
-You can re-use the SCSS mixins from Eufemia:
+You can reuse the SCSS mixins from Eufemia:
 
 ```scss
 // breakpoints.scss


### PR DESCRIPTION
The docs mixed "re-use"/"re-using" with the far more common "reuse"/"reusing" (32 vs 4 in prose). This standardizes the minority hyphenated spelling to the dominant form for consistency.
