### PR TITLE
feat(HelpButton): add openOnFind for inline content

### DIFF
--- a/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/HelpButtonInline.tsx
@@ -44,6 +44,10 @@ export type HelpProps = {
    * If set to `true`, no open/close animation will be shown when renderAs="dialog". Defaults to `false`.
    */
   noAnimation?: boolean
+  /**
+   * Only for the "inline" variant. Keeps collapsed content findable by the browser's find-in-page feature. Matching content opens the help. Defaults to `false`.
+   */
+  openOnFind?: boolean
 }
 
 export type HelpButtonInlineProps = HelpButtonProps & {
@@ -165,6 +169,7 @@ function HelpButtonInlineComponent(props: HelpButtonInlineProps) {
           contentId={controlId}
           help={help}
           focusOnOpen={focusOnOpen}
+          openOnFind={help?.openOnFind}
         >
           {children}
         </HelpButtonInlineContent>
@@ -183,6 +188,7 @@ export type HelpButtonInlineContentProps = SpacingProps & {
   outset?: boolean
   roundedCorner?: boolean
   focusOnOpen?: boolean
+  openOnFind?: boolean
 }
 
 function HelpButtonInlineContentComponent(
@@ -198,6 +204,7 @@ function HelpButtonInlineContentComponent(
     outset = false,
     roundedCorner,
     focusOnOpen: focusOnOpenProp,
+    openOnFind,
     ...rest
   } = props
   const { data, update, extend } =
@@ -296,6 +303,15 @@ function HelpButtonInlineContentComponent(
       element={element}
       className={clsx('dnb-help-button__content', className)}
       open={isOpen ?? open ?? false}
+      openOnFind={openOnFind}
+      onBeforeMatch={() =>
+        update({
+          isOpen: true,
+          isUserIntent: false,
+          buttonRef,
+          focusOnOpen,
+        })
+      }
       onAnimationEnd={onAnimationEnd}
     >
       <Section

--- a/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
+++ b/packages/dnb-eufemia/src/components/help-button/__tests__/HelpButtonInline.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from '@testing-library/react'
+import { act, render, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { makeUniqueId } from '../../../shared/component-helper'
 import HelpButtonInline, {
@@ -57,6 +57,29 @@ describe('HelpButtonInline', () => {
 
     await userEvent.click(button)
     expect(button).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('should open inline help when matching content is found', () => {
+    render(
+      <HelpButtonInline
+        help={{
+          title: 'Help title',
+          content: 'Findable help',
+          openOnFind: true,
+        }}
+      />
+    )
+
+    const button = document.querySelector('button')
+    const animation = document.querySelector('.dnb-height-animation')
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(document.body).toHaveTextContent('Findable help')
   })
 
   it('should toggle open state when Space key gets pressed', async () => {


### PR DESCRIPTION
## Motivation

Inline help can contain useful page content that is unavailable to browser find-in-page while collapsed.

Expose openOnFind through the inline help configuration and synchronize the button expanded state when matching content is revealed. Dialog rendering remains unchanged. Depends on #9117.