### PR TITLE
chore(analytics): host the dashboard on public S3 + CloudFront

### DIFF
--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -158,6 +158,11 @@ jobs:
           cp "$GITHUB_WORKSPACE/tools/analytics/dist/lambda.zip" dist/
           cp -R "$GITHUB_WORKSPACE/tools/analytics/infra" .
 
+          # Include the dashboard static files so the deploy job can publish
+          # them to the CloudFront-fronted bucket. config.json is generated at
+          # deploy time from the GHE variables, so it is not copied here.
+          cp -R "$GITHUB_WORKSPACE/tools/analytics/dashboard" .
+
           # Include the deploy workflow so it lives on (and triggers from) the deploy branch
           mkdir -p .github/workflows
           cp "$GITHUB_WORKSPACE/tools/analytics/ghe-deploy-workflow.yml" .github/workflows/deploy.yml

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -98,7 +98,11 @@ Because the OIDC deploy role's permissions boundary forbids `iam:CreateRole` (AD
 
 The dashboard is hosted separately as a static site:
 
-- **Dashboard bucket** (private, SSE-S3, public access blocked) holding the static UI, read only by CloudFront via an Origin Access Control.
-- **CloudFront distribution** serving the dashboard on its default `*.cloudfront.net` domain. The shell holds no data or secrets — access is gated entirely by the Entra sign-in and the token-protected `/data` API — so no Lambda@Edge, edge auth or extra IAM role is needed. The deploy job generates `dashboard/config.json` from the `ENTRA_CLIENT_ID`/`ENTRA_TENANT_ID` variables (redirect URI set to the CloudFront URL), syncs the files to the bucket and invalidates the cache. Add the CloudFront URL as a redirect URI on the app registration after the first deploy.
+- **Dashboard bucket** (private, versioned, SSE-S3, public access blocked) holding the static UI, read only by CloudFront via an Origin Access Control.
+- **CloudFront distribution** serving the dashboard on its default `*.cloudfront.net` domain. The shell holds no data or secrets — access is gated entirely by the Entra sign-in and the token-protected `/data` API — so no Lambda@Edge, edge auth or extra IAM role is needed. The deploy job generates `dashboard/config.json` (non-secret public identifiers: `clientId`/`tenantId` from `ENTRA_CLIENT_ID`/`ENTRA_TENANT_ID`, `redirectUri` set to the CloudFront URL, `apiBaseUrl` from the dashboard API endpoint, and `apiScope` = `api://<clientId>/Dashboard.Read`), syncs the files to the bucket and invalidates the cache.
+
+The CloudFront origin is added to the dashboard API's CORS automatically (the distribution domain is concatenated onto `DASHBOARD_ORIGINS`), so no second deploy is needed for cross-origin `/data` calls; `DASHBOARD_ORIGINS` only needs any extra origins such as a local-dev URL. After the first deploy, add the CloudFront URL as a redirect URI on the app registration.
+
+Prerequisites for sign-in and data to work end to end: the app registration must expose a `Dashboard.Read` scope under App ID URI `api://<clientId>` and issue v2 access tokens (`requestedAccessTokenVersion = 2`). The deploy role's CloudFront and S3 permissions are provisioned in the OIDC federation repo, alongside the Lambda execution role.
 
 Terraform state reuses the shared `eufemia-mcp-terraform-state` bucket under the `analytics/` key.

--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -68,9 +68,10 @@ Deployment mirrors the MCP Lambda pattern: public GitHub builds and tests, then 
 ```
 public GitHub (.github/workflows/analytics-lambda.yml)
   → test + build lambda.zip
-  → force-push dist/ + infra/ + deploy workflow to GHE repo `deploy` branch
+  → force-push dist/ + infra/ + dashboard/ + deploy workflow to GHE repo `deploy` branch
       → GHE (ghe-deploy-workflow.yml as .github/workflows/deploy.yml)
           → OIDC assume role → terraform apply
+          → generate dashboard/config.json → aws s3 sync → CloudFront invalidation
 ```
 
 - **Triggers** (`analytics-lambda.yml`): a push to `main` touching `tools/analytics/**` (or the workflow), or a manual `workflow_dispatch` from any branch. Analytics deploys on its own code changes, not on every Eufemia release (it has no Eufemia docs dependency, unlike the MCP server).
@@ -94,5 +95,10 @@ Because the OIDC deploy role's permissions boundary forbids `iam:CreateRole` (AD
 - **Athena workgroup** for the retrieve queries.
 - **Lambda function** (`nodejs22.x`) — its execution role is pre-created out-of-band, because the OIDC deploy role's permissions boundary forbids `iam:CreateRole` (ADR 0004); it is only referenced here.
 - **API Gateway HTTP API** with the two `/records` routes and throttling.
+
+The dashboard is hosted separately as a static site:
+
+- **Dashboard bucket** (private, SSE-S3, public access blocked) holding the static UI, read only by CloudFront via an Origin Access Control.
+- **CloudFront distribution** serving the dashboard on its default `*.cloudfront.net` domain. The shell holds no data or secrets — access is gated entirely by the Entra sign-in and the token-protected `/data` API — so no Lambda@Edge, edge auth or extra IAM role is needed. The deploy job generates `dashboard/config.json` from the `ENTRA_CLIENT_ID`/`ENTRA_TENANT_ID` variables (redirect URI set to the CloudFront URL), syncs the files to the bucket and invalidates the cache. Add the CloudFront URL as a redirect URI on the app registration after the first deploy.
 
 Terraform state reuses the shared `eufemia-mcp-terraform-state` bucket under the `analytics/` key.

--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -72,25 +72,27 @@ jobs:
           BUCKET=$(terraform output -raw dashboard_bucket)
           DIST=$(terraform output -raw dashboard_distribution_id)
           URL=$(terraform output -raw dashboard_url)
+          API_BASE_URL=$(terraform output -raw dashboard_api_endpoint)
 
           # Generate the per-host runtime config from the deploy variables. It
           # holds only non-secret public identifiers, so it is safe to serve.
-          # The redirect URI must be the CloudFront URL registered on the app.
+          # The redirect URI must be the CloudFront URL registered on the app;
+          # apiScope is the app registration's exposed "Dashboard.Read" scope.
           jq -n \
             --arg clientId "$ENTRA_CLIENT_ID" \
             --arg tenantId "$ENTRA_TENANT_ID" \
             --arg redirectUri "$URL" \
-            '{clientId: $clientId, tenantId: $tenantId, redirectUri: $redirectUri}' \
+            --arg apiBaseUrl "$API_BASE_URL" \
+            --arg apiScope "api://${ENTRA_CLIENT_ID}/Dashboard.Read" \
+            '{clientId: $clientId, tenantId: $tenantId, redirectUri: $redirectUri, apiBaseUrl: $apiBaseUrl, apiScope: $apiScope}' \
             > ../dashboard/config.json
 
-          # Publish everything users load; keep the local-only scaffold files
-          # (example config, docs, env) out of the bucket.
+          # Publish everything users load; keep the committed scaffold files
+          # (example config, docs) out of the bucket.
           aws s3 sync ../dashboard "s3://${BUCKET}" \
             --delete \
             --exclude 'config.example.json' \
-            --exclude 'README.md' \
-            --exclude '.env' \
-            --exclude '.env.example'
+            --exclude 'README.md'
 
           # Invalidate so the new config.json and assets are served immediately.
           aws cloudfront create-invalidation \

--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -62,12 +62,49 @@ jobs:
           terraform init -input=false
           terraform apply -auto-approve -input=false
 
+      - name: Publish dashboard
+        env:
+          ENTRA_CLIENT_ID: ${{ vars.ENTRA_CLIENT_ID }}
+          ENTRA_TENANT_ID: ${{ vars.ENTRA_TENANT_ID }}
+        run: |
+          set -euo pipefail
+          cd infra
+          BUCKET=$(terraform output -raw dashboard_bucket)
+          DIST=$(terraform output -raw dashboard_distribution_id)
+          URL=$(terraform output -raw dashboard_url)
+
+          # Generate the per-host runtime config from the deploy variables. It
+          # holds only non-secret public identifiers, so it is safe to serve.
+          # The redirect URI must be the CloudFront URL registered on the app.
+          jq -n \
+            --arg clientId "$ENTRA_CLIENT_ID" \
+            --arg tenantId "$ENTRA_TENANT_ID" \
+            --arg redirectUri "$URL" \
+            '{clientId: $clientId, tenantId: $tenantId, redirectUri: $redirectUri}' \
+            > ../dashboard/config.json
+
+          # Publish everything users load; keep the local-only scaffold files
+          # (example config, docs, env) out of the bucket.
+          aws s3 sync ../dashboard "s3://${BUCKET}" \
+            --delete \
+            --exclude 'config.example.json' \
+            --exclude 'README.md' \
+            --exclude '.env' \
+            --exclude '.env.example'
+
+          # Invalidate so the new config.json and assets are served immediately.
+          aws cloudfront create-invalidation \
+            --distribution-id "$DIST" \
+            --paths '/*'
+
       - name: Post deploy summary
         run: |
           cd infra
           ENDPOINT=$(terraform output -raw api_endpoint)
           BUCKET=$(terraform output -raw data_bucket)
+          DASHBOARD_URL=$(terraform output -raw dashboard_url)
           echo "## Analytics Lambda deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Endpoint:** \`${ENDPOINT}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Data bucket:** \`${BUCKET}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Dashboard:** ${DASHBOARD_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -88,9 +88,12 @@ jobs:
             > ../dashboard/config.json
 
           # Publish everything users load; keep the committed scaffold files
-          # (example config, docs) out of the bucket.
+          # (example config, docs) out of the bucket. no-cache: assets aren't
+          # fingerprinted, so make browsers revalidate (paired with the
+          # invalidation below) instead of serving a stale cached copy.
           aws s3 sync ../dashboard "s3://${BUCKET}" \
             --delete \
+            --cache-control 'no-cache' \
             --exclude 'config.example.json' \
             --exclude 'README.md'
 
@@ -100,6 +103,7 @@ jobs:
             --paths '/*'
 
       - name: Post deploy summary
+        if: always()
         run: |
           cd infra
           ENDPOINT=$(terraform output -raw api_endpoint)

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -497,6 +497,10 @@ resource "aws_cloudfront_distribution" "dashboard" {
 
     # AWS managed "CachingOptimized" policy.
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+    # AWS managed "SecurityHeadersPolicy": adds HSTS, X-Content-Type-Options,
+    # X-Frame-Options, Referrer-Policy. Managed id needs no extra deploy-role IAM.
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
   }
 
   # Return index.html for unknown paths so a refresh after the sign-in redirect

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -306,7 +306,12 @@ resource "aws_apigatewayv2_api" "dashboard" {
   tags          = local.tags
 
   cors_configuration {
-    allow_origins = var.dashboard_origins
+    # Always include the live dashboard origin so CORS works on the first deploy
+    # (no chicken-and-egg); dashboard_origins adds any extra, e.g. local dev.
+    allow_origins = concat(
+      var.dashboard_origins,
+      ["https://${aws_cloudfront_distribution.dashboard.domain_name}"],
+    )
     allow_methods = ["GET"]
     allow_headers = ["authorization"]
     max_age       = 3600
@@ -433,7 +438,7 @@ resource "aws_route53_record" "analytics" {
 }
 
 # ---------------------------------------------------------------------------
-# Dashboard static hosting (public S3 + CloudFront)
+# Dashboard static hosting (public site, private S3 bucket via CloudFront)
 # ---------------------------------------------------------------------------
 #
 # The dashboard shell holds no data and no secrets: all data lives behind the
@@ -457,6 +462,15 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "dashboard" {
   }
 }
 
+# Versioning + the --delete sync gives a free rollback for a bad publish.
+resource "aws_s3_bucket_versioning" "dashboard" {
+  bucket = aws_s3_bucket.dashboard.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 # The bucket is private; the objects are served to the public through the
 # distribution, never from the bucket directly.
 resource "aws_s3_bucket_public_access_block" "dashboard" {
@@ -477,6 +491,7 @@ resource "aws_cloudfront_origin_access_control" "dashboard" {
 
 resource "aws_cloudfront_distribution" "dashboard" {
   enabled             = true
+  is_ipv6_enabled     = true
   default_root_object = "index.html"
   comment             = "${local.function_name} dashboard"
   price_class         = "PriceClass_100"
@@ -501,22 +516,6 @@ resource "aws_cloudfront_distribution" "dashboard" {
     # AWS managed "SecurityHeadersPolicy": adds HSTS, X-Content-Type-Options,
     # X-Frame-Options, Referrer-Policy. Managed id needs no extra deploy-role IAM.
     response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
-  }
-
-  # Return index.html for unknown paths so a refresh after the sign-in redirect
-  # lands on the app instead of an S3 error.
-  custom_error_response {
-    error_code            = 403
-    response_code         = 200
-    response_page_path    = "/index.html"
-    error_caching_min_ttl = 10
-  }
-
-  custom_error_response {
-    error_code            = 404
-    response_code         = 200
-    response_page_path    = "/index.html"
-    error_caching_min_ttl = 10
   }
 
   restrictions {

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -431,3 +431,127 @@ resource "aws_route53_record" "analytics" {
     evaluate_target_health = false
   }
 }
+
+# ---------------------------------------------------------------------------
+# Dashboard static hosting (public S3 + CloudFront)
+# ---------------------------------------------------------------------------
+#
+# The dashboard shell holds no data and no secrets: all data lives behind the
+# Entra-authenticated /data API, so the UI is safe to serve as a plain public
+# site. Access control is entirely the Entra sign-in plus the /data API's JWT
+# authorizer — there is deliberately no Lambda@Edge and no edge auth here. The
+# bucket stays private; CloudFront reads it through an Origin Access Control.
+
+resource "aws_s3_bucket" "dashboard" {
+  bucket = "${local.function_name}-dashboard-${data.aws_caller_identity.current.account_id}"
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "dashboard" {
+  bucket = aws_s3_bucket.dashboard.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# The bucket is private; the objects are served to the public through the
+# distribution, never from the bucket directly.
+resource "aws_s3_bucket_public_access_block" "dashboard" {
+  bucket = aws_s3_bucket.dashboard.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "dashboard" {
+  name                              = "${local.function_name}-dashboard"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "dashboard" {
+  enabled             = true
+  default_root_object = "index.html"
+  comment             = "${local.function_name} dashboard"
+  price_class         = "PriceClass_100"
+  tags                = local.tags
+
+  origin {
+    domain_name              = aws_s3_bucket.dashboard.bucket_regional_domain_name
+    origin_id                = "dashboard-s3"
+    origin_access_control_id = aws_cloudfront_origin_access_control.dashboard.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "dashboard-s3"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    # AWS managed "CachingOptimized" policy.
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  }
+
+  # Return index.html for unknown paths so a refresh after the sign-in redirect
+  # lands on the app instead of an S3 error.
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # No custom domain: the default *.cloudfront.net certificate is used, so the
+  # CloudFront URL is added to the app registration redirect URIs after deploy.
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+
+# Allow only this distribution to read the bucket (OAC identity + SourceArn).
+data "aws_iam_policy_document" "dashboard" {
+  statement {
+    sid       = "AllowCloudFrontRead"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.dashboard.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.dashboard.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "dashboard" {
+  bucket = aws_s3_bucket.dashboard.id
+  policy = data.aws_iam_policy_document.dashboard.json
+
+  depends_on = [aws_s3_bucket_public_access_block.dashboard]
+}

--- a/tools/analytics/infra/outputs.tf
+++ b/tools/analytics/infra/outputs.tf
@@ -20,3 +20,18 @@ output "function_name" {
 output "data_bucket" {
   value = aws_s3_bucket.data.id
 }
+
+output "dashboard_bucket" {
+  description = "S3 bucket holding the static dashboard files"
+  value       = aws_s3_bucket.dashboard.id
+}
+
+output "dashboard_url" {
+  description = "Public CloudFront URL of the dashboard"
+  value       = "https://${aws_cloudfront_distribution.dashboard.domain_name}"
+}
+
+output "dashboard_distribution_id" {
+  description = "CloudFront distribution id (used for cache invalidation on publish)"
+  value       = aws_cloudfront_distribution.dashboard.id
+}


### PR DESCRIPTION
Hosts the analytics dashboard UI. Its data sits behind the Entra-authenticated `/data` API, so the shell itself carries no data or secrets and can be served as a plain public S3 + CloudFront site: the bucket stays private (read via an Origin Access Control) and access control is entirely the Entra sign-in plus the `/data` gate — no Lambda@Edge, edge auth or extra IAM role.

Go-live after the first deploy: add the CloudFront URL as an app-registration redirect URI and to `DASHBOARD_ORIGINS`, then drop `localhost`.

**Will merge 1st of September when in office just to be able to react quickly in case something needs to be fixed immediately after deplo**y 🙏 
