### PR TITLE
fix(Typography): align iOS Dynamic Type tokens

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -60,14 +60,15 @@ Type scaling curve. This would make iOS smaller than desktop by default and
 change the difference at larger accessibility sizes. It would also reduce all
 root-relative layout values.
 
-### Possible future improvements
+### Possible typography-token adjustment
 
-One option is to keep Apple's `Body` style and scale the resulting text by `16
-/ 17` with an iOS-only `text-size-adjust`. This produces an 18px DNB basis size
-at the default setting while retaining the `Body` Dynamic Type curve. It also
-keeps root-relative layout values at their current iOS sizes. Before using this
-as a framework default, it needs real-device testing across all text-size
-settings, nested typography, form controls, and representative layouts.
+One option is to keep Apple's `Body` style and scale Eufemia's typography tokens
+by `16 / 17`. This produces an 18px DNB basis size at the default setting while
+retaining the `Body` Dynamic Type curve. Component dimensions, spacing, and
+radii keep their current iOS sizes. Before using this as a framework default,
+it needs real-device testing across all text-size settings and representative
+layouts. Custom text that does not use Eufemia's typography tokens is not
+adjusted.
 
 The longer-term option is the standard
 [`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)

--- a/packages/dnb-eufemia/src/elements/typography/style/dnb-typography.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/dnb-typography.scss
@@ -5,6 +5,7 @@
 
 @use 'sass:meta';
 @use '../../../style/elements/ui-spacing.scss';
+@use '../../../style/core/typography.scss' as typography;
 @use './typography-mixins.scss';
 
 @include typography-mixins.typographySelectors() {
@@ -94,6 +95,12 @@
   --typography-h-x-small-font-family: var(--font-family-default);
 
   @include typography-mixins.responsiveTypographyVariables();
+
+  @include typography.ios-dynamic-type() {
+    @include typography-mixins.responsiveTypographyVariables(
+      typography.$ios-dynamic-type-scale
+    );
+  }
 }
 
 @include typography-mixins.headingClasses() {

--- a/packages/dnb-eufemia/src/elements/typography/style/typography-mixins.scss
+++ b/packages/dnb-eufemia/src/elements/typography/style/typography-mixins.scss
@@ -1,4 +1,5 @@
 @use '../../../components/space/style/space-mixins.scss' as space-mixins;
+@use '../../../style/core/typography.scss' as typography;
 @use '../../../style/core/utilities.scss' as utilities;
 
 // Global sizes
@@ -19,6 +20,72 @@ $t-lh-md: 1.5rem; // 24px --line-height-medium
 $t-lh-lg: 2rem; // 32px --line-height-large
 $t-lh-xl: 2.5rem; // 40px --line-height-x-large
 $t-lh-2xl: 3.5rem; // 56px --line-height-xx-large
+
+@mixin responsiveTypographyValues(
+  $fontSizeXSmall,
+  $fontSizeSmall,
+  $fontSizeBasis,
+  $fontSizeMedium,
+  $fontSizeLarge,
+  $fontSizeXLarge,
+  $fontSizeXxLarge,
+  $lineHeightXSmall,
+  $lineHeightSmall,
+  $lineHeightBasis,
+  $lineHeightMedium,
+  $lineHeightLarge,
+  $lineHeightXLarge,
+  $lineHeightXxLarge,
+  $scale: 1
+) {
+  --responsive-font-size-x-small: #{typography.scale(
+      $fontSizeXSmall,
+      $scale
+    )};
+  --responsive-font-size-small: #{typography.scale($fontSizeSmall, $scale)};
+  --responsive-font-size-basis: #{typography.scale($fontSizeBasis, $scale)};
+  --responsive-font-size-medium: #{typography.scale(
+      $fontSizeMedium,
+      $scale
+    )};
+  --responsive-font-size-large: #{typography.scale($fontSizeLarge, $scale)};
+  --responsive-font-size-x-large: #{typography.scale(
+      $fontSizeXLarge,
+      $scale
+    )};
+  --responsive-font-size-xx-large: #{typography.scale(
+      $fontSizeXxLarge,
+      $scale
+    )};
+  --responsive-line-height-x-small: #{typography.scale(
+      $lineHeightXSmall,
+      $scale
+    )};
+  --responsive-line-height-small: #{typography.scale(
+      $lineHeightSmall,
+      $scale
+    )};
+  --responsive-line-height-basis: #{typography.scale(
+      $lineHeightBasis,
+      $scale
+    )};
+  --responsive-line-height-medium: #{typography.scale(
+      $lineHeightMedium,
+      $scale
+    )};
+  --responsive-line-height-large: #{typography.scale(
+      $lineHeightLarge,
+      $scale
+    )};
+  --responsive-line-height-x-large: #{typography.scale(
+      $lineHeightXLarge,
+      $scale
+    )};
+  --responsive-line-height-xx-large: #{typography.scale(
+      $lineHeightXxLarge,
+      $scale
+    )};
+}
 
 // includes all classes, tags, etc. needed for "global" typography rules (like css variables)
 @mixin typographySelectors() {
@@ -324,66 +391,68 @@ $t-lh-2xl: 3.5rem; // 56px --line-height-xx-large
   }
 }
 
-@mixin responsiveTypographyVariables() {
+@mixin responsiveTypographyVariables($scale: 1) {
   @include utilities.allBelow(small) {
     // mobile
-    // font-size
-    --responsive-font-size-x-small: #{$t-fs-2xs};
-    --responsive-font-size-small: #{$t-fs-xs};
-    --responsive-font-size-basis: #{$t-fs-sm};
-    --responsive-font-size-medium: #{$t-fs-bs};
-    --responsive-font-size-large: #{$t-fs-md};
-    --responsive-font-size-x-large: #{$t-fs-lg};
-    --responsive-font-size-xx-large: #{$t-fs-xl};
-
-    // line-height
-    --responsive-line-height-x-small: #{$t-lh-xs};
-    --responsive-line-height-small: #{$t-lh-xs};
-    --responsive-line-height-basis: #{$t-lh-sm};
-    --responsive-line-height-medium: #{$t-lh-md};
-    --responsive-line-height-large: #{$t-lh-lg};
-    --responsive-line-height-x-large: #{$t-lh-lg};
-    --responsive-line-height-xx-large: #{$t-lh-lg};
+    @include responsiveTypographyValues(
+      $t-fs-2xs,
+      $t-fs-xs,
+      $t-fs-sm,
+      $t-fs-bs,
+      $t-fs-md,
+      $t-fs-lg,
+      $t-fs-xl,
+      $t-lh-xs,
+      $t-lh-xs,
+      $t-lh-sm,
+      $t-lh-md,
+      $t-lh-lg,
+      $t-lh-lg,
+      $t-lh-lg,
+      $scale
+    );
   }
 
   @include utilities.allBetween(small, medium) {
     // tablet
-    --responsive-font-size-x-small: #{$t-fs-xs};
-    --responsive-font-size-small: #{$t-fs-sm};
-    --responsive-font-size-basis: #{$t-fs-bs};
-    --responsive-font-size-medium: #{$t-fs-md};
-    --responsive-font-size-large: #{$t-fs-lg};
-    --responsive-font-size-x-large: #{$t-fs-xl};
-    --responsive-font-size-xx-large: #{$t-fs-2xl};
-
-    // line-height
-    --responsive-line-height-x-small: #{$t-lh-xs};
-    --responsive-line-height-small: #{$t-lh-sm};
-    --responsive-line-height-basis: #{$t-lh-bs};
-    --responsive-line-height-medium: #{$t-lh-md};
-    --responsive-line-height-large: #{$t-lh-lg};
-    --responsive-line-height-x-large: #{$t-lh-xl};
-    --responsive-line-height-xx-large: #{$t-lh-xl};
+    @include responsiveTypographyValues(
+      $t-fs-xs,
+      $t-fs-sm,
+      $t-fs-bs,
+      $t-fs-md,
+      $t-fs-lg,
+      $t-fs-xl,
+      $t-fs-2xl,
+      $t-lh-xs,
+      $t-lh-sm,
+      $t-lh-bs,
+      $t-lh-md,
+      $t-lh-lg,
+      $t-lh-xl,
+      $t-lh-xl,
+      $scale
+    );
   }
 
   @include utilities.allAbove(medium) {
     // desktop
-    --responsive-font-size-x-small: #{$t-fs-xs};
-    --responsive-font-size-small: #{$t-fs-sm};
-    --responsive-font-size-basis: #{$t-fs-bs};
-    --responsive-font-size-medium: #{$t-fs-md};
-    --responsive-font-size-large: #{$t-fs-lg};
-    --responsive-font-size-x-large: #{$t-fs-xl};
-    --responsive-font-size-xx-large: #{$t-fs-2xl};
-
-    // line-height
-    --responsive-line-height-x-small: #{$t-lh-xs};
-    --responsive-line-height-small: #{$t-lh-sm};
-    --responsive-line-height-basis: #{$t-lh-bs};
-    --responsive-line-height-medium: #{$t-lh-md};
-    --responsive-line-height-large: #{$t-lh-lg};
-    --responsive-line-height-x-large: #{$t-lh-xl};
-    --responsive-line-height-xx-large: #{$t-lh-2xl};
+    @include responsiveTypographyValues(
+      $t-fs-xs,
+      $t-fs-sm,
+      $t-fs-bs,
+      $t-fs-md,
+      $t-fs-lg,
+      $t-fs-xl,
+      $t-fs-2xl,
+      $t-lh-xs,
+      $t-lh-sm,
+      $t-lh-bs,
+      $t-lh-md,
+      $t-lh-lg,
+      $t-lh-xl,
+      $t-lh-2xl,
+      $scale
+    );
   }
 }
 

--- a/packages/dnb-eufemia/src/style/__tests__/TypographyTokens.test.ts
+++ b/packages/dnb-eufemia/src/style/__tests__/TypographyTokens.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { loadScss } from '../../core/test-utils/testSetup'
+
+describe('Typography tokens', () => {
+  it('corrects iOS typography without changing geometry tokens', () => {
+    const completeCss = loadScss(require.resolve('../index.scss'))
+
+    expect(completeCss).toContain('--font-size-basis: 1.125rem')
+    expect(completeCss).toContain('--line-height-basis: 1.5rem')
+    expect(completeCss).toContain(`
+@supports (-webkit-touch-callout: none) {
+  @supports (font: -apple-system-body) {
+    :root {
+      --font-size-xx-small: 0.7647058824rem;
+      --font-size-x-small: 0.8235294118rem;
+      --font-size-small: 0.9411764706rem;
+      --font-size-basis: 1.0588235294rem;
+      --font-size-medium: 1.1764705882rem;
+      --font-size-large: 1.5294117647rem;
+      --font-size-x-large: 2rem;
+      --font-size-xx-large: 2.8235294118rem;
+      --line-height-x-small: 1.1764705882rem;
+      --line-height-small: 1.1764705882rem;
+      --line-height-basis: 1.4117647059rem;
+      --line-height-medium: 1.4117647059rem;
+      --line-height-large: 1.8823529412rem;
+      --line-height-x-large: 2.3529411765rem;
+      --line-height-xx-large: 3.2941176471rem;
+    }
+  }
+}`)
+    expect(completeCss).toContain('--spacing-small: 1rem')
+    expect(completeCss).toContain('--button-height: 2.5rem')
+    expect(completeCss).toContain('--input-height: 2rem')
+    expect(completeCss).toContain(
+      '--responsive-font-size-basis: 0.9411764706rem'
+    )
+    expect(completeCss).toContain(
+      '--responsive-line-height-basis: 1.1764705882rem'
+    )
+  })
+})

--- a/packages/dnb-eufemia/src/style/core/typography.scss
+++ b/packages/dnb-eufemia/src/style/core/typography.scss
@@ -1,0 +1,19 @@
+@use 'sass:math';
+
+$ios-dynamic-type-scale: math.div(16, 17);
+
+@function ios-scale($value) {
+  @return $value * $ios-dynamic-type-scale;
+}
+
+@function scale($value, $factor: 1) {
+  @return $value * $factor;
+}
+
+@mixin ios-dynamic-type() {
+  @supports (-webkit-touch-callout: none) {
+    @supports (font: -apple-system-body) {
+      @content;
+    }
+  }
+}

--- a/packages/dnb-eufemia/src/style/themes/shared-globals.scss
+++ b/packages/dnb-eufemia/src/style/themes/shared-globals.scss
@@ -2,6 +2,8 @@
  *  Shared global rules across all themes.
  */
 
+@use '../core/typography.scss' as typography;
+
 :root,
 .eufemia-theme {
   // Scrollbar
@@ -12,4 +14,24 @@
   --scrollbar-thumb-hover-color: var(
     --token-color-background-action-hover
   );
+}
+
+@include typography.ios-dynamic-type() {
+  :root {
+    --font-size-xx-small: #{typography.ios-scale(0.8125rem)};
+    --font-size-x-small: #{typography.ios-scale(0.875rem)};
+    --font-size-small: #{typography.ios-scale(1rem)};
+    --font-size-basis: #{typography.ios-scale(1.125rem)};
+    --font-size-medium: #{typography.ios-scale(1.25rem)};
+    --font-size-large: #{typography.ios-scale(1.625rem)};
+    --font-size-x-large: #{typography.ios-scale(2.125rem)};
+    --font-size-xx-large: #{typography.ios-scale(3rem)};
+    --line-height-x-small: #{typography.ios-scale(1.25rem)};
+    --line-height-small: #{typography.ios-scale(1.25rem)};
+    --line-height-basis: #{typography.ios-scale(1.5rem)};
+    --line-height-medium: #{typography.ios-scale(1.5rem)};
+    --line-height-large: #{typography.ios-scale(2rem)};
+    --line-height-x-large: #{typography.ios-scale(2.5rem)};
+    --line-height-xx-large: #{typography.ios-scale(3.5rem)};
+  }
 }


### PR DESCRIPTION
Stacked on #9147.

Prototype an iOS-only `16 / 17` correction for Eufemia's font-size and line-height tokens while leaving component geometry, spacing, radii, and icon sizes unchanged. This preserves Dynamic Type and keeps round controls proportional.

Custom raw `rem` text and a few bespoke component font values remain outside the token correction and need review before this is ready.