### PR TITLE
chore(Portal): add GitHub release changelog page

### DIFF
--- a/packages/dnb-design-system-portal/src/declaration.d.ts
+++ b/packages/dnb-design-system-portal/src/declaration.d.ts
@@ -46,3 +46,9 @@ declare module 'virtual:scroll-position' {
   }): void
   export function useScrollPosition(): void
 }
+
+declare module 'virtual:github-releases' {
+  import type { GitHubRelease } from '../vite/client/plugins/github-releases'
+
+  export const releases: GitHubRelease[]
+}

--- a/packages/dnb-design-system-portal/src/docs/uilib/changelog.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/changelog.mdx
@@ -1,0 +1,14 @@
+---
+title: "What's new"
+description: 'Release history for @dnb/eufemia.'
+hideInMenu: true
+---
+
+import { releases } from 'virtual:github-releases'
+import GitHubChangelog from './changelog/GitHubChangelog'
+
+# What's new
+
+The release history is generated from [Eufemia releases on GitHub](https://github.com/dnbexperience/eufemia/releases).
+
+<GitHubChangelog releases={releases} />

--- a/packages/dnb-design-system-portal/src/docs/uilib/changelog/GitHubChangelog.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/changelog/GitHubChangelog.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Button, Hr, P } from '@dnb/eufemia/src'
+import AutoLinkHeader from '../../../shared/tags/AutoLinkHeader'
+import { basicComponents } from '../../../shared/tags'
+import type { GitHubRelease } from '../../../../vite/client/plugins/github-releases'
+
+const pageSize = 10
+
+export function prepareReleaseNotes(body: string) {
+  return body
+    .replace(/^##\s+.*(?:\r?\n)+/, '')
+    .replace(/^###\s+:[^:\n]+:\s*/gm, '### ')
+}
+
+export function getReleaseType(release: GitHubRelease) {
+  if (release.prerelease) {
+    return 'Pre-release'
+  }
+
+  const patch = Number(release.tagName.match(/\d+\.\d+\.(\d+)/)?.[1])
+  return patch > 0 ? 'Patch release' : 'Feature release'
+}
+
+export default function GitHubChangelog({
+  releases,
+}: {
+  releases: GitHubRelease[]
+}) {
+  const [visibleCount, setVisibleCount] = useState(pageSize)
+  const visibleReleases = releases.slice(0, visibleCount)
+
+  return (
+    <section aria-label="Eufemia release history">
+      {visibleReleases.map((release, index) => (
+        <article key={release.tagName}>
+          {index > 0 && <Hr top="large" bottom="large" />}
+          <AutoLinkHeader level={2} useSlug={release.tagName}>
+            {release.name}
+          </AutoLinkHeader>
+          <P bottom="medium">
+            {new Intl.DateTimeFormat('en-US', {
+              dateStyle: 'long',
+              timeZone: 'UTC',
+            }).format(new Date(release.publishedAt))}
+            {' · '}
+            {getReleaseType(release)}
+          </P>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            // @ts-expect-error -- strictFunctionTypes
+            components={basicComponents}
+          >
+            {prepareReleaseNotes(release.body)}
+          </ReactMarkdown>
+        </article>
+      ))}
+
+      {visibleCount < releases.length && (
+        <Button
+          top="large"
+          variant="secondary"
+          icon="arrow_down"
+          text="Show more releases"
+          onClick={() => setVisibleCount((count) => count + pageSize)}
+        />
+      )}
+    </section>
+  )
+}

--- a/packages/dnb-design-system-portal/src/shared/parts/__tests__/GitHubChangelog.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/__tests__/GitHubChangelog.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { resetLevels } from '@dnb/eufemia/src/components/Heading'
+import GitHubChangelog, {
+  getReleaseType,
+  prepareReleaseNotes,
+} from '../../../docs/uilib/changelog/GitHubChangelog'
+import type { GitHubRelease } from '../../../../vite/client/plugins/github-releases'
+
+beforeEach(() => resetLevels(2))
+afterEach(cleanup)
+
+const releases: GitHubRelease[] = Array.from(
+  { length: 11 },
+  (_, index) => ({
+    body: `## [11.${index}.0](https://example.com) (2026-08-25)\n\n### :sparkles: Features\n\n* A release change`,
+    name: `v11.${index}.0`,
+    prerelease: false,
+    publishedAt: '2026-08-25T10:56:24Z',
+    tagName: `v11.${index}.0`,
+  })
+)
+
+describe('GitHubChangelog', () => {
+  it('reveals releases in batches', () => {
+    render(
+      <MemoryRouter>
+        <GitHubChangelog releases={releases} />
+      </MemoryRouter>
+    )
+
+    expect(document.querySelectorAll('article')).toHaveLength(10)
+
+    fireEvent.click(document.querySelector('button') as HTMLButtonElement)
+
+    expect(document.querySelectorAll('article')).toHaveLength(11)
+    expect(document.querySelector('button')).toBeNull()
+  })
+
+  it('prepares GitHub release notes for the portal', () => {
+    expect(prepareReleaseNotes(releases[0].body)).toBe(
+      '### Features\n\n* A release change'
+    )
+    expect(getReleaseType(releases[0])).toBe('Feature release')
+    expect(getReleaseType({ ...releases[0], tagName: 'v11.0.1' })).toBe(
+      'Patch release'
+    )
+  })
+})

--- a/packages/dnb-design-system-portal/vite.config.ts
+++ b/packages/dnb-design-system-portal/vite.config.ts
@@ -21,6 +21,7 @@ import scrollPositionPlugin from './vite/client/plugins/scroll-position'
 import preloadStylesPlugin from './vite/client/plugins/preload-styles'
 import testPageFilterPlugin from './vite/client/plugins/test-page-filter'
 import buildInfoPlugin from './vite/client/plugins/build-info'
+import githubReleasesPlugin from './vite/client/plugins/github-releases'
 import eufemiaPrebuildPlugin from './vite/client/plugins/eufemia-prebuild'
 import gitBranchPlugin from './vite/client/plugins/git-branch'
 import analyticsCollectDevPlugin from './vite/client/plugins/analytics-collect-dev'
@@ -135,6 +136,11 @@ export default defineConfig({
     withFilter(buildInfoPlugin(), {
       resolveId: { id: /^virtual:build-info$/ },
       load: { id: /virtual:build-info|buildInfo/ },
+    }),
+
+    withFilter(githubReleasesPlugin(), {
+      resolveId: { id: /^virtual:github-releases$/ },
+      load: { id: /virtual:github-releases/ },
     }),
 
     withFilter(loadJsAsJsxPlugin(), {

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/github-releases.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/github-releases.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import githubReleasesPlugin, {
+  fetchGitHubReleases,
+  parseGitHubChangelog,
+} from '../../client/plugins/github-releases'
+
+const changelog = `# Changelog
+
+## [11.11.0](https://github.com/dnbexperience/eufemia/compare/v11.10.1...v11.11.0) (2026-08-25)
+
+### :sparkles: Features
+
+* A release change
+
+## [11.10.1-beta.1](https://github.com/dnbexperience/eufemia/compare/v11.10.0...v11.10.1-beta.1) (2026-08-17)
+
+### :bug: Bug Fixes
+
+* Another release change
+
+## [11.11.0](https://github.com/dnbexperience/eufemia/compare/v11.10.1...v11.11.0) (2026-08-25)
+
+* Duplicate release entry
+`
+
+describe('github-releases plugin', () => {
+  it('parses the generated GitHub changelog', () => {
+    expect(parseGitHubChangelog(changelog)).toEqual([
+      {
+        body: '### :sparkles: Features\n\n* A release change',
+        name: 'v11.11.0',
+        prerelease: false,
+        publishedAt: '2026-08-25T00:00:00Z',
+        tagName: 'v11.11.0',
+      },
+      {
+        body: '### :bug: Bug Fixes\n\n* Another release change',
+        name: 'v11.10.1-beta.1',
+        prerelease: true,
+        publishedAt: '2026-08-17T00:00:00Z',
+        tagName: 'v11.10.1-beta.1',
+      },
+    ])
+  })
+
+  it('fetches the generated changelog from the release branch', async () => {
+    const fetchImplementation = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => changelog,
+    } as Response)
+
+    await expect(
+      fetchGitHubReleases(fetchImplementation)
+    ).resolves.toEqual(parseGitHubChangelog(changelog))
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/release/packages/dnb-eufemia/build/CHANGELOG.md'
+      )
+    )
+  })
+
+  it('resolves only its virtual module', () => {
+    const plugin = githubReleasesPlugin()
+    const resolveId = plugin.resolveId as (
+      id: string
+    ) => string | undefined
+
+    expect(resolveId('virtual:github-releases')).toBe(
+      '\0virtual:github-releases'
+    )
+    expect(resolveId('other-module')).toBeUndefined()
+  })
+})

--- a/packages/dnb-design-system-portal/vite/client/plugins/github-releases.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/github-releases.ts
@@ -1,0 +1,80 @@
+import type { Plugin } from 'vite'
+
+const VIRTUAL_MODULE_ID = 'virtual:github-releases'
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`
+const changelogUrl =
+  'https://raw.githubusercontent.com/dnbexperience/eufemia/release/packages/dnb-eufemia/build/CHANGELOG.md'
+
+export type GitHubRelease = {
+  body: string
+  name: string
+  prerelease: boolean
+  publishedAt: string
+  tagName: string
+}
+
+const releaseHeading =
+  /^## \[([^\]]+)\]\([^\n]+\) \((\d{4}-\d{2}-\d{2})\)\s*$/gm
+
+export function parseGitHubChangelog(changelog: string) {
+  const headings = Array.from(changelog.matchAll(releaseHeading))
+  const versions = new Set<string>()
+
+  return headings.flatMap((heading, index): GitHubRelease[] => {
+    const version = heading[1]
+    if (versions.has(version)) {
+      return []
+    }
+    versions.add(version)
+
+    const bodyStart = heading.index + heading[0].length
+    const bodyEnd = headings[index + 1]?.index ?? changelog.length
+
+    return [
+      {
+        body: changelog.slice(bodyStart, bodyEnd).trim(),
+        name: `v${version}`,
+        prerelease: version.includes('-'),
+        publishedAt: `${heading[2]}T00:00:00Z`,
+        tagName: `v${version}`,
+      },
+    ]
+  })
+}
+
+export async function fetchGitHubReleases(
+  fetchImplementation: typeof fetch = fetch
+): Promise<GitHubRelease[]> {
+  const response = await fetchImplementation(changelogUrl)
+
+  if (!response.ok) {
+    throw new Error(
+      `Unable to load GitHub changelog (${response.status} ${response.statusText})`
+    )
+  }
+
+  return parseGitHubChangelog(await response.text())
+}
+
+export default function githubReleasesPlugin(): Plugin {
+  let releasesPromise: Promise<GitHubRelease[]> | undefined
+
+  return {
+    name: 'vite-plugin-github-releases',
+
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) {
+        return RESOLVED_VIRTUAL_MODULE_ID
+      }
+    },
+
+    async load(id) {
+      if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+        releasesPromise ||= fetchGitHubReleases()
+        const releases = await releasesPromise
+
+        return `export const releases = ${JSON.stringify(releases)}`
+      }
+    },
+  }
+}

--- a/tools/eufemia-llm-metadata/scripts/__tests__/githubChangelog.test.ts
+++ b/tools/eufemia-llm-metadata/scripts/__tests__/githubChangelog.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { createGitHubChangelogExtension } from '../../src/extensions/mdx/githubChangelog.ts'
+
+describe('GitHubChangelog MDX extension', () => {
+  it('replaces the component with the release archive link', () => {
+    const extension = createGitHubChangelogExtension()
+
+    expect(
+      extension.replace('<GitHubChangelog releases={releases} />')
+    ).toBe(
+      '[View all Eufemia releases on GitHub](https://github.com/dnbexperience/eufemia/releases)'
+    )
+  })
+})

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/githubChangelog.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/githubChangelog.ts
@@ -1,0 +1,12 @@
+import type { SpecialMdxComponentRenderer } from './types.ts'
+
+export function createGitHubChangelogExtension(): SpecialMdxComponentRenderer {
+  return {
+    name: 'GitHubChangelog',
+    replace: (content) =>
+      content.replace(
+        /<GitHubChangelog\b[^>]*\/>/g,
+        '[View all Eufemia releases on GitHub](https://github.com/dnbexperience/eufemia/releases)'
+      ),
+  }
+}

--- a/tools/eufemia-llm-metadata/src/extensions/mdx/registry.ts
+++ b/tools/eufemia-llm-metadata/src/extensions/mdx/registry.ts
@@ -1,6 +1,7 @@
 import { createAvailableCountriesTableExtension } from './availableCountriesTable.ts'
 import { createCardProductsTableExtension } from './cardProductsTable.ts'
 import { createColorTableExtension } from './colorTable.ts'
+import { createGitHubChangelogExtension } from './githubChangelog.ts'
 import { createListAllIconsExtension } from './listAllIcons.ts'
 import { createListComponentsOverviewExtension } from './listComponentsOverview.ts'
 import { createListSummaryFromEdgesExtension } from './listSummaryFromEdges.ts'
@@ -35,6 +36,7 @@ function createSpecialMdxExtensions(
     createTokenSectionTableExtension(deps),
     createRadiusTokenTableExtension(deps),
     createColorTableExtension(deps),
+    createGitHubChangelogExtension(),
     createListSummaryFromEdgesExtension(deps),
     createListComponentsOverviewExtension(deps),
     createRelatedComponentsExtension(deps),


### PR DESCRIPTION
Adds a dedicated `/uilib/changelog/` ([preview](https://feat-portal-github-changelog.eufemia-e25.pages.dev/uilib/changelog/)) page sourced from the generated GitHub changelog on the release branch. This gives developers a current, release history in the portal without depending on the GitHub API at runtime or build time.

Its not listed in the menu yet. We will do this in the new sidebar menu.