### PR TITLE
chore(analytics): hide dashboard until sign-in resolves

### DIFF
--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -210,14 +210,18 @@ function showError(message) {
 // Hide the sign-in placeholder and reveal the dashboard. Kept hidden until a
 // session is resolved so the dashboard does not flash before the login redirect.
 function revealDashboard() {
-  const status = document.getElementById('status')
-  if (status) {
-    status.hidden = true
-  }
+  hideStatus()
 
   const dashboard = document.getElementById('dashboard')
   if (dashboard) {
     dashboard.hidden = false
+  }
+}
+
+function hideStatus() {
+  const status = document.getElementById('status')
+  if (status) {
+    status.hidden = true
   }
 }
 
@@ -226,7 +230,7 @@ async function main() {
   try {
     session = await ensureSignedIn()
   } catch (error) {
-    document.getElementById('status').hidden = true
+    hideStatus()
     showError(`Sign-in failed: ${error.message}`)
 
     return

--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -207,15 +207,32 @@ function showError(message) {
   box.hidden = false
 }
 
+// Hide the sign-in placeholder and reveal the dashboard. Kept hidden until a
+// session is resolved so the dashboard does not flash before the login redirect.
+function revealDashboard() {
+  const status = document.getElementById('status')
+  if (status) {
+    status.hidden = true
+  }
+
+  const dashboard = document.getElementById('dashboard')
+  if (dashboard) {
+    dashboard.hidden = false
+  }
+}
+
 async function main() {
   let session
   try {
     session = await ensureSignedIn()
   } catch (error) {
+    document.getElementById('status').hidden = true
     showError(`Sign-in failed: ${error.message}`)
 
     return
   }
+
+  revealDashboard()
 
   renderUser(session)
 

--- a/tools/analytics/dashboard/index.html
+++ b/tools/analytics/dashboard/index.html
@@ -8,30 +8,34 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <header class="header">
-      <h1>Eufemia Analytics</h1>
-      <div class="controls">
-        <label for="env">Environment</label>
-        <select id="env" aria-label="Filter by environment">
-          <option value="">All</option>
-        </select>
-        <span id="user" class="user" hidden></span>
-      </div>
-    </header>
+    <p id="status" class="status" role="status">Checking sign-in…</p>
 
-    <p id="meta" class="meta"></p>
+    <main id="dashboard" hidden>
+      <header class="header">
+        <h1>Eufemia Analytics</h1>
+        <div class="controls">
+          <label for="env">Environment</label>
+          <select id="env" aria-label="Filter by environment">
+            <option value="">All</option>
+          </select>
+          <span id="user" class="user" hidden></span>
+        </div>
+      </header>
 
-    <section class="kpis" id="kpis" aria-label="Key figures"></section>
+      <p id="meta" class="meta"></p>
 
-    <section class="panel">
-      <h2>Records per day</h2>
-      <div id="per-day" class="chart"></div>
-    </section>
+      <section class="kpis" id="kpis" aria-label="Key figures"></section>
 
-    <section class="panel">
-      <h2>Top pages</h2>
-      <div id="top-names" class="chart"></div>
-    </section>
+      <section class="panel">
+        <h2>Records per day</h2>
+        <div id="per-day" class="chart"></div>
+      </section>
+
+      <section class="panel">
+        <h2>Top pages</h2>
+        <div id="top-names" class="chart"></div>
+      </section>
+    </main>
 
     <p id="error" class="error" hidden></p>
 

--- a/tools/analytics/dashboard/styles.css
+++ b/tools/analytics/dashboard/styles.css
@@ -78,6 +78,11 @@ select {
   margin: 0.5rem 0 1.5rem;
 }
 
+.status {
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
 .kpis {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));


### PR DESCRIPTION
The analytics dashboard rendered its full chrome (KPIs, charts) on load, then `app.js` ran the async sign-in check and redirected to Entra. Unauthenticated users saw the dashboard flash for a couple of seconds before being sent to the login page.

The dashboard content is now hidden by default behind a neutral "Checking sign-in…" placeholder, and only revealed once a session is resolved (or when sign-in is not configured, e.g. local preview). Since the login redirect never resolves its promise, the page stays on the placeholder and navigates away without ever exposing the dashboard.
