### PR TITLE
feat(Breadcrumb): add openOnFind

### DIFF
--- a/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/Breadcrumb.tsx
@@ -124,6 +124,10 @@ export type BreadcrumbProps = {
    */
   noAnimation?: boolean
   /**
+   * Keeps collapsed breadcrumb items findable by the browser's find-in-page feature. Matching content expands the breadcrumb. Defaults to `false`.
+   */
+  openOnFind?: boolean
+  /**
    * Will be called when breadcrumb expands or collapses.
    */
   onToggle?: (collapsed: boolean) => void
@@ -143,6 +147,7 @@ const breadcrumbDefaultProps: Partial<BreadcrumbAllProps> = {
   skeleton: false,
   collapsed: true,
   spacing: false,
+  openOnFind: false,
 }
 
 const Breadcrumb = (localProps: BreadcrumbAllProps) => {
@@ -171,6 +176,7 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
     collapsed: overrideCollapsed,
     spacing,
     noAnimation,
+    openOnFind,
     data,
     href,
     onToggle,
@@ -255,6 +261,7 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
             title={backToText}
             expanded={!isCollapsedRef.current}
             noAnimation={noAnimation}
+            openOnFind={openOnFind}
             onChange={({ expanded, event }) => {
               onClick?.(event as MouseEvent<HTMLButtonElement>)
               isCollapsedRef.current = !expanded
@@ -305,6 +312,12 @@ const Breadcrumb = (localProps: BreadcrumbAllProps) => {
             items={items}
             collapsed={isCollapsedRef.current}
             noAnimation={noAnimation}
+            openOnFind={openOnFind}
+            onBeforeMatch={() => {
+              isCollapsedRef.current = false
+              forceUpdate()
+              onToggle?.(false)
+            }}
           />
         </div>
       )}

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbDocs.ts
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbDocs.ts
@@ -77,6 +77,11 @@ export const BreadcrumbProperties: PropertiesTableProps = {
     type: 'boolean',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "Keeps collapsed breadcrumb items findable by the browser's find-in-page feature. Matching content expands the breadcrumb. Defaults to `false`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   '[Space](/uilib/layout/space/properties)': {
     doc: 'Spacing properties like `top` or `bottom` are supported.',
     type: ['string', 'object'],

--- a/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/BreadcrumbMultiple.tsx
@@ -9,6 +9,8 @@ type BreadcrumbMultipleProps = {
   collapsed: boolean
   noAnimation: boolean
   data: Array<BreadcrumbItemProps>
+  openOnFind?: boolean
+  onBeforeMatch?: () => void
   items:
     | ReactElement<BreadcrumbItemProps>
     | Array<ReactElement<BreadcrumbItemProps>>
@@ -19,11 +21,15 @@ export const BreadcrumbMultiple = ({
   items,
   noAnimation,
   data,
+  openOnFind,
+  onBeforeMatch,
 }: BreadcrumbMultipleProps) => {
   return (
     <HeightAnimation
       open={!collapsed}
       animate={!noAnimation}
+      openOnFind={openOnFind}
+      onBeforeMatch={onBeforeMatch}
       className="dnb-breadcrumb__multiple"
     >
       <ol className="dnb-breadcrumb__list">

--- a/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/dnb-eufemia/src/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -217,6 +217,36 @@ describe('Breadcrumb', () => {
     ).toBeDefined()
   })
 
+  it('opens collapsed responsive content when a match is found', () => {
+    setMedia({ width: '40em' })
+    const onToggle = vi.fn()
+    render(
+      <Breadcrumb
+        variant="collapse"
+        openOnFind
+        onToggle={onToggle}
+        data={[
+          { href: '/', text: 'Home' },
+          { href: '/page1', text: 'Findable page' },
+        ]}
+      />
+    )
+
+    const animation = document.querySelector(
+      '.dnb-accordion__content[hidden]'
+    )
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(
+      document.querySelector('.dnb-accordion__tertiary-button')
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(onToggle).toHaveBeenCalledWith(false)
+  })
+
   it('inherits skeleton prop from provider', () => {
     render(
       <Provider skeleton>


### PR DESCRIPTION
## Motivation

Collapsed breadcrumb paths cannot currently be discovered with browser find-in-page.

Expose openOnFind for the collapsed variant and synchronize its state and onToggle callback when matching content is revealed. Depends on #9117 and the tertiary Accordion support in #9119.