### PR TITLE
fix(Img): preserve internal error handling

### DIFF
--- a/packages/dnb-eufemia/src/elements/img/Img.tsx
+++ b/packages/dnb-eufemia/src/elements/img/Img.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState } from 'react'
-import type { HTMLProps } from 'react'
+import type { HTMLProps, SyntheticEvent } from 'react'
 import E from '../Element'
 import {
   useSpacing,
@@ -34,6 +34,7 @@ const Img = ({
   imgClass,
   className,
   loading = 'eager',
+  onError,
   ...p
 }: ImgProps) => {
   const [hasError, setError] = useState(false)
@@ -53,7 +54,10 @@ const Img = ({
         internalClass={clsx('dnb-img', hasError && 'dnb-img--error')}
         className={imgClass}
         skeleton={skeleton}
-        onError={() => setError(true)}
+        onError={(event) => {
+          setError(true)
+          onError?.(event as SyntheticEvent<HTMLImageElement>)
+        }}
         {...removeSpaceProps(p as Omit<ImgProps, 'ref'>)}
       />
       {caption && <figcaption>{caption}</figcaption>}

--- a/packages/dnb-eufemia/src/elements/img/__tests__/Img.test.tsx
+++ b/packages/dnb-eufemia/src/elements/img/__tests__/Img.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import Img from '../Img'
 
 describe('Img', () => {
@@ -63,5 +63,18 @@ describe('Img', () => {
 
     expect(document.querySelector('figure')).toHaveClass('figure-class')
     expect(document.querySelector('img')).toHaveClass('image-class')
+  })
+
+  it('preserves internal error handling when onError is provided', () => {
+    const onError = vi.fn()
+    render(
+      <Img src="invalid.png" alt="Image description" onError={onError} />
+    )
+
+    const image = document.querySelector('img')
+    fireEvent.error(image)
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(image).toHaveClass('dnb-img--error')
   })
 })


### PR DESCRIPTION
A consumer-provided `onError` currently replaces Img’s internal handler, preventing the error styling from being applied. Compose both handlers so the component retains its error state while still notifying the consumer.

Depends on #9135.