### PR TITLE
fix(Forms): preserve optional fields when editing array items

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/PushContainer/__tests__/PushContainer.test.tsx
@@ -2016,6 +2016,104 @@ describe('PushContainer', () => {
       })
     })
 
+    it('keeps optional nested fields valid after adding and editing an item', async () => {
+      const schema: JSONSchema = {
+        type: 'object',
+        required: ['beneficialOwners'],
+        properties: {
+          beneficialOwners: {
+            type: 'object',
+            required: ['otherBeneficialOwners'],
+            properties: {
+              otherBeneficialOwners: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    address: {
+                      type: 'object',
+                      properties: {
+                        addressLine1: { type: 'string' },
+                        addressLine2: { type: 'string' },
+                      },
+                      required: ['addressLine1'],
+                    },
+                  },
+                  required: ['address'],
+                },
+              },
+            },
+          },
+        },
+      }
+
+      render(
+        <Form.Handler schema={schema} ajvInstance={makeAjvInstance()}>
+          <Form.Section path="/beneficialOwners">
+            <Iterate.Array
+              id="owners"
+              path="/otherBeneficialOwners"
+              containerMode="view"
+            >
+              <Iterate.ViewContainer>Owner</Iterate.ViewContainer>
+              <Iterate.EditContainer>
+                <Field.String itemPath="/address/addressLine1" trim />
+                <Field.String itemPath="/address/addressLine2" trim />
+              </Iterate.EditContainer>
+            </Iterate.Array>
+
+            <Iterate.PushContainer
+              path="/otherBeneficialOwners"
+              showOpenButtonWhen={(items) => items.length > 0}
+            >
+              <Field.String itemPath="/address/addressLine1" trim />
+              <Field.String itemPath="/address/addressLine2" trim />
+            </Iterate.PushContainer>
+          </Form.Section>
+        </Form.Handler>
+      )
+
+      const [addressLine1, addressLine2] = Array.from(
+        document.querySelectorAll('input')
+      )
+      expect(addressLine1).toHaveAttribute('aria-required', 'true')
+      expect(addressLine2).not.toHaveAttribute('aria-required')
+
+      await userEvent.type(addressLine1, 'Main street 1')
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate__done-button')
+      )
+
+      const item = await waitFor(() => {
+        const item = document.querySelector(
+          '#owners > .dnb-forms-iterate__element'
+        )
+        expect(item).toBeInTheDocument()
+        return item
+      })
+      const editButton = Array.from(item.querySelectorAll('button')).find(
+        (button) =>
+          button.textContent?.trim() === nb.IterateViewContainer.editButton
+      )
+      await userEvent.click(editButton)
+
+      const inputs = item.querySelectorAll('input')
+      expect(inputs[0]).toHaveAttribute('aria-required', 'true')
+      expect(inputs[1]).not.toHaveAttribute('aria-required')
+
+      const doneButton = Array.from(item.querySelectorAll('button')).find(
+        (button) =>
+          button.textContent?.trim() === nb.IterateEditContainer.doneButton
+      )
+      await userEvent.click(doneButton)
+
+      await waitFor(() => {
+        expect(
+          item.querySelector('.dnb-forms-section-edit-block')
+        ).toHaveClass('dnb-height-animation--hidden')
+      })
+    })
+
     it('inherits Zod schema from Form.Handler', async () => {
       const onChange = vi.fn()
       const schema = z.object({

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -2871,6 +2871,80 @@ describe('useFieldProps', () => {
           'aria-required': 'true',
         })
       })
+
+      it('should resolve required fields inside array item schemas', () => {
+        const schema: JSONSchema = {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  requiredField: { type: 'string' },
+                  optionalField: { type: 'string' },
+                },
+                required: ['requiredField'],
+              },
+            },
+          },
+        }
+
+        const { result } = renderHook(
+          () => ({
+            requiredField: useFieldProps({
+              itemPath: '/requiredField',
+            }),
+            optionalField: useFieldProps({
+              itemPath: '/optionalField',
+            }),
+          }),
+          {
+            wrapper: ({ children }) => (
+              <Provider schema={schema} ajvInstance={makeAjvInstance()}>
+                <Iterate.Array path="/items" value={[{}]}>
+                  {children}
+                </Iterate.Array>
+              </Provider>
+            ),
+          }
+        )
+
+        expect(result.current.requiredField.htmlAttributes).toEqual({
+          'aria-required': 'true',
+        })
+        expect(result.current.optionalField.htmlAttributes).toEqual({})
+      })
+
+      it('should keep fields optional when only a described parent object is required', () => {
+        const schema: JSONSchema = {
+          type: 'object',
+          properties: {
+            section: {
+              type: 'object',
+              properties: {
+                optionalField: { type: 'string' },
+              },
+            },
+          },
+          required: ['section'],
+        }
+
+        const { result } = renderHook(
+          () => useFieldProps({ path: '/optionalField' }),
+          {
+            wrapper: ({ children }) => (
+              <Provider schema={schema} ajvInstance={makeAjvInstance()}>
+                <SectionContext value={{ path: '/section' }}>
+                  {children}
+                </SectionContext>
+              </Provider>
+            ),
+          }
+        )
+
+        expect(result.current.htmlAttributes).toEqual({})
+      })
     })
 
     it('should return true on required and invalid', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -76,6 +76,114 @@ type ChangeOptions = {
   preventUpdate?: boolean
 }
 
+type RequiredSchema = {
+  items?: unknown | unknown[]
+  prefixItems?: unknown[]
+  properties?: Record<string, unknown>
+  required?: readonly string[]
+}
+
+function isRequiredBySchema(
+  schema: unknown,
+  identifier: Identifier,
+  sectionPath?: string
+) {
+  if (!identifier?.startsWith('/')) {
+    return false
+  }
+
+  const path = pointer.parse(identifier)
+  const propertyName = path.at(-1)
+  const parentSchema = getSchemaAtPath(schema, path.slice(0, -1))
+
+  if (getRequired(parentSchema)?.includes(propertyName)) {
+    return true
+  }
+
+  const rootRequired = getRequired(schema)
+  if (
+    rootRequired?.some((requiredPath) =>
+      isSamePath(requiredPath, identifier)
+    )
+  ) {
+    return true
+  }
+
+  if (sectionPath?.startsWith('/')) {
+    const section = pointer.parse(sectionPath)
+    const sectionName = section.at(-1)
+    const sectionParent = getSchemaAtPath(schema, section.slice(0, -1))
+    const sectionIsRequired =
+      getRequired(sectionParent)?.includes(sectionName) ||
+      rootRequired?.some((requiredPath) =>
+        isSamePath(requiredPath, sectionPath)
+      )
+
+    if (
+      sectionIsRequired &&
+      getSchemaAtPath(schema, section) === undefined
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function getSchemaAtPath(schema: unknown, path: string[]) {
+  let current = schema
+
+  for (const segment of path) {
+    const currentSchema = getSchema(current)
+    if (!currentSchema) {
+      return undefined
+    }
+
+    if (
+      currentSchema.properties &&
+      Object.prototype.hasOwnProperty.call(
+        currentSchema.properties,
+        segment
+      )
+    ) {
+      current = currentSchema.properties[segment]
+      continue
+    }
+
+    if (/^(0|[1-9]\d*)$/.test(segment)) {
+      const index = Number(segment)
+      current =
+        currentSchema.prefixItems?.[index] ??
+        (Array.isArray(currentSchema.items)
+          ? currentSchema.items[index]
+          : currentSchema.items)
+
+      if (current !== undefined) {
+        continue
+      }
+    }
+
+    return undefined
+  }
+
+  return current
+}
+
+function getSchema(schema: unknown): RequiredSchema | undefined {
+  return schema && typeof schema === 'object' && !Array.isArray(schema)
+    ? (schema as RequiredSchema)
+    : undefined
+}
+
+function getRequired(schema: unknown) {
+  const required = getSchema(schema)?.required
+  return Array.isArray(required) ? required : undefined
+}
+
+function isSamePath(path: string, identifier: string) {
+  return `/${path}`.replace(/\/+/g, '/') === identifier
+}
+
 // Many variables are kept in refs to avoid triggering unnecessary update loops because updates using
 // useEffect depend on them (like the external `value`)
 
@@ -282,13 +390,12 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   const isParentRelativePath =
     typeof pathProp === 'string' && pathProp.startsWith('../')
   const hasItemPath = Boolean(itemPath)
-  const { path, identifier, makeIteratePath, joinPath, cleanPath } =
-    usePath({
-      id,
-      path: pathProp,
-      itemPath,
-      omitSectionPath,
-    })
+  const { path, identifier, makeIteratePath } = usePath({
+    id,
+    path: pathProp,
+    itemPath,
+    omitSectionPath,
+  })
 
   const sectionSchemaPaths = sectionSchemaPathsRef?.current
   const hasSectionSchema = Boolean(
@@ -399,57 +506,15 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       return requiredProp
     }
 
-    if (schema || dataContext?.schema) {
-      const paths = identifier.split('/')
-      if (paths.length > 0) {
-        const requiredInSchema = [schema?.['required']]
-
-        // - Handle context schema
-        if (paths.length > 1) {
-          const schema = dataContext.schema
-          const pathWithoutLast = paths.slice(0, -1).join('/properties/')
-          const schemaPart = pointer.has(schema, pathWithoutLast)
-            ? pointer.get(schema, pathWithoutLast)
-            : schema
-
-          const requiredSchemaList = schemaPart?.['required']
-          if (Array.isArray(requiredSchemaList)) {
-            const rootPath = pathWithoutLast.replace(/properties\//g, '')
-            const requiredList = requiredSchemaList.map((path) => {
-              path = cleanPath('/' + path)
-              return sectionPath && path.startsWith(sectionPath)
-                ? path
-                : joinPath([sectionPath || rootPath, path])
-            })
-            requiredInSchema.push(requiredList)
-          }
-        }
-
-        const collected = requiredInSchema
-          .flatMap((value) => value)
-          .filter(Boolean)
-
-        if (
-          collected.filter(Boolean).some((path) => {
-            path = cleanPath('/' + path)
-            return identifier === path || sectionPath === path
-          })
-        ) {
-          return true
-        }
-      }
+    if (
+      isRequiredBySchema(schema, identifier, sectionPath) ||
+      isRequiredBySchema(dataContext?.schema, identifier, sectionPath)
+    ) {
+      return true
     }
 
     return undefined
-  }, [
-    cleanPath,
-    dataContext.schema,
-    identifier,
-    joinPath,
-    requiredProp,
-    schema,
-    sectionPath,
-  ])
+  }, [dataContext.schema, identifier, requiredProp, schema, sectionPath])
 
   const getFieldByPath = useCallback(
     (path: string) => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -92,7 +92,7 @@ function isRequiredBySchema(
     return false
   }
 
-  const path = pointer.parse(identifier)
+  const path = pointer.parse(identifier) as string[]
   const propertyName = path.at(-1)
   const parentSchema = getSchemaAtPath(schema, path.slice(0, -1))
 
@@ -110,7 +110,7 @@ function isRequiredBySchema(
   }
 
   if (sectionPath?.startsWith('/')) {
-    const section = pointer.parse(sectionPath)
+    const section = pointer.parse(sectionPath) as string[]
     const sectionName = section.at(-1)
     const sectionParent = getSchemaAtPath(schema, section.slice(0, -1))
     const sectionIsRequired =


### PR DESCRIPTION
Optional fields from a JSON Schema could become required after moving from `Iterate.PushContainer` to `Iterate.EditContainer`.

Required-state lookup now follows object properties and array item schemas instead of falling back to the root schema, so editing preserves each field's declared required state.

Reprod: https://stackblitz.com/edit/eufemia-starter-3godohm2?file=src%2FBeneficialOwners.tsx
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1788263705206119
Preview: https://fix-forms-json-schema-requir.eufemia-e25.pages.dev/uilib/extensions/forms/Iterate/EditContainer