### PR TITLE
feat(List): add openOnFind to item accordions

### DIFF
--- a/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/list/ItemAccordion.tsx
@@ -42,6 +42,10 @@ export type ItemAccordionProps = {
    */
   keepInDOM?: boolean
   /**
+   * When `true`, keeps closed content findable by the browser's find-in-page feature. Defaults to the value of `keepInDOM`.
+   */
+  openOnFind?: boolean
+  /**
    * If set to `true`, the accordion is visually dimmed and interaction is prevented. Sets `aria-disabled`, removes tabbing, and disables click/keyboard handlers.
    * Default: `false`
    */
@@ -61,6 +65,7 @@ const ItemAccordionContext = createContext<{
   pending?: boolean
   disabled?: boolean
   keepInDOM?: boolean
+  openOnFind?: boolean
   chevronPosition?: ItemAccordionIconPosition
   accordionId: string
   icon?: IconIcon
@@ -68,6 +73,7 @@ const ItemAccordionContext = createContext<{
   handleToggle: (
     event: ReactMouseEvent<HTMLDivElement, MouseEvent>
   ) => void
+  handleBeforeMatch: () => void
 }>(undefined)
 
 function ItemAccordion(props: ItemAccordionProps) {
@@ -82,6 +88,7 @@ function ItemAccordion(props: ItemAccordionProps) {
     skeleton,
     open = false,
     keepInDOM = false,
+    openOnFind = keepInDOM,
     chevronPosition = 'right',
     icon,
     title,
@@ -116,6 +123,11 @@ function ItemAccordion(props: ItemAccordionProps) {
     [onClick, onChange, pending]
   )
 
+  const handleBeforeMatch = useCallback(() => {
+    setOpen(true)
+    onChange?.({ expanded: true })
+  }, [onChange])
+
   return (
     <ItemAccordionContext
       value={{
@@ -123,11 +135,13 @@ function ItemAccordion(props: ItemAccordionProps) {
         pending,
         disabled: appliedDisabled,
         keepInDOM,
+        openOnFind,
         chevronPosition,
         accordionId,
         icon,
         title,
         handleToggle,
+        handleBeforeMatch,
       }}
     >
       <ItemContent
@@ -251,7 +265,8 @@ function AccordionContent(props: ItemContentProps) {
     return null
   }
 
-  const { openState, accordionId, keepInDOM } = accordionContext
+  const { openState, accordionId, keepInDOM, openOnFind } =
+    accordionContext
 
   const spacingProps = pickSpacingProps(rest)
 
@@ -268,7 +283,16 @@ function AccordionContent(props: ItemContentProps) {
       aria-hidden={!openState}
       {...omitSpacingProps(rest)}
     >
-      <HeightAnimation open={openState} keepInDOM={keepInDOM}>
+      <HeightAnimation
+        open={openState}
+        keepInDOM={keepInDOM}
+        openOnFind={openOnFind}
+        onBeforeMatch={() => {
+          if (!openState) {
+            accordionContext.handleBeforeMatch()
+          }
+        }}
+      >
         <Hr bottom={false} />
         <Space {...spacingProps}>{children}</Space>
       </HeightAnimation>

--- a/packages/dnb-eufemia/src/components/list/ListDocs.ts
+++ b/packages/dnb-eufemia/src/components/list/ListDocs.ts
@@ -308,6 +308,11 @@ export const ItemAccordionProperties: PropertiesTableProps = {
     defaultValue: 'false',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "When `true`, keeps closed content findable by the browser's find-in-page feature. Defaults to the value of `keepInDOM`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   disabled: {
     doc: 'If set to `true`, the accordion is visually dimmed and interaction is prevented. Sets `aria-disabled`, removes tabbing, and disables click/keyboard handlers.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ItemAccordion.test.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { act, render, fireEvent } from '@testing-library/react'
 import ItemAccordion from '../ItemAccordion'
 import Container from '../Container'
 import Context from '../../../shared/Context'
@@ -323,6 +323,59 @@ describe('ItemAccordion', () => {
         '[data-testid="accordion-content"]'
       )
       expect(content).not.toBeInTheDocument()
+    })
+  })
+
+  describe('openOnFind', () => {
+    it('keeps closed content findable and expands on beforematch', () => {
+      const onChange = vi.fn()
+      render(
+        <ItemAccordion openOnFind onChange={onChange}>
+          <ItemAccordion.Header>Title</ItemAccordion.Header>
+          <ItemAccordion.Content>Findable content</ItemAccordion.Content>
+        </ItemAccordion>
+      )
+
+      const header = document.querySelector(
+        '.dnb-list__item__accordion__header'
+      )
+      const animation = document.querySelector('.dnb-height-animation')
+
+      expect(animation).toHaveAttribute('hidden', 'until-found')
+
+      act(() => {
+        animation.dispatchEvent(new Event('beforematch'))
+      })
+
+      expect(header).toHaveAttribute('aria-expanded', 'true')
+      expect(animation).not.toHaveAttribute('hidden')
+      expect(onChange).toHaveBeenCalledWith({ expanded: true })
+    })
+
+    it('defaults openOnFind to true when keepInDOM is true', () => {
+      render(
+        <ItemAccordion keepInDOM>
+          <ItemAccordion.Header>Title</ItemAccordion.Header>
+          <ItemAccordion.Content>Findable content</ItemAccordion.Content>
+        </ItemAccordion>
+      )
+
+      expect(
+        document.querySelector('.dnb-height-animation')
+      ).toHaveAttribute('hidden', 'until-found')
+    })
+
+    it('allows openOnFind to be disabled when keepInDOM is true', () => {
+      render(
+        <ItemAccordion keepInDOM openOnFind={false}>
+          <ItemAccordion.Header>Title</ItemAccordion.Header>
+          <ItemAccordion.Content>Hidden content</ItemAccordion.Content>
+        </ItemAccordion>
+      )
+
+      expect(
+        document.querySelector('.dnb-height-animation')
+      ).not.toHaveAttribute('hidden')
     })
   })
 


### PR DESCRIPTION
## Motivation

List.Item.Accordion has the same expandable-content behavior as Accordion but cannot currently reveal collapsed matches from browser find-in-page.

Expose openOnFind, synchronize the item header and onChange state when a match is revealed, and default it to the value of keepInDOM. Consumers can set openOnFind=false to retain regular hidden behavior. Depends on #9117.