### PR TITLE
chore(Automation): add shared AI runner

### DIFF
--- a/.github/automations/README.md
+++ b/.github/automations/README.md
@@ -1,0 +1,181 @@
+# Repository automations
+
+Most of these automations use a configurable Responses-compatible model gateway
+and the hosted Eufemia MCP server to produce advisory reports. They never label,
+assign, commit, push, approve, merge, deploy, or update snapshots. Human
+notifications are limited to update-in-place pull request comments and dedicated
+tracking issues. They do not post to Slack or any other external service.
+
+## Shared setup
+
+Create a GitHub Actions environment named `automation` with:
+
+- `SECRET_API_KEY`: an approved non-interactive gateway credential.
+- `API_GATEWAY`: the complete Responses endpoint.
+- `MODEL`: a model allowed by [`guardrails.json`](./guardrails.json).
+
+Create the repository Actions variable `AUTOMATIONS_ENABLED` with value `false`
+while reviewing or merging the stack. Change it to `true` only after the gateway
+configuration below is ready and the automation owners have approved the event
+triggers and output locations.
+
+Do not add required reviewers to this environment because event-driven and
+scheduled runs would pause for approval. Restrict the environment to the
+default branch, limit who can change its configuration, rotate its credential,
+and apply usage limits and monitoring at the gateway.
+
+The gateway address is intentionally not documented in this public repository.
+The protected environment controls the destination; the runtime guard requires
+HTTPS, the `/v1/responses` path, and an allowlisted model.
+
+The Eufemia MCP endpoint is:
+
+```text
+https://server.eufemia.dnb.no/mcp/web
+```
+
+The shared runner verifies its required tools before analyses that depend on
+Eufemia documentation. The contract matches the currently deployed endpoint and
+should be expanded when new tools are released. MCP failure diagnosis runs
+without MCP so that an outage does not prevent diagnosis.
+
+## Automations
+
+### CI failure triage
+
+- Trigger: completion of selected CI workflows with conclusion `failure`.
+- Scope: same-repository runs only; visual failures are handled separately.
+- Input: bounded failed logs, failed-job metadata, optional PR metadata and code.
+- Cost control: visual-regression and release-readiness checks are handled by
+  their dedicated automations. MCP deployment failures use CI triage; public
+  endpoint health has a separate deterministic monitor.
+- Output: an update-in-place comment on the affected pull request when one is
+  available, plus the complete Actions report and artifact.
+
+### Release readiness
+
+- Trigger: successful Verify run for a PR titled `release of ...`.
+- Input: PR metadata, commits, changed files, code, tests, and documentation.
+- Output: an update-in-place release-PR comment with advisory compatibility,
+  migration, documentation, testing, and security risks.
+
+### Documentation drift
+
+- Trigger: every Monday at 05:23 UTC or manual dispatch.
+- Input: the latest default branch plus commits and changed paths from the last
+  seven days.
+- Output: a dedicated tracking issue updated with specific
+  source-to-documentation contradictions or omissions.
+
+### Issue intake
+
+- Trigger: every six hours or manual dispatch.
+- Input: up to 20 public issues opened in the last seven hours and a bounded
+  recent-issue inventory. Batching limits cost and public-trigger abuse.
+- Output: one dedicated batch-summary issue with classification, likely
+  ownership, missing information, and plausible duplicates. The automation does
+  not change individual issues.
+
+### Visual regression triage
+
+- Trigger: failed Visual Regression Tests workflow.
+- Input: a bounded visual report, representative expected/actual/diff images,
+  failed log, and relevant source revision.
+- Output: an update-in-place PR comment with grouped likely causes and whether
+  human visual approval or more evidence is needed. It never approves or updates
+  snapshots.
+
+### MCP health
+
+- Trigger: daily at 05:17 UTC or manual dispatch after a deployment.
+- Deterministic path: checks the health endpoint and required MCP tool contract.
+- Model path: runs only when a deterministic check fails and diagnoses the
+  likely edge, origin, runtime, protocol, bundle, or contract layer.
+- Output: healthy runs stay in the Actions summary; failures update one dedicated
+  MCP health tracking issue.
+
+### Platform modernization
+
+- Trigger: 15 January and 15 July at 06:37 UTC, or manual dispatch.
+- Deterministic path: compares Eufemia's configured minimum browsers with
+  versioned MDN browser-compatibility data for curated compatibility code that
+  still exists in the repository.
+- Model path: prioritizes verified candidates and explains the code, tests,
+  documentation, accessibility, and consumer risks to review before removal.
+- Cost control: the model runs only when a registered candidate is eligible
+  across the complete configured browser matrix. Blocked candidates remain
+  visible in the deterministic job summary.
+- Output: eligible candidates update one dedicated modernization tracking issue
+  and retain the full Actions artifact. Add candidates to the registry when
+  temporary polyfills or fallbacks enter the codebase.
+
+### Release announcement
+
+- Trigger: successful `Release` workflow for the `release` branch. Waiting for
+  workflow completion avoids announcements for failed or superseded attempts.
+- Input: the published GitHub release and the pull requests and direct commits
+  included since the previous release.
+- Output: an AI-generated Slack draft in a version-specific comment on the
+  merged release pull request. The publisher checks the expected format, release
+  link, comment size, and every deployed documentation route and anchor first.
+- Human checkpoint: review the selected features and wording before copying the
+  draft to Slack. The automation never sends the announcement to Slack.
+
+### Release motivation links
+
+- Trigger: the same successful `Release` workflow.
+- Input: pull request bodies and direct commit messages included since the
+  previous published tag.
+- Output: a deterministic, version-specific release-PR comment containing the
+  collected links. Bot-generated dependency pull requests and URLs with
+  sensitive-looking parameters are excluded. This helper does not use AI or
+  require the `automation` environment.
+
+## Reports
+
+Every advisory model-backed automation returns the same structured report:
+
+- `status`: `ok`, `attention`, or `blocked`.
+- `summary`: concise overall result.
+- `findings`: up to 20 evidence-backed P1-P3 items.
+- `metrics`: small factual measurements relevant to the event.
+
+Reports are escaped before they are written to the Actions summary and uploaded
+as JSON artifacts. Human notifications escape model output again, include no more
+than five findings, link to the complete run, and are updated in place. Tracking
+issues are reopened when attention is needed and closed after a clean result.
+Context and report artifacts have bounded retention.
+Context is rejected before model access when it contains symlinks, unexpected
+file types, too many files, or more than 10 MiB.
+Secret-bearing jobs always run the trusted default-branch workflow and source.
+When a pull request or feature branch matters, its diff is supplied only as
+bounded inert context; branch-controlled scripts or instructions are never
+executed.
+
+## Guardrail ownership
+
+The gateway owns identity, provider and model access, content policy, audit
+logging, quotas, rate limits, retention, and regional processing.
+
+The repository owns event selection, trusted prompts, read-only permissions,
+same-repository checks, context limits, MCP contracts, report schemas, output
+escaping, and narrowly scoped release-comment publishing.
+Only notification jobs receive `issues: write`; secret-bearing model jobs and
+context collectors remain read-only.
+
+## Suggested stacked pull requests
+
+1. Shared runner, policy, schemas, tests, and this runbook.
+2. CI failure triage.
+3. Release readiness.
+4. Documentation drift.
+5. Issue intake.
+6. Visual regression triage.
+7. MCP health and failure diagnosis.
+8. Release announcement draft.
+9. Release motivation links.
+10. Platform modernization audit.
+
+Each automation PR should target the previous stack layer until the foundation
+is merged. Keep `AUTOMATIONS_ENABLED` set to `false` until the environment and
+gateway service credential are ready.

--- a/.github/automations/config-no-mcp.toml
+++ b/.github/automations/config-no-mcp.toml
@@ -1,0 +1,11 @@
+approval_policy = "never"
+default_permissions = "automation-read-only"
+project_doc_fallback_filenames = []
+web_search = "disabled"
+
+[features]
+apps = false
+
+[permissions.automation-read-only]
+description = "Read-only repository analysis."
+extends = ":read-only"

--- a/.github/automations/config.toml
+++ b/.github/automations/config.toml
@@ -1,0 +1,24 @@
+approval_policy = "never"
+default_permissions = "automation-read-only"
+project_doc_fallback_filenames = []
+web_search = "disabled"
+
+[features]
+apps = false
+
+[mcp_servers.eufemia]
+url = "https://server.eufemia.dnb.no/mcp/web"
+required = true
+enabled_tools = [
+  "docs_entry",
+  "docs_search",
+  "docs_read",
+  "component_find",
+  "component_props",
+  "component_doc",
+]
+default_tools_approval_mode = "auto"
+
+[permissions.automation-read-only]
+description = "Read-only repository analysis with Eufemia documentation access."
+extends = ":read-only"

--- a/.github/automations/guardrails.json
+++ b/.github/automations/guardrails.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "runtime": {
+    "allowedGatewayPath": "/v1/responses",
+    "allowedModels": ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]
+  },
+  "output": {
+    "maxBytes": 131072
+  },
+  "context": {
+    "maxFiles": 50,
+    "maxBytes": 10485760,
+    "allowedExtensions": [
+      ".json",
+      ".log",
+      ".patch",
+      ".png",
+      ".tsv",
+      ".txt"
+    ]
+  }
+}

--- a/.github/automations/mcp-contract.json
+++ b/.github/automations/mcp-contract.json
@@ -1,0 +1,12 @@
+{
+  "endpoint": "https://server.eufemia.dnb.no/mcp/web",
+  "healthEndpoint": "https://server.eufemia.dnb.no/healthz",
+  "requiredTools": [
+    "docs_entry",
+    "docs_search",
+    "docs_read",
+    "component_find",
+    "component_props",
+    "component_doc"
+  ]
+}

--- a/.github/automations/report.schema.json
+++ b/.github/automations/report.schema.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "title": {
+      "type": "string",
+      "maxLength": 160
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 4000
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "attention", "blocked"]
+    },
+    "findings": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["P1", "P2", "P3"]
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "evidence": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "recommendation": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": ["severity", "title", "evidence", "recommendation"]
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "maxLength": 100 },
+          "value": { "type": "string", "maxLength": 200 }
+        },
+        "required": ["name", "value"]
+      }
+    }
+  },
+  "required": ["title", "summary", "status", "findings", "metrics"]
+}

--- a/.github/automations/scripts/__tests__/check-mcp-tools.test.sh
+++ b/.github/automations/scripts/__tests__/check-mcp-tools.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+check_script=$(cd "$script_dir/.." && pwd)/check-mcp-tools.sh
+response_file=$(mktemp)
+trap 'rm -f "$response_file"' EXIT
+
+printf '%s' '{"result":{"tools":[{"name":"docs_search"},{"name":"docs_read"}]}}' > "$response_file"
+
+MCP_TOOLS_RESPONSE_FILE="$response_file" bash "$check_script" \
+  https://example.test/mcp \
+  docs_search \
+  docs_read
+
+if MCP_TOOLS_RESPONSE_FILE="$response_file" bash "$check_script" \
+  https://example.test/mcp \
+  docs_meta > /dev/null 2>&1; then
+  echo 'Expected a missing MCP tool to be rejected.' >&2
+  exit 1
+fi
+
+echo 'MCP tool checks passed'

--- a/.github/automations/scripts/__tests__/configuration.test.mjs
+++ b/.github/automations/scripts/__tests__/configuration.test.mjs
@@ -1,0 +1,79 @@
+import { readFileSync, readdirSync } from 'node:fs'
+
+const workflowFiles = readdirSync('.github/workflows').filter(
+  (filename) =>
+    filename.startsWith('automation-') &&
+    filename.endsWith('.yml') &&
+    filename !== 'automation-run.yml'
+)
+
+for (const workflowFile of workflowFiles) {
+  const workflow = readFileSync(
+    `.github/workflows/${workflowFile}`,
+    'utf8'
+  )
+  const promptMatches = workflow.matchAll(
+    /prompt-file:\s*([a-z0-9-]+\.md)/g
+  )
+
+  for (const [, promptFile] of promptMatches) {
+    readFileSync(`.github/automations/prompts/${promptFile}`, 'utf8')
+  }
+}
+
+const mcpContract = JSON.parse(
+  readFileSync('.github/automations/mcp-contract.json', 'utf8')
+)
+const codexConfig = readFileSync('.github/automations/config.toml', 'utf8')
+const runnerWorkflow = readFileSync(
+  '.github/workflows/automation-run.yml',
+  'utf8'
+)
+const notifierWorkflow = readFileSync(
+  '.github/workflows/automation-notify.yml',
+  'utf8'
+)
+
+if (!codexConfig.includes(`url = "${mcpContract.endpoint}"`)) {
+  throw new Error(
+    'MCP endpoint differs between config.toml and mcp-contract.json'
+  )
+}
+
+for (const tool of mcpContract.requiredTools) {
+  if (!codexConfig.includes(`"${tool}"`)) {
+    throw new Error(
+      `Required MCP tool is missing from config.toml: ${tool}`
+    )
+  }
+}
+
+if (runnerWorkflow.includes('secrets: inherit')) {
+  throw new Error(
+    'Automation workflows must not inherit repository secrets'
+  )
+}
+
+if (
+  runnerWorkflow.includes('checkout-ref') ||
+  runnerWorkflow.includes('inputs.checkout-ref')
+) {
+  throw new Error(
+    'The secret-bearing runner must not check out event-controlled revisions'
+  )
+}
+
+if (!runnerWorkflow.includes('environment: automation')) {
+  throw new Error(
+    'The runner must use the protected automation environment'
+  )
+}
+
+if (!notifierWorkflow.includes('issues: write')) {
+  throw new Error('The notifier must declare its issue-comment permission')
+}
+if (runnerWorkflow.includes('issues: write')) {
+  throw new Error('The secret-bearing runner must remain read-only')
+}
+
+console.log('automation configuration tests passed')

--- a/.github/automations/scripts/__tests__/notification.test.mjs
+++ b/.github/automations/scripts/__tests__/notification.test.mjs
@@ -1,0 +1,75 @@
+import { strict as assert } from 'node:assert'
+import {
+  findAutomationComment,
+  findAutomationIssue,
+  renderNotification,
+  validateNotificationMarker,
+} from '../notification-utils.mjs'
+
+const marker = 'eufemia-automation:ci-failure-triage:pr-123'
+const body = renderNotification({
+  marker,
+  repository: 'dnbexperience/eufemia',
+  runUrl: 'https://github.com/dnbexperience/eufemia/actions/runs/123',
+  title: 'CI failure triage',
+  report: {
+    status: 'attention',
+    summary: 'Inspect <script> and https://untrusted.example/path.',
+    findings: Array.from({ length: 6 }, (_, index) => ({
+      severity: 'P2',
+      title: `Finding ${index + 1}`,
+      evidence: 'Evidence',
+      recommendation: 'Review [the failure].',
+    })),
+    metrics: [],
+  },
+})
+
+assert.match(body, /^<!-- eufemia-automation:ci-failure-triage:pr-123 -->/)
+assert.match(body, /&lt;script&gt;/)
+assert.match(body, /\\\[external link omitted\\\]/)
+assert.doesNotMatch(body, /untrusted\.example/)
+assert.match(body, /Showing 5 of 6 findings/)
+assert.doesNotMatch(body, /Finding 6/)
+assert.throws(() =>
+  renderNotification({
+    marker,
+    repository: 'dnbexperience/eufemia',
+    runUrl: 'https://example.com/actions/runs/123',
+    title: 'Invalid',
+    report: { status: 'ok', summary: '', findings: [], metrics: [] },
+  })
+)
+assert.doesNotThrow(() => validateNotificationMarker(marker))
+assert.throws(() => validateNotificationMarker('invalid --> marker'))
+assert.equal(
+  findAutomationComment(
+    [
+      {
+        id: 1,
+        user: { login: 'github-actions[bot]' },
+        body: `quoted <!-- ${marker} -->`,
+      },
+      { id: 2, user: { login: 'github-actions[bot]' }, body },
+    ],
+    marker
+  ).id,
+  2
+)
+assert.equal(
+  findAutomationIssue(
+    [
+      {
+        number: 4,
+        title: 'Documentation drift',
+        user: { login: 'github-actions[bot]' },
+        body: '<!-- eufemia-automation:documentation-drift -->\nReport',
+      },
+    ],
+    'eufemia-automation:documentation-drift',
+    'Documentation drift'
+  ).number,
+  4
+)
+
+console.log('notification tests passed')

--- a/.github/automations/scripts/__tests__/report.test.sh
+++ b/.github/automations/scripts/__tests__/report.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+scripts_dir=$(cd "$script_dir/.." && pwd)
+guardrails=$(cd "$script_dir/../.." && pwd)/guardrails.json
+report=$(mktemp)
+trap 'rm -f "$report"' EXIT
+
+printf '%s' '{"title":"Test <report>","summary":"Summary #1\nnext","status":"ok","findings":[],"metrics":[{"name":"Files","value":"2"}]}' > "$report"
+
+node "$scripts_dir/validate-report.mjs" "$report" "$guardrails"
+rendered=$(node "$scripts_dir/render-report.mjs" "$report")
+grep -Fq '# Test &lt;report&gt;' <<< "$rendered"
+grep -Fq 'Summary \#1' <<< "$rendered"
+grep -Fq '<br>next' <<< "$rendered"
+
+printf '%s' '{"title":"Invalid","summary":"Summary","status":"unknown","findings":[],"metrics":[]}' > "$report"
+if node "$scripts_dir/validate-report.mjs" "$report" "$guardrails" > /dev/null 2>&1; then
+  echo 'Expected an invalid report status to be rejected.' >&2
+  exit 1
+fi
+
+echo 'report tests passed'

--- a/.github/automations/scripts/__tests__/validate-context.test.mjs
+++ b/.github/automations/scripts/__tests__/validate-context.test.mjs
@@ -1,0 +1,54 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const scriptsRoot = new URL('../', import.meta.url).pathname
+const validateScript = join(scriptsRoot, 'validate-context.mjs')
+const guardrails = new URL('../../guardrails.json', import.meta.url)
+  .pathname
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'automation-context-'))
+
+const run = (contextPath) =>
+  spawnSync(process.execPath, [validateScript, contextPath, guardrails], {
+    encoding: 'utf8',
+  })
+
+try {
+  const valid = join(fixtureRoot, 'valid')
+  mkdirSync(join(valid, 'images'), { recursive: true })
+  writeFileSync(join(valid, 'context.json'), '{}')
+  writeFileSync(join(valid, 'images', 'diff.png'), 'image')
+
+  if (run(valid).status !== 0) {
+    throw new Error('Expected valid context to pass')
+  }
+
+  const unsupported = join(fixtureRoot, 'unsupported')
+  mkdirSync(unsupported)
+  writeFileSync(join(unsupported, 'script.sh'), 'exit 0')
+  if (run(unsupported).status === 0) {
+    throw new Error('Expected executable-looking context to fail')
+  }
+
+  const linked = join(fixtureRoot, 'linked')
+  mkdirSync(linked)
+  writeFileSync(join(fixtureRoot, 'outside.txt'), 'outside')
+  symlinkSync(
+    join(fixtureRoot, 'outside.txt'),
+    join(linked, 'context.txt')
+  )
+  if (run(linked).status === 0) {
+    throw new Error('Expected symbolic-link context to fail')
+  }
+
+  console.log('context validation tests passed')
+} finally {
+  rmSync(fixtureRoot, { recursive: true, force: true })
+}

--- a/.github/automations/scripts/__tests__/validate-runtime-config.test.sh
+++ b/.github/automations/scripts/__tests__/validate-runtime-config.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+validate_script=$(cd "$script_dir/.." && pwd)/validate-runtime-config.sh
+guardrails=$(cd "$script_dir/../.." && pwd)/guardrails.json
+
+bash "$validate_script" \
+  https://gateway.example.test/v1/responses \
+  gpt-5.6-terra \
+  "$guardrails"
+
+if bash "$validate_script" \
+  http://gateway.example.test/v1/responses \
+  gpt-5.6-terra \
+  "$guardrails" > /dev/null 2>&1; then
+  echo 'Expected a non-HTTPS gateway to be rejected.' >&2
+  exit 1
+fi
+
+if bash "$validate_script" \
+  https://gateway.example.test/v1/responses?target=other \
+  gpt-5.6-terra \
+  "$guardrails" > /dev/null 2>&1; then
+  echo 'Expected a gateway URL with query parameters to be rejected.' >&2
+  exit 1
+fi
+
+if bash "$validate_script" \
+  https://gateway.example.test/v1/responses \
+  unapproved-model \
+  "$guardrails" > /dev/null 2>&1; then
+  echo 'Expected an unapproved model to be rejected.' >&2
+  exit 1
+fi
+
+echo 'runtime-config tests passed'

--- a/.github/automations/scripts/check-mcp-tools.sh
+++ b/.github/automations/scripts/check-mcp-tools.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+endpoint=${1:?Pass the MCP endpoint as the first argument}
+shift
+
+if (( $# == 0 )); then
+  echo 'Pass at least one required MCP tool.' >&2
+  exit 1
+fi
+
+if [[ -n "${MCP_TOOLS_RESPONSE_FILE:-}" ]]; then
+  response=$(<"$MCP_TOOLS_RESPONSE_FILE")
+else
+  response=$(curl --fail-with-body --silent --show-error \
+    --request POST \
+    --header 'Content-Type: application/json' \
+    --header 'Accept: application/json, text/event-stream' \
+    --header 'mcp-protocol-version: 2026-07-28' \
+    --header 'mcp-method: tools/list' \
+    --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"eufemia-automation","version":"1.0.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}' \
+    "$endpoint")
+fi
+
+for tool in "$@"; do
+  if ! jq --exit-status --arg tool "$tool" \
+    'any(.result.tools[]?; .name == $tool)' <<< "$response" > /dev/null; then
+    echo "::error::The Eufemia MCP server is missing the required $tool tool."
+    exit 1
+  fi
+done

--- a/.github/automations/scripts/notification-utils.mjs
+++ b/.github/automations/scripts/notification-utils.mjs
@@ -1,0 +1,124 @@
+const markdownCharacters = new Set([
+  String.fromCharCode(96),
+  '*',
+  '_',
+  '[',
+  ']',
+  '#',
+])
+
+export const escapeMarkdown = (value) =>
+  Array.from(
+    String(value)
+      .replace(/\\/g, () => '\\\\')
+      .replace(/https?:\/\/[^\s<>"']+/g, '[external link omitted]')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;'),
+    (character) =>
+      character === '\n'
+        ? '<br>'
+        : markdownCharacters.has(character)
+          ? String.fromCharCode(92) + character
+          : character
+  ).join('')
+
+export const validateNotificationMarker = (marker) => {
+  if (!/^eufemia-automation:[a-z0-9-]+(?::[a-z0-9-]+)*$/.test(marker)) {
+    throw new Error('Automation notification marker is invalid')
+  }
+}
+
+export const notificationMarker = (marker) => {
+  validateNotificationMarker(marker)
+  return `<!-- ${marker} -->`
+}
+
+export const findAutomationComment = (comments, marker) => {
+  const expectedMarker = notificationMarker(marker)
+
+  return comments.find(
+    (comment) =>
+      comment.user?.login === 'github-actions[bot]' &&
+      String(comment.body).startsWith(`${expectedMarker}\n`)
+  )
+}
+
+export const findAutomationIssue = (issues, marker, title) => {
+  const expectedMarker = notificationMarker(marker)
+
+  return issues.find(
+    (issue) =>
+      !issue.pull_request &&
+      issue.user?.login === 'github-actions[bot]' &&
+      issue.title === title &&
+      String(issue.body).startsWith(`${expectedMarker}\n`)
+  )
+}
+
+const validateRunUrl = (runUrl, repository) => {
+  const url = new URL(runUrl)
+  const escapedRepository = repository.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    '\\$&'
+  )
+  const expectedPath = new RegExp(
+    `^/${escapedRepository}/actions/runs/\\d+$`
+  )
+
+  if (
+    url.origin !== 'https://github.com' ||
+    url.search ||
+    url.hash ||
+    !expectedPath.test(url.pathname)
+  ) {
+    throw new Error('Automation run URL is invalid')
+  }
+
+  return url.href
+}
+
+export const renderNotification = ({
+  marker,
+  repository,
+  report,
+  runUrl,
+  title,
+}) => {
+  const validatedRunUrl = validateRunUrl(runUrl, repository)
+  const lines = [
+    notificationMarker(marker),
+    `## ${escapeMarkdown(title)}`,
+    '',
+    `Status: **${escapeMarkdown(report.status)}**`,
+    '',
+    escapeMarkdown(report.summary),
+  ]
+
+  if (report.findings.length > 0) {
+    lines.push('', '### Findings')
+    for (const finding of report.findings.slice(0, 5)) {
+      lines.push(
+        '',
+        `- **${escapeMarkdown(finding.severity)}: ${escapeMarkdown(finding.title)}**`,
+        `  ${escapeMarkdown(finding.recommendation)}`
+      )
+    }
+    if (report.findings.length > 5) {
+      lines.push(
+        '',
+        `_Showing 5 of ${report.findings.length} findings. Open the run for the complete report._`
+      )
+    }
+  }
+
+  lines.push(
+    '',
+    `[Open the full automation report →](${validatedRunUrl})`,
+    '',
+    '_This notification is updated in place. The complete JSON report is stored as a workflow artifact._',
+    ''
+  )
+
+  return lines.join('\n')
+}

--- a/.github/automations/scripts/publish-notification.mjs
+++ b/.github/automations/scripts/publish-notification.mjs
@@ -1,0 +1,164 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  findAutomationComment,
+  findAutomationIssue,
+  validateNotificationMarker,
+} from './notification-utils.mjs'
+
+const [repository, targetKind, target, marker, title, status, bodyPath] =
+  process.argv.slice(2)
+const body = readFileSync(bodyPath, 'utf8')
+
+if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+  throw new Error('Repository is invalid')
+}
+if (targetKind !== 'pr' && targetKind !== 'issue') {
+  throw new Error('Notification target kind is invalid')
+}
+if (targetKind === 'issue' && target !== marker.split(':').at(-1)) {
+  throw new Error(
+    'Tracking issue target must match its notification marker'
+  )
+}
+if (
+  !title ||
+  title.length > 160 ||
+  !/^[A-Za-z0-9 .:_-]+$/.test(title) ||
+  title.includes('\n') ||
+  title.includes('\r')
+) {
+  throw new Error('Notification title is invalid')
+}
+if (!['ok', 'attention', 'blocked'].includes(status)) {
+  throw new Error('Notification status is invalid')
+}
+const bodyBytes = Buffer.byteLength(body, 'utf8')
+if (bodyBytes === 0 || bodyBytes > 60 * 1024) {
+  throw new Error('Notification body has an invalid size')
+}
+validateNotificationMarker(marker)
+
+const ghJson = (args) =>
+  JSON.parse(
+    execFileSync('gh', args, {
+      encoding: 'utf8',
+      maxBuffer: 5 * 1024 * 1024,
+    })
+  )
+const temporaryDirectory = mkdtempSync(
+  join(tmpdir(), 'automation-notify-')
+)
+const payloadPath = join(temporaryDirectory, 'payload.json')
+
+try {
+  if (targetKind === 'pr') {
+    if (!/^\d+$/.test(target) || Number(target) < 1) {
+      throw new Error('Pull request target is invalid')
+    }
+
+    const comments = ghJson([
+      'api',
+      '--paginate',
+      '--slurp',
+      `repos/${repository}/issues/${target}/comments?per_page=100`,
+    ]).flat()
+    const existing = findAutomationComment(comments, marker)
+    writeFileSync(payloadPath, JSON.stringify({ body }))
+    execFileSync(
+      'gh',
+      existing
+        ? [
+            'api',
+            '--method',
+            'PATCH',
+            `repos/${repository}/issues/comments/${existing.id}`,
+            '--input',
+            payloadPath,
+          ]
+        : [
+            'api',
+            '--method',
+            'POST',
+            `repos/${repository}/issues/${target}/comments`,
+            '--input',
+            payloadPath,
+          ],
+      { stdio: 'inherit' }
+    )
+  } else {
+    const issues = ghJson([
+      'api',
+      '--method',
+      'GET',
+      'search/issues',
+      '-f',
+      `q=repo:${repository} is:issue in:title ${title}`,
+      '-f',
+      'per_page=100',
+    ]).items
+    const existing = findAutomationIssue(issues, marker, title)
+
+    if (existing) {
+      writeFileSync(
+        payloadPath,
+        JSON.stringify({
+          body,
+          title,
+          state: status === 'ok' ? 'closed' : 'open',
+        })
+      )
+      execFileSync(
+        'gh',
+        [
+          'api',
+          '--method',
+          'PATCH',
+          `repos/${repository}/issues/${existing.number}`,
+          '--input',
+          payloadPath,
+        ],
+        { stdio: 'inherit' }
+      )
+    } else if (status !== 'ok') {
+      writeFileSync(payloadPath, JSON.stringify({ body, title }))
+      execFileSync(
+        'gh',
+        [
+          'api',
+          '--method',
+          'POST',
+          `repos/${repository}/issues`,
+          '--input',
+          payloadPath,
+        ],
+        { stdio: 'inherit' }
+      )
+    }
+
+    if (existing && status !== 'ok') {
+      writeFileSync(
+        payloadPath,
+        JSON.stringify({
+          body: 'A new automation result is available in the updated issue description.',
+        })
+      )
+      execFileSync(
+        'gh',
+        [
+          'api',
+          '--method',
+          'POST',
+          `repos/${repository}/issues/${existing.number}/comments`,
+          '--input',
+          payloadPath,
+        ],
+        { stdio: 'inherit' }
+      )
+    }
+  }
+} finally {
+  rmSync(temporaryDirectory, { recursive: true, force: true })
+}

--- a/.github/automations/scripts/render-notification.mjs
+++ b/.github/automations/scripts/render-notification.mjs
@@ -1,0 +1,11 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { renderNotification } from './notification-utils.mjs'
+
+const [reportPath, marker, repository, runUrl, title, outputPath] =
+  process.argv.slice(2)
+const report = JSON.parse(readFileSync(reportPath, 'utf8'))
+
+writeFileSync(
+  outputPath,
+  renderNotification({ marker, repository, report, runUrl, title })
+)

--- a/.github/automations/scripts/render-report.mjs
+++ b/.github/automations/scripts/render-report.mjs
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs'
+
+const reportPath = process.argv[2]
+const report = JSON.parse(readFileSync(reportPath, 'utf8'))
+const markdownCharacters = new Set([
+  String.fromCharCode(92),
+  String.fromCharCode(96),
+  '*',
+  '_',
+  '[',
+  ']',
+  '#',
+])
+const escapeMarkdown = (value) =>
+  Array.from(
+    String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;'),
+    (character) =>
+      character === '\n'
+        ? '<br>'
+        : markdownCharacters.has(character)
+          ? String.fromCharCode(92) + character
+          : character
+  ).join('')
+
+console.log('# ' + escapeMarkdown(report.title))
+console.log()
+console.log('Status: **' + escapeMarkdown(report.status) + '**')
+console.log()
+console.log(escapeMarkdown(report.summary))
+
+if (report.findings.length > 0) {
+  console.log()
+  console.log('## Findings')
+
+  for (const finding of report.findings) {
+    console.log()
+    console.log(
+      '### ' +
+        escapeMarkdown(finding.severity) +
+        ': ' +
+        escapeMarkdown(finding.title)
+    )
+    console.log()
+    console.log(escapeMarkdown(finding.evidence))
+    console.log()
+    console.log(
+      'Recommendation: ' + escapeMarkdown(finding.recommendation)
+    )
+  }
+}
+
+if (report.metrics.length > 0) {
+  console.log()
+  console.log('## Metrics')
+  console.log()
+
+  for (const metric of report.metrics) {
+    console.log(
+      '- ' +
+        escapeMarkdown(metric.name) +
+        ': ' +
+        escapeMarkdown(metric.value)
+    )
+  }
+}

--- a/.github/automations/scripts/validate-context.mjs
+++ b/.github/automations/scripts/validate-context.mjs
@@ -1,0 +1,58 @@
+import { lstatSync, readdirSync, readFileSync } from 'node:fs'
+import { extname, join, relative, resolve } from 'node:path'
+
+const [contextPath, guardrailsPath] = process.argv.slice(2)
+const contextRoot = resolve(contextPath)
+const guardrails = JSON.parse(readFileSync(guardrailsPath, 'utf8'))
+const { allowedExtensions, maxBytes, maxFiles } = guardrails.context
+const files = []
+let totalBytes = 0
+
+const visit = (directory) => {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = join(directory, entry.name)
+    const relativePath = relative(contextRoot, absolutePath)
+
+    if (
+      entry.isSymbolicLink() ||
+      lstatSync(absolutePath).isSymbolicLink()
+    ) {
+      throw new Error(`Context contains a symbolic link: ${relativePath}`)
+    }
+
+    if (entry.isDirectory()) {
+      visit(absolutePath)
+      continue
+    }
+
+    if (!entry.isFile()) {
+      throw new Error(
+        `Context contains an unsupported entry: ${relativePath}`
+      )
+    }
+
+    if (!allowedExtensions.includes(extname(entry.name).toLowerCase())) {
+      throw new Error(
+        `Context contains an unsupported file: ${relativePath}`
+      )
+    }
+
+    const size = lstatSync(absolutePath).size
+    totalBytes += size
+    files.push(relativePath)
+  }
+}
+
+visit(contextRoot)
+
+if (files.length > maxFiles) {
+  throw new Error(`Context contains more than ${maxFiles} files`)
+}
+
+if (totalBytes > maxBytes) {
+  throw new Error(`Context exceeds ${maxBytes} bytes`)
+}
+
+console.log(
+  `Validated ${files.length} context files (${totalBytes} bytes)`
+)

--- a/.github/automations/scripts/validate-report.mjs
+++ b/.github/automations/scripts/validate-report.mjs
@@ -1,0 +1,52 @@
+import { readFileSync, statSync } from 'node:fs'
+
+const [reportPath, guardrailsPath] = process.argv.slice(2)
+const report = JSON.parse(readFileSync(reportPath, 'utf8'))
+const guardrails = JSON.parse(readFileSync(guardrailsPath, 'utf8'))
+const maxBytes = guardrails.output.maxBytes
+const allowedStatuses = new Set(['ok', 'attention', 'blocked'])
+const allowedSeverities = new Set(['P1', 'P2', 'P3'])
+const assertString = (value, maxLength, label) => {
+  if (typeof value !== 'string' || value.length > maxLength) {
+    throw new Error(`${label} is invalid`)
+  }
+}
+
+if (statSync(reportPath).size > maxBytes) {
+  throw new Error(`Automation report exceeds ${maxBytes} bytes`)
+}
+
+if (report.findings.length > 20 || report.metrics.length > 20) {
+  throw new Error('Automation report exceeds item limits')
+}
+
+if (
+  !allowedStatuses.has(report.status) ||
+  !Array.isArray(report.findings) ||
+  !Array.isArray(report.metrics)
+) {
+  throw new Error('Automation report has an invalid shape')
+}
+assertString(report.title, 160, 'Report title')
+assertString(report.summary, 4000, 'Report summary')
+
+for (const finding of report.findings) {
+  if (
+    !allowedSeverities.has(finding.severity) ||
+    typeof finding !== 'object' ||
+    finding === null
+  ) {
+    throw new Error('Automation report contains an invalid finding')
+  }
+  assertString(finding.title, 200, 'Finding title')
+  assertString(finding.evidence, 2000, 'Finding evidence')
+  assertString(finding.recommendation, 2000, 'Finding recommendation')
+}
+
+for (const metric of report.metrics) {
+  if (typeof metric !== 'object' || metric === null) {
+    throw new Error('Automation report contains an invalid metric')
+  }
+  assertString(metric.name, 100, 'Metric name')
+  assertString(metric.value, 200, 'Metric value')
+}

--- a/.github/automations/scripts/validate-runtime-config.sh
+++ b/.github/automations/scripts/validate-runtime-config.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+gateway=${1:?Pass API_GATEWAY as the first argument}
+model=${2:?Pass MODEL as the second argument}
+guardrails_path=${3:?Pass the guardrails path as the third argument}
+
+jq --exit-status '.schemaVersion == 1' "$guardrails_path" > /dev/null
+
+# shellcheck disable=SC2016
+gateway_parts=$(node -e '
+  const url = new URL(process.argv[1])
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    process.exit(1)
+  }
+  process.stdout.write(`${url.hostname}\n${url.pathname}`)
+' "$gateway") || {
+  echo "::error::API_GATEWAY must be an HTTPS URL without credentials, query parameters, or a fragment."
+  exit 1
+}
+
+gateway_path=${gateway_parts#*$'\n'}
+
+allowed_path=$(jq --raw-output '.runtime.allowedGatewayPath' "$guardrails_path")
+if [[ "$gateway_path" != "$allowed_path" ]]; then
+  echo "::error::API_GATEWAY path must be $allowed_path."
+  exit 1
+fi
+
+if ! jq --exit-status --arg model "$model" \
+  '.runtime.allowedModels | index($model) != null' \
+  "$guardrails_path" > /dev/null; then
+  echo "::error::MODEL is not allowed by the automation guardrails: $model"
+  exit 1
+fi

--- a/.github/workflows/automation-notify.yml
+++ b/.github/workflows/automation-notify.yml
@@ -1,0 +1,75 @@
+name: Automation notifier
+
+on:
+  workflow_call:
+    inputs:
+      marker:
+        description: Stable hidden marker used to update the notification
+        required: true
+        type: string
+      report:
+        description: Validated structured automation report
+        required: true
+        type: string
+      target:
+        description: Pull request number or tracking issue identifier
+        required: true
+        type: string
+      target-kind:
+        description: Notification target, either pr or issue
+        required: true
+        type: string
+      title:
+        description: Human-readable notification title
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish human notification
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write # Update a PR conversation comment or tracking issue.
+
+    steps:
+      - name: Check out trusted notification tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate and publish notification
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: ${{ inputs.marker }}
+          REPORT: ${{ inputs.report }}
+          TARGET: ${{ inputs.target }}
+          TARGET_KIND: ${{ inputs.target-kind }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          printf '%s' "$REPORT" > "$RUNNER_TEMP/report.json"
+          node .github/automations/scripts/validate-report.mjs \
+            "$RUNNER_TEMP/report.json" \
+            .github/automations/guardrails.json
+          node .github/automations/scripts/render-notification.mjs \
+            "$RUNNER_TEMP/report.json" \
+            "$MARKER" \
+            "$GITHUB_REPOSITORY" \
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            "$TITLE" \
+            "$RUNNER_TEMP/notification.md"
+          status=$(jq --raw-output '.status' "$RUNNER_TEMP/report.json")
+          node .github/automations/scripts/publish-notification.mjs \
+            "$GITHUB_REPOSITORY" \
+            "$TARGET_KIND" \
+            "$TARGET" \
+            "$MARKER" \
+            "$TITLE" \
+            "$status" \
+            "$RUNNER_TEMP/notification.md"

--- a/.github/workflows/automation-run.yml
+++ b/.github/workflows/automation-run.yml
@@ -1,0 +1,161 @@
+name: Automation runner
+
+on:
+  workflow_call:
+    outputs:
+      report:
+        description: Validated structured automation report
+        value: ${{ jobs.analyze.outputs.report }}
+    inputs:
+      context-artifact:
+        description: Artifact containing event context
+        required: true
+        type: string
+      prompt-file:
+        description: Prompt filename under .github/automations/prompts
+        required: true
+        type: string
+      require-mcp:
+        description: Require Eufemia MCP during analysis
+        required: false
+        default: true
+        type: boolean
+      report-name:
+        description: Artifact and report identifier
+        required: true
+        type: string
+
+permissions:
+  actions: read # Download context produced by the caller workflow.
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze event
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: automation
+    outputs:
+      report: ${{ steps.codex.outputs.final-message }}
+
+    steps:
+      - name: Check out trusted automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare trusted automation files
+        env:
+          CODEX_HOME: ${{ runner.temp }}/automation-codex-home
+          PROMPT_FILE: ${{ inputs.prompt-file }}
+          REQUIRE_MCP: ${{ inputs.require-mcp }}
+          TRUSTED_DIR: ${{ runner.temp }}/automation-trusted
+        run: |
+          mkdir -p "$CODEX_HOME" "$TRUSTED_DIR"
+          if [ "$REQUIRE_MCP" = true ]; then
+            cp .github/automations/config.toml "$CODEX_HOME/config.toml"
+          else
+            cp .github/automations/config-no-mcp.toml "$CODEX_HOME/config.toml"
+          fi
+          cp .github/automations/guardrails.json "$TRUSTED_DIR/guardrails.json"
+          cp .github/automations/mcp-contract.json "$TRUSTED_DIR/mcp-contract.json"
+          cp .github/automations/report.schema.json "$TRUSTED_DIR/report.schema.json"
+          cp .github/automations/scripts/check-mcp-tools.sh "$TRUSTED_DIR/check-mcp-tools.sh"
+          cp .github/automations/scripts/validate-context.mjs "$TRUSTED_DIR/validate-context.mjs"
+          cp .github/automations/scripts/validate-runtime-config.sh "$TRUSTED_DIR/validate-runtime-config.sh"
+          cp ".github/automations/prompts/$PROMPT_FILE" "$TRUSTED_DIR/prompt.md"
+          cp AGENTS.md "$TRUSTED_DIR/AGENTS.md"
+
+      - name: Download event context
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.context-artifact }}
+          path: ${{ runner.temp }}/automation-context
+
+      - name: Prepare inspected context
+        run: |
+          node "$RUNNER_TEMP/automation-trusted/validate-context.mjs" \
+            "$RUNNER_TEMP/automation-context" \
+            "$RUNNER_TEMP/automation-trusted/guardrails.json"
+          rm -rf .agents .claude .codex .github/skills .automation-context AGENTS.md
+          find . \( -type f -o -type l \) \
+            \( -name AGENTS.md -o -name AGENTS.override.md \) -delete
+          cp "$RUNNER_TEMP/automation-trusted/AGENTS.md" AGENTS.md
+          cp -R "$RUNNER_TEMP/automation-context" .automation-context
+
+      - name: Enforce runtime guardrails
+        env:
+          API_GATEWAY: ${{ vars.API_GATEWAY }}
+          MODEL: ${{ vars.MODEL }}
+        run: |
+          bash "$RUNNER_TEMP/automation-trusted/validate-runtime-config.sh" \
+            "$API_GATEWAY" \
+            "$MODEL" \
+            "$RUNNER_TEMP/automation-trusted/guardrails.json"
+
+      - name: Verify Eufemia MCP tools
+        if: inputs.require-mcp
+        run: |
+          mapfile -t required_tools < <(
+            jq --raw-output '.requiredTools[]' \
+              "$RUNNER_TEMP/automation-trusted/mcp-contract.json"
+          )
+          bash "$RUNNER_TEMP/automation-trusted/check-mcp-tools.sh" \
+            https://server.eufemia.dnb.no/mcp/web \
+            "${required_tools[@]}"
+
+      - name: Run analysis
+        id: codex
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
+        with:
+          codex-home: ${{ runner.temp }}/automation-codex-home
+          codex-version: 0.149.1
+          codex-args: '["--ephemeral"]'
+          effort: medium
+          model: ${{ vars.MODEL }}
+          openai-api-key: ${{ secrets.SECRET_API_KEY }}
+          allow-bots: true
+          output-schema-file: ${{ runner.temp }}/automation-trusted/report.schema.json
+          permission-profile: automation-read-only
+          prompt-file: ${{ runner.temp }}/automation-trusted/prompt.md
+          responses-api-endpoint: ${{ vars.API_GATEWAY }}
+          safety-strategy: drop-sudo
+
+  publish:
+    name: Publish advisory report
+    needs: analyze
+    if: needs.analyze.outputs.report != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out report tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate and render report
+        env:
+          REPORT: ${{ needs.analyze.outputs.report }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/automation-report"
+          printf '%s' "$REPORT" > "$RUNNER_TEMP/automation-report/report.json"
+          node .github/automations/scripts/validate-report.mjs \
+            "$RUNNER_TEMP/automation-report/report.json" \
+            .github/automations/guardrails.json
+          node .github/automations/scripts/render-report.mjs \
+            "$RUNNER_TEMP/automation-report/report.json" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.report-name }}
+          path: ${{ runner.temp }}/automation-report/report.json
+          retention-days: 30

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-automation-foundation:
+    name: Validate automation foundation
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run automation tests
+        run: |
+          bash .github/automations/scripts/__tests__/check-mcp-tools.test.sh
+          bash .github/automations/scripts/__tests__/report.test.sh
+          bash .github/automations/scripts/__tests__/validate-runtime-config.test.sh
+          node .github/automations/scripts/__tests__/configuration.test.mjs
+          node .github/automations/scripts/__tests__/notification.test.mjs
+          node .github/automations/scripts/__tests__/validate-context.test.mjs
+
   check-pr-title:
     name: Validate PR title
 


### PR DESCRIPTION
## Motivation and why

Repository automations need one reviewed trust boundary instead of duplicating gateway access, MCP configuration, validation, reporting, and GitHub publishing in every workflow. This foundation adds a read-only shared runner, bounded context and output contracts, gateway guardrails, an update-in-place notification publisher, test coverage, and an operational runbook.

Model jobs remain read-only. Only notification jobs receive `issues: write`. Model-provided external URLs are omitted from public notifications, which show at most five findings and link to the full Actions report.

The repository variable `AUTOMATIONS_ENABLED` keeps every automation inert until the environment is ready and maintainers explicitly activate it.

## Merge readiness

- [ ] Approve the shared security and data-handling model.
- [ ] Approve update-in-place PR comments and dedicated tracking issues as the human notification model.
- [ ] Confirm the `automation` environment will be restricted to the default branch.
- [ ] Keep `AUTOMATIONS_ENABLED` unset or `false` while the stack is reviewed.

## Required before activation

- [ ] Add `SECRET_API_KEY`, `API_GATEWAY`, and `MODEL` to the `automation` environment.
- [ ] Confirm the gateway model is allowed by the repository guardrails.
- [ ] Confirm gateway logging, retention, quotas, and credential rotation ownership.
- [ ] Run one manual gateway and notification smoke test before setting `AUTOMATIONS_ENABLED=true`.