### PR TITLE
test(Upload): smoke-test selective visual-regression scoping

### DIFF
--- a/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
+++ b/packages/dnb-eufemia/src/components/upload/UploadFileListLink.tsx
@@ -7,6 +7,8 @@ import { useSpacing } from '../space/SpacingUtils'
 export type UploadFileLinkProps = UploadFileAnchorProps &
   UploadFileButtonProps
 
+// Smoke test for #9104: touching this Upload source file should select only the
+// Upload screenshot tests, not the entire visual-regression suite.
 export const UploadFileLink = (props: UploadFileLinkProps) => {
   const { onClick, text, href, download, ...rest } = props
 


### PR DESCRIPTION
## Purpose

Smoke test for #9104. Stacked on that branch, this makes a single, visual-neutral change to the `Upload` component (a comment in `UploadFileListLink.tsx` — the same file [#9097](https://github.com/dnbexperience/eufemia/pull/9097) touched) so the visual-regression workflow exercises the **conditional** selection with #9104's fix applied.

## What to observe

The **Run visual-regression tests** job should report:

> Running 4/108 impacted screenshot test files.

i.e. only the Upload-related tests (`Upload`, `Field.Upload`, `Value.Upload`, plus the `Form/Appearance` demo that composes `Upload`) — instead of the full 108-test suite that the equivalent change in #9097 triggered before the fix.

## Notes

- Base is the #9104 branch, so the diff here is just the one-line comment.
- Demonstration only — close it (and drop the commit) once CI has shown the scoped run.
