### PR TITLE
feat(Tabs): add openOnFind

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -54,6 +54,7 @@ import useIsomorphicLayoutEffect from '../../shared/helpers/useIsomorphicLayoutE
 import useUpdateEffect from '../../shared/helpers/useUpdateEffect'
 import CustomContent from './TabsCustomContent'
 import ContentWrapper from './TabsContentWrapper'
+import { supportsOpenOnFind } from '../height-animation/HeightAnimation'
 import {
   createSharedState,
   useSharedState,
@@ -157,6 +158,10 @@ export type TabsProps = Omit<
      */
     keepInDOM?: boolean
     /**
+     * If set to `true`, all tab content is rendered and inactive content remains findable by the browser's find-in-page feature. Matching content selects its tab. Defaults to the value of `keepInDOM`.
+     */
+    openOnFind?: boolean
+    /**
      * If set to `true`, the Tabs content will stay in the DOM. The visibility will be handled by using the `hidden` and `aria-hidden` HTML attributes. Similar to `keepInDOM`, but in contrast, the content will render once the user is activating a tab. Defaults to `false`.
      */
     preventRerender?: boolean
@@ -186,7 +191,7 @@ export type TabsEvent = {
   selectedKey: TabsSelectedKey
   focusKey: TabsSelectedKey
   title: string | ReactNode
-  event?: SyntheticEvent
+  event?: SyntheticEvent | Event
 }
 
 export type TabsRenderComponents = {
@@ -236,6 +241,7 @@ const tabsDefaultProps: Record<string, unknown> = {
   navButtonEdge: false,
   onOpenTabNavigationFn: null,
   keepInDOM: false,
+  openOnFind: false,
   preventRerender: false,
   scroll: null,
   skeleton: null,
@@ -786,7 +792,7 @@ function TabsComponent(ownProps: TabsProps) {
 
   const openTab = (
     newSelectedKey: string | number,
-    event: SyntheticEvent | null = null,
+    event: SyntheticEvent | Event | null = null,
     mode: string | null = null
   ) => {
     // saving the position will avoid flickering if the new tab will be done by a new page load
@@ -1235,13 +1241,14 @@ function TabsComponent(ownProps: TabsProps) {
 
   renderContentRef.current = () => {
     const { preventRerender, keepInDOM } = propsRef.current
+    const shouldOpenOnFind = ownProps.openOnFind ?? keepInDOM
     const currentSelectedKey = selectedKeyRef.current
     const currentData = dataRef.current
 
     let content
-    if (preventRerender || keepInDOM) {
+    if (preventRerender || keepInDOM || shouldOpenOnFind) {
       // Cached content rendering
-      if (keepInDOM) {
+      if (keepInDOM || shouldOpenOnFind) {
         cacheRef.current = Object.entries(currentData).reduce(
           (acc, [_idx, cur]) => {
             acc[cur.key] = {
@@ -1268,16 +1275,15 @@ function TabsComponent(ownProps: TabsProps) {
         ([key, { content: cachedContent }]) => {
           const hide = key !== String(currentSelectedKey)
           return (
-            <div
+            <CachedContent
               key={key}
-              aria-hidden={hide ? true : undefined}
-              className={clsx(
-                'dnb-tabs__cached',
-                hide && 'dnb-tabs__cached--hidden'
-              )}
+              tabKey={key}
+              hidden={hide}
+              openOnFind={shouldOpenOnFind}
+              onBeforeMatch={(event) => openTab(key, event)}
             >
               {cachedContent}
-            </div>
+            </CachedContent>
           )
         }
       )
@@ -1470,6 +1476,56 @@ const Tabs = Object.assign(memo(TabsComponent), {
 withComponentMarkers(Tabs, { _supportsSpacingProps: true })
 
 export default Tabs
+
+function CachedContent({
+  tabKey,
+  hidden,
+  openOnFind,
+  onBeforeMatch,
+  children,
+}: {
+  tabKey: string
+  hidden: boolean
+  openOnFind?: boolean
+  onBeforeMatch: (event: Event) => void
+  children: ReactNode
+}) {
+  const elementRef = useRef<HTMLDivElement>(null)
+  const canOpenOnFind = openOnFind && supportsOpenOnFind()
+
+  useEffect(() => {
+    const element = elementRef.current
+    if (!element || !hidden || !canOpenOnFind) {
+      return undefined
+    }
+
+    element.setAttribute('hidden', 'until-found')
+    const handleBeforeMatch = (event: Event) => {
+      element.removeAttribute('hidden')
+      onBeforeMatch(event)
+    }
+    element.addEventListener('beforematch', handleBeforeMatch)
+
+    return () => {
+      element.removeEventListener('beforematch', handleBeforeMatch)
+    }
+  }, [canOpenOnFind, hidden, onBeforeMatch])
+
+  return (
+    <div
+      ref={elementRef}
+      data-tab-key={tabKey}
+      hidden={hidden && !canOpenOnFind ? true : undefined}
+      aria-hidden={hidden ? true : undefined}
+      className={clsx(
+        'dnb-tabs__cached',
+        hidden && 'dnb-tabs__cached--hidden'
+      )}
+    >
+      {children}
+    </div>
+  )
+}
 
 export const Dummy = ({ children }: { children: ReactNode }) => {
   /**

--- a/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
+++ b/packages/dnb-eufemia/src/components/tabs/TabsDocs.ts
@@ -56,6 +56,11 @@ export const TabsProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "If set to `true`, all tab content is rendered and inactive content remains findable by the browser's find-in-page feature. Matching content selects its tab. Defaults to the value of `keepInDOM`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   preventRerender: {
     doc: 'If set to `true`, the Tabs content will stay in the DOM. The visibility will be handled by using the `hidden` and `aria-hidden` HTML attributes. Similar to `keepInDOM`, but in contrast, the content will render once the user is activating a tab. Defaults to `false`.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -786,6 +786,54 @@ describe('A single Tab component', () => {
     ).toBe('Content two')
   })
 
+  it('opens matching content when keepInDOM is true', () => {
+    const onChange = vi.fn()
+    render(
+      <Tabs
+        {...props}
+        keepInDOM
+        onChange={onChange}
+        data={[
+          { title: 'One', key: 'one', content: 'Content one' },
+          { title: 'Two', key: 'two', content: 'Findable content' },
+        ]}
+      />
+    )
+
+    const contents = document.querySelectorAll('.dnb-tabs__cached')
+    expect(contents[1]).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      contents[1].dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(
+      document.querySelector('button[data-tab-key="two"]')
+    ).toHaveAttribute('aria-selected', 'true')
+    expect(contents[1]).not.toHaveAttribute('hidden')
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'two' })
+    )
+  })
+
+  it('allows openOnFind to be disabled when keepInDOM is true', () => {
+    render(
+      <Tabs
+        {...props}
+        keepInDOM
+        openOnFind={false}
+        data={[
+          { title: 'One', key: 'one', content: 'Content one' },
+          { title: 'Two', key: 'two', content: 'Content two' },
+        ]}
+      />
+    )
+
+    expect(
+      document.querySelectorAll('.dnb-tabs__cached')[1]
+    ).toHaveAttribute('hidden', '')
+  })
+
   it('has to work with "Tabs.Content" as children components', () => {
     render(
       <Tabs {...props} data={tablistData}>

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -369,6 +369,12 @@ html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-ta
 .dnb-tabs__cached--hidden * {
   height: 0 !important;
 }
+.dnb-tabs__cached--hidden[hidden=until-found] {
+  visibility: visible;
+}
+.dnb-tabs__cached--hidden[hidden]:not([hidden=until-found]) {
+  display: none;
+}
 .dnb-tabs__content:focus-visible {
   position: relative;
 }
@@ -794,6 +800,12 @@ html[data-whatinput=keyboard] .dnb-tabs__button__snap:last-of-type.focus .dnb-ta
 }
 .dnb-tabs__cached--hidden * {
   height: 0 !important;
+}
+.dnb-tabs__cached--hidden[hidden=until-found] {
+  visibility: visible;
+}
+.dnb-tabs__cached--hidden[hidden]:not([hidden=until-found]) {
+  display: none;
 }
 .dnb-tabs__content:focus-visible {
   position: relative;

--- a/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
+++ b/packages/dnb-eufemia/src/components/tabs/style/dnb-tabs.scss
@@ -396,6 +396,14 @@
     * {
       height: 0 !important;
     }
+
+    &[hidden='until-found'] {
+      visibility: visible;
+    }
+
+    &[hidden]:not([hidden='until-found']) {
+      display: none;
+    }
   }
 
   // Make focus ring when keyboard is used to navigate


### PR DESCRIPTION
## Motivation

Tabs can pre-render inactive panels with keepInDOM, but their content remains unavailable to browser find-in-page.

Expose openOnFind to pre-render searchable panels and select the matching tab when the browser reveals a match. When keepInDOM is enabled, openOnFind defaults to the same value and can be disabled explicitly. Depends on #9117.