### PR TITLE
chore(Accordion): document openOnFind browser-support limitation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
@@ -53,6 +53,8 @@ Tab order follows the order of the elements in the markup, just as a screen read
 
 The `openOnFind` prop keeps collapsed content in the DOM and available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”** and the accordion expands to reveal the match.
 
+`openOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `openOnFind` off) instead.
+
 <AccordionOpenOnFindExample />
 
 <VisibleWhenVisualTest>

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -93,7 +93,7 @@ export type AccordionProps = Omit<
      */
     keepInDOM?: boolean
     /**
-     * If set to `true` the collapsed content stays in the DOM and remains findable by the browser's find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to `false`.
+     * If set to `true` the collapsed content stays in the DOM and remains findable by the browser's find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.
      */
     openOnFind?: boolean
     /**

--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -72,7 +72,7 @@ export const AccordionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   openOnFind: {
-    doc: 'If set to `true` the collapsed content stays in the DOM and remains findable by the browser\'s find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to `false`.',
+    doc: 'If set to `true` the collapsed content stays in the DOM and remains findable by the browser\'s find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },


### PR DESCRIPTION
## Motivation

Follow-up to #9108 (targets its branch, not `main`).

The new `openOnFind` prop on `Accordion` relies on the native `hidden="until-found"` behavior, which is only supported in some browsers (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`.

#9108 documented what `openOnFind` does, but not this limitation. This PR adds the browser-support caveat so consumers can opt in consciously — mirroring what we did for `HeightAnimation`'s `untilFound`/`openOnFind` in #8977.

## Changes

- `Accordion.tsx` — add the caveat to the `openOnFind` prop JSDoc.
- `AccordionDocs.ts` — add the same caveat to the `openOnFind` properties-table doc.
- `accordion/demos.mdx` — add a prose paragraph in the "Find collapsed content" section explaining the limitation and pointing to `keepInDOM` for content that must stay hidden.

Docs-only; no runtime or behavior changes.