### PR TITLE
feat(Filter): add openOnFind to Panel

### DIFF
--- a/packages/dnb-eufemia/src/components/filter/FilterDocs.ts
+++ b/packages/dnb-eufemia/src/components/filter/FilterDocs.ts
@@ -95,6 +95,11 @@ export const PanelProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "Keeps closed panel content findable by the browser's find-in-page feature. Matching content opens the panel. Defaults to `false`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   children: {
     doc: 'Filter components rendered inside the panel, e.g. `Filter.Selection`, `Filter.Date`, or custom filters.',
     type: 'React.ReactNode',

--- a/packages/dnb-eufemia/src/components/filter/FilterPanel.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterPanel.tsx
@@ -10,10 +10,18 @@ import Hr from '../../elements/Hr'
 
 export type FilterPanelProps = {
   className?: string
+  /**
+   * Keeps closed panel content findable by the browser's find-in-page feature. Matching content opens the panel. Defaults to `false`.
+   */
+  openOnFind?: boolean
   children?: ReactNode
 }
 
-function FilterPanel({ className, children }: FilterPanelProps) {
+function FilterPanel({
+  className,
+  openOnFind = false,
+  children,
+}: FilterPanelProps) {
   const context = useContext(FilterContext)
   const sharedContext = useContext(SharedContext)
   const { hideFilterLabel, applyFilterLabel, cancelFilterLabel } =
@@ -53,7 +61,11 @@ function FilterPanel({ className, children }: FilterPanelProps) {
   const itemContextValue = useMemo(() => ({ panelRef: panelDivRef }), [])
 
   return (
-    <HeightAnimation open={panelOpen}>
+    <HeightAnimation
+      open={panelOpen}
+      openOnFind={openOnFind}
+      onBeforeMatch={() => setPanelOpen(true)}
+    >
       <FilterItemContext value={itemContextValue}>
         <div
           ref={panelDivRef}

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterPanel.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, fireEvent, waitFor } from '@testing-library/react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import FilterRoot from '../FilterRoot'
 import FilterPanel from '../FilterPanel'
@@ -47,6 +47,30 @@ describe('Filter.Panel', () => {
     const panel = document.querySelector('.dnb-filter__panel')
 
     expect(panel).toBeVisible()
+  })
+
+  it('opens when matching content is found', () => {
+    render(
+      <FilterRoot>
+        <FilterPanelButton>Filters</FilterPanelButton>
+        <FilterPanel openOnFind>
+          <p>Findable filter</p>
+        </FilterPanel>
+      </FilterRoot>
+    )
+
+    const animation = document.querySelector('.dnb-height-animation')
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(document.querySelector('.dnb-button')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(document.body).toHaveTextContent('Findable filter')
   })
 
   it('renders filter children as tertiary accordions', () => {


### PR DESCRIPTION
## Motivation

A closed Filter.Panel currently removes its filter controls from browser find-in-page.

Expose openOnFind and synchronize the panel button when matching filter content is revealed. Depends on #9117.