### PR TITLE
feat(StepIndicator): add openOnFind

### DIFF
--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicator.tsx
@@ -106,6 +106,10 @@ export type StepIndicatorProps = Omit<
      */
     expandedInitially?: boolean
     /**
+     * Keeps the collapsed step list findable by the browser's find-in-page feature. Matching content expands the list. Defaults to `false`.
+     */
+    openOnFind?: boolean
+    /**
      * Whether or not to break out (using negative margins) on larger screens. Defaults to `false`. Same as `outset` in [Card](/uilib/components/card/properties).
      */
     outset?: boolean
@@ -123,6 +127,7 @@ function StepIndicator({
   hideNumbers = stepIndicatorDefaultProps.hideNumbers,
   noAnimation = stepIndicatorDefaultProps.noAnimation,
   expandedInitially = stepIndicatorDefaultProps.expandedInitially,
+  openOnFind = stepIndicatorDefaultProps.openOnFind,
   ...restOfProps
 }: StepIndicatorProps) {
   const { outset, ...props } = {
@@ -132,6 +137,7 @@ function StepIndicator({
     hideNumbers,
     noAnimation,
     expandedInitially,
+    openOnFind,
     ...restOfProps,
   }
 

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorDocs.ts
@@ -41,6 +41,11 @@ export const StepIndicatorProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "Keeps the collapsed step list findable by the browser's find-in-page feature. Matching content expands the list. Defaults to `false`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   outset: {
     doc: 'Whether or not to break out (using negative margins) on larger screens. Defaults to `false`. Same as `outset` in [Card](/uilib/components/card/properties).',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorList.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/StepIndicatorList.tsx
@@ -24,6 +24,7 @@ function StepIndicatorList() {
     countSteps,
     data,
     noAnimation,
+    openOnFind,
   } = useContext(StepIndicatorContext)
   const Element = mode === 'static' ? 'div' : 'nav'
 
@@ -33,6 +34,8 @@ function StepIndicatorList() {
     <HeightAnimation
       animate={!noAnimation}
       open={open}
+      openOnFind={openOnFind}
+      onBeforeMatch={openHandler}
       onOpen={(state) => {
         if (state) {
           openHandler()

--- a/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
+++ b/packages/dnb-eufemia/src/components/step-indicator/__tests__/StepIndicator.test.tsx
@@ -222,6 +222,32 @@ describe('StepIndicator redesign', () => {
       document.querySelectorAll('li.dnb-step-indicator__item')
     ).toHaveLength(4)
   })
+
+  it('should expand when matching content is found', () => {
+    render(
+      <StepIndicator
+        mode="loose"
+        data={stepIndicatorListData}
+        openOnFind
+      />
+    )
+
+    const animation = document.querySelector(
+      '.dnb-step-indicator-wrapper .dnb-height-animation[hidden]'
+    )
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(
+      document.querySelector('.dnb-step-indicator__trigger__button')
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      document.querySelectorAll('.dnb-step-indicator__item')
+    ).toHaveLength(4)
+  })
 })
 
 describe('StepIndicator in loose mode', () => {

--- a/packages/dnb-eufemia/src/components/step-indicator/defaults.ts
+++ b/packages/dnb-eufemia/src/components/step-indicator/defaults.ts
@@ -11,4 +11,5 @@ export const stepIndicatorDefaultProps: Omit<StepIndicatorProps, 'mode'> =
     hideNumbers: false,
     noAnimation: false,
     expandedInitially: false,
+    openOnFind: false,
   }


### PR DESCRIPTION
## Motivation

The collapsed step overview is useful page content but cannot currently be discovered with browser find-in-page.

Expose openOnFind and synchronize the expanded trigger state when matching step content is revealed. Depends on #9117.