### PR TITLE
test(ProgressIndicator): smoke-test cross-component visual selection

### DIFF
--- a/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/progress-indicator/ProgressIndicator.tsx
@@ -32,6 +32,9 @@ import type {
 import { isValidSize } from './types'
 import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 
+// Smoke test for #9104: touching this shared component should select the
+// screenshot tests of the other components that use it (via TS imports and
+// demo composition), not the whole visual-regression suite.
 function ProgressIndicator(props: ProgressIndicatorAllProps) {
   const allProps = updatePropsWithContext(props, useContext(Context))
 


### PR DESCRIPTION
## Purpose

Second smoke test for #9104 — this one demonstrates **cross-component** selection. Stacked on that branch, it makes a single visual-neutral change (a comment) to the shared `ProgressIndicator` component, which is used by many other components both through TS imports and as children in demo/examples.

## What to observe

The **Run visual-regression tests** job should report:

> Running 18/108 impacted screenshot test files.

selecting the tests of the *other* components that depend on `ProgressIndicator`, with a mix of causes:

- **TS/JS dependency impact** — `Autocomplete`, `Filter`, `GlobalStatus`, `Input`, `Pagination`, `Upload`, and several `Field.*` (SelectCountry, SelectCurrency, PhoneNumber, …).
- **Component usage in demo/examples** — `Dialog`, `List`, `Skeleton`.

i.e. it correctly fans out to real dependents (18/108) instead of running the full suite — and, unlike the old barrel heuristic, without over- or under-selecting.

## Notes

- Base is the #9104 branch, so the diff here is just the one comment.
- Demonstration only — close it once CI has shown the scoped run.
