### PR TITLE
test(Img): cover native semantic contract

### DIFF
--- a/packages/dnb-eufemia/src/elements/img/__tests__/Img.test.tsx
+++ b/packages/dnb-eufemia/src/elements/img/__tests__/Img.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react'
+import Img from '../Img'
+
+describe('Img', () => {
+  it('renders with native figure and image semantics', () => {
+    render(<Img src="image.png" alt="Image description" />)
+
+    const figure = document.querySelector('figure')
+    const image = document.querySelector('img')
+
+    expect(figure).toContainElement(image)
+    expect(figure).not.toHaveAttribute('role')
+    expect(image).not.toHaveAttribute('role')
+    expect(image).toHaveAttribute('src', 'image.png')
+    expect(image).toHaveAttribute('alt', 'Image description')
+  })
+
+  it('renders a caption inside the figure', () => {
+    render(
+      <Img
+        src="image.png"
+        alt="Image description"
+        caption="Caption text"
+      />
+    )
+
+    const figure = document.querySelector('figure')
+    const caption = document.querySelector('figcaption')
+
+    expect(figure).toContainElement(caption)
+    expect(caption).toHaveTextContent('Caption text')
+  })
+
+  it('forwards native image properties to the image element', () => {
+    render(
+      <Img
+        src="image.png"
+        alt="Image description"
+        width={200}
+        height={100}
+        loading="lazy"
+        data-testid="image"
+      />
+    )
+
+    const image = document.querySelector('img')
+
+    expect(image).toHaveAttribute('width', '200')
+    expect(image).toHaveAttribute('height', '100')
+    expect(image).toHaveAttribute('loading', 'lazy')
+    expect(image).toHaveAttribute('data-testid', 'image')
+  })
+
+  it('applies className to the figure and imgClass to the image', () => {
+    render(
+      <Img
+        src="image.png"
+        alt="Image description"
+        className="figure-class"
+        imgClass="image-class"
+      />
+    )
+
+    expect(document.querySelector('figure')).toHaveClass('figure-class')
+    expect(document.querySelector('img')).toHaveClass('image-class')
+  })
+})


### PR DESCRIPTION
The Img element relies on native figure and image semantics, but this contract was only covered indirectly by visual tests. Add focused unit coverage for the rendered structure, caption, native image properties, and class routing.