### PR TITLE
chore(Modal): avoid unsafe regex in scroll-lock OS detection

### DIFF
--- a/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
+++ b/packages/dnb-eufemia/src/components/modal/bodyScrollLock.ts
@@ -9,7 +9,7 @@ const detectOS = (ua?: string) => {
   ua = ua || navigator.userAgent
   const ipad = /(iPad).*OS\s([\d_]+)/.test(ua)
   const iphone = !ipad && /(iPhone\sOS)\s([\d_]+)/.test(ua)
-  const android = /(Android);?[\s/]+([\d.]+)?/.test(ua)
+  const android = /(Android);?[\s/]+/.test(ua)
   const ios = iphone || ipad
   return { ios, android }
 }


### PR DESCRIPTION
The Android user-agent check used a nested quantifier, `([\d.]+)?`, which `security/detect-unsafe-regex` flags as an unsafe regular expression.

That trailing group is optional and the result is only read through `.test()`, so it never affected the outcome — it was dead weight. Removing it clears the warning while keeping the exact same match.
