### PR TITLE
chore(build): parallelize cjs/es/esm library compilation

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/postbuild.sh
+++ b/packages/dnb-eufemia/scripts/postbuild/postbuild.sh
@@ -6,13 +6,23 @@ echo 'Postbuild started ...'
 
 yarn build:types:definitions
 yarn prettier:other:write
-yarn build:cjs
+
+# The cjs/es/esm Babel passes only read ./src and each writes to its own
+# ./build/<target> dir, so run them concurrently to cut build time. set -e does
+# not catch background failures, so wait on every PID and let a non-zero exit
+# propagate.
+babel_pids=()
+yarn build:cjs & babel_pids+=($!)
+yarn build:esm & babel_pids+=($!)
 if [ -z "$BUILD_MINI" ]; then
-  yarn build:es
-  yarn build:esm
+  yarn build:es & babel_pids+=($!)
+fi
+for pid in "${babel_pids[@]}"; do
+  wait "$pid"
+done
+
+if [ -z "$BUILD_MINI" ]; then
   yarn build:docs
-else
-  yarn build:esm
 fi
 yarn build:lebab
 yarn build:skills


### PR DESCRIPTION
## Why

The library `postbuild` runs the cjs, es and esm Babel passes sequentially
(~80–100s of the e2e and build-check jobs). Each only reads `src` and writes to
its own `build/<target>` directory, so they don't need to run one at a time.

## What

Run the three Babel passes concurrently, waiting on each PID so a failure still
fails the build (`set -e` does not catch background jobs). Verified locally: the
output is byte-for-byte identical to the sequential build (27044 files, same
sizes), and a deliberately failing pass still exits non-zero.
