### PR TITLE
chore(Menu): standardize "customise" to "customize" spelling

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
@@ -14,7 +14,7 @@ Menu provides an accessible dropdown menu for actions and navigation with a comp
 
 Use `Menu.Root` as the wrapper, `Menu.Button` for the trigger, `Menu.List` for the list container, `Menu.Action` for individual items, and `Menu.Divider` for visual separators.
 
-`Menu.Button` supports all [Button](/uilib/components/button/properties) props (e.g. `text`, `icon`, `variant`, `size`, `disabled`), so you can customise the trigger the same way you would with a regular Button.
+`Menu.Button` supports all [Button](/uilib/components/button/properties) props (e.g. `text`, `icon`, `variant`, `size`, `disabled`), so you can customize the trigger the same way you would with a regular Button.
 
 Nested menus are supported by nesting another `Menu.Root` inside `Menu.List` — use a `Menu.Action` as the direct child of the nested `Menu.Root` to serve as the sub-menu trigger.
 


### PR DESCRIPTION
The Menu docs used the British spelling "customise", the lone exception among 73 uses of the American "customize" across the docs. This aligns it with the dominant convention for consistency.
