### PR TITLE
chore(CI): skip e2e library build on feature branches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,8 +26,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# No job-wide `env:` on purpose: only the public Algolia search config is
-# needed, and it is scoped to the portal build step (least privilege).
+env:
+  # Non-secret build flag only; the public Algolia search config stays scoped
+  # to the portal build step (least privilege). Feature branches skip the
+  # library build and test source (like visual-regression); main and v* test dist.
+  RUN_POST_BUILD: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/v') }}
 
 jobs:
   e2e:
@@ -65,9 +68,11 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Prebuild Library
+        if: env.RUN_POST_BUILD == 'true'
         run: yarn workspace @dnb/eufemia prebuild:ci
 
       - name: Postbuild Library
+        if: env.RUN_POST_BUILD == 'true'
         run: yarn workspace @dnb/eufemia postbuild:ci
 
       - name: Build portal


### PR DESCRIPTION
Feature branches now run e2e against the Eufemia **source** instead of building the library first — the same thing visual-regression already does with `RUN_POST_BUILD`. `main` and `v*` still build and test the compiled dist.

**Why:** the library build (prebuild + postbuild) runs on every e2e push today, but the portal resolves the source directly when no `build/` exists. The compiled dist is already built and checked on every PR by `build-check` (build + `test:postbuild` + bundlesize), so gating it here only skips a redundant build. Build-output regressions are still caught by `build-check`, and e2e covers the dist end-to-end on `main`/`v*`.
