### PR TITLE
chore(Theme): migrate internal consumers off the deprecated `name`

### DIFF
--- a/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/FormStatus.tsx
@@ -582,7 +582,7 @@ export default FormStatus
 
 export const ErrorIcon = (props: ErrorIconProps) => {
   const { title = 'error' } = props || {}
-  const isSbankenTheme = useTheme()?.name === 'sbanken'
+  const isSbankenTheme = useTheme()?.isSbanken
   const fill = isSbankenTheme
     ? properties.sbanken['--sb-color-magenta']
     : properties.ui['--color-fire-red']
@@ -614,7 +614,7 @@ export const ErrorIcon = (props: ErrorIconProps) => {
 
 export const WarnIcon = (props: WarnIconProps) => {
   const { title = 'error' } = props || {}
-  const isSbankenTheme = useTheme()?.name === 'sbanken'
+  const isSbankenTheme = useTheme()?.isSbanken
   const fill = isSbankenTheme
     ? properties.sbanken['--sb-color-yellow-dark']
     : properties.ui['--color-accent-yellow']
@@ -646,7 +646,7 @@ export const WarnIcon = (props: WarnIconProps) => {
 
 export const InfoIcon = (props: InfoIconProps) => {
   const { title = 'information' } = props || {}
-  const isSbankenTheme = useTheme()?.name === 'sbanken'
+  const isSbankenTheme = useTheme()?.isSbanken
   let fill = isSbankenTheme
     ? properties.sbanken['--sb-color-green-dark-2']
     : properties.ui['--color-sea-green']
@@ -683,7 +683,7 @@ export const InfoIcon = (props: InfoIconProps) => {
 
 export const MarketingIcon = (props: MarketingIconProps) => {
   const { title = 'marketing' } = props || {}
-  const isSbankenTheme = useTheme()?.name === 'sbanken'
+  const isSbankenTheme = useTheme()?.isSbanken
   const fill = isSbankenTheme
     ? properties.sbanken['--sb-color-violet-light']
     : properties.ui['--color-black-80']

--- a/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
+++ b/packages/dnb-eufemia/src/components/form-status/__tests__/FormStatus.test.tsx
@@ -5,7 +5,7 @@
 
 import { axeComponent, loadScss } from '../../../core/test-utils/testSetup'
 import type { FormStatusProps } from '../FormStatus'
-import FormStatus from '../FormStatus'
+import FormStatus, { ErrorIcon } from '../FormStatus'
 import Input from '../../input/Input'
 import { render, waitFor } from '@testing-library/react'
 import {
@@ -438,5 +438,35 @@ describe('FormStatus formElement', () => {
 
     const element = document.querySelector('.dnb-form-status')
     expect(element.querySelector('.dnb-skeleton')).toBeInTheDocument()
+  })
+})
+
+describe('FormStatus icon theming', () => {
+  const firstPathFill = (result: { container: HTMLElement }) =>
+    result.container.querySelector('path')?.getAttribute('fill')
+
+  it('resolves the Sbanken theme from brand and the deprecated name', () => {
+    const uiFill = firstPathFill(render(<ErrorIcon />))
+
+    const brandFill = firstPathFill(
+      render(
+        <Provider theme={{ brand: 'sbanken' }}>
+          <ErrorIcon />
+        </Provider>
+      )
+    )
+
+    const nameFill = firstPathFill(
+      render(
+        <Provider theme={{ name: 'sbanken' }}>
+          <ErrorIcon />
+        </Provider>
+      )
+    )
+
+    // Sbanken renders a different fill than the default DNB (ui) theme
+    expect(brandFill).not.toBe(uiFill)
+    // The new `brand` and the deprecated `name` resolve to the same theme
+    expect(nameFill).toBe(brandFill)
   })
 })

--- a/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
+++ b/packages/dnb-eufemia/src/components/global-status/GlobalStatus.tsx
@@ -289,7 +289,6 @@ function getIcon({
   state?: FormStatusState
   icon?: IconIcon
   iconSize?: IconSize
-  theme?: string
 }): ReactNode {
   if (typeof icon === 'string') {
     let IconToLoad: ComponentType<{ state?: FormStatusState }>
@@ -713,7 +712,6 @@ function GlobalStatusComponent(ownProps: GlobalStatusProps) {
     state,
     icon: icon || fallbackProps.icon,
     iconSize: iconSize || fallbackProps.iconSize,
-    theme: context?.theme?.name || 'ui',
   })
   const titleToRender =
     title || fallbackProps.title || fallbackProps.defaultTitle

--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -266,7 +266,7 @@ export default function Heading(props: HeadingAllProps) {
   if (element == null) {
     element = getHeadingElement(level)
     if (size == null) {
-      size = getHeadingSize(theme?.name)[level]
+      size = getHeadingSize(theme?.brand)[level]
     }
   } else {
     if (!attributes.role) {

--- a/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
+++ b/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
@@ -9,6 +9,7 @@ import { axeComponent, loadScss } from '../../../core/test-utils/testSetup'
 import { render } from '@testing-library/react'
 import Typography from '../../../elements/typography/Typography'
 import { Theme } from '../../../shared'
+import Provider from '../../../shared/Provider'
 import type { HeadingProps, HeadingLevel } from '../Heading'
 import Heading, { resetLevels, setNextLevel } from '../Heading'
 import { windupHeadings, teardownHeadings } from '../HeadingHelpers'
@@ -631,6 +632,38 @@ describe('Heading component', () => {
   it('has to match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))
     expect(css).toMatchSnapshot()
+  })
+})
+
+describe('Heading theming', () => {
+  it('uses Sbanken heading sizes when the brand is set via Provider', () => {
+    const ui = render(
+      <Heading.Level reset={1}>
+        <Heading>One</Heading>
+        <Heading>Two</Heading>
+      </Heading.Level>
+    )
+    // DNB (ui) maps a level-2 heading to "large"
+    expect(
+      ui.container
+        .querySelectorAll('.dnb-heading')[1]
+        .getAttribute('class')
+    ).toContain('dnb-h--large')
+
+    const sbanken = render(
+      <Provider theme={{ brand: 'sbanken' }}>
+        <Heading.Level reset={1}>
+          <Heading>One</Heading>
+          <Heading>Two</Heading>
+        </Heading.Level>
+      </Provider>
+    )
+    // Sbanken maps a level-2 heading to "x-large"
+    expect(
+      sbanken.container
+        .querySelectorAll('.dnb-heading')[1]
+        .getAttribute('class')
+    ).toContain('dnb-h--x-large')
   })
 })
 

--- a/packages/dnb-eufemia/src/components/logo/Logo.tsx
+++ b/packages/dnb-eufemia/src/components/logo/Logo.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../shared/component-helper'
 import { useSpacing } from '../space/SpacingUtils'
 import { DnbDefault } from './LogoSvg'
-import type { UseThemeReturn } from '../../shared/useTheme'
+import useTheme, { type UseThemeReturn } from '../../shared/useTheme'
 
 import type { IconColor } from '../Icon'
 import type { SpacingProps } from '../../shared/types'
@@ -90,21 +90,27 @@ function Logo(localProps: LogoProps) {
     ...rest
   } = props
 
-  // If svg is a function, call it with a sanitized theme (omit DOM-irrelevant keys)
+  // If svg is a function, call it with a sanitized theme (omit DOM-irrelevant keys).
+  // Read via useTheme so the resolved `brand` is used (this also covers the
+  // deprecated `name`), keeping this component free of the deprecated property.
+  const themeContext = useTheme()
+  const themeBrand = themeContext?.brand
+  const size = themeContext?.size
+  const hasTheme = Boolean(themeContext)
   const theme = useMemo(() => {
-    if (!context?.theme) {
+    if (!hasTheme) {
       return null
     }
-    const { name, size } = context.theme
     return {
-      name,
+      brand: themeBrand,
+      name: themeBrand,
       size,
-      isUi: name === 'ui',
-      isSbanken: name === 'sbanken',
-      isEiendom: name === 'eiendom',
-      isCarnegie: name === 'carnegie',
+      isUi: themeBrand === 'ui',
+      isSbanken: themeBrand === 'sbanken',
+      isEiendom: themeBrand === 'eiendom',
+      isCarnegie: themeBrand === 'carnegie',
     }
-  }, [context?.theme])
+  }, [hasTheme, themeBrand, size])
 
   const svg = useMemo(() => {
     if (Object.hasOwn(svgProp, 'brand')) {
@@ -133,7 +139,7 @@ function Logo(localProps: LogoProps) {
       return brand
     }
 
-    return theme?.name || 'ui'
+    return theme?.brand || 'ui'
   }, [svg, theme])
 
   const className = useMemo(() => {

--- a/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
+++ b/packages/dnb-eufemia/src/components/logo/__tests__/Logo.test.tsx
@@ -18,6 +18,7 @@ import Logo, {
 import { render } from '@testing-library/react'
 import Provider from '../../../shared/Provider'
 import Theme from '../../../shared/Theme'
+import type { UseThemeReturn } from '../../../shared/useTheme'
 
 describe('Logo component', () => {
   it('renders with empty props', () => {
@@ -298,6 +299,65 @@ describe('Logo component', () => {
     expect(svg).toBeInTheDocument()
     // Ensure known problematic keys are not present
     expect(svg.hasAttribute('isUi')).toBe(false)
+  })
+
+  it('passes the resolved brand to a custom svg factory', () => {
+    let receivedTheme: UseThemeReturn = null
+    const SvgFactory = (theme: UseThemeReturn) => {
+      receivedTheme = theme
+      return DnbDefault
+    }
+
+    render(
+      <Provider theme={{ brand: 'sbanken' }}>
+        <Logo svg={SvgFactory} />
+      </Provider>
+    )
+
+    expect(receivedTheme).toMatchObject({
+      brand: 'sbanken',
+      name: 'sbanken',
+      isSbanken: true,
+      isUi: false,
+    })
+  })
+
+  it('resolves brand from the deprecated name for a custom svg factory', () => {
+    let receivedTheme: UseThemeReturn = null
+    const SvgFactory = (theme: UseThemeReturn) => {
+      receivedTheme = theme
+      return EiendomDefault
+    }
+
+    render(
+      <Provider theme={{ name: 'eiendom' }}>
+        <Logo svg={SvgFactory} />
+      </Provider>
+    )
+
+    expect(receivedTheme).toMatchObject({
+      brand: 'eiendom',
+      name: 'eiendom',
+      isEiendom: true,
+    })
+  })
+
+  it('applies the theme brand class for a custom svg without a brand marker', () => {
+    const PlainSvg = (props) => (
+      <svg viewBox="0 0 10 10" {...props}>
+        <circle cx="5" cy="5" r="5" />
+      </svg>
+    )
+
+    render(
+      <Provider theme={{ brand: 'sbanken' }}>
+        <Logo svg={PlainSvg} />
+      </Provider>
+    )
+
+    expect(document.querySelector('.dnb-logo')).toHaveClass(
+      'dnb-logo--sbanken'
+    )
   })
 
   describe('Logo accessibility', () => {

--- a/packages/dnb-eufemia/src/elements/typography/H.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/H.tsx
@@ -65,7 +65,7 @@ const H = (props: HProps) => {
 
   const theme = useTheme()
   const targetSize =
-    (size === 'auto' && getHeadingSize(theme?.name)[numSiz]) ||
+    (size === 'auto' && getHeadingSize(theme?.brand)[numSiz]) ||
     size ||
     'xx-large'
 

--- a/packages/dnb-eufemia/src/elements/typography/__tests__/H.test.tsx
+++ b/packages/dnb-eufemia/src/elements/typography/__tests__/H.test.tsx
@@ -179,4 +179,28 @@ describe('H element', () => {
       expect(element.classList.contains('dnb-t--surface-dark')).toBe(true)
     })
   })
+
+  describe('auto size', () => {
+    it('resolves the auto size from the theme brand', () => {
+      const ui = render(
+        <H element="h2" size="auto">
+          Test heading
+        </H>
+      )
+      // DNB (ui) maps a level-2 heading to "large"
+      expect(ui.container.querySelector('h2')).toHaveClass('dnb-h--large')
+
+      const sbanken = render(
+        <Theme brand="sbanken">
+          <H element="h2" size="auto">
+            Test heading
+          </H>
+        </Theme>
+      )
+      // Sbanken maps a level-2 heading to "x-large"
+      expect(sbanken.container.querySelector('h2')).toHaveClass(
+        'dnb-h--x-large'
+      )
+    })
+  })
 })


### PR DESCRIPTION
Follow-up to #9186 (now merged).

#9186 makes `brand` the canonical Theme property and deprecates `name` (mirrored until v13). Several internal consumers still referenced the deprecated `name` — **8 places across 5 files**. Nothing breaks today because `name` is mirrored, but these all break at v13. This removes every internal reference to `name` (resolving via `useTheme`, which covers the deprecated `name`).