### PR TITLE
chore(Accordion): revert openOnFind browser-support limitation docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/demos.mdx
@@ -53,8 +53,6 @@ Tab order follows the order of the elements in the markup, just as a screen read
 
 The `openOnFind` prop keeps collapsed content in the DOM and available to the browser's find-in-page feature using `hidden="until-found"`. Search this page for **“Findable banking content”** and the accordion expands to reveal the match.
 
-`openOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, the collapsed content is **not reliably hidden** and can remain visible, because the collapse relies on the browser applying `content-visibility` for `hidden="until-found"`. For content that must stay hidden in those browsers, use `keepInDOM` (or leave `openOnFind` off) instead.
-
 <AccordionOpenOnFindExample />
 
 <VisibleWhenVisualTest>

--- a/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
+++ b/packages/dnb-eufemia/src/components/accordion/Accordion.tsx
@@ -93,7 +93,7 @@ export type AccordionProps = Omit<
      */
     keepInDOM?: boolean
     /**
-     * If set to `true` the collapsed content stays in the DOM and remains findable by the browser's find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.
+     * If set to `true` the collapsed content stays in the DOM and remains findable by the browser's find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to `false`.
      */
     openOnFind?: boolean
     /**

--- a/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
+++ b/packages/dnb-eufemia/src/components/accordion/AccordionDocs.ts
@@ -72,7 +72,7 @@ export const AccordionProperties: PropertiesTableProps = {
     status: 'optional',
   },
   openOnFind: {
-    doc: 'If set to `true` the collapsed content stays in the DOM and remains findable by the browser\'s find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. In browsers without `hidden="until-found"` support, the collapsed content may remain visible. Defaults to `false`.',
+    doc: 'If set to `true` the collapsed content stays in the DOM and remains findable by the browser\'s find-in-page feature, using `hidden="until-found"`. When matching content is found, the accordion expands. Defaults to `false`.',
     type: 'boolean',
     status: 'optional',
   },


### PR DESCRIPTION
Reverts #9113.

#9113 added a browser-support limitation caveat to the `Accordion` `openOnFind` documentation (JSDoc, the docs properties table, and the Accordion demos). It was merged into the `feat/accordion-open-on-find` branch and reached `main` as part of the #9108 squash merge. This PR removes that caveat again.
