### PR TITLE
fix(Typography): align iOS Dynamic Type sizing

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -31,12 +31,13 @@ On iPhone and iPad, Eufemia follows the user's system text-size setting. This
 means that text may not have exactly the same pixel size as it does on macOS or
 other desktop platforms.
 
-At the default text-size setting, the difference is:
+At the default text-size setting, the root sizes differ while Eufemia aligns
+the DNB basis text:
 
 | Platform              | Root size (`1rem`) | DNB basis size (`1.125rem`) |
 | --------------------- | ------------------ | --------------------------- |
 | Most desktop browsers | 16px               | 18px                        |
-| Safari on iOS         | 17px               | 19.125px                    |
+| Safari on iOS         | 17px               | 18px                        |
 
 Safari does not apply the iOS setting to ordinary web font sizes automatically.
 Eufemia therefore uses Apple's Dynamic Type
@@ -60,14 +61,14 @@ Type scaling curve. This would make iOS smaller than desktop by default and
 change the difference at larger accessibility sizes. It would also reduce all
 root-relative layout values.
 
-### Possible future improvements
+### How Eufemia aligns the default text size
 
-One option is to keep Apple's `Body` style and scale the resulting text by `16
-/ 17` with an iOS-only `text-size-adjust`. This produces an 18px DNB basis size
-at the default setting while retaining the `Body` Dynamic Type curve. It also
-keeps root-relative layout values at their current iOS sizes. Before using this
-as a framework default, it needs real-device testing across all text-size
-settings, nested typography, form controls, and representative layouts.
+Eufemia keeps Apple's `Body` style and scales text by `16 / 17` with an iOS-only
+`text-size-adjust`. This produces an 18px DNB basis size at the default setting
+while retaining the `Body` Dynamic Type curve. Root-relative layout values keep
+their iOS sizes.
+
+### Future improvements
 
 The longer-term option is the standard
 [`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)

--- a/packages/dnb-eufemia/src/style/__tests__/Scopes.test.ts
+++ b/packages/dnb-eufemia/src/style/__tests__/Scopes.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+
+import { loadScss } from '../../core/test-utils/testSetup'
+
+describe('Style scopes', () => {
+  it('corrects iOS Dynamic Type text without changing the root size', () => {
+    const css = loadScss(null, {
+      data: `
+        @use 'scopes.scss' as scopes;
+
+        @include scopes.htmlDefault();
+
+        body,
+        .dnb-core-style {
+          @include scopes.coreDefault();
+        }
+      `,
+    })
+
+    expect(css).toContain('font: -apple-system-body')
+    expect(css).toContain('-webkit-text-size-adjust: 100%')
+    expect(css).toContain(`
+@supports (-webkit-touch-callout: none) {
+  @supports (font: -apple-system-body) {
+    body,
+    .dnb-core-style {
+      /* stylelint-disable-next-line */
+      -webkit-text-size-adjust: 94.117647%;
+    }
+  }
+}`)
+    expect(css).not.toMatch(
+      /html \{[^}]*-webkit-text-size-adjust: 94\.117647%/
+    )
+  })
+})

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -37,6 +37,15 @@
   /* stylelint-disable-next-line */
   -webkit-text-size-adjust: 100%;
 
+  // Keep iOS Dynamic Type while aligning rendered text
+  // with the 16px web default
+  @supports (-webkit-touch-callout: none) {
+    @supports (font: -apple-system-body) {
+      /* stylelint-disable-next-line */
+      -webkit-text-size-adjust: 94.117647%;
+    }
+  }
+
   word-break: break-word;
 
   // Will add this to the body tag – later we can test for a version mismatch


### PR DESCRIPTION
Stacked on #9147.

Keep support for the user's iOS system text-size setting while aligning DNB's default basis text with the 18px desktop size. The correction stays on the typography scope so root-relative layout values continue to follow iOS Dynamic Type.