### PR TITLE
chore(deps): bump transitive postcss-selector-parser 6.x to 6.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
     "js-yaml@npm:^3.10.0": "3.15.1",
     "js-yaml@npm:^3.13.1": "3.15.1",
     "js-yaml@npm:^4.1.0": "4.3.1",
-    "js-yaml@npm:^4.1.1": "4.3.1"
+    "js-yaml@npm:^4.1.1": "4.3.1",
+    "postcss-selector-parser@npm:^6.0.4": "6.1.3",
+    "postcss-selector-parser@npm:^6.0.5": "6.1.3",
+    "postcss-selector-parser@npm:^6.0.11": "6.1.3"
   },
   "engines": {
     "node": ">=24.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15869,6 +15869,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-selector-parser@npm:6.1.3":
+  version: 6.1.3
+  resolution: "postcss-selector-parser@npm:6.1.3"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10/3623e8a9e411c73a3593f4f9b9ae6a87f972d79be4d820c559e36f6c4b405f0cf805714afae6b320faf8023068ca4affa28de78dfb605ab0be59df4ac5c791ae
+  languageName: node
+  linkType: hard
+
 "postcss-selector-parser@npm:7.1.3":
   version: 7.1.3
   resolution: "postcss-selector-parser@npm:7.1.3"
@@ -15876,16 +15886,6 @@ __metadata:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
   checksum: 10/b43dfff4ed0a102a16f47b52ef1119fe1494928e5c03db09e541a898228ef81be29917a89059ab620a07298f8952ef1cde205bd8cd0cade48276982cee62433c
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^6.0.11, postcss-selector-parser@npm:^6.0.4, postcss-selector-parser@npm:^6.0.5":
-  version: 6.1.2
-  resolution: "postcss-selector-parser@npm:6.1.2"
-  dependencies:
-    cssesc: "npm:^3.0.0"
-    util-deprecate: "npm:^1.0.2"
-  checksum: 10/190034c94d809c115cd2f32ee6aade84e933450a43ec3899c3e78e7d7b33efd3a2a975bb45d7700b6c5b196c06a7d9acf3f1ba6f1d87032d9675a29d8bca1dd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependabot alert [#555](https://github.com/dnbexperience/eufemia/security/dependabot/555) flags `postcss-selector-parser@6.1.2` for a low-severity denial of service through uncontrolled AST recursion ([CVE-2026-9358](https://github.com/advisories/GHSA-w9m9-85wc-3x92)). The vulnerable range is `>= 6.1.0, < 6.1.3`.

This 6.x copy is pulled in transitively by cssnano's `postcss-calc`, `postcss-merge-rules`, `postcss-minify-selectors`, `postcss-unique-selectors` and `stylehacks`. #9190 already bumped the direct 7.x dependency, but the transitive 6.x line stayed on the vulnerable `6.1.2`.

Scoped `resolutions` pin the 6.x descriptors to the patched `6.1.3`, following the existing resolutions convention. The 7.x line (direct `7.1.3`, transitive `7.1.4`) is unaffected.

## Scope and priority

Low priority — housekeeping to clear the alert, not a consumer-facing fix. The vulnerable 6.x is reached only through `cssnano`, a **devDependency** used at build time to minify Eufemia's own CSS; it is not in the published package's runtime dependency tree, and the parser only ever processes first-party CSS (no untrusted input). Dependabot labels it "runtime" because it can't infer dev scope from a Yarn Berry lockfile.
