### PR TITLE
chore(AGENTS): require approval before merging pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Gather the necessary context before making changes. Ask for clarification when required information is missing.
 - Add comments only when they clarify intent that the code cannot express on its own.
 - Do not update changelog files, such as `EUFEMIA_CHANGELOG.mdx` or `changelog.mdx`, unless the user explicitly asks, and preserve changelog changes already made by the user.
+- When deprecating or removing a public API, or introducing a breaking change, add migration guidance to the next major-version info file in `packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/`.
 
 ## Working on Code
 
@@ -54,12 +55,13 @@
 ### Creating Pull Requests
 
 - Before creating a pull request, check whether one already exists for the branch and review the complete diff against `main`.
-- Format the title according to the [Git convention style guide](packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx). Use a Conventional Commit decorator and, when targeting a component, a PascalCase scope.
+- Pull request titles are used in release logs. Make each title easy for developers to understand without issue, task, or repository context. Format it according to the [Git convention style guide](packages/dnb-design-system-portal/src/docs/contribute/style-guides/git.mdx), using a Conventional Commit decorator and, when targeting a component, a PascalCase scope.
 - Examples: `fix(Button): prevent double click submission` and `feat(DatePicker): add month-only mode`.
 - For extensions/forms, use the compound name, such as feat(Field.Date): ... or fix(Form.Section): .... Use Forms as the scope for changes that span the whole forms extension.
 - Keep the description short and focused on motivation: explain the problem and why the change matters. Link the relevant Slack discussion when available.
 - Do not list validation steps, tests run, changed files, or other information already visible elsewhere in the pull request.
-- Watch required checks and review feedback after opening the pull request. Do not merge unless the user explicitly asks.
+- Never merge unless the user explicitly asks, the current pull request revision is approved, and all required checks pass.
+- Use squash merge unless the user explicitly requests another merge method.
 
 ### Reviewing Pull Requests
 


### PR DESCRIPTION
Strengthen the shared agent merge policy so pull requests require explicit user authorization, approval, and passing required checks. Define squash merge as the default merge method.