### PR TITLE
feat(List): reveal limited items from browser find

### DIFF
--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -2,8 +2,10 @@ import {
   Children,
   cloneElement,
   isValidElement,
+  useEffect,
   useContext,
   useMemo,
+  useRef,
 } from 'react'
 import type { HTMLAttributes } from 'react'
 import { clsx } from 'clsx'
@@ -12,7 +14,9 @@ import { ListContext } from './ListContext'
 import type { StackProps as FlexProps } from '../flex/Stack'
 import FlexContainer from '../flex/Stack'
 import type { SkeletonShow } from '../Skeleton'
-import HeightAnimation from '../height-animation/HeightAnimation'
+import HeightAnimation, {
+  supportsOpenOnFind,
+} from '../height-animation/HeightAnimation'
 import SharedContext from '../../shared/Context'
 import { useSharedState } from '../../shared/helpers/useSharedState'
 import type { ListShowMoreButtonSharedState } from './ListShowMoreButton'
@@ -21,6 +25,11 @@ import withComponentMarkers from '../../shared/helpers/withComponentMarkers'
 export type ListContainerProps = {
   id?: string
   visibleCount?: number
+  /**
+   * Makes items hidden by `visibleCount` findable with browser find-in-page. Matching content is revealed and expands a list connected to `List.ShowMoreButton`. Defaults to `true` when `visibleCount` is used.
+   * Default: `true`
+   */
+  openOnFind?: boolean
   variant?: ListVariant
   separated?: boolean
   /**
@@ -37,6 +46,7 @@ function ListContainer(props: ListContainerProps) {
     className,
     children,
     visibleCount,
+    openOnFind = true,
     variant = 'basic',
     separated = false,
     striped = false,
@@ -46,6 +56,7 @@ function ListContainer(props: ListContainerProps) {
     wrapChildrenInSpace = false,
     ...rest
   } = props
+  const containerRef = useRef<HTMLElement>(null)
 
   const parentContext = useContext(ListContext)
   const globalContext = useContext(SharedContext)
@@ -60,7 +71,7 @@ function ListContainer(props: ListContainerProps) {
 
   const hasToggle = hasVisibleCount && props.id !== undefined
 
-  const { data: toggleData } =
+  const { data: toggleData, update: updateToggle } =
     useSharedState<ListShowMoreButtonSharedState>(
       hasToggle ? props.id : undefined,
       { expanded: false }
@@ -68,6 +79,35 @@ function ListContainer(props: ListContainerProps) {
 
   const expanded = hasToggle ? (toggleData?.expanded ?? false) : false
   const shouldLimit = hasVisibleCount && !expanded
+  const canOpenOnFind = openOnFind && supportsOpenOnFind()
+
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element || !canOpenOnFind || !shouldLimit) {
+      return undefined
+    }
+
+    const hiddenItems = Array.from(
+      element.querySelectorAll<HTMLElement>('[hidden]')
+    )
+    hiddenItems.forEach((item) => {
+      item.setAttribute('hidden', 'until-found')
+    })
+
+    const handleBeforeMatch = (event: Event) => {
+      ;(event.currentTarget as HTMLElement).removeAttribute('hidden')
+      updateToggle({ expanded: true })
+    }
+    hiddenItems.forEach((item) => {
+      item.addEventListener('beforematch', handleBeforeMatch)
+    })
+
+    return () => {
+      hiddenItems.forEach((item) => {
+        item.removeEventListener('beforematch', handleBeforeMatch)
+      })
+    }
+  }, [canOpenOnFind, shouldLimit, updateToggle])
 
   const renderedChildren = useMemo(() => {
     if (!hasVisibleCount) {
@@ -98,6 +138,7 @@ function ListContainer(props: ListContainerProps) {
   const listContent = (
     <FlexContainer
       element="ul"
+      ref={containerRef}
       layoutEngine={layoutEngine}
       rowGap={separated ? 'small' : false}
       wrap={false}

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -33,6 +33,12 @@ export const ContainerProperties: PropertiesTableProps = {
     type: 'number',
     status: 'optional',
   },
+  openOnFind: {
+    doc: 'Makes items hidden by `visibleCount` findable with browser find-in-page. Matching content is revealed and expands a list connected to `List.ShowMoreButton`. Defaults to `true` when `visibleCount` is used.',
+    type: 'boolean',
+    defaultValue: 'true',
+    status: 'optional',
+  },
   children: {
     doc: 'List items. Use `List.Item.Basic`, `List.Item.Action`, or `List.Item.Accordion` as direct children.',
     type: 'React.ReactNode',

--- a/packages/dnb-eufemia/src/components/list/__tests__/ListShowMoreButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ListShowMoreButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { act, render, fireEvent } from '@testing-library/react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import ListShowMoreButton from '../ListShowMoreButton'
 import Container from '../Container'
@@ -242,13 +242,51 @@ describe('List.ShowMoreButton', () => {
 
     expect(items[0]).not.toHaveAttribute('hidden')
     expect(items[1]).not.toHaveAttribute('hidden')
-    expect(items[2]).toHaveAttribute('hidden')
-    expect(items[3]).toHaveAttribute('hidden')
+    expect(items[2]).toHaveAttribute('hidden', 'until-found')
+    expect(items[3]).toHaveAttribute('hidden', 'until-found')
 
     fireEvent.click(getButton())
 
     expect(items[2]).not.toHaveAttribute('hidden')
     expect(items[3]).not.toHaveAttribute('hidden')
+  })
+
+  it('expands the list when hidden content is found', () => {
+    render(
+      <>
+        <ListShowMoreButton id="findable-list" />
+        <Container id="findable-list" visibleCount={1}>
+          <ItemContent>Item 1</ItemContent>
+          <ItemContent>Findable item</ItemContent>
+        </Container>
+      </>
+    )
+
+    const hiddenItem = document.querySelectorAll('.dnb-list__item')[1]
+    expect(hiddenItem).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      hiddenItem.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(getButton()).toHaveAttribute('aria-expanded', 'true')
+    expect(hiddenItem).not.toHaveAttribute('hidden')
+  })
+
+  it('allows openOnFind to be disabled', () => {
+    render(
+      <>
+        <ListShowMoreButton id="hidden-list" />
+        <Container id="hidden-list" visibleCount={1} openOnFind={false}>
+          <ItemContent>Item 1</ItemContent>
+          <ItemContent>Hidden item</ItemContent>
+        </Container>
+      </>
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-list__item')[1]
+    ).toHaveAttribute('hidden', '')
   })
 
   it('sets aria-controls pointing to the container id', () => {


### PR DESCRIPTION
## Motivation

List.Container already keeps items beyond visibleCount mounted with the hidden attribute. Make these existing DOM nodes findable by default and expand a connected List.ShowMoreButton when a match is revealed.

Consumers can set openOnFind=false to retain regular hidden behavior. Depends on #9117.