### PR TITLE
docs(Typography): explain iOS Dynamic Type sizing

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/spatial-system.mdx
@@ -207,7 +207,9 @@ For those familiar with CSS, we establish typographic rules in the following way
 
     `html { font-size: 100%; }`
 
-    This will set the default size for paragraph text to **16px**.
+    This usually sets the root size to **16px**. Safari on iOS is different
+    because Eufemia follows the user's system text-size setting. Read
+    [why text can be larger on iOS](/uilib/typography/font-size/#why-text-can-be-larger-on-ios).
 
 2.  Set font styles on paragraphs, headers, buttons, etc. (basically everything) in the following manner:
     - font sizes should be set with **em**

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -25,6 +25,58 @@ For details about what values Typographic elements use, have a look at the
 | {GetPropAsPx('--font-size-x-large')}  | `x-large`  | **{GetPropValue('--font-size-x-large')}**  | `--font-size-x-large`   | `.dnb-t__size--x-large`  |                                 |
 | {GetPropAsPx('--font-size-xx-large')} | `xx-large` | **{GetPropValue('--font-size-xx-large')}** | `--font-size-xx-large`  | `.dnb-t__size--xx-large` |                                 |
 
+## Why text can be larger on iOS
+
+On iPhone and iPad, Eufemia follows the user's system text-size setting. This
+means that text may not have exactly the same pixel size as it does on macOS or
+other desktop platforms.
+
+At the default text-size setting, the difference is:
+
+| Platform              | Root size (`1rem`) | DNB basis size (`1.125rem`) |
+| --------------------- | ------------------ | --------------------------- |
+| Most desktop browsers | 16px               | 18px                        |
+| Safari on iOS         | 17px               | 19.125px                    |
+
+Safari does not apply the iOS setting to ordinary web font sizes automatically.
+Eufemia therefore uses Apple's Dynamic Type
+[`Body` text style](https://webkit.org/blog/3709/using-the-system-font-in-web-content/)
+as the root font size. This allows text to grow or shrink when the user changes
+the system setting.
+
+Root-relative layout values follow the changed root size too. Test layouts with
+larger accessibility text sizes and avoid fixed heights around text.
+
+### Why not force the size to 18px?
+
+A fixed root size of 16px would make DNB's 1.125rem basis text exactly 18px. It
+would also stop the text from following the user's iOS text-size setting.
+
+### Why not use a smaller Apple text style?
+
+Apple's `Subheadline` style is 15px at the default setting, which would make
+DNB's basis text 16.875px instead of 18px. It also follows a different Dynamic
+Type scaling curve. This would make iOS smaller than desktop by default and
+change the difference at larger accessibility sizes. It would also reduce all
+root-relative layout values.
+
+### Possible future improvements
+
+One option is to keep Apple's `Body` style and scale the resulting text by `16
+/ 17` with an iOS-only `text-size-adjust`. This produces an 18px DNB basis size
+at the default setting while retaining the `Body` Dynamic Type curve. It also
+keeps root-relative layout values at their current iOS sizes. Before using this
+as a framework default, it needs real-device testing across all text-size
+settings, nested typography, form controls, and representative layouts.
+
+The longer-term option is the standard
+[`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)
+environment variable and
+[`<meta name="text-scale" content="scale">`](https://drafts.csswg.org/css-fonts-5/#text-scale-meta).
+These would give websites a standard way to read or apply the user's preferred
+text scale. They are experimental and are not yet supported by Safari, so
+Eufemia cannot use them today.
+
 ### Responsive typography (BETA)
 
 **NB**: This feature is in beta and may be subject to change.


### PR DESCRIPTION
Explain why typography can render larger in Safari on iOS when Eufemia follows the user's system text-size setting. Clarify the tradeoffs of fixed sizing and Apple's smaller text styles, and document the possible text-adjust and standards-based paths forward.