### PR TITLE
feat(Field.MultiSelection): add openOnFind for selected tags

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/info.mdx
@@ -100,6 +100,8 @@ When `showSelectedTags` is enabled and the **total number of available items** e
 
 The tag list expands and collapses with a smooth height animation.
 
+Set `openOnFind` to let browser find-in-page expand matching selected tags. This uses [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 Set `selectedItemsCollapsibleThreshold` to a custom number to control when the collapsible header kicks in:
 
 ```jsx

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -100,6 +100,11 @@ export type FieldMultiSelectionProps = FieldProps<
   selectedItemsCollapsibleThreshold?: number
 
   /**
+   * Keeps collapsed selected tags findable by the browser's find-in-page feature. Matching content expands the selected tags. Defaults to `false`.
+   */
+  openOnFind?: boolean
+
+  /**
    * Configure search behavior when `showSearchField` is enabled. An object with optional keys: `filter` (enable result filtering, default `true`), `reorder` (enable relevance reordering, default `true`), `numbers` (enable number-optimized matching, default `false`), `matchInsideWordsFrom` (threshold for in-word search, default `3`), and `match` (matching mode `"word"` or `"starts-with"`, default `"word"`). When `filter` is `false`, items are not filtered out but are still reordered by relevance unless `reorder` is also `false`. Example: `search={{ numbers: true }}`.
    */
   search?: Omit<SearchOptions, 'highlight'>
@@ -141,6 +146,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     showConfirmButton = false,
     showSelectAll = false,
     selectedItemsCollapsibleThreshold = 10,
+    openOnFind = false,
     value,
     disabled,
     emptyValue,
@@ -836,6 +842,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       show={showSelectedTags}
       disabled={disabled}
       isCollapsible={isCollapsible}
+      openOnFind={openOnFind}
       selectedItems={selectedItems}
       totalCount={totalCount}
       formatSelectionCount={formatSelectionCount}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionDocs.ts
@@ -54,6 +54,11 @@ export const MultiSelectionProperties: PropertiesTableProps = {
     type: ['number'],
     status: 'optional',
   },
+  openOnFind: {
+    doc: "Keeps collapsed selected tags findable by the browser's find-in-page feature. Matching content expands the selected tags. Defaults to `false`.",
+    type: ['boolean'],
+    status: 'optional',
+  },
   minItems: {
     doc: 'Minimum number of items required to be selected. Triggers a validation error if fewer items are selected.',
     type: ['number'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSelectedTags.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionSelectedTags.tsx
@@ -16,6 +16,7 @@ export type MultiSelectionSelectedTagsProps = {
   show: boolean
   disabled?: boolean
   isCollapsible: boolean
+  openOnFind?: boolean
   selectedItems: MultiSelectionItem[]
   totalCount: number
   formatSelectionCount: (count: number, total: number) => string
@@ -32,6 +33,7 @@ export function MultiSelectionSelectedTags({
   show,
   disabled,
   isCollapsible,
+  openOnFind,
   selectedItems,
   totalCount,
   formatSelectionCount,
@@ -81,6 +83,7 @@ export function MultiSelectionSelectedTags({
             id={`${id}-selected-accordion`}
             iconPosition="right"
             disabled={disabled}
+            openOnFind={openOnFind}
           />
           {selectedItems.length > 0 && (
             <Button
@@ -99,6 +102,7 @@ export function MultiSelectionSelectedTags({
         <Accordion.Content
           id={`${id}-selected-accordion`}
           className="dnb-forms-field-multi-selection__selected-items"
+          openOnFind={openOnFind}
         >
           {tagsContent}
         </Accordion.Content>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -1,4 +1,10 @@
-import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import {
+  act,
+  render,
+  fireEvent,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { afterAll, beforeEach, vi } from 'vitest'
 import { axeComponent } from '../../../../../core/test-utils/testSetup'
 import { Provider } from '../../../../../shared'
@@ -2064,7 +2070,51 @@ describe('MultiSelection', () => {
       )
     })
 
-    it('clears all items when clear all button is clicked', async () => {
+    it('opens collapsed selected tags when matching content is found', async () => {
+      const data = Array.from({ length: 25 }, (_, i) => ({
+        value: 'option' + (i + 1),
+        title: 'Option ' + (i + 1),
+      }))
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection
+            data={data}
+            showSelectedTags
+            openOnFind
+            value={data.slice(0, 22).map((item) => item.value)}
+          />
+        </Provider>
+      )
+
+      fireEvent.click(document.querySelector('button'))
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-multi-selection__selected-items-header'
+          )
+        ).toBeInTheDocument()
+      })
+
+      const toggleButton = document.querySelector(
+        '.dnb-forms-field-multi-selection__selected-items-header button:first-child'
+      )
+      const animation = document.querySelector(
+        '.dnb-forms-field-multi-selection__selected-items .dnb-height-animation'
+      )
+
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(animation).toHaveAttribute('hidden', 'until-found')
+
+      act(() => {
+        animation.dispatchEvent(new Event('beforematch'))
+      })
+
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('clears all selected tags when clear all is clicked', async () => {
       const data = Array.from({ length: 25 }, (_, i) => ({
         value: `option${i + 1}`,
         title: `Option ${i + 1}`,


### PR DESCRIPTION
## Motivation

Large selected-tag collections can be collapsed, making individual selected values unavailable to browser find-in-page.

Add an opt-in openOnFind property that expands the selected tags when matching content is revealed.