### PR TITLE
chore(HeightAnimation): link to MDN for `hidden` attribute browser support

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/height-animation/info.mdx
@@ -39,7 +39,7 @@ When `keepInDOM` or `openOnFind` keeps closed content in the DOM, HeightAnimatio
 
 `openOnFind` uses the native `hidden="until-found"` behavior, making collapsed text available to browser find-in-page. HeightAnimation opens matching content internally, so `onBeforeMatch` is optional. When an external control owns the `open` state, handle `onBeforeMatch` by updating the same state passed to `open`. This keeps the control's `aria-expanded` value synchronized when the browser reveals a match.
 
-`openOnFind` depends on native browser support for `hidden="until-found"` (Chromium 102+, Firefox 148+, with partial support in Safari 26.2+). In browsers without support, it falls back to `keepInDOM` behavior: the content remains mounted and hidden, but is unavailable to browser find-in-page.
+`openOnFind` depends on native browser support for [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden); see MDN for details and current compatibility. In browsers without support, it falls back to `keepInDOM` behavior: the content remains mounted and hidden, but is unavailable to browser find-in-page.
 
 Users who prefer reduced motion receive an effectively immediate transition. It is important to never animate to a fixed height such as 64px, because:
 


### PR DESCRIPTION
The HeightAnimation accessibility docs listed specific browser versions (Chromium 102+, Firefox 148+, Safari 26.2+) for `hidden="until-found"` support. Hardcoded version numbers go stale quickly and are a maintenance burden.

This replaces the version list with a link to the [`hidden` attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden), where readers can find details and up-to-date browser support. The guidance to fall back to `keepInDOM` in unsupported browsers is preserved.

Note: this deliberately keeps the caveat and links out for support, rather than removing it as in #9128 (which dropped the equivalent caveat from the Accordion docs).
