### PR TITLE
fix(Table): preserve open-on-find content without browser support

### DIFF
--- a/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/table/__tests__/TableAccordion.test.tsx
@@ -5,6 +5,7 @@ import {
   createEvent,
   act,
 } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
 import Table from '../Table'
 import Tr from '../TableTr'
 import Td from '../TableTd'
@@ -293,6 +294,67 @@ describe('TableAccordion', () => {
         'until-found'
       )
       expect(document.body).toHaveTextContent('Findable content')
+    })
+
+    it('keeps openOnFind content mounted when unsupported', () => {
+      const restores: Array<() => void> = []
+      let target: object | null = document.documentElement
+      while (target) {
+        const owner = target
+        const descriptor = Object.getOwnPropertyDescriptor(
+          owner,
+          'onbeforematch'
+        )
+        if (descriptor) {
+          delete (owner as Record<string, unknown>).onbeforematch
+          restores.push(() =>
+            Object.defineProperty(owner, 'onbeforematch', descriptor)
+          )
+        }
+        target = Object.getPrototypeOf(target)
+      }
+
+      try {
+        render(
+          <Table mode="accordion">
+            <tbody>
+              <Tr openOnFind>
+                <Td>content</Td>
+                <Td.AccordionContent>Fallback content</Td.AccordionContent>
+              </Tr>
+            </tbody>
+          </Table>
+        )
+
+        const contentRow = document.querySelectorAll('tr')[1]
+        expect(contentRow).toHaveAttribute('hidden', '')
+        expect(contentRow).toHaveTextContent('Fallback content')
+      } finally {
+        restores.forEach((restore) => restore())
+      }
+    })
+
+    it('keeps openOnFind content in server-rendered markup', () => {
+      const originalDocument = globalThis.document
+
+      try {
+        delete globalThis.document
+
+        const html = renderToString(
+          <Table mode="accordion">
+            <tbody>
+              <Tr openOnFind>
+                <Td>content</Td>
+                <Td.AccordionContent>Server content</Td.AccordionContent>
+              </Tr>
+            </tbody>
+          </Table>
+        )
+
+        expect(html).toContain('Server content')
+      } finally {
+        globalThis.document = originalDocument
+      }
     })
   })
 

--- a/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContent.tsx
+++ b/packages/dnb-eufemia/src/components/table/table-accordion/TableAccordionContent.tsx
@@ -62,7 +62,7 @@ function TableAccordionContent(
   const keepInDOM = Boolean(accordionContext?.keepInDOM)
   const openOnFind = Boolean(accordionContext?.openOnFind)
   const canOpenOnFind = openOnFind && supportsOpenOnFind()
-  const shouldRenderContent = isInDOM || keepInDOM || canOpenOnFind
+  const shouldRenderContent = isInDOM || keepInDOM || openOnFind
 
   useEffect(() => {
     const element = trRef.current


### PR DESCRIPTION
## Motivation

Table accordion content was only rendered for openOnFind when the browser supported beforematch. That made the content disappear entirely in unsupported browsers and from server-rendered markup.

Keep the content mounted whenever openOnFind is requested, while retaining the regular hidden fallback when native reveal support is unavailable.