### PR TITLE
chore(Theme): make the portal theme handler brand-aware

### DIFF
--- a/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
@@ -7,7 +7,7 @@ import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export default function ChangeStyleTheme(props) {
   const themes = getThemes()
-  const { name } = getTheme()
+  const { brand } = getTheme()
   const { update } = useContext(Context)
 
   const data = Object.entries(themes).reduce((acc, [key, value]) => {
@@ -20,12 +20,12 @@ export default function ChangeStyleTheme(props) {
   return (
     <Field.Selection
       id="change-theme"
-      value={name}
+      value={brand}
       data={data}
       label="Change Brand"
       onChange={(value) => {
         update({ skeleton: true })
-        setTheme({ name: value as ThemeNames }, () => {
+        setTheme({ brand: value as ThemeNames }, () => {
           update({ skeleton: false })
         })
       }}

--- a/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
+++ b/packages/dnb-design-system-portal/src/core/ChangeStyleTheme.tsx
@@ -1,8 +1,11 @@
 import { useContext } from 'react'
 import { Context } from '@dnb/eufemia/src/shared'
-import { getTheme } from '@dnb/eufemia/src/shared/Theme'
 import type { ThemeNames } from '@dnb/eufemia/src/shared/Theme'
-import { getThemes, setTheme } from '../../vite/client/shims/theme-handler'
+import {
+  getTheme,
+  getThemes,
+  setTheme,
+} from '../../vite/client/shims/theme-handler'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 
 export default function ChangeStyleTheme(props) {

--- a/packages/dnb-design-system-portal/src/core/ToggleDarkMode.tsx
+++ b/packages/dnb-design-system-portal/src/core/ToggleDarkMode.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import { getTheme } from '@dnb/eufemia/src/shared/Theme'
-import { setTheme } from '../../vite/client/shims/theme-handler'
+import { getTheme, setTheme } from '../../vite/client/shims/theme-handler'
 import type { ThemeColorScheme } from '@dnb/eufemia/src/shared/Theme'
 import { Field } from '@dnb/eufemia/src/extensions/forms'
 
@@ -22,7 +21,7 @@ export default function ToggleDarkMode(props) {
         { value: 'light', title: 'Light' },
       ]}
       onChange={(value: string) => {
-        setTheme({ colorScheme: value } as Record<string, unknown>)
+        setTheme({ colorScheme: value as ThemeColorScheme })
         updateColorScheme(value as ThemeColorScheme)
       }}
       {...rest}

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -65,6 +65,15 @@ The deprecated `name` property and `data-name` attribute have been removed. Use 
 
 Replace `useTheme().name` with `useTheme().brand`. For persisted theme state, replace `getTheme().name` and `setTheme({ name })` with `getTheme().brand` and `setTheme({ brand })`.
 
+`VisibilityByTheme` also matches on the theme object, so replace `name` there too:
+
+```diff
+-<VisibilityByTheme visible={[{ name: 'sbanken' }]}>
++<VisibilityByTheme visible={[{ brand: 'sbanken' }]}>
+```
+
+TypeScript flags `name` as an unknown property here, but plain JavaScript does not: an unmigrated `{ name }` simply stops matching, and the content silently disappears.
+
 The deprecated `size` property, `ThemeSizes` type, `data-size` attribute, and `eufemia-theme__size--*` CSS classes have also been removed. Use `density`, `ThemeDensities`, `data-density`, and `eufemia-theme__density--*` instead.
 
 ```diff

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -72,7 +72,7 @@ Replace `useTheme().name` with `useTheme().brand`. For persisted theme state, re
 +<VisibilityByTheme visible={[{ brand: 'sbanken' }]}>
 ```
 
-TypeScript flags `name` as an unknown property here, but plain JavaScript does not: an unmigrated `{ name }` simply stops matching, and the content silently disappears.
+With `name` removed, TypeScript reports it as an unknown property here. Plain JavaScript gets no such warning — the filter simply stops matching, and the content silently disappears.
 
 The deprecated `size` property, `ThemeSizes` type, `data-size` attribute, and `eufemia-theme__size--*` CSS classes have also been removed. Use `density`, `ThemeDensities`, `data-density`, and `eufemia-theme__density--*` instead.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/avatar/Examples.tsx
@@ -143,7 +143,7 @@ export const AvatarChildIcon = () => (
 )
 
 function getLogoSvg(theme: ThemeProps) {
-  switch (theme?.name) {
+  switch (theme?.brand) {
     case 'sbanken':
       return SbankenCompact
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/logo/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/logo/Examples.tsx
@@ -17,7 +17,7 @@ import MyThemeSelector from '../../../../core/ChangeStyleTheme'
 import type { ThemeProps } from '@dnb/eufemia/src/shared/Theme'
 
 function myLogoSelector(theme: ThemeProps) {
-  switch (theme?.name) {
+  switch (theme?.brand) {
     case 'sbanken':
       return SbankenDefault
 
@@ -109,7 +109,7 @@ export const LogoChangeExample = () => (
   >
     {() => {
       function myLogoSelector(theme: ThemeProps) {
-        switch (theme?.name) {
+        switch (theme?.brand) {
           case 'sbanken':
             return SbankenDefault
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/Examples.tsx
@@ -56,7 +56,7 @@ const FontUsageExample = ({ typoClass, fontFamily }) => (
 export function FontWeightByThemeExample() {
   const theme = useTheme()
 
-  if (theme?.name === 'sbanken') {
+  if (theme?.brand === 'sbanken') {
     return (
       <Wrapper>
         {/* Regular */}

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/_helpers.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/_helpers.tsx
@@ -12,7 +12,7 @@ const properties = {
 
 export const GetPropValue = (prop) => {
   const theme = useTheme()
-  const themeProps = properties[theme.name] || properties.ui
+  const themeProps = properties[theme.brand] || properties.ui
   const p = themeProps[prop]
   if (p && p.startsWith('var(')) {
     return GetPropValue(p.substring(4, p.indexOf(')')))

--- a/packages/dnb-design-system-portal/src/e2e/themeSwitch.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/themeSwitch.spec.ts
@@ -73,7 +73,7 @@ test.describe('Theme', () => {
         window.localStorage.getItem('eufemia-theme') || '{}'
       )
 
-      return theme.name === 'sbanken'
+      return theme.brand === 'sbanken'
     })
 
     const localStorageData = await page.evaluate(() => {
@@ -82,6 +82,8 @@ test.describe('Theme', () => {
       )
     })
 
+    expect(localStorageData.brand).toBe('sbanken')
+    // The deprecated `name` is kept mirrored until v13
     expect(localStorageData.name).toBe('sbanken')
   })
 

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -81,8 +81,8 @@ export default function PortalToolsMenu({
   const { skeleton } = useContext(Context)
   const storageKey = getPortalToolsOpenStorageKey(hideWhenMediaLarge)
   const [isOpen, setIsOpen] = useState(false)
-  const { name: themeName, colorScheme } = getTheme()
-  const themeKey = `${themeName}:${colorScheme || 'auto'}`
+  const { brand, colorScheme } = getTheme()
+  const themeKey = `${brand}:${colorScheme || 'auto'}`
   // Start with animation disabled so the initial open=false render
   // uses the immediate close path in Modal, avoiding a 300ms timer
   // that would race with the restore effect and close the drawer.

--- a/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
+++ b/packages/dnb-design-system-portal/src/shared/menu/PortalToolsMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { clsx } from 'clsx'
 import { Drawer, Tooltip } from '@dnb/eufemia/src/components'
 import { Anchor, Flex } from '@dnb/eufemia/src'
-import { getTheme } from '@dnb/eufemia/src/shared/Theme'
+import { getTheme } from '../../../vite/client/shims/theme-handler'
 import ToggleGrid from './ToggleGrid'
 import { Context } from '@dnb/eufemia/src/shared'
 import PortalSkeleton from '../../core/PortalSkeleton'

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -553,20 +553,21 @@ describe('eufemia-theme plugin', () => {
       const load = plugin.load as (id: string) => string | undefined
       const code = load('\0virtual:eufemia-theme-styles') || ''
 
+      // Assert the harness is live. This checks the INPUT, not the result: a
+      // shape change makes the rewrite below match nothing and leave the code
+      // untouched, which no assertion on the output can tell apart from a
+      // successful unwrap.
+      expect(
+        code,
+        'dev startup no longer wraps the first load in `requestAnimationFrame(() => {`, so the unwrap below is dead — update it'
+      ).toContain('requestAnimationFrame(() => {')
+
       // Same transform the other dev-mode tests use, so the first-load
       // requestAnimationFrame callback runs synchronously.
       const evalCode = code
         .replace(/import '[^']+';/g, '')
         .replace(/requestAnimationFrame\(\(\) => \{/, '{')
         .replace(/\}\);(\s*\})/, '}$1')
-
-      // Assert the unwrap applied: if the generated code changes shape the
-      // callback would stay async and the assertions below would fail for a
-      // misleading reason.
-      expect(
-        evalCode,
-        'dev startup rAF unwrap did not apply'
-      ).not.toContain('requestAnimationFrame(() => {')
 
       new Function(evalCode)()
     }

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -559,6 +559,15 @@ describe('eufemia-theme plugin', () => {
         .replace(/import '[^']+';/g, '')
         .replace(/requestAnimationFrame\(\(\) => \{/, '{')
         .replace(/\}\);(\s*\})/, '}$1')
+
+      // Assert the unwrap applied: if the generated code changes shape the
+      // callback would stay async and the assertions below would fail for a
+      // misleading reason.
+      expect(
+        evalCode,
+        'dev startup rAF unwrap did not apply'
+      ).not.toContain('requestAnimationFrame(() => {')
+
       new Function(evalCode)()
     }
 
@@ -580,6 +589,13 @@ describe('eufemia-theme plugin', () => {
           'window.__loadEufemiaTheme(initial)',
           'startupSpy(initial)'
         )
+
+      // Assert the harness is live: without this substitution the real
+      // loader would run and the spy would simply never be called.
+      expect(evalCode, 'build startup call was not substituted').toContain(
+        'startupSpy(initial)'
+      )
+
       new Function('startupSpy', evalCode)(startupSpy)
 
       return startupSpy

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -529,11 +529,8 @@ describe('eufemia-theme plugin', () => {
     })
   })
 
-  /**
-   * These startup paths run before React hydrates, so if they resolve the
-   * persisted brand differently from the runtime handler the visitor sees the
-   * wrong theme until hydration corrects it.
-   */
+  // Run before hydration; must resolve the brand like the runtime handler,
+  // or the visitor sees the wrong theme until hydration corrects it.
   describe('startup brand resolution', () => {
     beforeEach(() => {
       document.body.className = ''
@@ -553,17 +550,14 @@ describe('eufemia-theme plugin', () => {
       const load = plugin.load as (id: string) => string | undefined
       const code = load('\0virtual:eufemia-theme-styles') || ''
 
-      // Assert the harness is live. This checks the INPUT, not the result: a
-      // shape change makes the rewrite below match nothing and leave the code
-      // untouched, which no assertion on the output can tell apart from a
-      // successful unwrap.
+      // Assert the rewrite target still exists; otherwise the unwrap below
+      // silently no-ops and the test would pass for the wrong reason.
       expect(
         code,
         'dev startup no longer wraps the first load in `requestAnimationFrame(() => {`, so the unwrap below is dead — update it'
       ).toContain('requestAnimationFrame(() => {')
 
-      // Same transform the other dev-mode tests use, so the first-load
-      // requestAnimationFrame callback runs synchronously.
+      // Unwrap the first-load requestAnimationFrame so its callback runs sync.
       const evalCode = code
         .replace(/import '[^']+';/g, '')
         .replace(/requestAnimationFrame\(\(\) => \{/, '{')
@@ -591,8 +585,7 @@ describe('eufemia-theme plugin', () => {
           'startupSpy(initial)'
         )
 
-      // Assert the harness is live: without this substitution the real
-      // loader would run and the spy would simply never be called.
+      // Assert the substitution applied, else the real loader runs, not the spy.
       expect(evalCode, 'build startup call was not substituted').toContain(
         'startupSpy(initial)'
       )

--- a/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/plugins/eufemia-theme.test.ts
@@ -528,4 +528,122 @@ describe('eufemia-theme plugin', () => {
       expect(sbankenLink.disabled).toBe(false)
     })
   })
+
+  /**
+   * These startup paths run before React hydrates, so if they resolve the
+   * persisted brand differently from the runtime handler the visitor sees the
+   * wrong theme until hydration corrects it.
+   */
+  describe('startup brand resolution', () => {
+    beforeEach(() => {
+      document.body.className = ''
+      document.head.innerHTML = ''
+      localStorage.clear()
+      delete (window as any).__applyEufemiaThemeStyles__
+      delete globalThis.__loadEufemiaTheme
+    })
+
+    afterEach(() => {
+      delete (window as any).__applyEufemiaThemeStyles__
+      delete globalThis.__loadEufemiaTheme
+    })
+
+    function runDevStartup() {
+      const plugin = eufemiaThemePlugin()
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:eufemia-theme-styles') || ''
+
+      // Same transform the other dev-mode tests use, so the first-load
+      // requestAnimationFrame callback runs synchronously.
+      const evalCode = code
+        .replace(/import '[^']+';/g, '')
+        .replace(/requestAnimationFrame\(\(\) => \{/, '{')
+        .replace(/\}\);(\s*\})/, '}$1')
+      new Function(evalCode)()
+    }
+
+    function runBuildStartup() {
+      const plugin = eufemiaThemePlugin()
+      const configResolved = plugin.configResolved as (config: {
+        command: string
+      }) => void
+      configResolved({ command: 'build' })
+
+      const load = plugin.load as (id: string) => string | undefined
+      const code = load('\0virtual:eufemia-theme-styles') || ''
+
+      const startupSpy = vi.fn()
+      const evalCode = code
+        .replace(/import\([^)]+\)/g, 'Promise.resolve()')
+        .replace(/import '[^']+';/g, '')
+        .replace(
+          'window.__loadEufemiaTheme(initial)',
+          'startupSpy(initial)'
+        )
+      new Function('startupSpy', evalCode)(startupSpy)
+
+      return startupSpy
+    }
+
+    it('dev mode applies a brand-only payload before hydration', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'carnegie' })
+      )
+
+      runDevStartup()
+
+      expect(
+        document.body.classList.contains('eufemia-theme__carnegie')
+      ).toBe(true)
+      expect(document.body.classList.contains('eufemia-theme__ui')).toBe(
+        false
+      )
+    })
+
+    it('dev mode still applies a legacy name-only payload', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ name: 'eiendom' })
+      )
+
+      runDevStartup()
+
+      expect(
+        document.body.classList.contains('eufemia-theme__eiendom')
+      ).toBe(true)
+    })
+
+    it('build mode loads a brand-only payload before hydration', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'carnegie' })
+      )
+
+      expect(runBuildStartup()).toHaveBeenCalledWith('carnegie')
+    })
+
+    it('build mode still loads a legacy name-only payload', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ name: 'eiendom' })
+      )
+
+      expect(runBuildStartup()).toHaveBeenCalledWith('eiendom')
+    })
+
+    it('prefers brand over the deprecated name in both modes', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'carnegie', name: 'eiendom' })
+      )
+
+      expect(runBuildStartup()).toHaveBeenCalledWith('carnegie')
+
+      runDevStartup()
+      expect(
+        document.body.classList.contains('eufemia-theme__carnegie')
+      ).toBe(true)
+    })
+  })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   collectUrls,
   getRoutePreloads,
@@ -814,6 +816,142 @@ describe('prerender-utils', () => {
     it('swaps eufemia-theme__color-scheme-- classes', () => {
       const script = getContentScript()
       expect(script).toContain('eufemia-theme__color-scheme--')
+    })
+  })
+
+  /**
+   * The pre-paint head script decides which theme stylesheet stays enabled
+   * before the browser paints. If it resolves the persisted brand differently
+   * from the runtime handler, the visitor sees the wrong theme until hydration.
+   */
+  describe('pre-paint theme script', () => {
+    const template = [
+      '<!DOCTYPE html>',
+      '<html>',
+      '<head>',
+      '</head>',
+      '<body>',
+      '  <div id="root"></div>',
+      '</body>',
+      '</html>',
+    ].join('\n')
+
+    const themeCssPaths = {
+      ui: '/assets/ui.css',
+      carnegie: '/assets/carnegie.css',
+      eiendom: '/assets/eiendom.css',
+    }
+
+    beforeEach(() => {
+      localStorage.clear()
+      document.head.innerHTML = ''
+      delete (globalThis as { __eufemiaTheme?: string }).__eufemiaTheme
+    })
+
+    /**
+     * Run the generated head script against real <link> elements, so the
+     * assertions cover its behaviour rather than its syntax.
+     */
+    function runHeadScript() {
+      const html = injectHtml(
+        template,
+        '<h1>Hi</h1>',
+        { js: [], css: [] },
+        undefined,
+        undefined,
+        themeCssPaths
+      )
+
+      for (const name of Object.keys(themeCssPaths)) {
+        const link = document.createElement('link')
+        link.rel = 'stylesheet'
+        link.setAttribute('data-eufemia-theme', name)
+        document.head.appendChild(link)
+      }
+
+      // Several inline scripts read the same storage key, so pick the one
+      // that publishes the resolved theme rather than relying on document
+      // order.
+      const script = html
+        .match(/<script>([\s\S]*?)<\/script>/g)
+        ?.map((tag) => tag.slice('<script>'.length, -'</script>'.length))
+        .find((body) => body.includes('globalThis.__eufemiaTheme='))
+      expect(script, 'no pre-paint theme script found').toBeDefined()
+
+      new Function(script)()
+
+      return (globalThis as { __eufemiaTheme?: string }).__eufemiaTheme
+    }
+
+    const enabledThemes = () =>
+      Array.from(
+        document.querySelectorAll<HTMLLinkElement>(
+          'link[data-eufemia-theme]'
+        )
+      )
+        .filter((link) => !link.disabled)
+        .map((link) => link.getAttribute('data-eufemia-theme'))
+
+    it('activates a brand-only payload before the first paint', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'carnegie' })
+      )
+
+      expect(runHeadScript()).toBe('carnegie')
+      expect(enabledThemes()).toEqual(['carnegie'])
+    })
+
+    it('still activates a legacy name-only payload', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ name: 'eiendom' })
+      )
+
+      expect(runHeadScript()).toBe('eiendom')
+      expect(enabledThemes()).toEqual(['eiendom'])
+    })
+
+    it('prefers brand over the deprecated name', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'carnegie', name: 'eiendom' })
+      )
+
+      expect(runHeadScript()).toBe('carnegie')
+    })
+
+    it('falls back to the default brand when nothing is stored', () => {
+      expect(runHeadScript()).toBe('ui')
+      expect(enabledThemes()).toEqual(['ui'])
+    })
+
+    /**
+     * prerender.mjs carries its own copy of these scripts ("mirrored from
+     * prerender-utils.ts for testing"), and only the copy above is reachable
+     * from a unit test. Pin them together so a fix to one cannot silently miss
+     * the other — which is how the brand-only payload came to be mishandled
+     * here in the first place.
+     */
+    it('matches the copy in prerender.mjs', () => {
+      const prodDir = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '../../prod'
+      )
+      const extract = (file: string, name: string) => {
+        const source = fs.readFileSync(path.join(prodDir, file), 'utf-8')
+        const line = source
+          .split('\n')
+          .find((l) => l.includes(`const ${name} = `))
+        expect(line, `${name} not found in ${file}`).toBeDefined()
+        return line.trim()
+      }
+
+      for (const name of ['headThemeScript', 'bodyThemeScript']) {
+        expect(extract('prerender.mjs', name)).toBe(
+          extract('prerender-utils.ts', name)
+        )
+      }
     })
   })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -869,6 +869,12 @@ describe('prerender-utils', () => {
         document.head.appendChild(link)
       }
 
+      // Assert the harness is live: the script's disable loop is only
+      // meaningful if the links are actually in the document.
+      expect(
+        document.querySelectorAll('link[data-eufemia-theme]')
+      ).toHaveLength(Object.keys(themeCssPaths).length)
+
       // Several inline scripts read the same storage key, so pick the one
       // that publishes the resolved theme rather than relying on document
       // order. Parsed rather than regex-matched — DOMParser does not execute
@@ -928,6 +934,57 @@ describe('prerender-utils', () => {
     it('falls back to the default brand when nothing is stored', () => {
       expect(runHeadScript()).toBe('ui')
       expect(enabledThemes()).toEqual(['ui'])
+    })
+
+    /**
+     * An unknown brand matches no <link>, so without a validity check the
+     * loop below would disable every theme stylesheet and the page would
+     * render completely unstyled — recoverable only by clearing storage.
+     * getTheme() in the client shim already guards this with isValidTheme();
+     * these cases pin the same behaviour for the pre-hydration path.
+     */
+    const withSearch = <T>(search: string, fn: () => T): T => {
+      const original = window.location
+      Object.defineProperty(window, 'location', {
+        value: { ...original, search },
+        writable: true,
+      })
+
+      try {
+        return fn()
+      } finally {
+        Object.defineProperty(window, 'location', {
+          value: original,
+          writable: true,
+        })
+      }
+    }
+
+    it('falls back to the default brand when the stored brand is unknown', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'removed-in-a-later-release' })
+      )
+
+      expect(runHeadScript()).toBe('ui')
+      expect(enabledThemes()).toEqual(['ui'])
+    })
+
+    it('falls back to the default brand when the query param is unknown', () => {
+      expect(withSearch('?eufemia-theme=bogus', runHeadScript)).toBe('ui')
+      expect(enabledThemes()).toEqual(['ui'])
+    })
+
+    it('still honours a valid query param over the stored brand', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'eiendom' })
+      )
+
+      expect(withSearch('?eufemia-theme=carnegie', runHeadScript)).toBe(
+        'carnegie'
+      )
+      expect(enabledThemes()).toEqual(['carnegie'])
     })
 
     /**

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -1005,6 +1005,15 @@ describe('prerender-utils', () => {
           .split('\n')
           .find((l) => l.includes(`const ${name} = `))
         expect(line, `${name} not found in ${file}`).toBeDefined()
+
+        // The comparison below only covers this one line, so fail loudly if the
+        // constant is ever reformatted across several lines — otherwise this
+        // guard would quietly compare opening fragments and miss real drift.
+        expect(
+          line.trimEnd().endsWith('`'),
+          `${name} in ${file} is no longer a single-line template literal — update this guard`
+        ).toBe(true)
+
         return line.trim()
       }
 

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -819,11 +819,8 @@ describe('prerender-utils', () => {
     })
   })
 
-  /**
-   * The pre-paint head script decides which theme stylesheet stays enabled
-   * before the browser paints. If it resolves the persisted brand differently
-   * from the runtime handler, the visitor sees the wrong theme until hydration.
-   */
+  // Decides which stylesheet stays enabled before first paint; must resolve
+  // the brand like the runtime handler, or the visitor sees the wrong theme.
   describe('pre-paint theme script', () => {
     const template = [
       '<!DOCTYPE html>',
@@ -848,10 +845,8 @@ describe('prerender-utils', () => {
       delete (globalThis as { __eufemiaTheme?: string }).__eufemiaTheme
     })
 
-    /**
-     * Run the generated head script against real <link> elements, so the
-     * assertions cover its behaviour rather than its syntax.
-     */
+    // Run the generated script against real <link>s, so assertions cover
+    // behaviour, not syntax.
     function runHeadScript() {
       const html = injectHtml(
         template,
@@ -869,16 +864,13 @@ describe('prerender-utils', () => {
         document.head.appendChild(link)
       }
 
-      // Assert the harness is live: the script's disable loop is only
-      // meaningful if the links are actually in the document.
+      // The disable loop is only meaningful if the links are present.
       expect(
         document.querySelectorAll('link[data-eufemia-theme]')
       ).toHaveLength(Object.keys(themeCssPaths).length)
 
-      // Several inline scripts read the same storage key, so pick the one
-      // that publishes the resolved theme rather than relying on document
-      // order. Parsed rather than regex-matched — DOMParser does not execute
-      // scripts, so reading textContent is safe.
+      // Pick the script that publishes the resolved theme (not by document
+      // order). DOMParser doesn't run scripts, so reading textContent is safe.
       const script = Array.from(
         new DOMParser()
           .parseFromString(html, 'text/html')
@@ -936,13 +928,8 @@ describe('prerender-utils', () => {
       expect(enabledThemes()).toEqual(['ui'])
     })
 
-    /**
-     * An unknown brand matches no <link>, so without a validity check the
-     * loop below would disable every theme stylesheet and the page would
-     * render completely unstyled — recoverable only by clearing storage.
-     * getTheme() in the client shim already guards this with isValidTheme();
-     * these cases pin the same behaviour for the pre-hydration path.
-     */
+    // An unknown brand matches no <link>; without validation the loop disables
+    // every stylesheet. Pins the isValidTheme() guard for the pre-paint path.
     const withSearch = <T>(search: string, fn: () => T): T => {
       const original = window.location
       Object.defineProperty(window, 'location', {
@@ -987,13 +974,8 @@ describe('prerender-utils', () => {
       expect(enabledThemes()).toEqual(['carnegie'])
     })
 
-    /**
-     * prerender.mjs carries its own copy of these scripts ("mirrored from
-     * prerender-utils.ts for testing"), and only the copy above is reachable
-     * from a unit test. Pin them together so a fix to one cannot silently miss
-     * the other — which is how the brand-only payload came to be mishandled
-     * here in the first place.
-     */
+    // prerender.mjs carries its own copy of these scripts, unreachable from a
+    // unit test. Pin them together so a fix to one can't silently miss the other.
     it('matches the copy in prerender.mjs', () => {
       const prodDir = path.resolve(
         path.dirname(fileURLToPath(import.meta.url)),
@@ -1006,9 +988,8 @@ describe('prerender-utils', () => {
           .find((l) => l.includes(`const ${name} = `))
         expect(line, `${name} not found in ${file}`).toBeDefined()
 
-        // The comparison below only covers this one line, so fail loudly if the
-        // constant is ever reformatted across several lines — otherwise this
-        // guard would quietly compare opening fragments and miss real drift.
+        // Compares one line only, so fail loudly if the constant is ever
+        // reformatted across lines, where this guard would miss real drift.
         expect(
           line.trimEnd().endsWith('`'),
           `${name} in ${file} is no longer a single-line template literal — update this guard`

--- a/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/prod/prerender-utils.test.ts
@@ -871,10 +871,14 @@ describe('prerender-utils', () => {
 
       // Several inline scripts read the same storage key, so pick the one
       // that publishes the resolved theme rather than relying on document
-      // order.
-      const script = html
-        .match(/<script>([\s\S]*?)<\/script>/g)
-        ?.map((tag) => tag.slice('<script>'.length, -'</script>'.length))
+      // order. Parsed rather than regex-matched — DOMParser does not execute
+      // scripts, so reading textContent is safe.
+      const script = Array.from(
+        new DOMParser()
+          .parseFromString(html, 'text/html')
+          .querySelectorAll('script')
+      )
+        .map((element) => element.textContent || '')
         .find((body) => body.includes('globalThis.__eufemiaTheme='))
       expect(script, 'no pre-paint theme script found').toBeDefined()
 

--- a/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler-storage-contract.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler-storage-contract.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getTheme as getPortalTheme,
+  setTheme as setPortalTheme,
+} from '../../client/shims/theme-handler'
+import {
+  getTheme as getEufemiaTheme,
+  setTheme as setEufemiaTheme,
+} from '@dnb/eufemia/src/shared/Theme'
+
+/**
+ * The portal's theme-handler shim and Eufemia's own getTheme/setTheme are two
+ * independent implementations that share the `eufemia-theme` localStorage key.
+ * Nothing in the type system ties them together, so these tests lock them to
+ * the same payload contract: `brand` is canonical, the deprecated `name` is
+ * mirrored, and neither may leave the pair diverged.
+ */
+const STORAGE_KEY = 'eufemia-theme'
+
+const stored = () => JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+
+describe('portal shim and Eufemia share the same theme storage contract', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.history.replaceState({}, '', '/')
+  })
+
+  it('a brand written by the portal is read back by Eufemia', () => {
+    setPortalTheme({ brand: 'sbanken' })
+
+    expect(getEufemiaTheme().brand).toBe('sbanken')
+  })
+
+  it('a brand written by Eufemia is read back by the portal', () => {
+    setEufemiaTheme({ brand: 'eiendom' })
+
+    expect(getPortalTheme().brand).toBe('eiendom')
+  })
+
+  it('both agree on a brand-only payload', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ brand: 'carnegie' })
+    )
+
+    expect(getPortalTheme().brand).toBe('carnegie')
+    expect(getEufemiaTheme().brand).toBe('carnegie')
+  })
+
+  it('both agree on a legacy name-only payload', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ name: 'sbanken' }))
+
+    expect(getPortalTheme().brand).toBe('sbanken')
+    expect(getEufemiaTheme().brand).toBe('sbanken')
+  })
+
+  it('both write brand and the deprecated name mirrored', () => {
+    setPortalTheme({ brand: 'eiendom' })
+    expect(stored()).toMatchObject({ brand: 'eiendom', name: 'eiendom' })
+
+    localStorage.clear()
+
+    setEufemiaTheme({ brand: 'eiendom' })
+    expect(stored()).toMatchObject({ brand: 'eiendom', name: 'eiendom' })
+  })
+
+  it('neither leaves brand and name diverged when only name is given', () => {
+    setPortalTheme({ brand: 'eiendom' })
+    setPortalTheme({ name: 'sbanken' })
+    expect(getEufemiaTheme().brand).toBe('sbanken')
+
+    localStorage.clear()
+
+    setEufemiaTheme({ brand: 'eiendom' })
+    setEufemiaTheme({ name: 'sbanken' })
+    expect(getPortalTheme().brand).toBe('sbanken')
+  })
+
+  it('a colorScheme written by one is preserved by the other', () => {
+    setEufemiaTheme({ brand: 'sbanken', colorScheme: 'dark' })
+    setPortalTheme({ brand: 'eiendom' })
+
+    expect(getEufemiaTheme()).toMatchObject({
+      brand: 'eiendom',
+      colorScheme: 'dark',
+    })
+  })
+})

--- a/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler-storage-contract.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler-storage-contract.test.ts
@@ -9,11 +9,9 @@ import {
 } from '@dnb/eufemia/src/shared/Theme'
 
 /**
- * The portal's theme-handler shim and Eufemia's own getTheme/setTheme are two
- * independent implementations that share the `eufemia-theme` localStorage key.
- * Nothing in the type system ties them together, so these tests lock them to
- * the same payload contract: `brand` is canonical, the deprecated `name` is
- * mirrored, and neither may leave the pair diverged.
+ * The portal shim and Eufemia's getTheme/setTheme are independent
+ * implementations sharing the `eufemia-theme` key. These tests lock them to one
+ * contract: `brand` canonical, `name` mirrored, never diverged.
  */
 const STORAGE_KEY = 'eufemia-theme'
 
@@ -86,11 +84,8 @@ describe('portal shim and Eufemia share the same theme storage contract', () => 
     })
   })
 
-  /**
-   * Eufemia keeps a second mirrored pair in this payload, `density`/`size`.
-   * The portal does not manage it, so it must at least carry it through
-   * untouched rather than dropping it on the next brand switch.
-   */
+  // Eufemia also mirrors density/size here; the portal doesn't manage it but
+  // must carry it through untouched on a brand switch.
   it('the portal preserves the density pair it does not manage', () => {
     setEufemiaTheme({ brand: 'sbanken', density: 'basis' })
     setPortalTheme({ brand: 'eiendom' })
@@ -137,11 +132,8 @@ describe('portal shim and Eufemia read the ?eufemia-theme param alike', () => {
     expect(getEufemiaTheme().brand).toBe('sbanken')
   })
 
-  /**
-   * The one intentional difference: the portal can only apply a brand whose CSS
-   * it has bundled, so it validates and falls back. Eufemia deliberately does
-   * not. Asserted here so the divergence stays deliberate.
-   */
+  // Intentional difference: the portal validates the brand (it must have the
+  // CSS) and falls back; Eufemia does not. Asserted so it stays deliberate.
   it('only the portal validates an unknown brand', () => {
     setSearch('?eufemia-theme=not-a-brand')
 

--- a/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler-storage-contract.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler-storage-contract.test.ts
@@ -85,4 +85,67 @@ describe('portal shim and Eufemia share the same theme storage contract', () => 
       colorScheme: 'dark',
     })
   })
+
+  /**
+   * Eufemia keeps a second mirrored pair in this payload, `density`/`size`.
+   * The portal does not manage it, so it must at least carry it through
+   * untouched rather than dropping it on the next brand switch.
+   */
+  it('the portal preserves the density pair it does not manage', () => {
+    setEufemiaTheme({ brand: 'sbanken', density: 'basis' })
+    setPortalTheme({ brand: 'eiendom' })
+
+    expect(getEufemiaTheme()).toMatchObject({
+      brand: 'eiendom',
+      density: 'basis',
+      size: 'basis',
+    })
+  })
+})
+
+describe('portal shim and Eufemia read the ?eufemia-theme param alike', () => {
+  const setSearch = (search: string) =>
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, search },
+      writable: true,
+    })
+
+  beforeEach(() => {
+    localStorage.clear()
+    setSearch('')
+  })
+
+  it('both ignore a param that merely ends with the key', () => {
+    setSearch('?x-eufemia-theme=sbanken')
+
+    expect(getPortalTheme().brand).toBe('ui')
+    expect(getEufemiaTheme().brand).toBe('ui')
+  })
+
+  it('both take the first value when the param is repeated', () => {
+    setSearch('?eufemia-theme=eiendom&eufemia-theme=sbanken')
+
+    expect(getPortalTheme().brand).toBe('eiendom')
+    expect(getEufemiaTheme().brand).toBe('eiendom')
+  })
+
+  it('both let the param override the stored brand', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ brand: 'eiendom' }))
+    setSearch('?eufemia-theme=sbanken')
+
+    expect(getPortalTheme().brand).toBe('sbanken')
+    expect(getEufemiaTheme().brand).toBe('sbanken')
+  })
+
+  /**
+   * The one intentional difference: the portal can only apply a brand whose CSS
+   * it has bundled, so it validates and falls back. Eufemia deliberately does
+   * not. Asserted here so the divergence stays deliberate.
+   */
+  it('only the portal validates an unknown brand', () => {
+    setSearch('?eufemia-theme=not-a-brand')
+
+    expect(getPortalTheme().brand).toBe('ui')
+    expect(getEufemiaTheme().brand).toBe('not-a-brand')
+  })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler.test.ts
@@ -39,27 +39,51 @@ describe('theme-handler shim', () => {
   describe('getTheme', () => {
     it('returns default theme when nothing is stored', () => {
       const theme = getTheme()
+      expect(theme.brand).toBe('ui')
       expect(theme.name).toBe('ui')
     })
 
-    it('reads theme from localStorage', () => {
+    it('reads brand from localStorage', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'sbanken' })
+      )
+
+      const theme = getTheme()
+      expect(theme.brand).toBe('sbanken')
+      expect(theme.name).toBe('sbanken')
+    })
+
+    it('reads a deprecated name-only payload from localStorage', () => {
       localStorage.setItem(
         'eufemia-theme',
         JSON.stringify({ name: 'sbanken' })
       )
 
       const theme = getTheme()
+      expect(theme.brand).toBe('sbanken')
       expect(theme.name).toBe('sbanken')
+    })
+
+    it('prefers brand when both brand and name are stored', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'carnegie', name: 'sbanken' })
+      )
+
+      const theme = getTheme()
+      expect(theme.brand).toBe('carnegie')
+      expect(theme.name).toBe('carnegie')
     })
 
     it('falls back to default for invalid stored theme', () => {
       localStorage.setItem(
         'eufemia-theme',
-        JSON.stringify({ name: 'invalid-theme' })
+        JSON.stringify({ brand: 'invalid-theme' })
       )
 
       const theme = getTheme()
-      expect(theme.name).toBe('ui')
+      expect(theme.brand).toBe('ui')
     })
 
     it('reads theme from query parameter', () => {
@@ -70,7 +94,7 @@ describe('theme-handler shim', () => {
       })
 
       const theme = getTheme()
-      expect(theme.name).toBe('eiendom')
+      expect(theme.brand).toBe('eiendom')
 
       Object.defineProperty(window, 'location', {
         value: { ...window.location, search: originalSearch },
@@ -81,27 +105,52 @@ describe('theme-handler shim', () => {
     it('preserves additional stored properties like colorScheme', () => {
       localStorage.setItem(
         'eufemia-theme',
-        JSON.stringify({ name: 'ui', colorScheme: 'dark' })
+        JSON.stringify({ brand: 'ui', colorScheme: 'dark' })
       )
 
       const theme = getTheme()
-      expect(theme.name).toBe('ui')
+      expect(theme.brand).toBe('ui')
       expect(theme.colorScheme).toBe('dark')
     })
   })
 
   describe('setTheme', () => {
-    it('saves theme to localStorage', () => {
+    it('saves brand to localStorage, mirrored to the deprecated name', () => {
+      setTheme({ brand: 'sbanken' })
+
+      const stored = JSON.parse(
+        localStorage.getItem('eufemia-theme') || '{}'
+      )
+      expect(stored.brand).toBe('sbanken')
+      expect(stored.name).toBe('sbanken')
+    })
+
+    it('supports the deprecated name property', () => {
+      setTheme({ name: 'eiendom' })
+
+      const stored = JSON.parse(
+        localStorage.getItem('eufemia-theme') || '{}'
+      )
+      expect(stored.brand).toBe('eiendom')
+      expect(stored.name).toBe('eiendom')
+    })
+
+    it('never leaves brand and name diverged', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'eiendom', name: 'eiendom' })
+      )
+
       setTheme({ name: 'sbanken' })
 
       const stored = JSON.parse(
         localStorage.getItem('eufemia-theme') || '{}'
       )
-      expect(stored.name).toBe('sbanken')
+      expect(stored).toEqual({ brand: 'sbanken', name: 'sbanken' })
     })
 
-    it('does not save invalid theme names', () => {
-      setTheme({ name: 'nonexistent' as never })
+    it('does not save invalid brands', () => {
+      setTheme({ brand: 'nonexistent' as never })
 
       const stored = localStorage.getItem('eufemia-theme')
       expect(stored).toBeNull()
@@ -111,16 +160,16 @@ describe('theme-handler shim', () => {
       const applyFn = vi.fn()
       window.__applyEufemiaThemeStyles__ = applyFn
 
-      setTheme({ name: 'eiendom' })
+      setTheme({ brand: 'eiendom' })
       expect(applyFn).toHaveBeenCalledWith('eiendom')
     })
 
     it('invokes the callback with the new theme', () => {
       const callback = vi.fn()
-      setTheme({ name: 'sbanken' }, callback)
+      setTheme({ brand: 'sbanken' }, callback)
 
       expect(callback).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'sbanken' })
+        expect.objectContaining({ brand: 'sbanken', name: 'sbanken' })
       )
     })
   })
@@ -128,7 +177,7 @@ describe('theme-handler shim', () => {
   describe('useThemeHandler', () => {
     it('returns the current theme', () => {
       const { result } = renderHook(() => useThemeHandler())
-      expect(result.current.name).toBe('ui')
+      expect(result.current.brand).toBe('ui')
       expect(typeof result.current.setTheme).toBe('function')
     })
 
@@ -136,12 +185,12 @@ describe('theme-handler shim', () => {
       const { result } = renderHook(() => useThemeHandler())
 
       act(() => {
-        result.current.setTheme({ name: 'sbanken' })
+        result.current.setTheme({ brand: 'sbanken' })
       })
 
       // The ref is updated but no React re-render is triggered.
       // The theme change is reflected in localStorage and getTheme().
-      expect(getTheme().name).toBe('sbanken')
+      expect(getTheme().brand).toBe('sbanken')
     })
 
     it('calls __applyEufemiaThemeStyles__ on mount', () => {

--- a/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/shims/theme-handler.test.ts
@@ -86,6 +86,17 @@ describe('theme-handler shim', () => {
       expect(theme.brand).toBe('ui')
     })
 
+    it('keeps the rest of the state when the stored brand is unknown', () => {
+      localStorage.setItem(
+        'eufemia-theme',
+        JSON.stringify({ brand: 'invalid-theme', colorScheme: 'dark' })
+      )
+
+      const theme = getTheme()
+      expect(theme.brand).toBe('ui')
+      expect(theme.colorScheme).toBe('dark')
+    })
+
     it('reads theme from query parameter', () => {
       const originalSearch = window.location.search
       Object.defineProperty(window, 'location', {

--- a/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
@@ -322,7 +322,7 @@ ${loaderEntries}
   try {
     var stored = JSON.parse(localStorage.getItem('eufemia-theme') || '{}');
     var params = new URLSearchParams(location.search);
-    var initial = params.get('eufemia-theme') || stored.name || '${config.defaultTheme}';
+    var initial = params.get('eufemia-theme') || stored.brand || stored.name || '${config.defaultTheme}';
     window.__loadEufemiaTheme(initial);
   } catch(e) {
     window.__loadEufemiaTheme('${config.defaultTheme}');
@@ -360,7 +360,7 @@ if (typeof window !== 'undefined') {
       const data = localStorage.getItem('eufemia-theme');
       const stored = JSON.parse(data?.startsWith('{') ? data : '{}');
       const params = new URLSearchParams(location.search);
-      return params.get('eufemia-theme') || stored?.name || ${JSON.stringify(config.defaultTheme)};
+      return params.get('eufemia-theme') || stored?.brand || stored?.name || ${JSON.stringify(config.defaultTheme)};
     } catch { return ${JSON.stringify(config.defaultTheme)}; }
   };
 

--- a/packages/dnb-design-system-portal/vite/client/portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/portal-app.tsx
@@ -43,8 +43,7 @@ import 'virtual:eufemia-theme-styles'
 const emotionCache = createEmotionCache({ key: 'css' })
 
 function RootLayout() {
-  // `name` is the deprecated mirror of `brand` — drop it so the portal does
-  // not hand a deprecated property to its own Theme.
+  // Drop the deprecated `name` mirror so it isn't passed to <Theme>.
   const {
     setTheme,
     colorScheme,

--- a/packages/dnb-design-system-portal/vite/client/portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/portal-app.tsx
@@ -43,7 +43,14 @@ import 'virtual:eufemia-theme-styles'
 const emotionCache = createEmotionCache({ key: 'css' })
 
 function RootLayout() {
-  const { setTheme, colorScheme, ...theme } = useThemeHandler()
+  // `name` is the deprecated mirror of `brand` — drop it so the portal does
+  // not hand a deprecated property to its own Theme.
+  const {
+    setTheme,
+    colorScheme,
+    name: _name,
+    ...theme
+  } = useThemeHandler()
 
   const translationsLoader = useCallback(async (locale: string) => {
     try {

--- a/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
+++ b/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
@@ -92,17 +92,19 @@ export function getTheme(): ThemeState {
     const data = window.localStorage.getItem(STORAGE_KEY)
     const stored = JSON.parse(data?.startsWith('{') ? data : '{}')
 
-    // Also allow ?eufemia-theme=<brand> query param
-    const regex = /.*eufemia-theme=([^&]*).*/
-    const query = window.location.search
+    // Also allow ?eufemia-theme=<brand> query param. Parsed the same way as
+    // Eufemia's getTheme, so the two cannot disagree about which value wins.
     const fromQuery =
-      (regex.test(query) && query?.replace(regex, '$1')) || null
+      new URLSearchParams(window.location.search).get('eufemia-theme') ||
+      null
 
     const brand =
       fromQuery || stored?.brand || stored?.name || DEFAULT_THEME
 
     if (!isValidTheme(brand)) {
-      return withBrand({}, DEFAULT_THEME)
+      // Keep the rest of the state: an unknown brand should not cost the
+      // visitor their colorScheme.
+      return withBrand(stored, DEFAULT_THEME)
     }
 
     return withBrand(stored, brand)

--- a/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
+++ b/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
@@ -8,12 +8,10 @@
  * All theme CSS is already loaded by vite-plugin-eufemia-theme,
  * so switching only requires updating localStorage + the HTML attribute.
  *
- * NOTE: this shim shares the `eufemia-theme` localStorage key with Eufemia's
- * own getTheme/setTheme (shared/Theme.tsx). Nothing in the type system ties
- * the two together, so the payload contract has to be kept in sync by hand:
- * `brand` is canonical, the deprecated `name` is mirrored until v13, and the
- * pair must never diverge. theme-handler-storage-contract.test.ts asserts this
- * against the real Eufemia implementation.
+ * Shares the `eufemia-theme` localStorage key with Eufemia's getTheme/setTheme
+ * (shared/Theme.tsx). The payload contract is kept in sync by hand — `brand`
+ * canonical, `name` mirrored until v13, never diverged — and locked by
+ * theme-handler-storage-contract.test.ts.
  */
 
 import { useState, useEffect, useCallback } from 'react'
@@ -48,18 +46,12 @@ const themeNames: ThemeNames[] = Object.keys(
 
 export type ThemeState = {
   brand: ThemeNames
-  /**
-   * Deprecated. Use `brand` instead.
-   * @deprecated Use `brand` instead. This property will be removed in v13.
-   */
+  /** @deprecated Use `brand` instead. Removed in v13. */
   name?: ThemeNames
   colorScheme?: ThemeColorScheme
 }
 
-/**
- * Mirror `brand` onto the deprecated `name`, so every payload this shim writes
- * satisfies both keys. `getTheme` therefore always resolves a `brand`.
- */
+/** Mirror `brand` onto the deprecated `name` so every written payload has both. */
 function withBrand(
   state: Record<string, unknown>,
   brand: ThemeNames
@@ -92,8 +84,7 @@ export function getTheme(): ThemeState {
     const data = window.localStorage.getItem(STORAGE_KEY)
     const stored = JSON.parse(data?.startsWith('{') ? data : '{}')
 
-    // Also allow ?eufemia-theme=<brand> query param. Parsed the same way as
-    // Eufemia's getTheme, so the two cannot disagree about which value wins.
+    // ?eufemia-theme=<brand> wins; parsed like Eufemia's getTheme so they agree.
     const fromQuery =
       new URLSearchParams(window.location.search).get('eufemia-theme') ||
       null
@@ -102,8 +93,7 @@ export function getTheme(): ThemeState {
       fromQuery || stored?.brand || stored?.name || DEFAULT_THEME
 
     if (!isValidTheme(brand)) {
-      // Keep the rest of the state: an unknown brand should not cost the
-      // visitor their colorScheme.
+      // Keep the rest of the state (e.g. colorScheme) on an unknown brand.
       return withBrand(stored, DEFAULT_THEME)
     }
 
@@ -126,8 +116,7 @@ export function setTheme(
     return // stop here
   }
 
-  // Re-derive both keys from the resolved brand, so a caller passing only the
-  // deprecated `name` can never leave a stale `brand` behind (or vice versa).
+  // Re-derive both keys so passing only `name` (or only `brand`) can't diverge.
   const theme = withBrand({ ...current, ...themeProps }, brand)
 
   const applyAndNotify = () => {

--- a/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
+++ b/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
@@ -7,6 +7,13 @@
  *
  * All theme CSS is already loaded by vite-plugin-eufemia-theme,
  * so switching only requires updating localStorage + the HTML attribute.
+ *
+ * NOTE: this shim shares the `eufemia-theme` localStorage key with Eufemia's
+ * own getTheme/setTheme (shared/Theme.tsx). Nothing in the type system ties
+ * the two together, so the payload contract has to be kept in sync by hand:
+ * `brand` is canonical, the deprecated `name` is mirrored until v13, and the
+ * pair must never diverge. theme-handler-storage-contract.test.ts asserts this
+ * against the real Eufemia implementation.
  */
 
 import { useState, useEffect, useCallback } from 'react'
@@ -40,8 +47,24 @@ const themeNames: ThemeNames[] = Object.keys(
 ) as ThemeNames[]
 
 export type ThemeState = {
-  name: ThemeNames
+  brand: ThemeNames
+  /**
+   * Deprecated. Use `brand` instead.
+   * @deprecated Use `brand` instead. This property will be removed in v13.
+   */
+  name?: ThemeNames
   colorScheme?: ThemeColorScheme
+}
+
+/**
+ * Mirror `brand` onto the deprecated `name`, so every payload this shim writes
+ * satisfies both keys. `getTheme` therefore always resolves a `brand`.
+ */
+function withBrand(
+  state: Record<string, unknown>,
+  brand: ThemeNames
+): ThemeState {
+  return { ...state, brand, name: brand } as ThemeState
 }
 
 // Simple event emitter for cross-component theme updates
@@ -56,34 +79,35 @@ export function getThemes() {
   return availableThemes
 }
 
-export function isValidTheme(name: string): name is ThemeNames {
-  return themeNames.includes(name as ThemeNames)
+export function isValidTheme(brand: string): brand is ThemeNames {
+  return themeNames.includes(brand as ThemeNames)
 }
 
 export function getTheme(): ThemeState {
   if (typeof window === 'undefined') {
-    return { name: DEFAULT_THEME }
+    return withBrand({}, DEFAULT_THEME)
   }
 
   try {
     const data = window.localStorage.getItem(STORAGE_KEY)
     const stored = JSON.parse(data?.startsWith('{') ? data : '{}')
 
-    // Also allow ?eufemia-theme=<name> query param
+    // Also allow ?eufemia-theme=<brand> query param
     const regex = /.*eufemia-theme=([^&]*).*/
     const query = window.location.search
     const fromQuery =
       (regex.test(query) && query?.replace(regex, '$1')) || null
 
-    const themeName = fromQuery || stored?.name || DEFAULT_THEME
+    const brand =
+      fromQuery || stored?.brand || stored?.name || DEFAULT_THEME
 
-    if (!isValidTheme(themeName)) {
-      return { name: DEFAULT_THEME }
+    if (!isValidTheme(brand)) {
+      return withBrand({}, DEFAULT_THEME)
     }
 
-    return { ...stored, name: themeName }
+    return withBrand(stored, brand)
   } catch {
-    return { name: DEFAULT_THEME }
+    return withBrand({}, DEFAULT_THEME)
   }
 }
 
@@ -91,11 +115,18 @@ export function setTheme(
   themeProps: Partial<ThemeState>,
   callback?: (theme: ThemeState) => void
 ) {
-  const theme = { ...getTheme(), ...themeProps }
+  const current = getTheme()
+  const brand = (themeProps.brand ??
+    themeProps.name ??
+    current.brand) as ThemeNames
 
-  if (!isValidTheme(theme.name)) {
+  if (!isValidTheme(brand)) {
     return // stop here
   }
+
+  // Re-derive both keys from the resolved brand, so a caller passing only the
+  // deprecated `name` can never leave a stale `brand` behind (or vice versa).
+  const theme = withBrand({ ...current, ...themeProps }, brand)
 
   const applyAndNotify = () => {
     // Dev mode: toggle style.disabled on <style> elements
@@ -103,7 +134,7 @@ export function setTheme(
       typeof window !== 'undefined' &&
       window.__applyEufemiaThemeStyles__
     ) {
-      window.__applyEufemiaThemeStyles__(theme.name)
+      window.__applyEufemiaThemeStyles__(theme.brand)
     }
 
     // Update body color-scheme class so CSS responds immediately
@@ -135,7 +166,7 @@ export function setTheme(
 
   // Build mode: lazy-load theme CSS before applying
   if (typeof window !== 'undefined' && window.__loadEufemiaTheme) {
-    window.__loadEufemiaTheme(theme.name).then(applyAndNotify)
+    window.__loadEufemiaTheme(theme.brand).then(applyAndNotify)
   } else {
     applyAndNotify()
   }
@@ -149,12 +180,12 @@ export function useThemeHandler() {
     // In build mode, lazy-load non-default theme CSS first.
     const applyInitial = () => {
       if (window.__applyEufemiaThemeStyles__) {
-        window.__applyEufemiaThemeStyles__(theme.name)
+        window.__applyEufemiaThemeStyles__(theme.brand)
       }
     }
 
     if (window.__loadEufemiaTheme) {
-      window.__loadEufemiaTheme(theme.name).then(applyInitial)
+      window.__loadEufemiaTheme(theme.brand).then(applyInitial)
     } else {
       applyInitial()
     }

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -359,11 +359,8 @@ export function injectHtml(
     // Runs in <head> after the render-blocking links have loaded,
     // so the disable is instant — no network delay.
     //
-    // The resolved brand is validated against the themes actually present,
-    // mirroring isValidTheme() in the client shim. Without that check an
-    // unknown brand — a ?eufemia-theme= link, or a stored brand that a later
-    // release renamed or removed — matches no link, so every theme stylesheet
-    // would be disabled and the page would render completely unstyled.
+    // Validate the brand against the themes present (like isValidTheme in the
+    // shim): an unknown brand matches no link and would disable every stylesheet.
     const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');var known=[];for(var i=0;i<links.length;i++){known.push(links[i].getAttribute('data-eufemia-theme'))}if(known.length&&known.indexOf(n)<0){n='${defaultTheme}'}for(var j=0;j<links.length;j++){links[j].disabled=known[j]!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -358,7 +358,7 @@ export function injectHtml(
     // links, and store the name on globalThis for the body script.
     // Runs in <head> after the render-blocking links have loaded,
     // so the disable is instant — no network delay.
-    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
+    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after
     // the opening tag, before any content is rendered.

--- a/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
+++ b/packages/dnb-design-system-portal/vite/prod/prerender-utils.ts
@@ -358,7 +358,13 @@ export function injectHtml(
     // links, and store the name on globalThis for the body script.
     // Runs in <head> after the render-blocking links have loaded,
     // so the disable is instant — no network delay.
-    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
+    //
+    // The resolved brand is validated against the themes actually present,
+    // mirroring isValidTheme() in the client shim. Without that check an
+    // unknown brand — a ?eufemia-theme= link, or a stored brand that a later
+    // release renamed or removed — matches no link, so every theme stylesheet
+    // would be disabled and the page would render completely unstyled.
+    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');var known=[];for(var i=0;i<links.length;i++){known.push(links[i].getAttribute('data-eufemia-theme'))}if(known.length&&known.indexOf(n)<0){n='${defaultTheme}'}for(var j=0;j<links.length;j++){links[j].disabled=known[j]!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after
     // the opening tag, before any content is rendered.

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -515,7 +515,7 @@ function injectHtml(
     // links, and store the name on globalThis for the body script.
     // Runs in <head> after the render-blocking links have loaded,
     // so the disable is instant — no network delay.
-    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
+    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after
     // the opening tag, before any content is rendered.

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -516,11 +516,8 @@ function injectHtml(
     // Runs in <head> after the render-blocking links have loaded,
     // so the disable is instant — no network delay.
     //
-    // The resolved brand is validated against the themes actually present,
-    // mirroring isValidTheme() in the client shim. Without that check an
-    // unknown brand — a ?eufemia-theme= link, or a stored brand that a later
-    // release renamed or removed — matches no link, so every theme stylesheet
-    // would be disabled and the page would render completely unstyled.
+    // Validate the brand against the themes present (like isValidTheme in the
+    // shim): an unknown brand matches no link and would disable every stylesheet.
     const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');var known=[];for(var i=0;i<links.length;i++){known.push(links[i].getAttribute('data-eufemia-theme'))}if(known.length&&known.indexOf(n)<0){n='${defaultTheme}'}for(var j=0;j<links.length;j++){links[j].disabled=known[j]!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after

--- a/packages/dnb-design-system-portal/vite/prod/prerender.mjs
+++ b/packages/dnb-design-system-portal/vite/prod/prerender.mjs
@@ -515,7 +515,13 @@ function injectHtml(
     // links, and store the name on globalThis for the body script.
     // Runs in <head> after the render-blocking links have loaded,
     // so the disable is instant — no network delay.
-    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');for(var i=0;i<links.length;i++){links[i].disabled=links[i].getAttribute('data-eufemia-theme')!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
+    //
+    // The resolved brand is validated against the themes actually present,
+    // mirroring isValidTheme() in the client shim. Without that check an
+    // unknown brand — a ?eufemia-theme= link, or a stored brand that a later
+    // release renamed or removed — matches no link, so every theme stylesheet
+    // would be disabled and the page would render completely unstyled.
+    const headThemeScript = `<script>(function(){try{var t=JSON.parse(localStorage.getItem('eufemia-theme')||'{}');var p=new URLSearchParams(location.search);var n=p.get('eufemia-theme')||t.brand||t.name||'${defaultTheme}';var links=document.querySelectorAll('link[data-eufemia-theme]');var known=[];for(var i=0;i<links.length;i++){known.push(links[i].getAttribute('data-eufemia-theme'))}if(known.length&&known.indexOf(n)<0){n='${defaultTheme}'}for(var j=0;j<links.length;j++){links[j].disabled=known[j]!==n}globalThis.__eufemiaTheme=n}catch(e){globalThis.__eufemiaTheme='${defaultTheme}'}})()</script>`
 
     // Body script: add the brand class to <body> immediately after
     // the opening tag, before any content is rendered.

--- a/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/Theme.test.tsx
@@ -2,6 +2,7 @@ import { Fragment, act, useContext } from 'react'
 import type { ReactNode, Ref } from 'react'
 import { render } from '@testing-library/react'
 import Context from '../Context'
+import Provider from '../Provider'
 import type { ThemeAllProps } from '../Theme'
 import Theme, { getTheme, setTheme } from '../Theme'
 import {
@@ -63,6 +64,24 @@ describe('Theme', () => {
     })
     expect(element).toHaveAttribute('data-brand', 'carnegie')
     expect(element).toHaveAttribute('data-name', 'carnegie')
+  })
+
+  it('resolves brand from a context that only provides the deprecated name', () => {
+    render(
+      <Provider theme={{ name: 'sbanken' }}>
+        <Theme id="inner" variant="soft">
+          content
+        </Theme>
+      </Provider>
+    )
+
+    const element = document.querySelector('#inner')
+    expect(element).toHaveClass(
+      'eufemia-theme eufemia-theme__sbanken eufemia-theme__sbanken--soft',
+      { exact: true }
+    )
+    expect(element).toHaveAttribute('data-brand', 'sbanken')
+    expect(element).toHaveAttribute('data-name', 'sbanken')
   })
 
   it('supports nested themes', () => {


### PR DESCRIPTION
Follow-up to #9186 and #9187 (both merged). Covers the review findings neither addressed: the **portal**, the **docs**, and **missing tests**. Each fix was reproduced as a failing test first.

## 1. Portal theme runtime disagreed with Eufemia

The portal's theme runtime shares the `eufemia-theme` localStorage key with Eufemia's `getTheme`/`setTheme`, but nothing types the two together — so every mismatch below was invisible to the compiler.

- **Startup activated the wrong brand** (caught in review — thanks @tujoworker). Four pre-hydration paths resolved `stored.name` only, so `{"brand":"carnegie"}` activated `ui` first → theme flash: build startup (`__loadEufemiaTheme`), dev startup (`getInitialTheme`), the pre-paint head script in `prerender-utils.ts`, and its copy in `prerender.mjs`. All four now resolve `brand` before `name` (`||`, matching `shared/Theme.tsx`).
- **Unknown brand disabled every stylesheet.** The pre-paint script never checked the page ships the brand; an unknown one matches no `link[data-eufemia-theme]`, so the disable loop left the page unstyled — reachable via `?eufemia-theme=`, but the real case is a brand a later release renames/removes (returning visitor stuck until they clear storage). Now validated against the theme links present, like `getTheme()`'s `isValidTheme()`. Build startup already no-ops on an unknown name.
- **Handler ignored `brand`.** A `brand`-only payload resolved to `'ui'` (selected brand silently lost); switching brand while a `brand` key was present wrote a diverged `{ brand: 'eiendom', name: 'sbanken' }`, after which Eufemia reported the old brand. Now resolves `brand ?? name` and re-derives both keys, never diverging.
- **Parsed `?eufemia-theme=` differently.** The regex `/.*eufemia-theme=([^&]*).*/` matched any param whose name merely *ends* with the key (`?x-eufemia-theme=sbanken`) and took the *last* repeated value, where Eufemia's `URLSearchParams` takes the *first*. Now uses `URLSearchParams` too.
- **Unknown brand cost you dark mode.** The fallback to the default discarded the rest of the stored state, including the `colorScheme` that `ColorSchemeScript` (rendered for FOUC prevention) keeps reading. Now keeps the state and replaces only the brand.
- **One source of truth.** `ToggleDarkMode`, `ChangeStyleTheme` and `PortalToolsMenu` wrote through the shim but read Eufemia's `getTheme`; since the shim applies the CSS and feeds `<Theme>` in `portal-app`, they now read it too, so the brand is validated on read. `portal-app` no longer spreads the deprecated `name` into its own `<Theme>`, and `ToggleDarkMode` drops an `as Record<string, unknown>` cast that defeated the `setTheme` signature.

The shim is deliberately **not** refactored to delegate to Eufemia's `getTheme`/`setTheme`: it stays free of library runtime imports, so the contract is documented at its top and locked by tests instead. Happy to do the deeper refactor separately.

## 2. Docs taught the deprecated property

Migrated to `brand`: `typography/Examples.tsx`, `typography/_helpers.tsx`, `components/logo/Examples.tsx` (x2), `components/avatar/Examples.tsx`, and `SidebarMenu`. Logo/Avatar were held back until **#9187** landed — their theme argument comes from `Logo`'s `svg` factory, which now carries `brand` (verified for both `brand` and the deprecated `name`); migrating early defaulted every themed logo and failed 11 visual-regression tests. No deprecated theme-name reads remain in the portal.

## 3. v13 guide: the shape that fails silently

`VisibilityByTheme` matches on raw object keys, so `visible={[{ name: 'sbanken' }]}` works today only because `name` is mirrored into the context. At v13 it stops matching and **the content just disappears**; TypeScript then reports `TS2353` for an inline object, but plain JavaScript still gets nothing. Added to the guide.

## 4. Tests for the paths that had none

- **`theme-handler-storage-contract.test.ts`** (new) — shim and Eufemia agree on the stored payload and query-parameter resolution, both directions, for brand-only / legacy name-only / mirrored payloads. Pins the one deliberate difference (only the portal validates the brand, because only it must have the CSS) and the `density`/`size` pair the portal carries through but does not manage (added after #9191).
- **Generated startup code** — dev and build modules evaluated with a brand-only payload, asserting the body brand class and the theme handed to the lazy loader.
- **Pre-paint head script** — run against real `link[data-eufemia-theme]` elements, asserting which stylesheet stays enabled and the published `globalThis.__eufemiaTheme`.
- **`prerender.mjs` drift guard** — that file's copy of the scripts isn't reachable from a unit test, so a guard pins it to the `prerender-utils.ts` copy; reverting either alone now fails. That is how this defect survived.
- **`shared/Theme.test.tsx`** — `Theme` resolving a brand from a context that provides only the deprecated `name`; that block had no coverage at all (removing it left all 46 existing tests green).

Legacy `{"name":...}` payloads are covered alongside every new case, so the v12 storage format keeps working in each startup path.

## Verification

- Portal touched suites 150/150; library `shared` suites green; `tsc --noEmit` 0 errors on both; lint + Prettier clean; rebased on current `main` (includes #9187, #9191).
- **Every fix is mutation-tested** — reverted in turn to confirm a test actually fails: brand resolution, query parsing, retained state, carried-through state, the four startup paths, the pre-paint validation, the `prerender.mjs` drift guard, and the `Theme.tsx` block.

## Deliberately left out

- **`VisibilityByTheme.Name`** (used on 3 docs pages) still returns the brand display name — the same "name means brand" confusion this rename targets. Adding `.Brand` and deprecating `.Name` is new public API, so it wants a maintainer decision.
- A defensive `brand ?? name` fallback in `ThemeWrapper`'s data attributes — unreachable today, so dead code.
- Stripping the deprecated `size` alongside `name` in `portal-app` — the shim never writes `density`/`size`, so that branch would be dead.
