### PR TITLE
docs(Portal): improve heading anchor handling and feedback

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/code-block.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/code-block.spec.ts
@@ -31,6 +31,14 @@ test.describe('CodeBlock', () => {
 
     await page.keyboard.down('Tab')
 
+    await expect(
+      page.getByRole('link', {
+        name: 'Link to Textarea with placeholder text',
+      })
+    ).toBeFocused()
+
+    await page.keyboard.down('Tab')
+
     await expect(textareaList.nth(1)).toBeFocused()
 
     // Tab past the toolbar (Copy button + StackBlitz button + Dark mode checkbox + Focus mode button) to reach the code editor

--- a/packages/dnb-design-system-portal/src/e2e/pageLists.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageLists.spec.ts
@@ -14,7 +14,7 @@ const getHeadingTextWithoutSrDescription = async (locator: Locator) =>
   locator.evaluate((element: HTMLElement) => {
     const clone = element.cloneNode(true) as HTMLElement
     clone
-      .querySelectorAll('.dnb-tooltip__sr-description')
+      .querySelectorAll('.dnb-tooltip__sr-description, .anchor-hash')
       .forEach((node) => node.remove())
     return (clone.textContent || '').trim()
   })
@@ -35,7 +35,7 @@ test.describe('Page Lists', () => {
       const headingText = await getHeadingTextWithoutSrDescription(
         page.locator('h1')
       )
-      await expect(headingText).toBe('#Components')
+      await expect(headingText).toBe('Components')
       await expect(page.locator('h1')).toHaveCount(1)
     })
 
@@ -71,7 +71,7 @@ test.describe('Page Lists', () => {
       const headingText = await getHeadingTextWithoutSrDescription(
         page.locator('h1')
       )
-      await expect(headingText).toBe('#Extensions')
+      await expect(headingText).toBe('Extensions')
       await expect(page.locator('h1')).toHaveCount(1)
     })
 
@@ -107,7 +107,7 @@ test.describe('Page Lists', () => {
       const headingText = await getHeadingTextWithoutSrDescription(
         page.locator('h1')
       )
-      await expect(headingText).toBe('#HTML Elements')
+      await expect(headingText).toBe('HTML Elements')
       await expect(page.locator('h1')).toHaveCount(1)
     })
 

--- a/packages/dnb-design-system-portal/src/e2e/routeFocus.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/routeFocus.spec.ts
@@ -11,7 +11,15 @@ test.describe('Route Focus', () => {
     const figmaLink = page
       .getByRole('tabpanel', { name: 'Info' })
       .getByRole('link', { name: 'Figma', exact: true })
+    const headingLink = page.getByRole('link', {
+      name: 'Link to Relevant links',
+    })
     const skipLink = page.locator('.dnb-skip-link')
+
+    await page.keyboard.press('Tab')
+
+    await expect(headingLink).toBeFocused()
+    await expect(skipLink).not.toBeFocused()
 
     await page.keyboard.press('Tab')
 
@@ -44,9 +52,17 @@ test.describe('Route Focus', () => {
     await expect(page).toHaveURL('/uilib/components/accordion')
 
     const pageHeading = page.locator('.dnb-app-content h1').first()
+    const headingLink = page.getByRole('link', {
+      name: 'Link to Accordion',
+      exact: true,
+    })
     const tabList = page.locator('.dnb-tabs__tabs__tablist')
 
     await expect(pageHeading).toBeFocused()
+
+    await page.keyboard.press('Tab')
+
+    await expect(headingLink).toBeFocused()
 
     await page.keyboard.press('Tab')
 

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
@@ -1,77 +1,62 @@
 .anchorLinkStyle {
   :global {
     .anchor-hash {
+      position: absolute;
+      left: 100%;
+
       display: inline-block;
       visibility: hidden;
 
       width: 1em;
-      margin-left: -1em;
+      margin-left: 0.25em;
       padding: 0;
 
       line-height: 1;
       text-align: center;
       border-bottom: none;
 
-      transition: opacity 300ms ease-out 200ms;
+      transition:
+        opacity 300ms ease-out,
+        visibility 0s linear 300ms;
       opacity: 0;
-    }
-
-    .anchor-hash.focus {
-      animation: link-attention-focus 2.2s var(--easing-default) 1 10ms;
-
-      @keyframes link-attention-focus {
-        0%,
-        100% {
-          visibility: visible;
-          color: var(--token-color-text-action);
-          background-color: transparent;
-        }
-
-        35% {
-          color: var(--token-color-text-neutral-inverse);
-          background-color: var(--token-color-background-action);
-        }
-
-        // stylelint-disable-next-line
-        0%,
-        80% {
-          opacity: 1;
-        }
-
-        // stylelint-disable-next-line
-        100% {
-          opacity: 0;
-        }
-      }
     }
   }
 
   :global(.anchor-hash:hover),
   &:hover :global(.anchor-hash) {
     visibility: visible;
+
+    transition-delay: 0s;
     opacity: 1;
   }
+}
+
+.headingContentStyle {
+  position: relative;
 
   &:global(.focus) {
-    display: inline-block;
+    border-radius: 0.125rem;
 
-    @keyframes parent-attention-focus {
+    @keyframes target-attention-focus {
       0%,
-      100% {
-        color: initial;
-        background-color: initial;
+      33% {
+        background-color: var(--token-color-background-selected-subtle);
+        box-shadow: 0 0 0 0.25rem
+          var(--token-color-background-selected-subtle);
       }
 
-      35% {
-        color: var(--token-color-text-neutral-inverse);
-        background-color: var(--token-color-background-action);
+      100% {
+        background-color: transparent;
+        box-shadow: 0 0 0 0.25rem transparent;
       }
     }
 
-    animation: parent-attention-focus 2.2s var(--easing-default) 1 10ms;
+    animation: target-attention-focus 2.2s var(--easing-default) 1 10ms;
+  }
 
-    * {
-      animation: parent-attention-focus 3s var(--easing-default) 1 150ms;
+  @media (prefers-reduced-motion: reduce) {
+    &:global(.focus) {
+      animation-duration: 1ms;
     }
   }
 }

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.module.scss
@@ -5,7 +5,6 @@
       left: 100%;
 
       display: inline-block;
-      visibility: hidden;
 
       width: 1em;
       margin-left: 0.25em;
@@ -15,19 +14,18 @@
       text-align: center;
       border-bottom: none;
 
-      transition:
-        opacity 300ms ease-out,
-        visibility 0s linear 300ms;
+      transition: opacity 300ms ease-out;
       opacity: 0;
+      pointer-events: none;
     }
   }
 
   :global(.anchor-hash:hover),
+  :global(.anchor-hash:focus-visible),
   &:hover :global(.anchor-hash) {
-    visibility: visible;
-
     transition-delay: 0s;
     opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -1,4 +1,4 @@
-import { isValidElement } from 'react'
+import { isValidElement, useEffect, useRef, useState } from 'react'
 import type { MouseEvent, ReactNode } from 'react'
 import { clsx } from 'clsx'
 import Anchor from './Anchor'
@@ -38,10 +38,24 @@ const AutoLinkHeader = ({
 }: AutoLinkHeaderProps) => {
   const location = useLocation()
   const id = makeSlug(children, useSlug)
+  const [anchorUrlSet, setAnchorUrlSet] = useState(false)
+  const tooltipTimeoutRef =
+    useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    return () => clearTimeout(tooltipTimeoutRef.current)
+  }, [])
 
   if (typeof children === 'string' && /\{#(.*)\}/.test(children)) {
     children = children.replace(/\{#(.*)\}/g, '').trim()
   }
+
+  const accessibleTitle =
+    typeof children === 'string'
+      ? children
+      : typeof title === 'string'
+        ? title
+        : id
 
   const clickHandler =
     className && /skip-anchor/g.test(String(className))
@@ -53,10 +67,12 @@ const AutoLinkHeader = ({
             try {
               window.history.replaceState(undefined, undefined, '#' + id)
 
-              const headingContent = event.currentTarget.parentElement
-              headingContent?.classList.remove('focus')
-              headingContent?.getBoundingClientRect()
-              headingContent?.classList.add('focus')
+              setAnchorUrlSet(true)
+              clearTimeout(tooltipTimeoutRef.current)
+              tooltipTimeoutRef.current = setTimeout(
+                () => setAnchorUrlSet(false),
+                2000
+              )
             } catch (e) {
               console.error('Could not call replaceState:', e)
             }
@@ -68,26 +84,29 @@ const AutoLinkHeader = ({
       level={level}
       element={element}
       className={clsx(anchorLinkStyle, className)}
+      aria-label={accessibleTitle}
       {...props}
     >
       <span className={headingContentStyle}>
-        {typeof addToSearchIndex === 'function'
-          ? addToSearchIndex({
-              location,
-              title: isValidElement(children) ? children : title,
-              hash: id,
-            })
-          : children}
+        <>
+          {typeof addToSearchIndex === 'function'
+            ? addToSearchIndex({
+                location,
+                title: isValidElement(children) ? children : title,
+                hash: id,
+              })
+            : children}
+        </>
         {clickHandler && id && (
           <Anchor
             className="anchor-hash"
-            tooltip="Click to set an Anchor URL"
+            tooltip={
+              anchorUrlSet ? 'Copied' : 'Click to set an Anchor URL'
+            }
             id={id}
             href={`#${id}`}
             onClick={clickHandler}
-            aria-hidden
-            // aria-hidden decorative affordance: keep out of the tab order
-            tabIndex={-1}
+            aria-label={'Link to ' + accessibleTitle}
           >
             #
           </Anchor>

--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -1,5 +1,5 @@
 import { isValidElement } from 'react'
-import type { ReactNode } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 import { clsx } from 'clsx'
 import Anchor from './Anchor'
 import Heading, {
@@ -7,7 +7,10 @@ import Heading, {
 } from '@dnb/eufemia/src/components/Heading'
 import { makeSlug } from '../../uilib/utils/slug'
 import { useLocation } from 'react-router'
-import { anchorLinkStyle } from './AutoLinkHeader.module.scss'
+import {
+  anchorLinkStyle,
+  headingContentStyle,
+} from './AutoLinkHeader.module.scss'
 
 type AutoLinkHeaderProps = {
   element?: string
@@ -43,10 +46,17 @@ const AutoLinkHeader = ({
   const clickHandler =
     className && /skip-anchor/g.test(String(className))
       ? null
-      : () => {
+      : (event: MouseEvent<HTMLAnchorElement>) => {
+          event.preventDefault()
+
           if (typeof window !== 'undefined' && id) {
             try {
-              window.history.replaceState(undefined, undefined, `#${id}`)
+              window.history.replaceState(undefined, undefined, '#' + id)
+
+              const headingContent = event.currentTarget.parentElement
+              headingContent?.classList.remove('focus')
+              headingContent?.getBoundingClientRect()
+              headingContent?.classList.add('focus')
             } catch (e) {
               console.error('Could not call replaceState:', e)
             }
@@ -60,7 +70,14 @@ const AutoLinkHeader = ({
       className={clsx(anchorLinkStyle, className)}
       {...props}
     >
-      <>
+      <span className={headingContentStyle}>
+        {typeof addToSearchIndex === 'function'
+          ? addToSearchIndex({
+              location,
+              title: isValidElement(children) ? children : title,
+              hash: id,
+            })
+          : children}
         {clickHandler && id && (
           <Anchor
             className="anchor-hash"
@@ -75,14 +92,7 @@ const AutoLinkHeader = ({
             #
           </Anchor>
         )}
-        {typeof addToSearchIndex === 'function'
-          ? addToSearchIndex({
-              location,
-              title: isValidElement(children) ? children : title,
-              hash: id,
-            })
-          : children}
-      </>
+      </span>
     </Heading>
   )
 }

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { cleanup, render } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 
 vi.mock('../AutoLinkHeader.module.scss', () => ({
@@ -25,7 +30,8 @@ describe('AutoLinkHeader', () => {
   it('renders the decorative "#" anchor after the heading text', () => {
     renderHeader()
 
-    const anchor = document.querySelector('.anchor-hash')
+    const anchor =
+      document.querySelector<HTMLAnchorElement>('.anchor-hash')
     const heading = anchor?.parentElement
 
     expect(anchor).toBeTruthy()
@@ -36,26 +42,25 @@ describe('AutoLinkHeader', () => {
     )
   })
 
-  it('keeps the decorative "#" anchor out of the keyboard tab order', () => {
-    // Regression: the anchor is only revealed on :hover, so a leftover
-    // pointer hover after a click-navigation could make it tabbable and let
-    // Tab land on it instead of the next element (e.g. the page tablist).
+  it('makes the anchor available to keyboard and screen reader users', () => {
     renderHeader()
 
-    const anchor = document.querySelector('.anchor-hash')
+    const anchor =
+      document.querySelector<HTMLAnchorElement>('.anchor-hash')
 
-    expect(anchor?.getAttribute('tabindex')).toBe('-1')
+    expect(anchor?.getAttribute('tabindex')).toBeNull()
+    expect(anchor?.getAttribute('aria-hidden')).toBeNull()
+    expect(anchor?.getAttribute('aria-label')).toBe('Link to My Heading')
+    expect(anchor?.closest('h1')?.getAttribute('aria-label')).toBe(
+      'My Heading'
+    )
+
+    anchor?.focus()
+
+    expect(document.activeElement).toBe(anchor)
   })
 
-  it('hides the decorative "#" anchor from assistive technology', () => {
-    renderHeader()
-
-    const anchor = document.querySelector('.anchor-hash')
-
-    expect(anchor?.getAttribute('aria-hidden')).toBe('true')
-  })
-
-  it('updates the hash without native navigation and highlights the heading', () => {
+  it('updates the hash without native navigation or highlighting the heading', async () => {
     renderHeader()
 
     const anchor =
@@ -66,10 +71,14 @@ describe('AutoLinkHeader', () => {
       cancelable: true,
     })
 
-    anchor?.dispatchEvent(event)
+    fireEvent.mouseEnter(anchor)
+    fireEvent(anchor, event)
 
     expect(event.defaultPrevented).toBe(true)
     expect(window.location.hash).toBe('#my-heading')
-    expect(headingContent?.classList).toContain('focus')
+    expect(headingContent?.classList).not.toContain('focus')
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Copied')
+    })
   })
 })

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router'
 
 vi.mock('../AutoLinkHeader.module.scss', () => ({
   anchorLinkStyle: 'anchorLinkStyle',
+  headingContentStyle: 'headingContentStyle',
 }))
 
 import AutoLinkHeader from '../AutoLinkHeader'
@@ -21,13 +22,18 @@ function renderHeader(props = {}) {
 }
 
 describe('AutoLinkHeader', () => {
-  it('renders the decorative "#" anchor inside the heading', () => {
+  it('renders the decorative "#" anchor after the heading text', () => {
     renderHeader()
 
     const anchor = document.querySelector('.anchor-hash')
+    const heading = anchor?.parentElement
 
     expect(anchor).toBeTruthy()
     expect(anchor?.getAttribute('href')).toBe('#my-heading')
+    expect(heading?.textContent?.startsWith('My Heading#')).toBe(true)
+    expect(anchor?.parentElement?.classList).toContain(
+      'headingContentStyle'
+    )
   })
 
   it('keeps the decorative "#" anchor out of the keyboard tab order', () => {
@@ -47,5 +53,23 @@ describe('AutoLinkHeader', () => {
     const anchor = document.querySelector('.anchor-hash')
 
     expect(anchor?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('updates the hash without native navigation and highlights the heading', () => {
+    renderHeader()
+
+    const anchor =
+      document.querySelector<HTMLAnchorElement>('.anchor-hash')
+    const headingContent = anchor?.parentElement
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    })
+
+    anchor?.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(window.location.hash).toBe('#my-heading')
+    expect(headingContent?.classList).toContain('focus')
   })
 })


### PR DESCRIPTION
Heading anchor navigation currently combines a strong text-colour animation with a page jump, which makes linked sections feel disruptive and makes the permalink difficult to use without a pointer.

Use a subtle background-only tint, keep the viewport stable when setting the hash, and expose the trailing permalink to keyboard and screen-reader users.