### PR TITLE
feat(DatePicker): add option to hide adjacent month dates

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/Examples.tsx
@@ -128,6 +128,7 @@ export const DatePickerHiddenNav = () => (
       returnFormat="dd/MM/yyyy"
       hideNavigation
       hideDays
+      hideAdjacentMonthDates
       onChange={({ date }) => {
         console.log('onChange', date)
       }}

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/date-picker/info.mdx
@@ -24,6 +24,10 @@ The DatePicker component should be used whenever the user is to enter a single d
 
 The Eufemia Forms equivalent of `DatePicker` is [Field.Date](/uilib/extensions/forms/feature-fields/Date/).
 
+## Dates from adjacent months
+
+By default, DatePicker shows dates from the previous and next month to provide context around month boundaries. Set `hideAdjacentMonthDates` when the extra dates could cause confusion or when a simpler calendar would reduce cognitive load. The grid cells remain in place, so the calendar layout does not change.
+
 ## Relevant links
 
 - [Figma](https://www.figma.com/design/cdtwQD8IJ7pTeE45U148r1/%F0%9F%92%BB-Eufemia---Web?node-id=4243-1497)

--- a/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePicker.tsx
@@ -153,6 +153,10 @@ export type DatePickerProps = {
    */
   hideDays?: boolean
   /**
+   * If set to `true`, dates from the previous and next month will be hidden. Empty grid cells remain to preserve the calendar layout. Defaults to `false`.
+   */
+  hideAdjacentMonthDates?: boolean
+  /**
    * If set to `true`, the calendar only displays days belonging to the currently displayed month, and month navigation via buttons and keyboard is disabled. The displayed month is determined by the `month` or `startMonth` prop, and ultimately defaults to the current month. Use `'without-label'` to also hide the month label. Defaults to `false`.
    */
   onlyMonth?: boolean | 'without-label'
@@ -368,6 +372,7 @@ export type DatePickerAllProps = DatePickerProps &
 const datePickerDefaultProps: Partial<DatePickerAllProps> = {
   hideNavigation: false,
   hideDays: false,
+  hideAdjacentMonthDates: false,
   onlyMonth: false,
   hideLastWeek: false,
   disableAutofocus: false,
@@ -575,6 +580,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
     title,
     labelDirection,
     labelSrOnly,
+    hideAdjacentMonthDates,
     onlyMonth,
     hideLastWeek,
     disableAutofocus,
@@ -763,6 +769,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                   isSync={sync}
                   hideDays={hideDays}
                   hideNavigation={hideNavigation}
+                  hideAdjacentMonthDates={hideAdjacentMonthDates}
                   onlyMonth={Boolean(onlyMonth)}
                   hideMonthLabel={onlyMonth === 'without-label'}
                   hideNextMonthWeek={hideLastWeek}
@@ -859,6 +866,7 @@ function DatePicker(externalProps: DatePickerAllProps) {
                       isSync={sync}
                       hideDays={hideDays}
                       hideNavigation={hideNavigation}
+                      hideAdjacentMonthDates={hideAdjacentMonthDates}
                       onlyMonth={Boolean(onlyMonth)}
                       hideMonthLabel={onlyMonth === 'without-label'}
                       hideNextMonthWeek={hideLastWeek}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerCalendar.tsx
@@ -82,6 +82,7 @@ export type DatePickerCalendarProps = Omit<
   firstDayOfWeek?: string
   hideNavigation?: boolean
   hideDays?: boolean
+  hideAdjacentMonthDates?: boolean
   onlyMonth?: boolean
   hideMonthLabel?: boolean
   hideNextMonthWeek?: boolean
@@ -123,6 +124,7 @@ type DayObject = {
 const datePickerCalendarDefaultProps: DatePickerCalendarProps = {
   hideNavigation: false,
   hideDays: false,
+  hideAdjacentMonthDates: false,
   onlyMonth: false,
   hideMonthLabel: false,
   hideNextMonthWeek: false,
@@ -166,6 +168,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
     hideNavigation,
     locale,
     hideDays,
+    hideAdjacentMonthDates,
     onSelect,
     onKeyDown,
     resetDate,
@@ -720,19 +723,25 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                     },
                   })
 
+                  const isHiddenAdjacentMonthDate =
+                    hideAdjacentMonthDates &&
+                    (day.isLastMonth || day.isNextMonth)
                   const handleAsDisabled =
                     day.isLastMonth ||
                     day.isNextMonth ||
                     day.isDisabled ||
                     day.isInactive
 
-                  const dateType = day.isStartDate
-                    ? 'start'
-                    : day.isEndDate
-                      ? 'end'
-                      : undefined
+                  const dateType = !isHiddenAdjacentMonthDate
+                    ? day.isStartDate
+                      ? 'start'
+                      : day.isEndDate
+                        ? 'end'
+                        : undefined
+                    : undefined
                   const isSelectedDate =
-                    nr === 0 ? day.isStartDate : day.isEndDate
+                    !isHiddenAdjacentMonthDate &&
+                    (nr === 0 ? day.isStartDate : day.isEndDate)
 
                   // cell params
                   const paramsCell = {
@@ -763,6 +772,7 @@ function DatePickerCalendar(restOfProps: DatePickerCalendarProps) {
                         variant="secondary"
                         text={day.date.getDate()}
                         bounding
+                        hidden={isHiddenAdjacentMonthDate}
                         disabled={handleAsDisabled}
                         tabIndex={handleAsDisabled ? 0 : -1} // fix for NVDA
                         aria-disabled={handleAsDisabled}

--- a/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
+++ b/packages/dnb-eufemia/src/components/date-picker/DatePickerDocs.ts
@@ -198,6 +198,11 @@ export const DatePickerProperties: PropertiesTableProps = {
     type: ['boolean', `'without-label'`],
     status: 'optional',
   },
+  hideAdjacentMonthDates: {
+    doc: 'If set to `true`, dates from the previous and next month will be hidden. Empty grid cells remain to preserve the calendar layout. Defaults to `false`.',
+    type: 'boolean',
+    status: 'optional',
+  },
   hideLastWeek: {
     doc: 'Use `true` to only show the last week in the current month if it needs to be shown. The result is that mainly five (5) weeks (rows) will be shown instead of six (6). Defaults to `false`.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/packages/dnb-eufemia/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5175,6 +5175,25 @@ describe('DatePicker component', () => {
 
     expect(header).toBeInTheDocument()
   })
+
+  it('should hide adjacent month dates while preserving grid cells', () => {
+    render(<DatePicker inline month="2024-10-01" hideAdjacentMonthDates />)
+
+    const calendar = document.querySelector('.dnb-date-picker__calendar')
+    const previousMonthCell = calendar.querySelector(
+      'td[data-date="2024-09-30"]'
+    )
+    const nextMonthCell = calendar.querySelector(
+      'td[data-date="2024-11-01"]'
+    )
+
+    expect(calendar.querySelectorAll('[role="gridcell"]')).toHaveLength(42)
+    expect(previousMonthCell.querySelector('button')).not.toBeVisible()
+    expect(nextMonthCell.querySelector('button')).not.toBeVisible()
+    expect(
+      calendar.querySelector('td[data-date="2024-10-01"] button')
+    ).toBeVisible()
+  })
 })
 
 // for the unit calc tests

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/__tests__/Date.test.tsx
@@ -1303,6 +1303,29 @@ describe('Field.Date', () => {
     })
   })
 
+  describe('hideAdjacentMonthDates prop', () => {
+    it('should hide dates from the previous and next month', async () => {
+      render(
+        <Field.Date
+          hideAdjacentMonthDates
+          month="2024-10-01"
+          value="2024-10-15"
+        />
+      )
+
+      await userEvent.click(
+        document.querySelector('button.dnb-input__submit-button__button')
+      )
+
+      expect(
+        document.querySelector('td[data-date="2024-09-30"] button')
+      ).not.toBeVisible()
+      expect(
+        document.querySelector('td[data-date="2024-11-01"] button')
+      ).not.toBeVisible()
+    })
+  })
+
   it('should parse dates in specified format', async () => {
     render(<Field.Date value="01/10/2024" dateFormat="dd/MM/yyyy" />)
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Date/datePickerPropKeys.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Date/datePickerPropKeys.ts
@@ -17,6 +17,7 @@ export const datePickerPropKeys = [
   'returnFormat',
   'hideNavigation',
   'hideDays',
+  'hideAdjacentMonthDates',
   'onlyMonth',
   'hideLastWeek',
   'disableAutofocus',


### PR DESCRIPTION
Adds a `hideAdjacentMonthDates` property to DatePicker and Field.Date. It hides dates from the previous and next month while retaining their grid cells, so the calendar layout and accessible grid structure remain stable. The documentation explains when hiding them may reduce confusion and cognitive load, and demonstrates the option in a limited-range calendar.

This is independent from #9189, which makes adjacent month dates selectable.

Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1752567655383199
Preview: https://agents-datepicker-hide-adjac.eufemia-e25.pages.dev/uilib/components/date-picker/demos#hidden-nav