### PR TITLE
chore(visual-regression): remove retired portal branch from base refs

### DIFF
--- a/packages/dnb-eufemia/scripts/tools/runScreenshotsConditionally/config.ts
+++ b/packages/dnb-eufemia/scripts/tools/runScreenshotsConditionally/config.ts
@@ -37,10 +37,7 @@ export const CHANGED_FILES_ENV_VAR = 'VISUAL_TEST_CHANGED_FILES'
 export const BASE_REF_ENV_VAR = 'VISUAL_TEST_BASE_REF'
 
 // Default base refs used to find merge-base when no override is provided.
-export const DEFAULT_BRANCH_BASE_REFS = [
-  'origin/main',
-  'main',
-]
+export const DEFAULT_BRANCH_BASE_REFS = ['origin/main', 'main']
 
 // Adds support for release branches like v1, v2, etc. as potential bases.
 export const VERSION_BRANCH_REF_PATTERN = /^(origin\/)?v[0-9]/

--- a/packages/dnb-eufemia/scripts/tools/runScreenshotsConditionally/config.ts
+++ b/packages/dnb-eufemia/scripts/tools/runScreenshotsConditionally/config.ts
@@ -40,8 +40,6 @@ export const BASE_REF_ENV_VAR = 'VISUAL_TEST_BASE_REF'
 export const DEFAULT_BRANCH_BASE_REFS = [
   'origin/main',
   'main',
-  'origin/portal',
-  'portal',
 ]
 
 // Adds support for release branches like v1, v2, etc. as potential bases.


### PR DESCRIPTION
Follow-up to #9096, which retired the legacy `portal` branch as a deployment source and removed its references from the CI workflows.

While reviewing #9096, one remaining reference to the `portal` branch was found outside the workflow files: the conditional visual-regression test-selection tool still listed it as a fallback base ref.

## Change

Remove `'origin/portal'` and `'portal'` from `DEFAULT_BRANCH_BASE_REFS` in `runScreenshotsConditionally/config.ts`.

## Why it's safe

These entries are candidate merge-base refs used to compute the changed-file set when no base ref is provided. In `git.ts` the refs are de-duplicated and each is tried with `git merge-base <ref> HEAD`; any ref that does not resolve is silently skipped, and nothing depends on the list's length or order. Removing the two retired-branch entries simply stops treating `portal` as a comparison base. No test asserts the contents of this list.

This completes the removal of `portal` branch references started in #9096.