### PR TITLE
feat(Theme): deprecate `size` in favor of `density`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -64,6 +64,13 @@ The deprecated `name` property and `data-name` attribute have been removed. Use 
 
 Replace `useTheme().name` with `useTheme().brand`. For persisted theme state, replace `getTheme().name` and `setTheme({ name })` with `getTheme().brand` and `setTheme({ brand })`.
 
+The deprecated `size` property, `ThemeSizes` type, `data-size` attribute, and `eufemia-theme__size--*` CSS classes have also been removed. Use `density`, `ThemeDensities`, `data-density`, and `eufemia-theme__density--*` instead.
+
+```diff
+-<Theme size="basis">
++<Theme density="basis">
+```
+
 ### [Flex](/uilib/layout/flex/)
 
 Flex now uses native CSS gap and renders React children unchanged. The following legacy migration APIs are deprecated:

--- a/packages/dnb-eufemia/src/shared/Theme.tsx
+++ b/packages/dnb-eufemia/src/shared/Theme.tsx
@@ -17,7 +17,11 @@ import type { ThemeName } from '../style/themes/capabilities'
 
 export type ThemeNames = ThemeName
 export type ThemeVariants = string
-export type ThemeSizes = 'basis'
+export type ThemeDensities = 'basis'
+/**
+ * @deprecated Use `ThemeDensities` instead. This type will be removed in v13.
+ */
+export type ThemeSizes = ThemeDensities
 export type ContrastMode = boolean
 /**
  * Controls the color scheme. Use `'dark'` or `'light'` to set explicitly, or `'auto'` to follow the user's system preference. Defaults to `undefined`.
@@ -37,6 +41,11 @@ export type ThemeProps = {
    */
   name?: ThemeNames
   variant?: ThemeVariants
+  density?: ThemeDensities
+  /**
+   * Deprecated. Use `density` instead.
+   * @deprecated Use `density` instead. This property will be removed in v13.
+   */
   size?: ThemeSizes
   contrastMode?: ContrastMode
   colorScheme?: ThemeColorScheme
@@ -55,6 +64,7 @@ export default function Theme(themeProps: ThemeAllProps) {
     brand,
     name,
     variant,
+    density,
     size,
     contrastMode,
     colorScheme,
@@ -84,7 +94,8 @@ export default function Theme(themeProps: ThemeAllProps) {
       brand: brand ?? name,
       name: brand ?? name,
       variant,
-      size,
+      density: density ?? size,
+      size: density ?? size,
       contrastMode,
       colorScheme: activeColorScheme,
       surface,
@@ -96,6 +107,10 @@ export default function Theme(themeProps: ThemeAllProps) {
   const resolvedBrand = theme.brand ?? theme.name
   theme.brand = resolvedBrand
   theme.name = resolvedBrand
+
+  const resolvedDensity = theme.density ?? theme.size
+  theme.density = resolvedDensity
+  theme.size = resolvedDensity
 
   // When surface is "initial", reset it to break context inheritance
   if (surface === 'initial') {
@@ -141,7 +156,7 @@ export function ThemeWrapper({
   useSyncElementColorScheme(ref, theme)
 
   const classNames = getThemeClasses(theme, className)
-  const { brand, variant, size } = theme
+  const { brand, variant, density } = theme
 
   if (Wrapper === Fragment) {
     return children
@@ -154,7 +169,8 @@ export function ThemeWrapper({
       data-brand={brand}
       data-name={brand}
       data-variant={variant}
-      data-size={size}
+      data-density={density}
+      data-size={density}
       className={classNames}
       {...rest}
     >
@@ -168,8 +184,17 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
     return className
   }
 
-  const { brand, name, variant, size, contrastMode, colorScheme } = theme
+  const {
+    brand,
+    name,
+    variant,
+    density,
+    size,
+    contrastMode,
+    colorScheme,
+  } = theme
   const resolvedBrand = brand ?? name
+  const resolvedDensity = density ?? size
 
   return clsx(
     className,
@@ -180,7 +205,8 @@ export function getThemeClasses(theme: ThemeProps, className = null) {
       `eufemia-theme__${resolvedBrand}--${variant}`,
     contrastMode && 'eufemia-theme__contrast-mode',
     colorScheme && `eufemia-theme__color-scheme--${colorScheme}`,
-    size && `eufemia-theme__size--${size}`
+    resolvedDensity && `eufemia-theme__density--${resolvedDensity}`,
+    resolvedDensity && `eufemia-theme__size--${resolvedDensity}`
   )
 }
 
@@ -261,8 +287,16 @@ export function getTheme(defaultBrand: ThemeNames = 'ui'): ThemeState {
       theme?.brand ||
       theme?.name ||
       defaultBrand) as ThemeNames
+    const density = (theme?.density ?? theme?.size) as
+      | ThemeDensities
+      | undefined
 
-    return { ...theme, brand, name: brand }
+    return {
+      ...theme,
+      brand,
+      name: brand,
+      ...(density && { density, size: density }),
+    }
   } catch {
     return { brand: defaultBrand, name: defaultBrand }
   }
@@ -286,11 +320,16 @@ export function setTheme(
       themeProps.name ??
       currentTheme.brand ??
       currentTheme.name) as ThemeNames
+    const density = (themeProps.density ??
+      themeProps.size ??
+      currentTheme.density ??
+      currentTheme.size) as ThemeDensities | undefined
     const theme = {
       ...currentTheme,
       ...themeProps,
       brand,
       name: brand,
+      ...(density && { density, size: density }),
     }
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(theme))
     callback?.(theme)

--- a/packages/dnb-eufemia/src/shared/ThemeDocs.ts
+++ b/packages/dnb-eufemia/src/shared/ThemeDocs.ts
@@ -11,10 +11,15 @@ export const ThemeProperties: PropertiesTableProps = {
     type: ['"ui"', '"eiendom"', '"sbanken"', '"carnegie"'],
     status: 'deprecated',
   },
-  size: {
-    doc: 'Will define what sizes of components are used (WIP).',
+  density: {
+    doc: 'Defines the component density (WIP).',
     type: '"basis"',
     status: 'optional',
+  },
+  size: {
+    doc: 'Deprecated. Use `density` instead.',
+    type: '"basis"',
+    status: 'deprecated',
   },
   variant: {
     doc: '(WIP).',

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -85,14 +85,56 @@ describe('Theme', () => {
     )
   })
 
-  it('sets size as HTML classes', () => {
+  it('sets density as HTML classes and attributes', () => {
+    render(<Theme density="basis">content</Theme>)
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(element).toHaveClass(
+      'eufemia-theme eufemia-theme__density--basis eufemia-theme__size--basis',
+      { exact: true }
+    )
+    expect(element).toHaveAttribute('data-density', 'basis')
+    expect(element).toHaveAttribute('data-size', 'basis')
+  })
+
+  it('supports the deprecated size prop', () => {
     render(<Theme size="basis">content</Theme>)
 
     const element = document.querySelector('.eufemia-theme')
     expect(element).toHaveClass(
-      'eufemia-theme eufemia-theme__size--basis',
+      'eufemia-theme eufemia-theme__density--basis eufemia-theme__size--basis',
       { exact: true }
     )
+    expect(element).toHaveAttribute('data-density', 'basis')
+    expect(element).toHaveAttribute('data-size', 'basis')
+  })
+
+  it('prefers density when density and size are both set', () => {
+    render(
+      <Theme density="basis" size={'compact' as never}>
+        content
+      </Theme>
+    )
+
+    const element = document.querySelector('.eufemia-theme')
+    expect(element).toHaveClass(
+      'eufemia-theme eufemia-theme__density--basis eufemia-theme__size--basis',
+      { exact: true }
+    )
+    expect(element).toHaveAttribute('data-density', 'basis')
+    expect(element).toHaveAttribute('data-size', 'basis')
+  })
+
+  it('inherits density in nested themes', () => {
+    render(
+      <Theme density="basis">
+        <Theme id="nested">content</Theme>
+      </Theme>
+    )
+
+    const element = document.querySelector('#nested')
+    expect(element).toHaveAttribute('data-density', 'basis')
+    expect(element).toHaveAttribute('data-size', 'basis')
   })
 
   it('sets contrast-mode as HTML classes', () => {
@@ -658,6 +700,17 @@ describe('Portals', () => {
       expect(result.colorScheme).toBe('dark')
     })
 
+    it('reads a persisted deprecated size from localStorage', () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ size: 'basis' })
+      )
+
+      const result = getTheme()
+      expect(result.density).toBe('basis')
+      expect(result.size).toBe('basis')
+    })
+
     it('supports URL query override for theme name', () => {
       window.localStorage.setItem(
         STORAGE_KEY,
@@ -713,6 +766,22 @@ describe('Portals', () => {
       const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
       expect(stored.brand).toBe('eiendom')
       expect(stored.name).toBe('eiendom')
+    })
+
+    it('persists density with the deprecated size property', () => {
+      setTheme({ density: 'basis' })
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      expect(stored.density).toBe('basis')
+      expect(stored.size).toBe('basis')
+    })
+
+    it('prefers density when density and size are both persisted', () => {
+      setTheme({ density: 'basis', size: 'compact' as never })
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      expect(stored.density).toBe('basis')
+      expect(stored.size).toBe('basis')
     })
 
     it('prefers brand when brand and name are both set', () => {


### PR DESCRIPTION
The Theme `size` property describes component density rather than a specific size. This adds `density` as the canonical property across Theme and persisted theme state, while keeping `size`, `ThemeSizes`, and the legacy DOM hooks backwards compatible and deprecated until v13.

The v13 guide covers replacing the deprecated API.