### PR TITLE
fix(Accordion): support openOnFind across variants

### DIFF
--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -93,7 +93,7 @@ export type AccordionProps = Omit<
      */
     keepInDOM?: boolean
     /**
-     * If set to `true` the collapsed content stays in the DOM and remains findable by the browser's find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to `false`.
+     * If set to `true` the collapsed content stays in the DOM and remains findable by the browser's find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to the value of `keepInDOM`.
      */
     openOnFind?: boolean
     /**
@@ -384,7 +384,7 @@ function AccordionDefault({
     variant: extendedVariant,
     className,
     keepInDOM,
-    openOnFind,
+    openOnFind: openOnFindProp,
     preventRerender,
     preventRerenderConditional,
     singleContainer,
@@ -411,6 +411,8 @@ function AccordionDefault({
 
     ...restOfExtendedProps
   } = extendedProps
+
+  const openOnFind = openOnFindProp ?? keepInDOM
 
   const mainParams = useSpacing(extendedProps, {
     id,

--- a/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionContent.tsx
@@ -44,6 +44,10 @@ export type AccordionContentProps = Omit<
      */
     keepInDOM?: boolean
     /**
+     * If set to `true`, collapsed standalone tertiary content remains findable by the browser's find-in-page feature.
+     */
+    openOnFind?: boolean
+    /**
      * If set to `true`, the open and close animation will be omitted in standalone tertiary mode.
      */
     noAnimation?: boolean
@@ -84,6 +88,7 @@ function AccordionContentStandalone({
     children,
     title,
     keepInDOM: keepInDOMProp = false,
+    openOnFind: openOnFindProp,
     noAnimation = false,
     ...rest
   } = props
@@ -92,6 +97,7 @@ function AccordionContentStandalone({
   const { data: sharedData, set } =
     useSharedState<AccordionTertiarySharedState>(connectionId)
   const expanded = sharedData?.expanded ?? false
+  const openOnFind = openOnFindProp ?? keepInDOMProp
   const shouldFocusContent = sharedData?.shouldFocusContent ?? false
   const contentId = `${connectionId}-content`
   const content = processChildren(props) as ReactNode
@@ -114,6 +120,14 @@ function AccordionContentStandalone({
         set({ ...sharedData, shouldFocusContent: false })
       }
       keepInDOM={keepInDOMProp}
+      openOnFind={openOnFind}
+      onBeforeMatch={() =>
+        set({
+          ...sharedData,
+          expanded: true,
+          shouldFocusContent: false,
+        })
+      }
       title={title}
       aria-label={title}
     >
@@ -195,7 +209,7 @@ function AccordionContentComponent(props: AccordionContentProps) {
       /**
        * Ensure we do not render, if it is not expanded
        */
-      if (!(expanded || keepInDOM)) {
+      if (!(expanded || keepInDOM || openOnFind)) {
         content = null
       }
 

--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -72,7 +72,7 @@ export const AccordionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   openOnFind: {
-    doc: 'If set to `true` the collapsed content stays in the DOM and remains findable by the browser\'s find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to `false`.',
+    doc: 'If set to `true` the collapsed content stays in the DOM and remains findable by the browser\'s find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to the value of `keepInDOM`.',
     type: 'boolean',
     status: 'optional',
   },
@@ -151,6 +151,11 @@ export const AccordionContentProperties: PropertiesTableProps = {
   },
   keepInDOM: {
     doc: 'If set to `true` the content will be present, even when the accordion is not expanded. In standalone tertiary mode, the content region stays mounted to preserve `aria-controls`.',
+    type: 'boolean',
+    status: 'optional',
+  },
+  openOnFind: {
+    doc: "If set to `true`, collapsed standalone tertiary content remains findable by the browser's find-in-page feature.",
     type: 'boolean',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionGroup.tsx
@@ -64,6 +64,7 @@ const AccordionGroup = (props: AccordionGroupProps) => {
     expanded,
     expandedId,
     keepInDOM,
+    openOnFind,
     preventRerender,
     singleContainer,
     contentRef,

--- a/packages/dnb-eufemia/src/components/accordion/AccordionTertiary.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionTertiary.tsx
@@ -36,9 +36,22 @@ export type AccordionTertiaryProps = Omit<
   noAnimation?: boolean
 
   /**
+   * If set to `true`, the content remains mounted when collapsed.
+   */
+  keepInDOM?: boolean
+
+  /**
+   * If set to `true`, collapsed content remains findable by the browser's find-in-page feature.
+   */
+  openOnFind?: boolean
+
+  /**
    * Will be called by user click interaction. Returns an object with a boolean state `expanded` inside `{ expanded, event }`.
    */
-  onChange?: (event: { expanded: boolean; event: MouseEvent }) => void
+  onChange?: (event: {
+    expanded: boolean
+    event: MouseEvent | Event
+  }) => void
 
   children?: ReactNode
 }
@@ -60,6 +73,8 @@ export default function AccordionTertiary(props: AccordionTertiaryProps) {
     title,
     expanded: expandedProp,
     noAnimation,
+    openOnFind: openOnFindProp,
+    keepInDOM,
     className,
     children,
     onChange,
@@ -67,6 +82,7 @@ export default function AccordionTertiary(props: AccordionTertiaryProps) {
     iconPosition,
     ...rest
   } = props
+  const openOnFind = openOnFindProp ?? keepInDOM
 
   const id = useId(props.id)
   const contentId = `${id}-content`
@@ -94,6 +110,16 @@ export default function AccordionTertiary(props: AccordionTertiaryProps) {
       onChange?.({ expanded: next, event })
     },
     [expanded, set, onChange]
+  )
+
+  const handleBeforeMatch = useCallback(
+    (event: Event) => {
+      if (!expanded) {
+        set({ expanded: true, shouldFocusContent: false })
+        onChange?.({ expanded: true, event })
+      }
+    },
+    [expanded, onChange, set]
   )
 
   const mainParams = useSpacing(props, {
@@ -132,6 +158,9 @@ export default function AccordionTertiary(props: AccordionTertiaryProps) {
           onFocusHandled={() =>
             set({ ...data, shouldFocusContent: false })
           }
+          openOnFind={openOnFind}
+          onBeforeMatch={handleBeforeMatch}
+          keepInDOM={keepInDOM}
         >
           {children}
         </AccordionTertiaryContent>

--- a/packages/dnb-eufemia/src/components/accordion/AccordionTertiaryContent.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionTertiaryContent.tsx
@@ -35,8 +35,10 @@ export default function AccordionTertiaryContent({
 }: AccordionTertiaryContentProps) {
   const {
     keepInDOM = false,
+    openOnFind,
     onAnimationStart,
     onAnimationEnd,
+    onBeforeMatch,
     title,
     ['aria-label']: ariaLabel,
     ...wrapperProps
@@ -71,6 +73,8 @@ export default function AccordionTertiaryContent({
         open={expanded}
         animate={!noAnimation}
         keepInDOM={keepInDOM}
+        openOnFind={openOnFind}
+        onBeforeMatch={onBeforeMatch}
         onAnimationStart={onAnimationStart}
         onAnimationEnd={onAnimationEnd}
         onOpen={handleOpen}

--- a/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/__tests__/Accordion.test.tsx
@@ -262,10 +262,15 @@ describe('Accordion openOnFind', () => {
     ).toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('should not listen for "beforematch" when "openOnFind" is not set', () => {
+  it('should not listen for "beforematch" when "openOnFind" is false', () => {
     const onChange = vi.fn()
     render(
-      <Accordion {...props} keepInDOM onChange={onChange}>
+      <Accordion
+        {...props}
+        keepInDOM
+        openOnFind={false}
+        onChange={onChange}
+      >
         <span className="content">findable content</span>
       </Accordion>
     )
@@ -280,6 +285,28 @@ describe('Accordion openOnFind', () => {
     expect(
       document.querySelector('.dnb-accordion__header')
     ).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('should default openOnFind to true when keepInDOM is true', () => {
+    render(
+      <Accordion {...props} keepInDOM>
+        <span className="content">findable content</span>
+      </Accordion>
+    )
+
+    expect(
+      document.querySelector('.dnb-height-animation')
+    ).toHaveAttribute('hidden', 'until-found')
+  })
+
+  it('should render findable content when preventRerender is set', () => {
+    render(
+      <Accordion {...props} openOnFind preventRerender>
+        <span className="content">findable content</span>
+      </Accordion>
+    )
+
+    expect(document.querySelector('.content')).toBeInTheDocument()
   })
 })
 
@@ -613,6 +640,37 @@ describe('Accordion container component', () => {
 })
 
 describe('Accordion tertiary variant', () => {
+  it('opens matching content when openOnFind is set', () => {
+    const onChange = vi.fn()
+    render(
+      <Accordion
+        variant="tertiary"
+        title="Toggle"
+        openOnFind
+        onChange={onChange}
+      >
+        <p>Findable content</p>
+      </Accordion>
+    )
+
+    const button = document.querySelector(
+      '.dnb-accordion__tertiary-button'
+    )
+    const animation = document.querySelector('.dnb-height-animation')
+
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(animation).not.toHaveAttribute('hidden')
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ expanded: true })
+    )
+  })
+
   it('renders a tertiary button with chevron icon', () => {
     render(
       <Accordion variant="tertiary" title="Toggle" noAnimation>
@@ -1197,6 +1255,35 @@ describe('Accordion tertiary variant', () => {
     expect(
       document.getElementById('keep-in-dom-test-content').textContent
     ).toContain('Content')
+  })
+
+  it('opens matching standalone Accordion.Content', () => {
+    render(
+      <>
+        <Accordion
+          variant="tertiary"
+          title="Toggle"
+          id="find-standalone"
+        />
+        <Accordion.Content connectedTo="find-standalone" openOnFind>
+          <p>Findable content</p>
+        </Accordion.Content>
+      </>
+    )
+
+    const button = document.querySelector(
+      '.dnb-accordion__tertiary-button'
+    )
+    const animation = document.querySelector('.dnb-height-animation')
+
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(animation).not.toHaveAttribute('hidden')
   })
 
   it('supports noAnimation on standalone Accordion.Content', () => {


### PR DESCRIPTION
## Motivation

Complete the openOnFind feature introduced in #9108. Tertiary and standalone accordion content currently ignore it, while preventRerender can remove initially collapsed content before browser find can discover it.

This keeps those variants and combinations searchable and synchronizes their expanded state when a match is revealed. When keepInDOM is enabled, openOnFind now defaults to the same value and can be disabled explicitly. Depends on #9117.