### PR TITLE
feat(Filter): add openOnFind to active filters

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/filter/info.mdx
@@ -281,7 +281,7 @@ When the filter panel is closed — via the "Hide filter" button, the "Apply" bu
 
 ### Find-in-page
 
-When `openOnFind` is enabled, the panel keeps closed content findable by the browser's find-in-page feature, powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+When `openOnFind` is enabled, the panel and collapsible active filters keep closed content findable by the browser's find-in-page feature, powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
 
 ## Relevant links
 

--- a/packages/dnb-eufemia/src/components/filter/FilterActiveFilters.tsx
+++ b/packages/dnb-eufemia/src/components/filter/FilterActiveFilters.tsx
@@ -14,6 +14,7 @@ export type FilterActiveFiltersProps = {
   label?: string
   showCategoryLabel?: boolean
   collapsibleThreshold?: number
+  openOnFind?: boolean
   onRemove?: (filterKey: string) => void
   className?: string
 }
@@ -22,6 +23,7 @@ function FilterActiveFilters({
   label,
   showCategoryLabel,
   collapsibleThreshold,
+  openOnFind = false,
   onRemove,
   className,
 }: FilterActiveFiltersProps) {
@@ -103,6 +105,7 @@ function FilterActiveFilters({
                   )}
                   id={accordionId}
                   iconPosition="right"
+                  openOnFind={openOnFind}
                 />
                 <Button
                   variant="tertiary"
@@ -113,7 +116,7 @@ function FilterActiveFilters({
                 </Button>
               </Flex.Horizontal>
 
-              <Accordion.Content id={accordionId}>
+              <Accordion.Content id={accordionId} openOnFind={openOnFind}>
                 <ScrollView className="dnb-filter__active-filters__scroll">
                   {tags}
                 </ScrollView>

--- a/packages/dnb-eufemia/src/components/filter/FilterDocs.ts
+++ b/packages/dnb-eufemia/src/components/filter/FilterDocs.ts
@@ -136,6 +136,11 @@ export const ActiveFiltersProperties: PropertiesTableProps = {
     type: 'number',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "Keeps collapsed active filters findable by the browser's find-in-page feature. Matching content expands the active filters. Defaults to `false`.",
+    type: 'boolean',
+    status: 'optional',
+  },
   className: {
     doc: 'Custom CSS class name.',
     type: 'string',

--- a/packages/dnb-eufemia/src/components/filter/__tests__/FilterActiveFilters.test.tsx
+++ b/packages/dnb-eufemia/src/components/filter/__tests__/FilterActiveFilters.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { act, render, fireEvent } from '@testing-library/react'
 import { axeComponent } from '../../../core/test-utils/testSetup'
 import FilterRoot from '../FilterRoot'
 import FilterActiveFilters from '../FilterActiveFilters'
@@ -585,5 +585,32 @@ describe('Filter.ActiveFilters collapsible', () => {
     const tags = document.querySelectorAll('.dnb-tag')
 
     expect(tags.length).toBe(6)
+  })
+
+  it('opens collapsed active filters when matching content is found', () => {
+    render(
+      <FilterRoot>
+        <SetManyFilters count={6} />
+        <FilterActiveFilters collapsibleThreshold={5} openOnFind />
+      </FilterRoot>
+    )
+
+    fireEvent.click(document.querySelector('[data-testid="set-many"]'))
+
+    const accordionButton = document.querySelector(
+      '.dnb-accordion__tertiary-button'
+    )
+    const animation = document.querySelector(
+      '.dnb-accordion__content.dnb-height-animation'
+    )
+
+    expect(accordionButton).toHaveAttribute('aria-expanded', 'false')
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(accordionButton).toHaveAttribute('aria-expanded', 'true')
   })
 })


### PR DESCRIPTION
## Motivation

Collapsible active-filter tags are unavailable to browser find-in-page while closed.

Add an opt-in openOnFind property that expands matching active filters and document it with the existing panel behavior.