### PR TITLE
feat(Menu): add openOnFind to accordion items

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/menu/info.mdx
@@ -27,6 +27,8 @@ For inline expandable groups, use `Menu.Accordion` instead of a nested `Menu.Roo
 
 ## Accessibility
 
+When `openOnFind` is enabled on `Menu.Accordion`, find-in-page support is powered by [HeightAnimation](/uilib/components/height-animation/#accessibility); see its accessibility notes for behavior details and browser support.
+
 - The menu uses ARIA `role="menu"` and `role="menuitem"` semantics.
 - The trigger receives `aria-haspopup="menu"` and `aria-expanded` attributes automatically.
 - Keyboard navigation follows the [WAI-ARIA Menu Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu/):

--- a/packages/dnb-eufemia/src/components/menu/MenuAccordion.tsx
+++ b/packages/dnb-eufemia/src/components/menu/MenuAccordion.tsx
@@ -23,6 +23,7 @@ export default function MenuAccordion(props: MenuAccordionProps) {
     icon,
     text,
     disabled = false,
+    openOnFind = false,
     onOpenChange,
     ...rest
   } = props
@@ -79,10 +80,11 @@ export default function MenuAccordion(props: MenuAccordionProps) {
     return {
       ...parentContext,
       level,
+      isOpen,
       closeAll,
       closeSelf,
     }
-  }, [parentContext, level, closeAll, closeSelf])
+  }, [parentContext, level, isOpen, closeAll, closeSelf])
 
   const handleClick = useCallback(() => {
     if (disabled) {
@@ -178,7 +180,11 @@ export default function MenuAccordion(props: MenuAccordionProps) {
         </span>
       </div>
 
-      <HeightAnimation open={isOpen}>
+      <HeightAnimation
+        open={isOpen}
+        openOnFind={openOnFind}
+        onBeforeMatch={() => setIsOpen(true)}
+      >
         {childContextValue && (
           <MenuContext value={childContextValue}>
             <ul

--- a/packages/dnb-eufemia/src/components/menu/MenuDocs.ts
+++ b/packages/dnb-eufemia/src/components/menu/MenuDocs.ts
@@ -126,6 +126,12 @@ export const MenuActionProperties: PropertiesTableProps = {
     defaultValue: 'false',
     status: 'optional',
   },
+  openOnFind: {
+    doc: "Keeps collapsed menu items findable by the browser's find-in-page feature. Matching content opens the accordion.",
+    type: 'boolean',
+    defaultValue: 'false',
+    status: 'optional',
+  },
   children: {
     doc: 'Custom content rendered inside the action item.',
     type: 'React.ReactNode',

--- a/packages/dnb-eufemia/src/components/menu/__tests__/MenuAccordion.test.tsx
+++ b/packages/dnb-eufemia/src/components/menu/__tests__/MenuAccordion.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { act, render, fireEvent } from '@testing-library/react'
 import Menu from '../Menu'
 import { MenuContext } from '../MenuContext'
 import { createMockContext } from './testHelpers'
@@ -430,6 +430,62 @@ describe('MenuAccordion', () => {
     fireEvent.click(trigger)
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(onOpenChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens matching content when openOnFind is true', () => {
+    const onOpenChange = vi.fn()
+    const ctx = createMockContext()
+
+    render(
+      <MenuContext value={ctx}>
+        <ul role="menu">
+          <Menu.Accordion
+            text="Export as"
+            openOnFind
+            onOpenChange={onOpenChange}
+          >
+            <Menu.Action text="Findable PDF" />
+          </Menu.Accordion>
+        </ul>
+      </MenuContext>
+    )
+
+    const trigger = document.querySelector('.dnb-menu__accordion__trigger')
+    const animation = document.querySelector('.dnb-height-animation')
+
+    expect(animation).toHaveAttribute('hidden', 'until-found')
+
+    act(() => {
+      animation.dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+  })
+
+  it('does not register collapsed findable menu items', () => {
+    const registerItem = vi.fn().mockReturnValue(0)
+    const ctx = createMockContext({ registerItem })
+
+    render(
+      <MenuContext value={ctx}>
+        <ul role="menu">
+          <Menu.Accordion text="Export as" openOnFind>
+            <Menu.Action text="PDF" />
+          </Menu.Accordion>
+        </ul>
+      </MenuContext>
+    )
+
+    expect(registerItem).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      document
+        .querySelector('.dnb-height-animation')
+        .dispatchEvent(new Event('beforematch'))
+    })
+
+    expect(registerItem).toHaveBeenCalledTimes(2)
   })
 
   it('calls onOpenChange when opened via keyboard', () => {

--- a/packages/dnb-eufemia/src/components/menu/types.ts
+++ b/packages/dnb-eufemia/src/components/menu/types.ts
@@ -140,6 +140,11 @@ export type MenuAccordionProps = {
    */
   disabled?: boolean
   /**
+   * Keeps collapsed menu items findable by the browser's find-in-page feature. Matching content opens the accordion.
+   * Default: `false`
+   */
+  openOnFind?: boolean
+  /**
    * Called whenever the accordion open state changes. Receives the new open state as a boolean.
    */
   onOpenChange?: (open: boolean) => void


### PR DESCRIPTION
## Motivation

Menu.Accordion can contain useful nested actions that browser find-in-page cannot discover while collapsed.

Add opt-in openOnFind behavior, synchronize the expanded state and callback when content is revealed, and keep collapsed children out of menu keyboard navigation.