### PR TITLE
chore(analytics): gate the analytics workspace in verify CI and harden session reuse

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -79,11 +79,13 @@ jobs:
 
       - name: Audit dependencies
         # Audit the shipped (production) dependency tree of everything we ship:
-        # the @dnb/eufemia npm library and the @dnb/eufemia-mcp Lambda. Both must
-        # pass; dev/build tooling advisories are tracked via Dependabot instead.
+        # the @dnb/eufemia npm library, the @dnb/eufemia-mcp Lambda and the
+        # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
+        # are tracked via Dependabot instead.
         run: |
           yarn workspace @dnb/eufemia audit:ci
           yarn workspace @dnb/eufemia-mcp audit:ci
+          yarn workspace eufemia-analytics audit:ci
 
       - name: Verify SBOM + audit generation (release smoke test)
         # release.yml generates a CycloneDX SBOM and a vulnerability report after

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -175,6 +175,7 @@ jobs:
           yarn workspace @dnb/eufemia lint:ci
           yarn workspace @dnb/eufemia-mcp-legacy-proxy lint
           yarn workspace eufemia-raiwork-plugin lint
+          yarn workspace eufemia-analytics lint
 
   lint-portal:
     name: Run portal lint
@@ -246,6 +247,7 @@ jobs:
           yarn workspace eufemia-llm-metadata test:types
           yarn workspace eufemia-raiwork-plugin test:types
           yarn workspace @dnb/eufemia-mcp-legacy-proxy typecheck
+          yarn workspace eufemia-analytics test:types
 
   test:
     name: Run tests
@@ -285,6 +287,7 @@ jobs:
           yarn workspace eufemia-llm-metadata test
           yarn workspace eufemia-raiwork-plugin test
           yarn workspace @dnb/eufemia-mcp-legacy-proxy test
+          yarn workspace eufemia-analytics test
 
   deps:
     name: Run dependency checks

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -4,6 +4,7 @@ import {
   beginAuthRetry,
   clearAuthRetry,
   clearSession,
+  readSession,
 } from '../dashboard/auth.js'
 import { loadDashboardData } from '../dashboard/app.js'
 
@@ -79,6 +80,56 @@ describe('clearSession', () => {
     )
     clearSession()
     expect(sessionStorage.getItem('eufemia-analytics-session')).toBe(null)
+  })
+})
+
+describe('readSession', () => {
+  const SESSION_KEY = 'eufemia-analytics-session'
+  const future = Date.now() + 60000
+
+  beforeEach(() => {
+    globalThis.sessionStorage = new MemoryStorage()
+  })
+
+  afterEach(() => {
+    delete globalThis.sessionStorage
+  })
+
+  it('returns a non-expired session that carries an access token', () => {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({
+        name: 'Signed in',
+        accessToken: 'token-abc',
+        expiresAt: future,
+      })
+    )
+
+    expect(readSession()).toMatchObject({ accessToken: 'token-abc' })
+  })
+
+  it('rejects and clears a session without an access token', () => {
+    // A session shape persisted by an older build: no accessToken.
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ name: 'Signed in', expiresAt: future })
+    )
+
+    expect(readSession()).toBe(null)
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe(null)
+  })
+
+  it('rejects an expired session even with an access token', () => {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({
+        name: 'Signed in',
+        accessToken: 'token-abc',
+        expiresAt: Date.now() - 1000,
+      })
+    )
+
+    expect(readSession()).toBe(null)
   })
 })
 

--- a/tools/analytics/dashboard/auth.js
+++ b/tools/analytics/dashboard/auth.js
@@ -80,12 +80,15 @@ function decodeJwt(token) {
   }
 }
 
-function readSession() {
+export function readSession() {
   try {
     const session = JSON.parse(
       sessionStorage.getItem(SESSION_KEY) || 'null'
     )
-    if (session && session.expiresAt > Date.now()) {
+    // Require an access token as well: a session persisted by an older build
+    // has no token and can't call the data API, so treat it as invalid and
+    // force a clean re-auth rather than sending "Bearer undefined".
+    if (session && session.accessToken && session.expiresAt > Date.now()) {
       return session
     }
   } catch {

--- a/tools/analytics/package.json
+++ b/tools/analytics/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "vitest run",
     "test:types": "../../node_modules/.bin/tsc --noEmit",
-    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts' && node ../../node_modules/.bin/prettier --check 'dashboard/**/*.{js,css,html,json,md}'",
+    "lint": "node ../../node_modules/.bin/eslint 'src/**/*.ts' && node ../../node_modules/.bin/prettier --check 'dashboard/**/*.{js,css,html,json,md}' 'src/**/*.ts' '__tests__/**/*.{js,ts}'",
     "audit:ci": "yarn npm audit --recursive --environment production --severity high",
     "build": "rm -rf dist && esbuild src/lambda/index.ts --bundle --platform=node --target=node22 --format=esm --sourcemap --outfile=dist/index.mjs '--external:@aws-sdk/*' && cd dist && zip -rq lambda.zip index.mjs index.mjs.map",
     "deploy": "yarn build && terraform -chdir=infra init && terraform -chdir=infra apply -auto-approve",


### PR DESCRIPTION
Follow-up improvements for #9170, targeting that PR's branch so they land together.

While reviewing #9170 I confirmed two gaps and one narrow edge case, then self-reviewed this PR and closed a related consistency gap. This PR addresses all of them.

## 1. The analytics workspace never ran on pull requests
`verify.yml` (the workflow that gates PRs) runs lint, type-check and tests per workspace, but `eufemia-analytics` was never in any of those lists. The only workflow that exercised the tool was `analytics-lambda.yml`, which triggers on **push to `main`** — so the dashboard tests added in #9170 (and the existing lambda tests) never ran as a PR check.

Fix: add `eufemia-analytics` to the `lint`, `typecheck` and `test` jobs in `verify.yml`, matching how the other self-contained tool workspaces (`eufemia-raiwork-plugin`, `@dnb/eufemia-mcp-legacy-proxy`) are already gated.

## 2. Auditing was also main-only
For the same reason, the tool's production-dependency audit (`audit:ci`) only ran on push to `main`. Added `eufemia-analytics` to the verify `audit` job alongside `@dnb/eufemia` and `@dnb/eufemia-mcp`, so the supply-chain gate is consistent across everything we ship.

## 3. The dashboard test file was never format-checked
The tool's `lint` script only Prettier-checked `dashboard/**`, so `__tests__/dashboard.test.js` was covered by neither ESLint nor Prettier. Widened the Prettier glob to also cover `src/**/*.ts` and `__tests__/**/*.{js,ts}` (all currently clean).

## 4. A stale session sent `Bearer undefined`
`readSession()` accepted any non-expired session. A session persisted by an older build has no `accessToken`, so the dashboard would call the data API with `Authorization: Bearer undefined` (reproduced locally). Now `readSession()` also requires `accessToken`, so such a session is treated as invalid and forces a clean re-auth. `readSession` is exported and covered by three new tests.

## Verification
All analytics checks now run on this PR and pass:
- **Run lint** — includes `yarn workspace eufemia-analytics lint`
- **Audit dependencies** — includes `yarn workspace eufemia-analytics audit:ci`
- **Run type checks** — includes `yarn workspace eufemia-analytics test:types`
- **Run tests** — includes `yarn workspace eufemia-analytics test` → `__tests__/dashboard.test.js (18 tests)`, 80 passed

No changes to the runtime behaviour of the normal (freshly-signed-in) path.
