### PR TITLE
feat(Img): deprecate imgClass and element props

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -18,6 +18,7 @@ draft: true
     - [Autocomplete](#autocomplete)
     - [Modal, Dialog and Drawer](#modal-dialog-and-drawer)
     - [InfoCard](#infocard)
+    - [Img](#img)
     - [Popover](#popover)
     - [ScrollView](#scrollview)
 
@@ -248,6 +249,16 @@ Note that the `disable*` props invert, so a disabled feature becomes `false`:
 ```diff
 -<InfoCard acceptButtonAttributes={{ href: '/path' }} />
 +<InfoCard acceptButtonProps={{ href: '/path' }} />
+```
+
+### [Img](/uilib/elements/image/)
+
+- Replace `imgClass` with `imageClassName`.
+- The `element` prop is deprecated. Keep the default `figure` wrapper and use `figureProps` to pass native properties to it.
+
+```diff
+-<Img src="image.png" alt="Description" imgClass="image-class" />
++<Img src="image.png" alt="Description" imageClassName="image-class" />
 ```
 
 ### [Popover](/uilib/components/popover/)

--- a/packages/dnb-design-system-portal/src/docs/uilib/elements/image/properties.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/elements/image/properties.mdx
@@ -7,4 +7,8 @@ import { ImgProperties } from '@dnb/eufemia/src/elements/img/ImgDocs'
 
 ## Properties
 
+`className` targets the wrapping `figure` element. All other native image
+properties target the inner `img` element. Use `figureProps` to pass additional
+native properties to the wrapper.
+
 <PropertiesTable props={ImgProperties} />

--- a/packages/dnb-eufemia/src/components/upload/__tests__/Upload.screenshot.test.ts
+++ b/packages/dnb-eufemia/src/components/upload/__tests__/Upload.screenshot.test.ts
@@ -97,12 +97,16 @@ describe.each(['ui', 'sbanken'])(`Upload for %s`, (themeName) => {
   it('have to match when displaying text', async () => {
     await makeScreenshot({
       selector: '[data-visual-test="upload-file-empty-size"]',
+      wrapperStyle: {
+        width: themeName === 'ui' ? '36rem' : '35.5rem',
+      },
     })
   })
 
   it('have to match when disabling drag and drop', async () => {
     await makeScreenshot({
       selector: '[data-visual-test="upload-disabled-drag-and-drop"]',
+      wrapperStyle: { width: '32rem' },
     })
   })
 

--- a/packages/dnb-eufemia/src/elements/img/Img.tsx
+++ b/packages/dnb-eufemia/src/elements/img/Img.tsx
@@ -20,7 +20,17 @@ export type ImgProps = SpacingProps &
     src: string
     alt: string
     skeleton?: SkeletonShow
+    /**
+     * Deprecated. Use `imageClassName` instead.
+     * @deprecated
+     */
     imgClass?: string
+    imageClassName?: string
+    figureProps?: Omit<HTMLProps<HTMLElement>, 'children'>
+    /**
+     * Deprecated. The wrapper should remain a `figure` to preserve its semantics.
+     * @deprecated
+     */
     element?: DynamicElement & 'figure'
     caption?: string
     loading?: 'eager' | 'lazy'
@@ -32,6 +42,8 @@ const Img = ({
   element = 'figure',
   skeleton,
   imgClass,
+  imageClassName,
+  figureProps,
   className,
   loading = 'eager',
   onError,
@@ -43,7 +55,14 @@ const Img = ({
     <E
       as={element}
       internalClass="dnb-img"
-      {...useSpacing(p, { className }, p.is)}
+      {...useSpacing(
+        p,
+        {
+          ...figureProps,
+          className: clsx(className, figureProps?.className),
+        },
+        p.is
+      )}
       skeleton={skeleton}
       skeletonMethod="shape"
     >
@@ -52,7 +71,7 @@ const Img = ({
         loading={loading}
         alt={alt}
         internalClass={clsx('dnb-img', hasError && 'dnb-img--error')}
-        className={imgClass}
+        className={clsx(imgClass, imageClassName)}
         skeleton={skeleton}
         onError={(event) => {
           setError(true)

--- a/packages/dnb-eufemia/src/elements/img/ImgDocs.ts
+++ b/packages/dnb-eufemia/src/elements/img/ImgDocs.ts
@@ -7,14 +7,24 @@ export const ImgProperties: PropertiesTableProps = {
     status: 'optional',
   },
   imgClass: {
-    doc: 'Custom `className` on the `<img>`-element.',
+    doc: 'Deprecated. Use `imageClassName` instead.',
+    type: 'string',
+    status: 'deprecated',
+  },
+  imageClassName: {
+    doc: 'Custom `className` for the inner `img` element.',
     type: 'string',
     status: 'optional',
   },
-  element: {
-    doc: 'Defines the Element Type, like `figure`.',
-    type: ['HTMLElement', 'string'],
+  figureProps: {
+    doc: 'Native HTML properties for the wrapping `figure` element.',
+    type: 'HTMLProps<HTMLElement>',
     status: 'optional',
+  },
+  element: {
+    doc: 'Deprecated. The wrapper should remain a `figure` to preserve its semantics.',
+    type: ['HTMLElement', 'string'],
+    status: 'deprecated',
   },
   caption: {
     doc: 'Use to define a caption for the image. Uses `<figcaption>`.',

--- a/packages/dnb-eufemia/src/elements/img/__tests__/Img.test.tsx
+++ b/packages/dnb-eufemia/src/elements/img/__tests__/Img.test.tsx
@@ -65,6 +65,28 @@ describe('Img', () => {
     expect(document.querySelector('img')).toHaveClass('image-class')
   })
 
+  it('applies figureProps to the figure and imageClassName to the image', () => {
+    render(
+      <Img
+        src="image.png"
+        alt="Image description"
+        className="figure-class"
+        figureProps={{
+          className: 'figure-props-class',
+          title: 'Figure title',
+        }}
+        imageClassName="image-class"
+        caption="Caption text"
+      />
+    )
+
+    const figure = document.querySelector('figure')
+
+    expect(figure).toHaveClass('figure-class', 'figure-props-class')
+    expect(figure).toHaveAttribute('title', 'Figure title')
+    expect(document.querySelector('img')).toHaveClass('image-class')
+  })
+
   it('preserves internal error handling when onError is provided', () => {
     const onError = vi.fn()
     render(


### PR DESCRIPTION
Img currently mixes wrapper and native image concerns: `className` targets the wrapper, `imgClass` targets the image, and other native properties target the image. Add explicit `figureProps` and `imageClassName` APIs, while preserving existing behavior and deprecating the ambiguous `imgClass` and wrapper `element` escape hatch.

Depends on #9136.