### PR TITLE
chore: add Figma MCP server config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,5 +1,10 @@
 {
   "servers": {
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+
     // Commented out to avoid MCP server being activated by default
     // This is only useful for development purposes
     // "eufemia": {


### PR DESCRIPTION
Adds the official Figma MCP endpoint to the workspace configuration so contributors can use Figma tools from supported editors.

Validated the configuration with the repository's Prettier setup and VS Code diagnostics.