### PR TITLE
fix(HeightAnimation): hide open-on-find content in unsupported browsers

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -39,7 +39,7 @@ When `keepInDOM` or `openOnFind` keeps closed content in the DOM, HeightAnimatio
 
 `openOnFind` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation opens matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
-`openOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `openOnFind` off) instead.
+`openOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, it falls back to `keepInDOM` behavior: the content remains mounted and hidden, but is unavailable to browser find-in-page.
 
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimation.tsx
@@ -20,7 +20,7 @@ export type HeightAnimationProps = {
   keepInDOM?: boolean
 
   /**
-   * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.
+   * Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. Unsupported browsers fall back to regular `keepInDOM` hiding. Defaults to `false`.
    */
   openOnFind?: boolean
 
@@ -68,6 +68,13 @@ export type HeightAnimationAllProps = HeightAnimationProps &
     'ref' | 'onAnimationEnd' | 'onAnimationStart'
   >
 
+export function supportsOpenOnFind() {
+  return (
+    typeof document !== 'undefined' &&
+    'onbeforematch' in document.documentElement
+  )
+}
+
 function HeightAnimation({
   open = true,
   animate = true,
@@ -94,11 +101,12 @@ function HeightAnimation({
   const targetRef = ref || elementRef
   const [isOpenedByFind, setOpenedByFind] = useState(false)
   const shouldOpenOnFind = openOnFind ?? untilFound ?? false
-  const resolvedOpen = open || (shouldOpenOnFind && isOpenedByFind)
+  const canOpenOnFind = shouldOpenOnFind && supportsOpenOnFind()
+  const resolvedOpen = open || (canOpenOnFind && isOpenedByFind)
 
   const handleAnimationStart: UseHeightAnimationOptions['onAnimationStart'] =
     (state) => {
-      if (shouldOpenOnFind && state === 'opening') {
+      if (canOpenOnFind && state === 'opening') {
         targetRef.current?.removeAttribute('hidden')
       }
       onAnimationStart?.(state)
@@ -106,7 +114,7 @@ function HeightAnimation({
   const handleAnimationEnd: UseHeightAnimationOptions['onAnimationEnd'] = (
     state
   ) => {
-    if (shouldOpenOnFind) {
+    if (canOpenOnFind) {
       if (state === 'closed') {
         targetRef.current?.style.removeProperty('visibility')
         targetRef.current?.setAttribute('hidden', 'until-found')
@@ -142,7 +150,7 @@ function HeightAnimation({
     }
 
     if (
-      shouldOpenOnFind &&
+      canOpenOnFind &&
       !resolvedOpen &&
       element.classList.contains('dnb-height-animation--hidden')
     ) {
@@ -150,17 +158,17 @@ function HeightAnimation({
     } else if (element.getAttribute('hidden') === 'until-found') {
       element.removeAttribute('hidden')
     }
-  }, [resolvedOpen, shouldOpenOnFind, targetRef])
+  }, [canOpenOnFind, resolvedOpen, targetRef])
 
   useLayoutEffect(() => {
-    if (isOpenedByFind && (open || !shouldOpenOnFind)) {
+    if (isOpenedByFind && (open || !canOpenOnFind)) {
       setOpenedByFind(false)
     }
-  }, [isOpenedByFind, open, shouldOpenOnFind])
+  }, [canOpenOnFind, isOpenedByFind, open])
 
   useLayoutEffect(() => {
     const element = targetRef.current
-    if (!element || !shouldOpenOnFind) {
+    if (!element || !canOpenOnFind) {
       return undefined
     }
 
@@ -176,7 +184,7 @@ function HeightAnimation({
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
     }
-  }, [onBeforeMatch, shouldOpenOnFind, targetRef])
+  }, [canOpenOnFind, onBeforeMatch, targetRef])
 
   // Set CSS custom properties via the DOM instead of React's style
   // prop. React's SSR serializes custom properties without spaces

--- a/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
+++ b/packages/dnb-eufemia/src/components/height-animation/HeightAnimationDocs.ts
@@ -17,7 +17,7 @@ export const HeightAnimationProperties: PropertiesTableProps = {
     status: 'optional',
   },
   openOnFind: {
-    doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.',
+    doc: 'Set to `true` to keep closed content available to the browser find-in-page feature with `hidden="until-found"`. This implies `keepInDOM`. Unsupported browsers fall back to regular `keepInDOM` hiding. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
+++ b/packages/dnb-eufemia/src/components/height-animation/__tests__/HeightAnimation.test.tsx
@@ -293,6 +293,28 @@ describe('HeightAnimation', () => {
   })
 
   describe('openOnFind', () => {
+    function simulateOpenOnFindUnsupported() {
+      const restores: Array<() => void> = []
+      let target: object | null = document.documentElement
+
+      while (target) {
+        const owner = target
+        const descriptor = Object.getOwnPropertyDescriptor(
+          owner,
+          'onbeforematch'
+        )
+        if (descriptor) {
+          delete (owner as Record<string, unknown>).onbeforematch
+          restores.push(() =>
+            Object.defineProperty(owner, 'onbeforematch', descriptor)
+          )
+        }
+        target = Object.getPrototypeOf(target)
+      }
+
+      return () => restores.forEach((restore) => restore())
+    }
+
     it('should preserve a regular hidden attribute', () => {
       const { rerender } = render(
         <HeightAnimation hidden>content</HeightAnimation>
@@ -404,6 +426,27 @@ describe('HeightAnimation', () => {
       )
 
       expect(getElement()).not.toBeInTheDocument()
+    })
+
+    it('should fall back to regular keepInDOM hiding when unsupported', () => {
+      const restore = simulateOpenOnFindUnsupported()
+
+      try {
+        render(
+          <HeightAnimation open={false} openOnFind>
+            content
+          </HeightAnimation>
+        )
+
+        expect(getElement()).not.toHaveAttribute('hidden')
+        expect(getElement()).toHaveClass('dnb-height-animation--hidden')
+        expect(getElement()).toHaveAttribute('aria-hidden', 'true')
+
+        getElement().dispatchEvent(new Event('beforematch'))
+        expect(getElement()).toHaveClass('dnb-height-animation--hidden')
+      } finally {
+        restore()
+      }
     })
   })
 


### PR DESCRIPTION
## Motivation

The openOnFind feature relies on native hidden=until-found support. Without it, collapsed content can remain visible because the browser does not apply content-visibility: hidden.

Feature-detect the beforematch API and fall back to the existing keepInDOM hiding behavior when unavailable. This makes it safe for components that already retain content in the DOM to enable find-in-page behavior by default.