### PR TITLE
feat(Table): add openOnFind to accordion rows

### DIFF
--- a/packages/dnb-eufemia/src/components/table/TableDocs.ts
+++ b/packages/dnb-eufemia/src/components/table/TableDocs.ts
@@ -134,6 +134,11 @@ export const TrProperties: PropertiesTableProps = {
     defaultValue: 'false',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "When `true`, keeps collapsed accordion content findable by the browser's find-in-page feature. Defaults to the value of `keepInDOM`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   highlight: {
     doc: 'If set to `true`, all `<Td>` and `<Th>` cells in the row receive a highlighted background.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/table/TableTr.tsx
+++ b/packages/dnb-eufemia/src/components/table/TableTr.tsx
@@ -67,6 +67,11 @@ export type TableTrProps = {
   keepInDOM?: boolean
 
   /**
+   * When `true`, keeps collapsed accordion content findable by the browser's find-in-page feature. Defaults to the value of `keepInDOM`.
+   */
+  openOnFind?: boolean
+
+  /**
    * Will emit when user clicks/expands or on keydown space/enter (in `mode="accordion"` and `mode="navigation"`) in the table row. The second argument is an object with `trElement` (the `HTMLTableRowElement`).
    * Default: `undefined`
    */
@@ -143,6 +148,7 @@ export default function Tr(
     disabled,
     noAnimation,
     keepInDOM,
+    openOnFind,
     onClick,
     onOpen,
     onClose,

--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -229,6 +229,71 @@ describe('TableAccordion', () => {
       )
       expect(content).not.toBeInTheDocument()
     })
+
+    it('opens matching content by default when keepInDOM is true', () => {
+      render(
+        <Table mode="accordion">
+          <tbody>
+            <Tr keepInDOM>
+              <Td>content</Td>
+              <Td.AccordionContent>Findable content</Td.AccordionContent>
+            </Tr>
+          </tbody>
+        </Table>
+      )
+
+      const rows = document.querySelectorAll('tr')
+      const header = rows[0]
+      const content = rows[1]
+      expect(content).toHaveAttribute('hidden', 'until-found')
+
+      act(() => {
+        content.dispatchEvent(new Event('beforematch'))
+      })
+
+      expect(header.querySelector('.dnb-button')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+      expect(content).not.toHaveAttribute('hidden')
+    })
+
+    it('allows openOnFind to be disabled when keepInDOM is true', () => {
+      render(
+        <Table mode="accordion">
+          <tbody>
+            <Tr keepInDOM openOnFind={false}>
+              <Td>content</Td>
+              <Td.AccordionContent>Hidden content</Td.AccordionContent>
+            </Tr>
+          </tbody>
+        </Table>
+      )
+
+      expect(document.querySelectorAll('tr')[1]).toHaveAttribute(
+        'hidden',
+        ''
+      )
+    })
+
+    it('keeps openOnFind opt-in when keepInDOM is false', () => {
+      render(
+        <Table mode="accordion">
+          <tbody>
+            <Tr openOnFind>
+              <Td>content</Td>
+              <Td.AccordionContent>Findable content</Td.AccordionContent>
+            </Tr>
+          </tbody>
+        </Table>
+      )
+
+      expect(document.querySelectorAll('tr')[1]).toHaveAttribute(
+        'hidden',
+        'until-found'
+      )
+      expect(document.body).toHaveTextContent('Findable content')
+    })
   })
 
   it('expanded accordion content td should contain correct roles', () => {

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContent.tsx
@@ -1,10 +1,11 @@
-import { useContext, useRef } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import type { TableHTMLAttributes } from 'react'
 import { clsx } from 'clsx'
 import useId from '../../../shared/helpers/useId'
 import useTableAnimationHandler from './useTableAnimationHandler'
 import { TableContext } from '../TableContext'
 import { TableAccordionContext } from './TableAccordionContext'
+import { supportsOpenOnFind } from '../../height-animation/HeightAnimation'
 
 type TableAccordionContentProps = {
   /** Set to true to expanded the content on initial render */
@@ -57,8 +58,26 @@ function TableAccordionContent(
     expanded,
     noAnimation,
   })
-  const keepInDOM = Boolean(useContext(TableAccordionContext)?.keepInDOM)
-  const shouldRenderContent = isInDOM || keepInDOM
+  const accordionContext = useContext(TableAccordionContext)
+  const keepInDOM = Boolean(accordionContext?.keepInDOM)
+  const openOnFind = Boolean(accordionContext?.openOnFind)
+  const canOpenOnFind = openOnFind && supportsOpenOnFind()
+  const shouldRenderContent = isInDOM || keepInDOM || canOpenOnFind
+
+  useEffect(() => {
+    const element = trRef.current
+    if (!element || isInDOM || !canOpenOnFind) {
+      return undefined
+    }
+
+    element.setAttribute('hidden', 'until-found')
+    const handleBeforeMatch = () => accordionContext?.openFromFind()
+    element.addEventListener('beforematch', handleBeforeMatch)
+
+    return () => {
+      element.removeEventListener('beforematch', handleBeforeMatch)
+    }
+  }, [accordionContext, canOpenOnFind, isInDOM])
 
   const chevronTdProps = {
     ariaLive,
@@ -76,7 +95,7 @@ function TableAccordionContent(
        * - Firefox on Windows does it as well, but not when used with NVDA.
        */
       aria-hidden={!isInDOM} // NVDA and VoiceOver needs "aria-hidden" to remove it from the accessibility tree
-      hidden={isInDOM ? undefined : true} // NVDA and VoiceOver needs "hidden" to be true in order to not count invisible table rows (based on "tr" element)
+      hidden={isInDOM ? undefined : true} // Enhanced to hidden="until-found" after mount when openOnFind is enabled
       role={isInDOM ? 'row' : undefined} // NVDA and VoiceOver needs "hidden" to be true in order to not count invisible table rows (based on "role" element)
       style={{
         ...firstPaintStyle,

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContext.ts
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContext.ts
@@ -14,6 +14,8 @@ type TableAccordionContextProps = {
   ) => void
   trIsOpen: boolean
   keepInDOM: TableTrProps['keepInDOM']
+  openOnFind: TableTrProps['openOnFind']
+  openFromFind: () => void
   countTds: number
   noAnimation: TableTrProps['noAnimation']
   onOpen: TableTrProps['onOpen']

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionHead.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionHead.tsx
@@ -57,6 +57,7 @@ export function TableAccordionHead(allProps: TableAccordionHeadProps) {
     expanded,
     noAnimation,
     keepInDOM,
+    openOnFind: openOnFindProp,
     onClick,
     onOpen,
     onClose,
@@ -79,6 +80,7 @@ export function TableAccordionHead(allProps: TableAccordionHeadProps) {
   })
   const [trIsHover, setHover] = useState(false)
   const [trHadClick, setHadClick] = useState(false)
+  const openOnFind = openOnFindProp ?? keepInDOM ?? false
 
   let headerContent = Children.toArray(children)
 
@@ -212,6 +214,8 @@ export function TableAccordionHead(allProps: TableAccordionHeadProps) {
         trIsOpen,
         noAnimation,
         keepInDOM,
+        openOnFind,
+        openFromFind: () => setOpen(true),
         countTds,
         onOpen,
         onClose,


### PR DESCRIPTION
## Motivation

Expandable table rows can retain collapsed content with keepInDOM, but browser find-in-page cannot reveal it.

Expose openOnFind, synchronize the row toggle when a match is revealed, and default it to the value of keepInDOM. Consumers can set openOnFind=false to retain regular hidden behavior. Depends on #9117.