### PR TITLE
fix(List): keep selection outline visible in Safari

### DIFF
--- a/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
+++ b/packages/dnb-eufemia/src/components/list/style/dnb-list.scss
@@ -272,6 +272,18 @@
     &--selection:has(.dnb-radio__input) {
       overflow: clip;
       overflow-clip-margin: var(--list-item-outline-width);
+
+      // Safari lacks overflow-clip-margin, so draw the (otherwise clipped) outline inside.
+      @supports not (overflow-clip-margin: 1px) {
+        &::after {
+          inset: 0;
+          bottom: calc(var(--list-item-outline-width) * -1);
+        }
+        &:not([hidden]):has(+ [hidden])::after,
+        &:last-of-type:not([hidden])::after {
+          bottom: 0;
+        }
+      }
     }
     &--selection .dnb-checkbox__input {
       --checkbox-bounding--medium: 100;


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1788178021582509
Issue: https://eufemia.dnb.no/uilib/components/list/demos/#with-form-elements
Reprod fix: https://fix-list-selection-border-sa.eufemia-e25.pages.dev/uilib/components/list/demos/#with-form-elements

Selectable `List` items (radio/checkbox) use `overflow: clip` for the full-row hit area, and show the outline — drawn just outside the item — via `overflow-clip-margin`. Safari doesn't support `overflow-clip-margin` at any version, so it clips the outline away and the border disappears (Safari only). This hits the documented `radio-list` → `Field.Selection` + `List` composition, so it surfaced after v11 upgrades.

Fix: a Safari-only `@supports not (overflow-clip-margin: 1px)` fallback that draws the outline inside the item, overlapping the next item so dividers stay a single line — the same technique `--inset-outline` and `--pending` already use. Chrome and Firefox keep the existing path, so no visual baselines move.

I believe it's been like this since #6520
