### PR TITLE
fix(Dialog): prevent scroll jump to top when opening on long pages

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
+++ b/packages/dnb-eufemia/src/components/modal/__tests__/Modal.test.tsx
@@ -1176,7 +1176,7 @@ describe('Modal component', () => {
     expect(outsideButton.getAttribute('aria-hidden')).toEqual('true')
   })
 
-  it('runs expected side effects on desktop', () => {
+  it('locks body scroll without fixing its height on desktop', () => {
     render(
       <Modal {...props}>
         <DialogContent />
@@ -1190,7 +1190,8 @@ describe('Modal component', () => {
     fireEvent.click(elem)
 
     expect(document.body.style.overflow).toBe('hidden')
-    expect(document.body.style.height).toBe('100%')
+    expect(document.body.style.height).toBe('auto')
+    expect(document.body.style.minHeight).toBe('100%')
     expect(document.body.style.boxSizing).toBe('border-box')
     expect(document.body.style.marginRight).toBe('0px')
     expect(document.documentElement.style.height).toBe('100%')
@@ -1291,7 +1292,8 @@ describe('Modal component', () => {
     expect(document.body.style.top).toBe('0px')
     expect(document.body.style.left).toBe('0px')
     expect(document.body.style.right).toBe('0px')
-    expect(document.body.style.height).toBe('100%')
+    expect(document.body.style.height).toBe('auto')
+    expect(document.body.style.minHeight).toBe('100%')
     expect(document.documentElement.style.height).toBe('100%')
     expect(
       document.documentElement.getAttribute('data-dnb-modal-active')

--- a/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
+++ b/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
@@ -40,7 +40,11 @@ const setOverflowHidden = () => {
     )
 
     bodyElement.style.overflow = 'hidden'
-    bodyElement.style.height = '100%'
+    // `height: auto` (not `100%`): with the html height above now definite, a
+    // `body` height of `100%` collapses a long page to the viewport and resets
+    // scroll to the top on open. `min-height` still fills the viewport if short.
+    bodyElement.style.height = 'auto'
+    bodyElement.style.minHeight = '100%'
     bodyElement.style.boxSizing = 'border-box'
     bodyElement.style.marginRight = `${scrollBarWidth}px`
 
@@ -49,7 +53,13 @@ const setOverflowHidden = () => {
         ;['overflow', 'height'].forEach((x) => {
           htmlElement.style[x] = htmlStyle[x] || ''
         })
-        ;['overflow', 'height', 'boxSizing', 'margin'].forEach((x) => {
+        ;[
+          'overflow',
+          'height',
+          'minHeight',
+          'boxSizing',
+          'margin',
+        ].forEach((x) => {
           bodyElement.style[x] = bodyStyle[x] || ''
         })
         htmlElement.style.removeProperty('--scrollbar-width')

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/DrawerList.test.tsx
@@ -834,7 +834,7 @@ describe('DrawerList component', () => {
     rerender(<MockComponent open />)
 
     expect(document.body.getAttribute('style')).toBe(
-      'overflow: hidden; height: 100%; box-sizing: border-box; margin-right: 0px;'
+      'overflow: hidden; height: auto; min-height: 100%; box-sizing: border-box; margin-right: 0px;'
     )
 
     rerender(<MockComponent open={false} />)


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1788172271827289

Can be demoed https://eufemia.dnb.no/uilib/components/dialog/demos or https://eufemia.dnb.no/uilib/components/help-button/#help-button-inside-a-suffix

Opening a `Dialog` (for example via `HelpButton`) on a page taller than the viewport scrolled the page to the top, which looked like a page refresh.

The scroll lock set the body to `height: 100%`. Once the locked `html` height is definite and the app authors `body { height: 100% }` (as the portal and most DNB apps do), a long page collapses to the viewport height, so the browser clamps the scroll position to the top when the Dialog opens.

The locked body now uses `height: auto` with `min-height: 100%`, so short documents still fill the viewport without collapsing long ones.

Introduced by #8985 (v11.10.0).
