### PR TITLE
feat: add opt-in iOS Dynamic Type scaling

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -60,14 +60,40 @@ Type scaling curve. This would make iOS smaller than desktop by default and
 change the difference at larger accessibility sizes. It would also reduce all
 root-relative layout values.
 
-### Possible future improvements
+### Optional JavaScript root scaling
 
-One option is to keep Apple's `Body` style and scale the resulting text by `16
-/ 17` with an iOS-only `text-size-adjust`. This produces an 18px DNB basis size
-at the default setting while retaining the `Body` Dynamic Type curve. It also
-keeps root-relative layout values at their current iOS sizes. Before using this
-as a framework default, it needs real-device testing across all text-size
-settings, nested typography, form controls, and representative layouts.
+Eufemia provides an opt-in blocking script that measures Apple's Dynamic Type
+`Body` style. It sets the root to `16px × measured size / 17px`, so the default
+root remains 16px while the user's text scale is preserved. This makes
+typography and all `rem`-based geometry scale together on iOS.
+
+For server-rendered applications, place `TextScaleHeadScript` in the initial
+document head, after the viewport meta tag and before stylesheets. It runs
+synchronously before the browser paints, avoiding a flash at the unscaled size.
+
+```tsx
+import { TextScaleHeadScript } from '@dnb/eufemia/shared/TextScaleScript'
+
+export function Document() {
+  return (
+    <html>
+      <head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1"
+        />
+        <TextScaleHeadScript />
+        {/* stylesheets */}
+      </head>
+    </html>
+  )
+}
+```
+
+Client-rendered applications can instead render `TextScaleClient` near the app
+root. It uses a layout effect, but cannot guarantee a flash-free result when
+hydrating server-rendered HTML. If the script cannot measure a text scale,
+Eufemia keeps its existing CSS behavior.
 
 The longer-term option is the standard
 [`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -62,10 +62,10 @@ root-relative layout values.
 
 ### Optional JavaScript root scaling
 
-Use this opt-in script when you want the default 18px DNB text size on iOS
-while still respecting the user's system text-size setting. It scales all
-`rem`-based text and layout together. Place it after the viewport meta tag and
-before stylesheets to avoid a visible layout change.
+At the default iOS text size, this opt-in script keeps DNB basis text at 18px.
+If the user changes the system text size, all `rem`-based text and layout scale
+proportionally. Place it after the viewport meta tag and before stylesheets to
+avoid a visible layout change.
 
 ```tsx
 import { TextScaleHeadScript } from '@dnb/eufemia/shared/TextScaleScript'
@@ -82,8 +82,9 @@ import { TextScaleHeadScript } from '@dnb/eufemia/shared/TextScaleScript'
 Pass the page's CSP nonce to `TextScaleHeadScript` when required.
 
 Client-rendered applications can use `TextScaleClient`, but server-rendered
-pages may show a layout change during hydration. Without the script, Eufemia
-keeps its current fallback.
+pages may show a layout change during hydration. Without the script, the root
+is 17px and DNB basis text is 19.125px at the default iOS setting. Text still
+follows the user's system text-size setting.
 
 The longer-term option is the standard
 [`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -78,8 +78,7 @@ layout change.
 
 Client-rendered applications can use `TextScaleClient`, but server-rendered
 pages may show a layout change during hydration. Without the script, Eufemia
-keeps its current fallback. With isolated styles, the fallback cannot scale the
-document root, so text and `rem`-based layout may not scale together.
+keeps its current fallback.
 
 The longer-term option is the standard
 [`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -62,46 +62,30 @@ root-relative layout values.
 
 ### Optional JavaScript root scaling
 
-Eufemia provides an opt-in blocking script that measures Apple's Dynamic Type
-`Body` style. It sets the root to `16px × measured size / 17px`, so the default
-root remains 16px while the user's text scale is preserved. This makes
-typography and all `rem`-based geometry scale together on iOS.
-
-For server-rendered applications, place `TextScaleHeadScript` in the initial
-document head, after the viewport meta tag and before stylesheets. It runs
-synchronously before the browser paints, avoiding a flash at the unscaled size.
+Import `TextScaleHeadScript` from
+`@dnb/eufemia/shared/TextScaleScript`. It keeps the default root at 16px while
+scaling all `rem`-based text and layout with the user's iOS text-size setting.
+Place it after the viewport meta tag and before stylesheets to avoid a visible
+layout change.
 
 ```tsx
-import { TextScaleHeadScript } from '@dnb/eufemia/shared/TextScaleScript'
-
-export function Document() {
-  return (
-    <html>
-      <head>
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1"
-        />
-        <TextScaleHeadScript />
-        {/* stylesheets */}
-      </head>
-    </html>
-  )
-}
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <TextScaleHeadScript />
+  {/* stylesheets */}
+</head>
 ```
 
-Client-rendered applications can instead render `TextScaleClient` near the app
-root. It uses a layout effect, but cannot guarantee a flash-free result when
-hydrating server-rendered HTML. If the script cannot measure a text scale,
-Eufemia keeps its existing CSS behavior.
+Client-rendered applications can use `TextScaleClient`, but server-rendered
+pages may show a layout change during hydration. Without the script, Eufemia
+keeps its current fallback. With isolated styles, the fallback cannot scale the
+document root, so text and `rem`-based layout may not scale together.
 
 The longer-term option is the standard
 [`env(preferred-text-scale)`](https://drafts.csswg.org/css-env-1/#text-zoom)
 environment variable and
 [`<meta name="text-scale" content="scale">`](https://drafts.csswg.org/css-fonts-5/#text-scale-meta).
-These would give websites a standard way to read or apply the user's preferred
-text scale. They are experimental and are not yet supported by Safari, so
-Eufemia cannot use them today.
+These are not yet supported by Safari.
 
 ### Responsive typography (BETA)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -62,11 +62,14 @@ root-relative layout values.
 
 ### Optional JavaScript root scaling
 
-Import `TextScaleHeadScript` from
-`@dnb/eufemia/shared/TextScaleScript`. It keeps the default root at 16px while
-scaling all `rem`-based text and layout with the user's iOS text-size setting.
-Place it after the viewport meta tag and before stylesheets to avoid a visible
-layout change.
+Use this opt-in script when you want the default 18px DNB text size on iOS
+while still respecting the user's system text-size setting. It scales all
+`rem`-based text and layout together. Place it after the viewport meta tag and
+before stylesheets to avoid a visible layout change.
+
+```tsx
+import { TextScaleHeadScript } from '@dnb/eufemia/shared/TextScaleScript'
+```
 
 ```tsx
 <head>
@@ -75,6 +78,8 @@ layout change.
   {/* stylesheets */}
 </head>
 ```
+
+Pass the page's CSP nonce to `TextScaleHeadScript` when required.
 
 Client-rendered applications can use `TextScaleClient`, but server-rendered
 pages may show a layout change during hydration. Without the script, Eufemia

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -233,6 +233,21 @@ describe('eufemia-theme plugin', () => {
       const load = plugin.load as (id: string) => string | undefined
       expect(load('other-id')).toBeUndefined()
     })
+
+    it('injects text scale before the body content', () => {
+      const plugin = eufemiaThemePlugin()
+      const transformIndexHtml = plugin.transformIndexHtml as (
+        html: string
+      ) => string
+      const html = transformIndexHtml(
+        '<html><head></head><body class="dnb-page-background"></body></html>'
+      )
+
+      expect(html).toContain('data-eufemia-text-scale')
+      expect(html.indexOf('data-eufemia-text-scale')).toBeLessThan(
+        html.indexOf('</head>')
+      )
+    })
   })
 
   describe('dev mode applyThemeStyles behavior', () => {

--- a/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
@@ -15,6 +15,7 @@ import path from 'node:path'
 import { sync as globSync } from 'globby'
 import micromatch from 'micromatch'
 import { hasPrebuild } from './eufemia-prebuild'
+import { getTextScaleScript } from '@dnb/eufemia/src/shared/TextScaleScriptUtils'
 
 /**
  * FOUC-prevention scripts matching @dnb/eufemia/shared/ColorSchemeScript.
@@ -425,7 +426,8 @@ if (typeof window !== 'undefined') {
      * module into the HTML template.
      */
     transformIndexHtml(html) {
-      const headScript = `<script>${getHeadScript()}</script>`
+      const headScript = `<script>${getHeadScript()}</script>
+<script>${getTextScaleScript()}</script>`
       const bodyScript = `<script>${getBodyScript()}</script>`
 
       html = html.replace('</head>', `${headScript}\n</head>`)

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/__tests__/isolated-style-scope-plugin.test.ts
@@ -240,6 +240,14 @@ describe('isolated-style-scope-plugin', () => {
       )
     })
 
+    it('should keep a root-only html pseudo-class global', async () => {
+      return await run(
+        'html:not([data-test]) { font-size: 100%; }',
+        'html:not([data-test]) { font-size: 100%; }',
+        { scopeHash: 'test-scope' }
+      )
+    })
+
     it('should handle body tag', async () => {
       return await run(
         'body .module-class { color: red; }',

--- a/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
+++ b/packages/dnb-eufemia/src/plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js
@@ -554,7 +554,13 @@ function isGlobalSelector(nodes) {
   }
   // Case 3: html, body, html body
   if (parts[0].type === 'tag' && parts[0].value === 'html') {
-    if (parts.length === 1) return true // html
+    if (
+      parts
+        .slice(1)
+        .every((part) => ['attribute', 'pseudo'].includes(part.type))
+    ) {
+      return true // html, html[attribute], html:pseudo
+    }
     if (
       parts.length === 2 &&
       parts[1].type === 'tag' &&

--- a/packages/dnb-eufemia/src/shared/TextScaleScript.tsx
+++ b/packages/dnb-eufemia/src/shared/TextScaleScript.tsx
@@ -1,0 +1,31 @@
+/**
+ * Opt-in text-scale helpers.
+ *
+ * `TextScaleHeadScript` runs synchronously in the document head before paint.
+ * `TextScaleClient` is a client-rendering fallback that runs in a layout effect.
+ */
+
+import useIsomorphicLayoutEffect from './helpers/useIsomorphicLayoutEffect'
+import { applyTextScale, getTextScaleScript } from './TextScaleScriptUtils'
+
+export { applyTextScale, getTextScaleScript } from './TextScaleScriptUtils'
+
+export function TextScaleHeadScript({ nonce }: { nonce?: string } = {}) {
+  return (
+    <script
+      nonce={nonce}
+      dangerouslySetInnerHTML={{
+        __html: getTextScaleScript(),
+      }}
+    />
+  )
+}
+
+/**
+ * Client-rendering fallback. This runs before React paints, but cannot prevent
+ * a flash when hydrating server-rendered HTML. Prefer `TextScaleHeadScript`.
+ */
+export function TextScaleClient() {
+  useIsomorphicLayoutEffect(() => applyTextScale(), [])
+  return null
+}

--- a/packages/dnb-eufemia/src/shared/TextScaleScriptUtils.ts
+++ b/packages/dnb-eufemia/src/shared/TextScaleScriptUtils.ts
@@ -1,0 +1,130 @@
+type TextScaleRuntime = typeof globalThis & {
+  __eufemiaTextScaleCleanup?: () => void
+}
+
+export function applyTextScale(): (() => void) | undefined {
+  try {
+    const root = document.documentElement
+    const runtime = globalThis as TextScaleRuntime
+    const attribute = 'data-eufemia-text-scale'
+    const probeStyle =
+      'position:absolute;visibility:hidden;pointer-events:none;' +
+      'contain:layout style;display:block;left:-10000px;top:0;' +
+      'padding:0;border:0;margin:0;'
+
+    runtime.__eufemiaTextScaleCleanup?.()
+
+    const createProbe = (style: string, text = '') => {
+      const element = document.createElement('span')
+      element.setAttribute('aria-hidden', 'true')
+      element.style.cssText = probeStyle + style
+      element.textContent = text
+      root.appendChild(element)
+      return element
+    }
+
+    const removeProbe = (element?: HTMLElement) => {
+      element?.parentNode?.removeChild(element)
+    }
+
+    const readAppleTextScale = (element?: HTMLElement) => {
+      if (
+        !runtime.CSS?.supports('-webkit-touch-callout:none') ||
+        !runtime.CSS.supports('font:-apple-system-body')
+      ) {
+        return 0
+      }
+
+      const probe =
+        element ??
+        createProbe(
+          'font:-apple-system-body;width:max-content;height:auto;' +
+            'white-space:nowrap;',
+          'M'
+        )
+      const scale = parseFloat(getComputedStyle(probe).fontSize) / 17
+
+      if (!element) {
+        removeProbe(probe)
+      }
+
+      return isFinite(scale) && scale > 0 ? scale : 0
+    }
+
+    const appleScale = readAppleTextScale()
+
+    const apply = (scale: number) => {
+      if (!scale) {
+        return
+      }
+
+      root.style.fontSize = `${16 * scale}px`
+      root.setAttribute(attribute, 'apple')
+    }
+
+    apply(appleScale)
+
+    if (!appleScale) {
+      return undefined
+    }
+
+    let probe: HTMLElement | undefined
+    let observer: ResizeObserver | undefined
+    let observing = false
+
+    const update = () => {
+      apply(readAppleTextScale(probe))
+    }
+
+    const observe = () => {
+      if (observing) {
+        return
+      }
+      observing = true
+
+      probe = createProbe(
+        'font:-apple-system-body;width:max-content;height:auto;' +
+          'white-space:nowrap;',
+        'M'
+      )
+
+      if (runtime.ResizeObserver) {
+        observer = new ResizeObserver(update)
+        observer.observe(probe)
+      }
+
+      addEventListener('pageshow', update)
+      addEventListener('focus', update)
+      document.addEventListener('visibilitychange', update)
+    }
+
+    const cleanup = () => {
+      observer?.disconnect()
+      removeProbe(probe)
+      document.removeEventListener('DOMContentLoaded', observe)
+      removeEventListener('pageshow', update)
+      removeEventListener('focus', update)
+      document.removeEventListener('visibilitychange', update)
+      delete runtime.__eufemiaTextScaleCleanup
+    }
+
+    runtime.__eufemiaTextScaleCleanup = cleanup
+
+    if (document.body) {
+      observe()
+    } else {
+      document.addEventListener('DOMContentLoaded', observe, {
+        once: true,
+      })
+    }
+
+    return cleanup
+  } catch {
+    // Keep the CSS fallback when measurement is unavailable.
+    return undefined
+  }
+}
+
+export function getTextScaleScript() {
+  return `(${applyTextScale.toString()})()`
+}

--- a/packages/dnb-eufemia/src/shared/__tests__/TextScaleScript.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/TextScaleScript.test.tsx
@@ -1,0 +1,142 @@
+import { render } from '@testing-library/react'
+import {
+  getTextScaleScript,
+  TextScaleClient,
+  TextScaleHeadScript,
+} from '../TextScaleScript'
+
+describe('TextScaleScript', () => {
+  const getComputedStyleOriginal = window.getComputedStyle
+  const cssOriginal = globalThis.CSS
+  const resizeObserverOriginal = globalThis.ResizeObserver
+
+  afterEach(() => {
+    globalThis.__eufemiaTextScaleCleanup?.()
+    document.documentElement.style.fontSize = ''
+    document.documentElement.removeAttribute('data-eufemia-text-scale')
+    window.getComputedStyle = getComputedStyleOriginal
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: cssOriginal,
+    })
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: resizeObserverOriginal,
+    })
+    delete globalThis.__eufemiaTextScaleCleanup
+  })
+
+  it('sets the root size synchronously from Apple Dynamic Type', () => {
+    mockSupport({ appleBodySize: 17 })
+
+    Function(getTextScaleScript())()
+
+    expect(document.documentElement.style.fontSize).toBe('16px')
+    expect(
+      document.documentElement.getAttribute('data-eufemia-text-scale')
+    ).toBe('apple')
+  })
+
+  it('leaves unsupported browsers unchanged', () => {
+    mockSupport({})
+
+    Function(getTextScaleScript())()
+
+    expect(document.documentElement.style.fontSize).toBe('')
+    expect(
+      document.documentElement.hasAttribute('data-eufemia-text-scale')
+    ).toBe(false)
+  })
+
+  it('updates the root size when the measured Apple text size changes', () => {
+    let appleBodySize = 17
+    let resizeCallback: () => void
+    mockSupport({ getAppleBodySize: () => appleBodySize })
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: class {
+        constructor(callback: () => void) {
+          resizeCallback = callback
+        }
+        observe() {}
+        disconnect() {}
+      },
+    })
+
+    Function(getTextScaleScript())()
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+
+    appleBodySize = 34
+    expect(resizeCallback).toBeTypeOf('function')
+    resizeCallback()
+
+    expect(document.documentElement.style.fontSize).toBe('32px')
+  })
+
+  it('rechecks the Apple text size when the window regains focus', () => {
+    let appleBodySize = 17
+    mockSupport({ getAppleBodySize: () => appleBodySize })
+
+    Function(getTextScaleScript())()
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+
+    appleBodySize = 34
+    dispatchEvent(new Event('focus'))
+
+    expect(document.documentElement.style.fontSize).toBe('32px')
+  })
+
+  it('renders a blocking script for the document head', () => {
+    render(<TextScaleHeadScript nonce="nonce-value" />)
+
+    const script = document.querySelector('script')
+    expect(script).toHaveAttribute('nonce', 'nonce-value')
+    expect(script?.textContent).toBe(getTextScaleScript())
+  })
+
+  it('provides a client-rendering fallback', () => {
+    mockSupport({ appleBodySize: 17 })
+
+    render(<TextScaleClient />)
+
+    expect(document.documentElement.style.fontSize).toBe('16px')
+  })
+
+  function mockSupport({
+    appleBodySize = 0,
+    getAppleBodySize,
+  }: {
+    appleBodySize?: number
+    getAppleBodySize?: () => number
+  }) {
+    const readAppleBodySize = getAppleBodySize ?? (() => appleBodySize)
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: {
+        supports: vi.fn((property: string) => {
+          return property.replaceAll(' ', '') ===
+            '-webkit-touch-callout:none'
+            ? readAppleBodySize() > 0
+            : property.replaceAll(' ', '') === 'font:-apple-system-body'
+              ? readAppleBodySize() > 0
+              : false
+        }),
+      },
+    })
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: undefined,
+    })
+
+    window.getComputedStyle = vi.fn((element: Element) => {
+      return {
+        fontSize: `${readAppleBodySize()}px`,
+        width: '0px',
+      } as CSSStyleDeclaration
+    })
+  }
+})
+
+declare global {
+  var __eufemiaTextScaleCleanup: (() => void) | undefined
+}

--- a/packages/dnb-eufemia/src/shared/index.tsx
+++ b/packages/dnb-eufemia/src/shared/index.tsx
@@ -18,6 +18,7 @@ export { default as useSharedContext } from './useSharedContext'
 export { default as Translation } from './Translation'
 export { default as renderWithFormatting } from './renderWithFormatting'
 export * from './Translation'
+export * from './TextScaleScript'
 export { icu } from './icuFormatMessage'
 
 export type { ThemeNames } from './Theme'

--- a/packages/dnb-eufemia/src/style/__tests__/TextScale.test.ts
+++ b/packages/dnb-eufemia/src/style/__tests__/TextScale.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment node
 
 import { loadScss } from '../../core/test-utils/testSetup'
+import postcss from 'postcss'
+import isolatedStyleScopePlugin from '../../plugins/postcss-isolated-style-scope/isolated-style-scope-plugin.js'
 
 describe('Text scale CSS', () => {
-  it('keeps Apple Dynamic Type as a fallback until the script succeeds', () => {
+  it('keeps Apple Dynamic Type as a global fallback until the script succeeds', async () => {
     const css = loadScss(null, {
       data: `
         @use 'scopes.scss' as scopes;
@@ -13,5 +15,14 @@ describe('Text scale CSS', () => {
 
     expect(css).toContain('html:not([data-eufemia-text-scale])')
     expect(css).toContain('font: -apple-system-body')
+
+    const isolated = await postcss([
+      isolatedStyleScopePlugin({ scopeHash: 'test-scope' }),
+    ]).process(css, { from: '/file.css' })
+
+    expect(isolated.css).toContain('html:not([data-eufemia-text-scale]) {')
+    expect(isolated.css).not.toContain(
+      'html:not([data-eufemia-text-scale]) .test-scope'
+    )
   })
 })

--- a/packages/dnb-eufemia/src/style/__tests__/TextScale.test.ts
+++ b/packages/dnb-eufemia/src/style/__tests__/TextScale.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { loadScss } from '../../core/test-utils/testSetup'
+
+describe('Text scale CSS', () => {
+  it('keeps Apple Dynamic Type as a fallback until the script succeeds', () => {
+    const css = loadScss(null, {
+      data: `
+        @use 'scopes.scss' as scopes;
+        @include scopes.htmlDefault();
+      `,
+    })
+
+    expect(css).toContain('html:not([data-eufemia-text-scale])')
+    expect(css).toContain('font: -apple-system-body')
+  })
+})

--- a/packages/dnb-eufemia/src/style/core/scopes.scss
+++ b/packages/dnb-eufemia/src/style/core/scopes.scss
@@ -75,7 +75,9 @@
     // IS_SAFARI_MOBILE
     @supports (-webkit-touch-callout: none) {
       @supports (font: -apple-system-body) {
-        font: -apple-system-body; /* stylelint-disable-line */
+        &:not([data-eufemia-text-scale]) {
+          font: -apple-system-body; /* stylelint-disable-line */
+        }
       }
     }
   }


### PR DESCRIPTION
iOS Dynamic Type changes the computed Apple body size, while Eufemia layouts rely on the root `rem` size. This opt-in bridge measures that preference before first paint and applies it coherently to typography and `rem`-based geometry.

It preserves the existing CSS behavior when JavaScript or measurement is unavailable.

### How it works

At the default iOS text setting, Apple’s `Body` size measures 17px. The blocking head script converts this to a 16px root while preserving the user’s Dynamic Type scale, then adds `data-eufemia-text-scale="apple"`. Because this happens before stylesheets and first paint, it does not cause a layout shift. If the script cannot run, the existing 17px `-apple-system-body` CSS remains as the fallback.

**17px basis:**
<img width="402" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-31 at 10 47 51" src="https://github.com/user-attachments/assets/e1835384-8c50-4ef4-84f1-1b3f2d74a3d1" />

**16px basis (new):**
<img width="402" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-31 at 10 47 58" src="https://github.com/user-attachments/assets/643ab3bb-4c5c-4278-ad4b-db6a19b35087" />
