### PR TITLE
test: cover openOnFind in Chromium

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,12 +56,12 @@ jobs:
             ~/Library/Caches/ms-playwright
             ~/.cache/ms-playwright
             %USERPROFILE%\AppData\Local\ms-playwright
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-playwright-firefox-chromium-${{ hashFiles('**/yarn.lock') }}
       - name: Install Playwright browsers
-        run: yarn workspace dnb-design-system-portal playwright install --with-deps firefox
+        run: yarn workspace dnb-design-system-portal playwright install --with-deps firefox chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
-        run: yarn workspace dnb-design-system-portal playwright install-deps firefox
+        run: yarn workspace dnb-design-system-portal playwright install-deps firefox chromium
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Prebuild Library

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/table/Examples.tsx
@@ -728,7 +728,13 @@ export const Accordion = () => (
               <Td.AccordionContent>
                 <Section innerSpace={{ block: 'small' }}>
                   <Dl>
-                    <Dt>Favorittfarge</Dt>
+                    <Dt
+                      id={
+                        nr === '2' ? id + '-open-on-find-match' : undefined
+                      }
+                    >
+                      Favorittfarge
+                    </Dt>
                     <Dd>Grønn</Dd>
                   </Dl>
                 </Section>
@@ -752,7 +758,7 @@ export const Accordion = () => (
 
             <tbody>
               <Row nr="1" />
-              <Row nr="2" />
+              <Row nr="2" keepInDOM />
               <Row nr="3" expanded />
             </tbody>
           </Table>

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/tabs/Examples.tsx
@@ -71,7 +71,7 @@ export const TabsExampleContentObject = () => (
 
 export const TabsExampleKeepInDOM = () => (
   <Wrapper>
-    <ComponentBox>
+    <ComponentBox data-visual-test="tabs-open-on-find">
       <>
         <Tabs keepInDOM contentStyle="information">
           <Tabs.Content title="Tab 1" key="first">
@@ -85,7 +85,7 @@ export const TabsExampleKeepInDOM = () => (
                 alignItems: 'flex-end',
               }}
             >
-              <H2>Content 2</H2>
+              <H2 id="open-on-find-tab-match">Content 2</H2>
             </div>
           </Tabs.Content>
           <Tabs.Content title="Tab 3" key="third">

--- a/packages/dnb-eufemia/playwright.config.e2e.ts
+++ b/packages/dnb-eufemia/playwright.config.e2e.ts
@@ -13,8 +13,18 @@ export default defineConfig({
     baseURL:
       process.env.PLAYWRIGHT_BASE_URL ||
       (isCI ? 'http://localhost:8001' : 'http://localhost:8000'),
-
-    // Name of the browser that runs tests. For example `chromium`, `firefox`, `webkit`.
-    browserName: 'firefox',
   },
+
+  projects: [
+    {
+      name: 'firefox',
+      testIgnore: 'OpenOnFind.e2e.spec.ts',
+      use: { browserName: 'firefox' },
+    },
+    {
+      name: 'chromium-open-on-find',
+      testMatch: 'OpenOnFind.e2e.spec.ts',
+      use: { browserName: 'chromium' },
+    },
+  ],
 })

--- a/packages/dnb-eufemia/src/__tests__/e2e/OpenOnFind.e2e.spec.ts
+++ b/packages/dnb-eufemia/src/__tests__/e2e/OpenOnFind.e2e.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('openOnFind', () => {
+  test('selects the tab from native fragment navigation', async ({
+    page,
+  }) => {
+    await page.goto('/uilib/components/tabs/demos')
+
+    const example = page.locator('[data-visual-test="tabs-open-on-find"]')
+    const matchingContent = example.locator('#open-on-find-tab-match')
+    const matchingTab = example.getByRole('tab', { name: 'Tab 2' })
+
+    await expect(matchingTab).toHaveAttribute('aria-selected', 'false')
+    await expect(matchingContent).toBeHidden()
+
+    await page.evaluate(() => {
+      window.location.hash = 'open-on-find-tab-match'
+    })
+
+    await expect(matchingTab).toHaveAttribute('aria-selected', 'true')
+    await expect(matchingContent).toBeVisible()
+  })
+
+  test('expands the table row from native fragment navigation', async ({
+    page,
+  }) => {
+    await page.goto('/uilib/components/table/demos')
+
+    const example = page.locator('[data-visual-test="table-accordion"]')
+    const table = example.locator('table').first()
+    const matchingContent = table.locator(
+      '#accordion-table-1-open-on-find-match'
+    )
+    const row = matchingContent.locator('xpath=ancestor::tr')
+    const toggle = row.locator('xpath=preceding-sibling::tr[1]//button')
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(row).toHaveAttribute('hidden', 'until-found')
+
+    await page.evaluate(() => {
+      window.location.hash = 'accordion-table-1-open-on-find-match'
+    })
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(matchingContent).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Motivation

Unit tests can dispatch beforematch, but they cannot verify the native hidden=until-found reveal path. The existing component E2E suite runs Firefox only.

Run dedicated open-on-find specs in Chromium and verify native fragment navigation reveals matching Tabs and Table content while leaving the existing Firefox suite unchanged.