### PR TITLE
fix(List): scope open-on-find to overflow items

### DIFF
--- a/packages/dnb-eufemia/src/components/list/Container.tsx
+++ b/packages/dnb-eufemia/src/components/list/Container.tsx
@@ -88,7 +88,7 @@ function ListContainer(props: ListContainerProps) {
     }
 
     const hiddenItems = Array.from(
-      element.querySelectorAll<HTMLElement>('[hidden]')
+      element.querySelectorAll<HTMLElement>(':scope > [hidden]')
     )
     hiddenItems.forEach((item) => {
       item.setAttribute('hidden', 'until-found')

--- a/packages/dnb-eufemia/src/components/list/__tests__/ListShowMoreButton.test.tsx
+++ b/packages/dnb-eufemia/src/components/list/__tests__/ListShowMoreButton.test.tsx
@@ -289,6 +289,28 @@ describe('List.ShowMoreButton', () => {
     ).toHaveAttribute('hidden', '')
   })
 
+  it('does not change nested hidden elements to until-found', () => {
+    render(
+      <>
+        <ListShowMoreButton id="nested-hidden-list" />
+        <Container id="nested-hidden-list" visibleCount={1}>
+          <ItemContent>
+            Item 1<span hidden>Nested hidden content</span>
+          </ItemContent>
+          <ItemContent>Item 2</ItemContent>
+        </Container>
+      </>
+    )
+
+    const nested = document.querySelector(
+      '.dnb-list__item:first-child [hidden]'
+    )
+    const overflow = document.querySelectorAll('.dnb-list__item')[1]
+
+    expect(nested).toHaveAttribute('hidden', '')
+    expect(overflow).toHaveAttribute('hidden', 'until-found')
+  })
+
   it('sets aria-controls pointing to the container id', () => {
     render(
       <>


### PR DESCRIPTION
## Motivation

List.Container currently upgrades every hidden descendant to hidden=until-found when visibleCount is used. Nested content may own its hidden state independently and should not be changed.

Limit open-on-find handling to the direct overflow items controlled by the list.