### PR TITLE
chore(analytics): fetch dashboard data from the protected API

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -79,11 +79,13 @@ jobs:
 
       - name: Audit dependencies
         # Audit the shipped (production) dependency tree of everything we ship:
-        # the @dnb/eufemia npm library and the @dnb/eufemia-mcp Lambda. Both must
-        # pass; dev/build tooling advisories are tracked via Dependabot instead.
+        # the @dnb/eufemia npm library, the @dnb/eufemia-mcp Lambda and the
+        # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
+        # are tracked via Dependabot instead.
         run: |
           yarn workspace @dnb/eufemia audit:ci
           yarn workspace @dnb/eufemia-mcp audit:ci
+          yarn workspace eufemia-analytics audit:ci
 
       - name: Verify SBOM + audit generation (release smoke test)
         # release.yml generates a CycloneDX SBOM and a vulnerability report after
@@ -175,6 +177,7 @@ jobs:
           yarn workspace @dnb/eufemia lint:ci
           yarn workspace @dnb/eufemia-mcp-legacy-proxy lint
           yarn workspace eufemia-raiwork-plugin lint
+          yarn workspace eufemia-analytics lint
 
   lint-portal:
     name: Run portal lint
@@ -246,6 +249,7 @@ jobs:
           yarn workspace eufemia-llm-metadata test:types
           yarn workspace eufemia-raiwork-plugin test:types
           yarn workspace @dnb/eufemia-mcp-legacy-proxy typecheck
+          yarn workspace eufemia-analytics test:types
 
   test:
     name: Run tests
@@ -285,6 +289,7 @@ jobs:
           yarn workspace eufemia-llm-metadata test
           yarn workspace eufemia-raiwork-plugin test
           yarn workspace @dnb/eufemia-mcp-legacy-proxy test
+          yarn workspace eufemia-analytics test
 
   deps:
     name: Run dependency checks

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -63,6 +63,25 @@ describe('auth retry guard', () => {
   })
 })
 
+describe('clearSession', () => {
+  beforeEach(() => {
+    globalThis.sessionStorage = new MemoryStorage()
+  })
+
+  afterEach(() => {
+    delete globalThis.sessionStorage
+  })
+
+  it('removes the stored session', () => {
+    sessionStorage.setItem(
+      'eufemia-analytics-session',
+      '{"name":"Signed in"}'
+    )
+    clearSession()
+    expect(sessionStorage.getItem('eufemia-analytics-session')).toBe(null)
+  })
+})
+
 describe('loadDashboardData', () => {
   const session = { accessToken: 'token-abc' }
 

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  scopes,
+  beginAuthRetry,
+  clearAuthRetry,
+  clearSession,
+} from '../dashboard/auth.js'
+
+class MemoryStorage {
+  store = new Map()
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null
+  }
+
+  setItem(key, value) {
+    this.store.set(key, String(value))
+  }
+
+  removeItem(key) {
+    this.store.delete(key)
+  }
+}
+
+describe('scopes', () => {
+  it('returns the base scope when no API scope is configured', () => {
+    expect(scopes({})).toBe('openid profile email')
+  })
+
+  it('appends the API scope when configured', () => {
+    expect(scopes({ apiScope: 'api://app-id/Dashboard.Read' })).toBe(
+      'openid profile email api://app-id/Dashboard.Read'
+    )
+  })
+})
+
+describe('auth retry guard', () => {
+  beforeEach(() => {
+    globalThis.sessionStorage = new MemoryStorage()
+  })
+
+  afterEach(() => {
+    delete globalThis.sessionStorage
+  })
+
+  it('allows a single retry, then blocks further attempts', () => {
+    expect(beginAuthRetry()).toBe(true)
+    expect(beginAuthRetry()).toBe(false)
+    expect(beginAuthRetry()).toBe(false)
+  })
+
+  it('allows a retry again after the marker is cleared', () => {
+    expect(beginAuthRetry()).toBe(true)
+    clearAuthRetry()
+    expect(beginAuthRetry()).toBe(true)
+  })
+
+  it('keeps the retry marker when only the session is cleared', () => {
+    expect(beginAuthRetry()).toBe(true)
+    clearSession()
+    expect(beginAuthRetry()).toBe(false)
+  })
+})

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -4,6 +4,7 @@ import {
   beginAuthRetry,
   clearAuthRetry,
   clearSession,
+  readSession,
 } from '../dashboard/auth.js'
 import { loadDashboardData } from '../dashboard/app.js'
 
@@ -79,6 +80,56 @@ describe('clearSession', () => {
     )
     clearSession()
     expect(sessionStorage.getItem('eufemia-analytics-session')).toBe(null)
+  })
+})
+
+describe('readSession', () => {
+  const SESSION_KEY = 'eufemia-analytics-session'
+  const future = Date.now() + 60000
+
+  beforeEach(() => {
+    globalThis.sessionStorage = new MemoryStorage()
+  })
+
+  afterEach(() => {
+    delete globalThis.sessionStorage
+  })
+
+  it('returns a non-expired session that carries an access token', () => {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({
+        name: 'Signed in',
+        accessToken: 'token-abc',
+        expiresAt: future,
+      })
+    )
+
+    expect(readSession()).toMatchObject({ accessToken: 'token-abc' })
+  })
+
+  it('rejects and clears a session without an access token', () => {
+    // A session shape persisted by an older build: no accessToken.
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ name: 'Signed in', expiresAt: future })
+    )
+
+    expect(readSession()).toBe(null)
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe(null)
+  })
+
+  it('rejects an expired session even with an access token', () => {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({
+        name: 'Signed in',
+        accessToken: 'token-abc',
+        expiresAt: Date.now() - 1000,
+      })
+    )
+
+    expect(readSession()).toBe(null)
   })
 })
 

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -5,6 +5,7 @@ import {
   clearAuthRetry,
   clearSession,
 } from '../dashboard/auth.js'
+import { loadDashboardData } from '../dashboard/app.js'
 
 class MemoryStorage {
   store = new Map()
@@ -59,5 +60,118 @@ describe('auth retry guard', () => {
     expect(beginAuthRetry()).toBe(true)
     clearSession()
     expect(beginAuthRetry()).toBe(false)
+  })
+})
+
+describe('loadDashboardData', () => {
+  const session = { accessToken: 'token-abc' }
+
+  beforeEach(() => {
+    globalThis.sessionStorage = new MemoryStorage()
+  })
+
+  afterEach(() => {
+    delete globalThis.sessionStorage
+    delete globalThis.fetch
+  })
+
+  it('returns the empty state when there is no session', async () => {
+    expect(await loadDashboardData(null, 'https://api.example')).toEqual({
+      kind: 'empty',
+    })
+  })
+
+  it('returns the empty state when no API base URL is configured', async () => {
+    expect(await loadDashboardData(session, '')).toEqual({ kind: 'empty' })
+  })
+
+  it('sends the access token and returns fetched records', async () => {
+    let captured
+    globalThis.fetch = async (url, options) => {
+      captured = { url, options }
+
+      return {
+        status: 200,
+        ok: true,
+        json: async () => ({ records: [{ id: 1 }] }),
+      }
+    }
+
+    const result = await loadDashboardData(session, 'https://api.example')
+
+    expect(captured.url).toBe('https://api.example/data')
+    expect(captured.options.headers.Authorization).toBe('Bearer token-abc')
+    expect(result).toEqual({
+      kind: 'data',
+      payload: { records: [{ id: 1 }] },
+    })
+  })
+
+  it('clears the retry marker after a successful fetch', async () => {
+    beginAuthRetry()
+    globalThis.fetch = async () => ({
+      status: 200,
+      ok: true,
+      json: async () => ({}),
+    })
+
+    await loadDashboardData(session, 'https://api.example')
+
+    // Marker cleared, so a later rejection is allowed to retry again.
+    expect(beginAuthRetry()).toBe(true)
+  })
+
+  it('allows one retry on 401, then reports rejection', async () => {
+    globalThis.fetch = async () => ({ status: 401, ok: false })
+
+    expect(
+      await loadDashboardData(session, 'https://api.example')
+    ).toEqual({
+      kind: 'retry',
+    })
+    expect(
+      await loadDashboardData(session, 'https://api.example')
+    ).toEqual({
+      kind: 'rejected',
+    })
+  })
+
+  it('reports an error for a non-ok, non-401 status', async () => {
+    globalThis.fetch = async () => ({ status: 403, ok: false })
+
+    expect(
+      await loadDashboardData(session, 'https://api.example')
+    ).toEqual({
+      kind: 'error',
+      status: 403,
+    })
+  })
+
+  it('returns the empty state when the body is malformed', async () => {
+    globalThis.fetch = async () => ({
+      status: 200,
+      ok: true,
+      json: async () => {
+        throw new Error('invalid json')
+      },
+    })
+
+    expect(
+      await loadDashboardData(session, 'https://api.example')
+    ).toEqual({
+      kind: 'empty',
+    })
+  })
+
+  it('returns the empty state when the request throws', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('network down')
+    }
+
+    expect(
+      await loadDashboardData(session, 'https://api.example')
+    ).toEqual({
+      kind: 'empty',
+    })
   })
 })

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -107,6 +107,19 @@ describe('loadDashboardData', () => {
     })
   })
 
+  it('strips a trailing slash from the API base URL', async () => {
+    let captured
+    globalThis.fetch = async (url) => {
+      captured = url
+
+      return { status: 200, ok: true, json: async () => ({}) }
+    }
+
+    await loadDashboardData(session, 'https://api.example/')
+
+    expect(captured).toBe('https://api.example/data')
+  })
+
   it('clears the retry marker after a successful fetch', async () => {
     beginAuthRetry()
     globalThis.fetch = async () => ({

--- a/tools/analytics/dashboard/README.md
+++ b/tools/analytics/dashboard/README.md
@@ -25,9 +25,10 @@ only users assigned to the app registration receive a token, which controls who
 can sign in.
 
 Configure it per host: copy `config.example.json` to `config.json` (gitignored)
-and fill in the `clientId`, `tenantId` and a `redirectUri` that exactly matches
-one registered on the app (SPA platform). Without a `config.json`, the page
-renders without sign-in for local preview.
+and fill in the `clientId`, `tenantId`, a `redirectUri` that exactly matches one
+registered on the app (SPA platform), the `apiBaseUrl` of the dashboard data API
+and the `apiScope` (`api://<client-id>/Dashboard.Read`) it requests a token for.
+Without a `config.json`, the page renders without sign-in for local preview.
 
 ## Data and access
 

--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -36,7 +36,8 @@ function toRecords(payload) {
 
 /**
  * Fetch dashboard records from the protected API. Returns a discriminated
- * result so the caller owns all DOM and navigation side effects:
+ * result so the caller owns DOM and navigation; this function only manages the
+ * sign-in retry marker:
  *   { kind: 'empty' }         no session, no API configured, or a network error
  *   { kind: 'retry' }         token rejected and a sign-in retry is allowed
  *   { kind: 'rejected' }      token rejected after the retry was already used
@@ -48,9 +49,11 @@ export async function loadDashboardData(session, apiBaseUrl) {
     return { kind: 'empty' }
   }
 
+  const base = apiBaseUrl.replace(/\/$/, '')
+
   let response
   try {
-    response = await fetch(`${apiBaseUrl}/data`, {
+    response = await fetch(`${base}/data`, {
       headers: { Authorization: `Bearer ${session.accessToken}` },
       cache: 'no-store',
     })

--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -1,9 +1,13 @@
 // Renders analytics records as key figures and bar charts. Data is loaded from
-// DATA_URL; the page shows an empty state until a data source is wired up.
+// the access-controlled dashboard API; the page shows an empty state when there
+// is no data or no data source is configured.
 
-import { ensureSignedIn, signOut } from './auth.js'
-
-const DATA_URL = './data/records.json'
+import {
+  ensureSignedIn,
+  getConfig,
+  clearSession,
+  signOut,
+} from './auth.js'
 
 /** Normalise the stored shape to a common view model. */
 function normalise(record) {
@@ -163,14 +167,30 @@ async function main() {
 
   renderUser(session)
 
+  const { apiBaseUrl } = getConfig()
+
   let payload = null
-  try {
-    const response = await fetch(DATA_URL, { cache: 'no-store' })
-    if (response.ok) {
-      payload = await response.json()
+  if (session && apiBaseUrl) {
+    try {
+      const response = await fetch(`${apiBaseUrl}/data`, {
+        headers: { Authorization: `Bearer ${session.accessToken}` },
+        cache: 'no-store',
+      })
+
+      if (response.status === 401) {
+        // Token no longer accepted; clear it and re-run sign-in.
+        clearSession()
+        window.location.reload()
+
+        return
+      }
+
+      if (response.ok) {
+        payload = await response.json()
+      }
+    } catch {
+      // Network or endpoint issue; fall through to the empty state.
     }
-  } catch {
-    // No data source yet; fall through to the empty state.
   }
 
   const all = toRecords(payload).map(normalise)

--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -6,6 +6,8 @@ import {
   ensureSignedIn,
   getConfig,
   clearSession,
+  beginAuthRetry,
+  clearAuthRetry,
   signOut,
 } from './auth.js'
 
@@ -178,14 +180,25 @@ async function main() {
       })
 
       if (response.status === 401) {
-        // Token no longer accepted; clear it and re-run sign-in.
-        clearSession()
-        window.location.reload()
+        // Token rejected; retry sign-in once, then surface an error instead of
+        // looping between clearing the session and reloading.
+        if (beginAuthRetry()) {
+          clearSession()
+          window.location.reload()
+
+          return
+        }
+
+        const box = document.getElementById('error')
+        box.textContent =
+          'The data API rejected your access. Please try again later, or contact the dashboard owner if it persists.'
+        box.hidden = false
 
         return
       }
 
       if (response.ok) {
+        clearAuthRetry()
         payload = await response.json()
       }
     } catch {

--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -4,7 +4,7 @@
 
 import {
   ensureSignedIn,
-  getConfig,
+  getApiBaseUrl,
   clearSession,
   beginAuthRetry,
   clearAuthRetry,
@@ -32,6 +32,49 @@ function toRecords(payload) {
   }
 
   return []
+}
+
+/**
+ * Fetch dashboard records from the protected API. Returns a discriminated
+ * result so the caller owns all DOM and navigation side effects:
+ *   { kind: 'empty' }         no session, no API configured, or a network error
+ *   { kind: 'retry' }         token rejected and a sign-in retry is allowed
+ *   { kind: 'rejected' }      token rejected after the retry was already used
+ *   { kind: 'error', status } the API responded with a non-ok status
+ *   { kind: 'data', payload } records fetched successfully
+ */
+export async function loadDashboardData(session, apiBaseUrl) {
+  if (!session || !apiBaseUrl) {
+    return { kind: 'empty' }
+  }
+
+  let response
+  try {
+    response = await fetch(`${apiBaseUrl}/data`, {
+      headers: { Authorization: `Bearer ${session.accessToken}` },
+      cache: 'no-store',
+    })
+  } catch {
+    // Network or endpoint issue; show the empty state.
+    return { kind: 'empty' }
+  }
+
+  if (response.status === 401) {
+    return beginAuthRetry() ? { kind: 'retry' } : { kind: 'rejected' }
+  }
+
+  if (!response.ok) {
+    return { kind: 'error', status: response.status }
+  }
+
+  clearAuthRetry()
+
+  try {
+    return { kind: 'data', payload: await response.json() }
+  } catch {
+    // Malformed body; show the empty state rather than crashing the page.
+    return { kind: 'empty' }
+  }
 }
 
 function countBy(items, key) {
@@ -155,57 +198,52 @@ function renderUser(session) {
   container.hidden = false
 }
 
+function showError(message) {
+  const box = document.getElementById('error')
+  box.textContent = message
+  box.hidden = false
+}
+
 async function main() {
   let session
   try {
     session = await ensureSignedIn()
   } catch (error) {
-    const box = document.getElementById('error')
-    box.textContent = `Sign-in failed: ${error.message}`
-    box.hidden = false
+    showError(`Sign-in failed: ${error.message}`)
 
     return
   }
 
   renderUser(session)
 
-  const { apiBaseUrl } = getConfig()
+  const result = await loadDashboardData(session, getApiBaseUrl())
 
-  let payload = null
-  if (session && apiBaseUrl) {
-    try {
-      const response = await fetch(`${apiBaseUrl}/data`, {
-        headers: { Authorization: `Bearer ${session.accessToken}` },
-        cache: 'no-store',
-      })
+  if (result.kind === 'retry') {
+    // Token rejected; retry sign-in once, then surface an error instead of
+    // looping between clearing the session and reloading.
+    clearSession()
+    window.location.reload()
 
-      if (response.status === 401) {
-        // Token rejected; retry sign-in once, then surface an error instead of
-        // looping between clearing the session and reloading.
-        if (beginAuthRetry()) {
-          clearSession()
-          window.location.reload()
-
-          return
-        }
-
-        const box = document.getElementById('error')
-        box.textContent =
-          'The data API rejected your access. Please try again later, or contact the dashboard owner if it persists.'
-        box.hidden = false
-
-        return
-      }
-
-      if (response.ok) {
-        clearAuthRetry()
-        payload = await response.json()
-      }
-    } catch {
-      // Network or endpoint issue; fall through to the empty state.
-    }
+    return
   }
 
+  if (result.kind === 'rejected') {
+    showError(
+      'The data API rejected your access. Please try again later, or contact the dashboard owner if it persists.'
+    )
+
+    return
+  }
+
+  if (result.kind === 'error') {
+    showError(
+      `The data API returned an error (${result.status}). Please try again later, or contact the dashboard owner if it persists.`
+    )
+
+    return
+  }
+
+  const payload = result.kind === 'data' ? result.payload : null
   const all = toRecords(payload).map(normalise)
 
   if (all.length === 0) {
@@ -227,4 +265,8 @@ async function main() {
   apply('')
 }
 
-main()
+// Browser entry point. Guarded so importing this module for its exports (tests)
+// does not run the page flow.
+if (typeof document !== 'undefined') {
+  main()
+}

--- a/tools/analytics/dashboard/auth.js
+++ b/tools/analytics/dashboard/auth.js
@@ -218,8 +218,8 @@ export function signOut() {
   window.location.assign(`${authority()}/oauth2/v2.0/logout?${params}`)
 }
 
-export function getConfig() {
-  return { ...config }
+export function getApiBaseUrl() {
+  return config.apiBaseUrl
 }
 
 export function clearSession() {

--- a/tools/analytics/dashboard/auth.js
+++ b/tools/analytics/dashboard/auth.js
@@ -80,12 +80,15 @@ function decodeJwt(token) {
   }
 }
 
-function readSession() {
+export function readSession() {
   try {
     const session = JSON.parse(
       sessionStorage.getItem(SESSION_KEY) || 'null'
     )
-    if (session && session.expiresAt > Date.now()) {
+    // Require an access token as well: a session persisted by an older build
+    // has no token and can't call the data API, so treat it as invalid and
+    // force a clean re-auth rather than sending "Bearer undefined".
+    if (session && session.accessToken && session.expiresAt > Date.now()) {
       return session
     }
   } catch {

--- a/tools/analytics/dashboard/auth.js
+++ b/tools/analytics/dashboard/auth.js
@@ -12,6 +12,7 @@ let config = {}
 const BASE_SCOPE = 'openid profile email'
 const SESSION_KEY = 'eufemia-analytics-session'
 const FLOW_KEY = 'eufemia-analytics-flow'
+const RETRY_KEY = 'eufemia-analytics-retry'
 
 function authority() {
   return `https://login.microsoftonline.com/${config.tenantId}`
@@ -19,8 +20,8 @@ function authority() {
 
 // Request the API scope alongside sign-in so the token endpoint returns an
 // access token the dashboard API accepts.
-function scopes() {
-  return config.apiScope ? `${BASE_SCOPE} ${config.apiScope}` : BASE_SCOPE
+export function scopes(cfg = config) {
+  return cfg.apiScope ? `${BASE_SCOPE} ${cfg.apiScope}` : BASE_SCOPE
 }
 
 async function loadConfig() {
@@ -91,7 +92,7 @@ function readSession() {
     // Fall through to a clean state.
   }
 
-  sessionStorage.removeItem(SESSION_KEY)
+  clearSession()
 
   return null
 }
@@ -209,7 +210,7 @@ export async function ensureSignedIn() {
 }
 
 export function signOut() {
-  sessionStorage.removeItem(SESSION_KEY)
+  clearSession()
 
   const params = new URLSearchParams({
     post_logout_redirect_uri: config.redirectUri || window.location.origin,
@@ -218,9 +219,25 @@ export function signOut() {
 }
 
 export function getConfig() {
-  return config
+  return { ...config }
 }
 
 export function clearSession() {
   sessionStorage.removeItem(SESSION_KEY)
+}
+
+// Grant a single sign-in retry after the API rejects a token, so a persistently
+// refused token surfaces an error instead of looping between clear and reload.
+export function beginAuthRetry() {
+  if (sessionStorage.getItem(RETRY_KEY)) {
+    return false
+  }
+
+  sessionStorage.setItem(RETRY_KEY, '1')
+
+  return true
+}
+
+export function clearAuthRetry() {
+  sessionStorage.removeItem(RETRY_KEY)
 }

--- a/tools/analytics/dashboard/auth.js
+++ b/tools/analytics/dashboard/auth.js
@@ -9,12 +9,18 @@
 // to enforce auth on the files, or serving data from a token-protected API.
 
 let config = {}
-const SCOPE = 'openid profile email'
+const BASE_SCOPE = 'openid profile email'
 const SESSION_KEY = 'eufemia-analytics-session'
 const FLOW_KEY = 'eufemia-analytics-flow'
 
 function authority() {
   return `https://login.microsoftonline.com/${config.tenantId}`
+}
+
+// Request the API scope alongside sign-in so the token endpoint returns an
+// access token the dashboard API accepts.
+function scopes() {
+  return config.apiScope ? `${BASE_SCOPE} ${config.apiScope}` : BASE_SCOPE
 }
 
 async function loadConfig() {
@@ -99,7 +105,7 @@ async function redirectToLogin() {
     client_id: config.clientId,
     response_type: 'code',
     redirect_uri: config.redirectUri,
-    scope: SCOPE,
+    scope: scopes(),
     code_challenge: await challengeFrom(verifier),
     code_challenge_method: 'S256',
     state,
@@ -137,6 +143,7 @@ async function exchangeCode(code, returnedState) {
 
   const session = {
     name: claims.name || claims.preferred_username || 'Signed in',
+    accessToken: tokens.access_token,
     expiresAt:
       Date.now() + (Number(tokens.expires_in) || 3600) * 1000 - 60000,
   }
@@ -208,4 +215,12 @@ export function signOut() {
     post_logout_redirect_uri: config.redirectUri || window.location.origin,
   })
   window.location.assign(`${authority()}/oauth2/v2.0/logout?${params}`)
+}
+
+export function getConfig() {
+  return config
+}
+
+export function clearSession() {
+  sessionStorage.removeItem(SESSION_KEY)
 }

--- a/tools/analytics/dashboard/config.example.json
+++ b/tools/analytics/dashboard/config.example.json
@@ -1,5 +1,7 @@
 {
   "clientId": "00000000-0000-0000-0000-000000000000",
   "tenantId": "00000000-0000-0000-0000-000000000000",
-  "redirectUri": "http://localhost:4173"
+  "redirectUri": "http://localhost:4173",
+  "apiBaseUrl": "https://<dashboard-api-host>",
+  "apiScope": "api://00000000-0000-0000-0000-000000000000/Dashboard.Read"
 }

--- a/tools/analytics/package.json
+++ b/tools/analytics/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "vitest run",
     "test:types": "../../node_modules/.bin/tsc --noEmit",
-    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts' && node ../../node_modules/.bin/prettier --check 'dashboard/**/*.{js,css,html,json,md}'",
+    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts' && node ../../node_modules/.bin/prettier --check 'dashboard/**/*.{js,css,html,json,md}' 'src/**/*.ts' '__tests__/**/*.{js,ts}'",
     "audit:ci": "yarn npm audit --recursive --environment production --severity high",
     "build": "rm -rf dist && esbuild src/lambda/index.ts --bundle --platform=node --target=node22 --format=esm --sourcemap --outfile=dist/index.mjs '--external:@aws-sdk/*' && cd dist && zip -rq lambda.zip index.mjs index.mjs.map",
     "deploy": "yarn build && terraform -chdir=infra init && terraform -chdir=infra apply -auto-approve",


### PR DESCRIPTION
Wires the dashboard to its data source: after Entra sign-in the page requests an access token for the API scope and fetches the protected `/data` endpoint with it, showing an empty state when there is no data or no configuration. A rejected token triggers a fresh sign-in.

Depends on the dashboard data API (the `/data` endpoint) being deployed.
