### PR TITLE
chore(analytics): enforce Dashboard.Read scope on the dashboard /data route

### DIFF
--- a/tools/analytics/dashboard/README.md
+++ b/tools/analytics/dashboard/README.md
@@ -36,3 +36,8 @@ Data is served by a separate, access-controlled API rather than bundled into
 these files. On a static host the sign-in gates the UI, so the API itself also
 enforces access by validating the Entra token. These pieces are layered on top
 of this UI shell.
+
+The API also requires the `Dashboard.Read` scope, so the app registration must
+issue v2 access tokens (`requestedAccessTokenVersion = 2`) that carry a `scp`
+claim. Confirm end to end after a deploy: sign in, then check the `/data` call
+returns 200 (a 401/403 usually means the token is v1 or is missing the scope).

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -352,6 +352,10 @@ resource "aws_apigatewayv2_route" "dashboard_data" {
   target             = "integrations/${aws_apigatewayv2_integration.dashboard.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.entra.id
+
+  # Require the exposed scope so an ID token (same aud/iss, no scp) can't stand
+  # in for the access token the browser requests.
+  authorization_scopes = ["Dashboard.Read"]
 }
 
 resource "aws_lambda_permission" "dashboard_apigw" {


### PR DESCRIPTION
The dashboard `/data` route authorizes with a JWT authorizer that validates only issuer and audience. An ID token from the same app registration carries the same `aud`/`iss` and no `scp` claim, so it would pass — meaning the `Dashboard.Read` scope the browser requests is currently decorative. This adds `authorization_scopes = ["Dashboard.Read"]` so the route actually requires the scope, closing the ID-token-substitution gap.