### PR TITLE
chore: link openOnFind docs to HeightAnimation accessibility

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/accordion/info.mdx
@@ -26,6 +26,8 @@ The component is designed to let you compose different parts according to your t
 
 By default, the Accordion component animates user events, resulting in a final height of `auto`. This keeps the content responsive after the animation ends.
 
+When `openOnFind` is enabled, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 ### Accordion provider
 
 Use the `Accordion.Provider` to pass accordion properties to all nested accordions.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/breadcrumb/info.mdx
@@ -12,6 +12,10 @@ import { Breadcrumb } from '@dnb/eufemia'
 
 The Breadcrumb is a component for navigation and for showing the current website path or tree.
 
+## Accessibility
+
+When `openOnFind` is enabled, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 ## Relevant links
 
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=17025-0)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
@@ -279,6 +279,10 @@ When the filter panel is closed — via the "Hide filter" button, the "Apply" bu
 - `Filter.PanelButton` uses `aria-expanded` to communicate whether the panel is open or closed.
 - `Filter.ActiveFilters` renders a labeled group so screen readers can identify the active filter tags.
 
+### Find-in-page
+
+When `openOnFind` is enabled, the panel keeps closed content findable by the browser's find-in-page feature, powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 ## Relevant links
 
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=15807-0)

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/list/info.mdx
@@ -139,5 +139,6 @@ Only reuse the presentational cells (`List.Cell.*`) this way. Do not place inter
 - **List.Item.Action** uses `role="button"` so assistive technologies announce it as a button. It is focusable (`tabIndex={0}`) and activates on Enter and Space. When `pending` is true, it is not focusable and has `aria-disabled="true"`. You can override the role via the `role` prop (e.g. `role="link"`).
 - **List.Item.Accordion** exposes full ARIA for expand/collapse: the header has `id`, `aria-controls`, and `aria-expanded`; the content region has `id`, `aria-labelledby`, `aria-hidden`, and `aria-expanded`. Pass an `id` prop for stable references, or leave it unset for an auto-generated id. When `pending` is true, the header is not focusable and has `aria-disabled="true"`.
 - Use `aria-label` or other ARIA attributes on the container or items when needed for screen readers.
+- When `openOnFind` is enabled, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
 
 <RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/step-indicator/info.mdx
@@ -59,4 +59,8 @@ const steps = [
 
 More details about modifying steps in the [properties panel](/uilib/components/step-indicator/properties#step-item-properties).
 
+## Accessibility
+
+When `openOnFind` is enabled, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 <RelatedComponents />

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/info.mdx
@@ -45,6 +45,8 @@ Here is a list of things you may follow along in order to ensure your coded tabl
 - Never put a table inside a table.
 - Text inside tables do not need to be wrapped inside a paragraph as well. They give screen readers no additional useful information.
 
+When `openOnFind` is enabled on accordion rows, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 ### Table header components
 
 - `<Th.SortButton />` to be used for additional sorting functionality.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/info.mdx
@@ -22,4 +22,6 @@ Tabs are a set of buttons that allow navigation between content that is related 
 
 The Tabs component follows the [WAI-ARIA Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). It uses `role="tablist"`, `role="tab"`, and `role="tabpanel"` with proper ARIA attributes. Keyboard navigation includes arrow keys to move between tabs and Tab key to navigate into the active panel content.
 
+When `openOnFind` is enabled, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 <RelatedComponents />


### PR DESCRIPTION
## Motivation

`openOnFind` now ships across many components (Accordion, Breadcrumb, Filter, List, StepIndicator, Table, Tabs), all built on HeightAnimation. The accessibility and browser-support details live in one place — the HeightAnimation accessibility docs — but nothing pointed there.

This adds a short linking sentence to each consuming component's Accessibility section in `info.mdx`, keeping a single source of truth in HeightAnimation. Breadcrumb and StepIndicator get a new short Accessibility section, since they didn't have one.

Docs only; no behavior changes. Avoids re-adding the browser caveat previously removed from Accordion.
