### PR TITLE
chore: standardize "dialogue" to "dialog" spelling

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer.mdx
@@ -36,6 +36,6 @@ What you should read from the brand guidelines before starting to design for DNB
 4. Choose DNB Bank ASA <InlineImg src={FigmaTeam} caption="Join the DNB UX team" alt="Join the DNB UX team" />.
 5. Create a new file.
 6. Add Eufemia library to your file by selecting the 'open book' icon on the top right of the Figma interface. <InlineImg src={FigmaLibrary} caption="Figma's library icon" alt="Library icon" />.
-7. This opens a new dialogue window. Choose Eufemia by toggling the switch: <InlineImg src={FigmaLibraries} caption="Add the Eufemia library" alt="Add Eufemia team" />.
+7. This opens a new dialog window. Choose Eufemia by toggling the switch: <InlineImg src={FigmaLibraries} caption="Add the Eufemia library" alt="Add Eufemia team" />.
 8. In preferences set your nudge amount to 8px - this will snap items to the 8px grid.
 9. Add a layout grid and set it to 8px: <InlineImg src={FigmaLayoutGrid} caption="Add an 8px layout grid" alt="Add 8px layout grid" />.


### PR DESCRIPTION
The designer quick guide described a Figma "dialogue window", the lone British spelling against 122 uses of "dialog" across the docs. This aligns it with the dominant convention for consistency.
