### PR TITLE
feat(Theme): deprecate `name` in favor of `brand`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -12,6 +12,7 @@ draft: true
   - [Install](#install)
   - [CSS custom properties](#css-custom-properties)
   - [Component changes](#component-changes)
+    - [Theme](#theme)
     - [Flex](#flex)
     - [Accordion](#accordion)
     - [Autocomplete](#autocomplete)
@@ -51,6 +52,17 @@ $ yarn add @dnb/eufemia@13
 - Replace `--leading-sb-*` with `--leading-*`
 
 ## Component changes
+
+### [Theme](/uilib/usage/customisation/theming/theme)
+
+The deprecated `name` property and `data-name` attribute have been removed. Use `brand` and `data-brand` instead.
+
+```diff
+-<Theme name="carnegie">
++<Theme brand="carnegie">
+```
+
+Replace `useTheme().name` with `useTheme().brand`. For persisted theme state, replace `getTheme().name` and `setTheme({ name })` with `getTheme().brand` and `setTheme({ brand })`.
 
 ### [Flex](/uilib/layout/flex/)
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming.mdx
@@ -35,14 +35,14 @@ import '@dnb/eufemia/style/core' // or /basis when "dnb-core-style" is used
 + import '@dnb/eufemia/style/themes/eiendom'
 ```
 
-Set the same theme name on the application-level `Theme` component so
+Set the same brand on the application-level `Theme` component so
 components receive the matching theme context:
 
 ```tsx
 import { Theme } from '@dnb/eufemia/shared'
 
 render(
-  <Theme name="eiendom">
+  <Theme brand="eiendom">
     <App />
   </Theme>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/Examples.tsx
@@ -37,18 +37,18 @@ export const ThemeBasis = () => (
       }
 
       const Demo = () => {
-        const [name, setName] = useState<ThemeNames>('dnb' as ThemeNames)
+        const [brand, setBrand] = useState<ThemeNames>('dnb' as ThemeNames)
 
         return (
           <MyColors>
             <Dropdown
               data={{ dnb: 'DNB', sbanken: 'Sbanken' }}
-              value={name}
+              value={brand}
               onChange={({ data }) =>
-                setName(data.selectedKey as ThemeNames)
+                setBrand(data.selectedKey as ThemeNames)
               }
             />
-            <Theme name={name}>
+            <Theme brand={brand}>
               <MyComponent />
             </Theme>
           </MyColors>

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -12,12 +12,12 @@ The Theme component is a helper component that lets you create nested theming so
 import { Theme, useTheme } from '@dnb/eufemia/shared'
 
 const Component = () => {
-  const themeName = useTheme()?.name
+  const themeBrand = useTheme()?.brand
   return 'My Component'
 }
 
 render(
-  <Theme name="sbanken">
+  <Theme brand="sbanken">
     <App>
       <MyComponent />
     </App>
@@ -28,7 +28,9 @@ render(
 From CSS you can use it as so:
 
 - `.eufemia-theme__sbanken`
-- `.eufemia-theme[data-name="sbanken"]` (alternative)
+- `.eufemia-theme[data-brand="sbanken"]` (alternative)
+
+The deprecated `data-name` attribute remains available until v13.
 
 **CSS**
 
@@ -56,14 +58,14 @@ For accessing the theme context, you can use the `useTheme` Hook. It returns the
 import { Theme, useTheme } from '@dnb/eufemia/shared'
 
 const Component = () => {
-  // Result: { name: 'sbanken', isUi: false, isSbanken: true, isEiendom: false }
+  // Result: { brand: 'sbanken', isUi: false, isSbanken: true, isEiendom: false }
   const theme = useTheme()
-  const { name, isUi, isSbanken, isEiendom } = theme || {}
+  const { brand, isUi, isSbanken, isEiendom } = theme || {}
   return null
 }
 
 render(
-  <Theme name="sbanken">
+  <Theme brand="sbanken">
     <App>
       <MyComponent />
     </App>
@@ -99,9 +101,9 @@ const Component = ({ className ...props }) => {
 }
 
 render(
-  <Theme name="theme-name">
+  <Theme brand="theme-name">
     <App>
-      <Theme name="sbanken" element={Component}>
+      <Theme brand="sbanken" element={Component}>
         ...
       </Theme>
     </App>
@@ -186,18 +188,18 @@ import { getTheme, setTheme } from '@dnb/eufemia/shared/Theme'
 
 // Read the current persisted theme
 const theme = getTheme()
-// { name: 'ui', colorScheme: 'auto', ... }
+// { brand: 'ui', colorScheme: 'auto', ... }
 
 // Update one or more properties (merges with existing state)
 setTheme({ colorScheme: 'dark' })
 
 // With a callback
-setTheme({ name: 'sbanken' }, (updatedTheme) => {
+setTheme({ brand: 'sbanken' }, (updatedTheme) => {
   console.log(updatedTheme)
 })
 ```
 
-`getTheme` also supports a `?eufemia-theme=<name>` URL query parameter, which overrides the persisted theme name. This is useful for testing or previewing themes via a link.
+`getTheme` also supports a `?eufemia-theme=<brand>` URL query parameter, which overrides the persisted theme brand. This is useful for testing or previewing themes via a link.
 
 ### Preventing dark mode flash (FOUC)
 
@@ -240,7 +242,7 @@ With this helper function you show or hide content based on inherited theme prop
 import { Theme, VisibilityByTheme } from '@dnb/eufemia/shared'
 
 render(
-  <Theme name="...">
+  <Theme brand="...">
     <VisibilityByTheme visible="sbanken">
       Only shown in Sbanken theme
     </VisibilityByTheme>
@@ -254,13 +256,16 @@ render(
     </VisibilityByTheme>
 
     <VisibilityByTheme
-      visible={[{ name: 'sbanken' }, { name: 'eiendom' }]}
+      visible={[{ brand: 'sbanken' }, { brand: 'eiendom' }]}
     >
       Only shown in Sbanken or Eiendom theme
     </VisibilityByTheme>
 
     <VisibilityByTheme
-      visible={[{ name: 'sbanken' }, { name: 'eiendom', variant: 'blue' }]}
+      visible={[
+        { brand: 'sbanken' },
+        { brand: 'eiendom', variant: 'blue' },
+      ]}
     >
       Only shown in Sbanken then or Eiendom theme – that also includes the
       fictive variant="blue".

--- a/packages/dnb-eufemia/src/shared/Context.tsx
+++ b/packages/dnb-eufemia/src/shared/Context.tsx
@@ -133,7 +133,7 @@ export type ContextProps = ContextComponents & {
   // -- Global properties --
 
   /**
-   * Contains theme related properties, such as a theme name
+   * Contains theme related properties, such as a theme brand
    */
   theme?: ThemeProps
 

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -30,6 +30,11 @@ export type ThemeColorScheme = 'auto' | 'light' | 'dark'
 export type ThemeSurface = 'light' | 'dark' | 'initial'
 
 export type ThemeProps = {
+  brand?: ThemeNames
+  /**
+   * Deprecated. Use `brand` instead.
+   * @deprecated Use `brand` instead. This property will be removed in v13.
+   */
   name?: ThemeNames
   variant?: ThemeVariants
   size?: ThemeSizes
@@ -47,6 +52,7 @@ export default function Theme(themeProps: ThemeAllProps) {
   const {
     children,
     element,
+    brand,
     name,
     variant,
     size,
@@ -75,7 +81,8 @@ export default function Theme(themeProps: ThemeAllProps) {
 
   const theme = extendPropsWithContext(
     {
-      name,
+      brand: brand ?? name,
+      name: brand ?? name,
       variant,
       size,
       contrastMode,
@@ -85,6 +92,10 @@ export default function Theme(themeProps: ThemeAllProps) {
     null,
     context?.theme
   )
+
+  const resolvedBrand = theme.brand ?? theme.name
+  theme.brand = resolvedBrand
+  theme.name = resolvedBrand
 
   // When surface is "initial", reset it to break context inheritance
   if (surface === 'initial') {
@@ -130,7 +141,7 @@ export function ThemeWrapper({
   useSyncElementColorScheme(ref, theme)
 
   const classNames = getThemeClasses(theme, className)
-  const { name, variant, size } = theme
+  const { brand, variant, size } = theme
 
   if (Wrapper === Fragment) {
     return children
@@ -140,7 +151,8 @@ export function ThemeWrapper({
 
   return (
     <Wrapper
-      data-name={name}
+      data-brand={brand}
+      data-name={brand}
       data-variant={variant}
       data-size={size}
       className={classNames}
@@ -156,13 +168,16 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
     return className
   }
 
-  const { name, variant, size, contrastMode, colorScheme } = theme
+  const { brand, name, variant, size, contrastMode, colorScheme } = theme
+  const resolvedBrand = brand ?? name
 
   return clsx(
     className,
     'eufemia-theme',
-    name && `eufemia-theme__${name}`,
-    name && variant && `eufemia-theme__${name}--${variant}`,
+    resolvedBrand && `eufemia-theme__${resolvedBrand}`,
+    resolvedBrand &&
+      variant &&
+      `eufemia-theme__${resolvedBrand}--${variant}`,
     contrastMode && 'eufemia-theme__contrast-mode',
     colorScheme && `eufemia-theme__color-scheme--${colorScheme}`,
     size && `eufemia-theme__size--${size}`
@@ -227,11 +242,11 @@ export type ThemeState = ThemeProps & Record<string, unknown>
 
 /**
  * Read the persisted theme state from localStorage.
- * Supports a `?eufemia-theme=<name>` URL query override for the theme name.
+ * Supports a `?eufemia-theme=<brand>` URL query override for the theme brand.
  */
-export function getTheme(defaultTheme: ThemeNames = 'ui'): ThemeState {
+export function getTheme(defaultBrand: ThemeNames = 'ui'): ThemeState {
   if (typeof window === 'undefined') {
-    return { name: defaultTheme }
+    return { brand: defaultBrand, name: defaultBrand }
   }
 
   try {
@@ -242,11 +257,14 @@ export function getTheme(defaultTheme: ThemeNames = 'ui'): ThemeState {
       new URLSearchParams(window.location.search).get('eufemia-theme') ||
       null
 
-    const name = (fromQuery || theme?.name || defaultTheme) as ThemeNames
+    const brand = (fromQuery ||
+      theme?.brand ||
+      theme?.name ||
+      defaultBrand) as ThemeNames
 
-    return { ...theme, name }
+    return { ...theme, brand, name: brand }
   } catch {
-    return { name: defaultTheme }
+    return { brand: defaultBrand, name: defaultBrand }
   }
 }
 
@@ -263,7 +281,17 @@ export function setTheme(
   }
 
   try {
-    const theme = { ...getTheme(), ...themeProps }
+    const currentTheme = getTheme()
+    const brand = (themeProps.brand ??
+      themeProps.name ??
+      currentTheme.brand ??
+      currentTheme.name) as ThemeNames
+    const theme = {
+      ...currentTheme,
+      ...themeProps,
+      brand,
+      name: brand,
+    }
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(theme))
     callback?.(theme)
   } catch {

--- a/packages/dnb-eufemia/src/shared/ThemeDocs.ts
+++ b/packages/dnb-eufemia/src/shared/ThemeDocs.ts
@@ -1,10 +1,15 @@
 import type { PropertiesTableProps } from '../shared/types'
 
 export const ThemeProperties: PropertiesTableProps = {
-  name: {
-    doc: 'The name of a branding theme. Can be `ui` (universal identity), `eiendom`, `sbanken` or `carnegie`.',
+  brand: {
+    doc: 'The branding theme. Can be `ui` (universal identity), `eiendom`, `sbanken` or `carnegie`.',
     type: ['"ui"', '"eiendom"', '"sbanken"', '"carnegie"'],
     status: 'optional',
+  },
+  name: {
+    doc: 'Deprecated. Use `brand` instead.',
+    type: ['"ui"', '"eiendom"', '"sbanken"', '"carnegie"'],
+    status: 'deprecated',
   },
   size: {
     doc: 'Will define what sizes of components are used (WIP).',

--- a/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
+++ b/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
@@ -4,13 +4,13 @@ import type { ThemeNames, ThemeProps } from './Theme'
 
 type VisibilityByThemeProps = {
   /**
-   * A valid theme name or object.
+   * A valid theme brand or object.
    * Will pass children on a match.
    */
   visible?: ThemeParams
 
   /**
-   * A valid theme name or object.
+   * A valid theme brand or object.
    * Will omit passing children on a match.
    * NB: "visible" takes presence over "hidden"
    */
@@ -50,7 +50,7 @@ export default function VisibilityByTheme({
   function match(theme: ThemeProps) {
     return (themeItem: ThemeItem) => {
       return typeof themeItem === 'string'
-        ? theme.name === themeItem
+        ? theme.brand === themeItem
         : matchObject(theme, themeItem)
     }
   }

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -20,7 +20,23 @@ describe('Theme', () => {
     expect(document.querySelector('.eufemia-theme')).toBeInTheDocument()
   })
 
-  it('sets name and variant as HTML classes', () => {
+  it('sets brand and variant as HTML classes and attributes', () => {
+    render(
+      <Theme brand="eiendom" variant="soft">
+        content
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(element).toHaveClass(
+      'eufemia-theme eufemia-theme__eiendom eufemia-theme__eiendom--soft',
+      { exact: true }
+    )
+    expect(element).toHaveAttribute('data-brand', 'eiendom')
+    expect(element).toHaveAttribute('data-name', 'eiendom')
+  })
+
+  it('supports the deprecated name prop', () => {
     render(
       <Theme name="eiendom" variant="soft">
         content
@@ -32,6 +48,21 @@ describe('Theme', () => {
       'eufemia-theme eufemia-theme__eiendom eufemia-theme__eiendom--soft',
       { exact: true }
     )
+  })
+
+  it('prefers brand when brand and name are both set', () => {
+    render(
+      <Theme brand="carnegie" name="eiendom">
+        content
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(element).toHaveClass('eufemia-theme eufemia-theme__carnegie', {
+      exact: true,
+    })
+    expect(element).toHaveAttribute('data-brand', 'carnegie')
+    expect(element).toHaveAttribute('data-name', 'carnegie')
   })
 
   it('supports nested themes', () => {
@@ -595,12 +626,12 @@ describe('Portals', () => {
 
     it('returns default theme when localStorage is empty', () => {
       const result = getTheme()
-      expect(result).toEqual({ name: 'ui' })
+      expect(result).toEqual({ brand: 'ui', name: 'ui' })
     })
 
     it('returns custom default theme', () => {
       const result = getTheme('sbanken')
-      expect(result).toEqual({ name: 'sbanken' })
+      expect(result).toEqual({ brand: 'sbanken', name: 'sbanken' })
     })
 
     it('reads persisted theme from localStorage', () => {
@@ -610,7 +641,20 @@ describe('Portals', () => {
       )
 
       const result = getTheme()
+      expect(result.brand).toBe('eiendom')
       expect(result.name).toBe('eiendom')
+      expect(result.colorScheme).toBe('dark')
+    })
+
+    it('reads a persisted brand from localStorage', () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ brand: 'carnegie', colorScheme: 'dark' })
+      )
+
+      const result = getTheme()
+      expect(result.brand).toBe('carnegie')
+      expect(result.name).toBe('carnegie')
       expect(result.colorScheme).toBe('dark')
     })
 
@@ -623,6 +667,7 @@ describe('Portals', () => {
       window.history.replaceState({}, '', '?eufemia-theme=sbanken')
 
       const result = getTheme()
+      expect(result.brand).toBe('sbanken')
       expect(result.name).toBe('sbanken')
 
       window.history.replaceState({}, '', '/')
@@ -639,34 +684,52 @@ describe('Portals', () => {
 
       window.history.replaceState({}, '', '/')
 
-      expect(result).toEqual({ name: 'ui' })
+      expect(result).toEqual({ brand: 'ui', name: 'ui' })
       expect(elapsed).toBeLessThan(1000)
     })
 
     it('persists theme state to localStorage', () => {
-      setTheme({ name: 'eiendom', colorScheme: 'dark' })
+      setTheme({ brand: 'eiendom', colorScheme: 'dark' })
 
       const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      expect(stored.brand).toBe('eiendom')
       expect(stored.name).toBe('eiendom')
       expect(stored.colorScheme).toBe('dark')
     })
 
     it('merges with existing state', () => {
-      setTheme({ name: 'sbanken' })
+      setTheme({ brand: 'sbanken' })
       setTheme({ colorScheme: 'dark' })
 
       const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      expect(stored.brand).toBe('sbanken')
       expect(stored.name).toBe('sbanken')
       expect(stored.colorScheme).toBe('dark')
     })
 
+    it('supports the deprecated name property', () => {
+      setTheme({ name: 'eiendom' })
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      expect(stored.brand).toBe('eiendom')
+      expect(stored.name).toBe('eiendom')
+    })
+
+    it('prefers brand when brand and name are both set', () => {
+      setTheme({ brand: 'carnegie', name: 'eiendom' })
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      expect(stored.brand).toBe('carnegie')
+      expect(stored.name).toBe('carnegie')
+    })
+
     it('calls callback with merged theme', () => {
       const callback = vi.fn()
-      setTheme({ name: 'eiendom' }, callback)
+      setTheme({ brand: 'eiendom' }, callback)
 
       expect(callback).toHaveBeenCalledTimes(1)
       expect(callback).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'eiendom' })
+        expect.objectContaining({ brand: 'eiendom', name: 'eiendom' })
       )
     })
 
@@ -674,7 +737,7 @@ describe('Portals', () => {
       window.localStorage.setItem(STORAGE_KEY, 'not-json')
 
       const result = getTheme()
-      expect(result).toEqual({ name: 'ui' })
+      expect(result).toEqual({ brand: 'ui', name: 'ui' })
     })
   })
 })

--- a/packages/dnb-eufemia/src/shared/__tests__/VisibilityByTheme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/VisibilityByTheme.test.tsx
@@ -17,9 +17,9 @@ describe('VisibilityByTheme', () => {
     expect(document.body.textContent).toBe("I'm visible")
   })
 
-  it('renders content on name match', () => {
+  it('renders content on brand match', () => {
     const Component = (props) => (
-      <Theme name="eiendom" {...props}>
+      <Theme brand="eiendom" {...props}>
         <VisibilityByTheme visible="eiendom">
           <p>I'm visible</p>
         </VisibilityByTheme>
@@ -30,7 +30,7 @@ describe('VisibilityByTheme', () => {
 
     expect(document.body.textContent).toBe("I'm visible")
 
-    rerender(<Component name="sbanken" />)
+    rerender(<Component brand="sbanken" />)
 
     expect(document.body.textContent).toBe('')
   })
@@ -101,11 +101,11 @@ describe('VisibilityByTheme', () => {
     expect(document.body.textContent).toBe('')
   })
 
-  it('renders content on match from names in an object inside an array', () => {
+  it('renders content on match from brands in an object inside an array', () => {
     const Component = (props) => (
-      <Theme name="eiendom" {...props}>
+      <Theme brand="eiendom" {...props}>
         <VisibilityByTheme
-          visible={[{ name: 'eiendom' }, { name: 'sbanken' }]}
+          visible={[{ brand: 'eiendom' }, { brand: 'sbanken' }]}
         >
           <p>I'm visible</p>
         </VisibilityByTheme>
@@ -116,11 +116,11 @@ describe('VisibilityByTheme', () => {
 
     expect(document.body.textContent).toBe("I'm visible")
 
-    rerender(<Component name="sbanken" />)
+    rerender(<Component brand="sbanken" />)
 
     expect(document.body.textContent).toBe("I'm visible")
 
-    rerender(<Component name="ui" />)
+    rerender(<Component brand="ui" />)
 
     expect(document.body.textContent).toBe('')
   })

--- a/packages/dnb-eufemia/src/shared/__tests__/useTheme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTheme.test.tsx
@@ -11,7 +11,7 @@ describe('useTheme', () => {
 
   it('returns given theme context', () => {
     const wrapper = ({ children }) => (
-      <Theme name="eiendom" variant="soft" surface="dark">
+      <Theme brand="eiendom" variant="soft" surface="dark">
         {children}
       </Theme>
     )
@@ -19,6 +19,7 @@ describe('useTheme', () => {
 
     expect(result.current).toEqual(
       expect.objectContaining({
+        brand: 'eiendom',
         name: 'eiendom',
         variant: 'soft',
         surface: 'dark',
@@ -28,11 +29,12 @@ describe('useTheme', () => {
 
   it('returns boolean constants', () => {
     const wrapper = ({ children }) => (
-      <Theme name="sbanken">{children}</Theme>
+      <Theme brand="sbanken">{children}</Theme>
     )
     const { result } = renderHook(() => useTheme(), { wrapper })
 
     expect(result.current).toEqual({
+      brand: 'sbanken',
       name: 'sbanken',
       isEiendom: false,
       isSbanken: true,
@@ -41,11 +43,23 @@ describe('useTheme', () => {
     })
   })
 
-  it('will return false on all constants when no name was given', () => {
+  it('supports the deprecated name prop', () => {
+    const wrapper = ({ children }) => (
+      <Theme name="sbanken">{children}</Theme>
+    )
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    expect(result.current).toEqual(
+      expect.objectContaining({ brand: 'sbanken', name: 'sbanken' })
+    )
+  })
+
+  it('will return false on all constants when no brand was given', () => {
     const wrapper = ({ children }) => <Theme>{children}</Theme>
     const { result } = renderHook(() => useTheme(), { wrapper })
 
     expect(result.current).toEqual({
+      brand: undefined,
       name: undefined,
       isEiendom: false,
       isSbanken: false,

--- a/packages/dnb-eufemia/src/shared/useTheme.ts
+++ b/packages/dnb-eufemia/src/shared/useTheme.ts
@@ -20,13 +20,15 @@ export default function useTheme(): UseThemeReturn {
   const { theme } = useContext(Context) || {}
 
   if (theme) {
-    const { name } = theme
+    const brand = theme.brand ?? theme.name
     return {
       ...theme,
-      isUi: name === 'ui',
-      isSbanken: name === 'sbanken',
-      isEiendom: name === 'eiendom',
-      isCarnegie: name === 'carnegie',
+      brand,
+      name: brand,
+      isUi: brand === 'ui',
+      isSbanken: brand === 'sbanken',
+      isEiendom: brand === 'eiendom',
+      isCarnegie: brand === 'carnegie',
     }
   }
 


### PR DESCRIPTION
The Theme `name` property describes brand identity rather than an arbitrary name. This adds `brand` as the canonical property across Theme, `useTheme`, persisted theme state, and `VisibilityByTheme`, while keeping `name` backwards compatible and deprecated until v13.

The Theme documentation now uses `brand`, and the v13 guide covers removing the deprecated API.