### PR TITLE
feat(Form.Section): support async EditContainer completion

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/Examples.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import ComponentBox from '../../../../../../../shared/tags/ComponentBox'
+import { FormStatus } from '@dnb/eufemia/src'
 import {
   Field,
   Form,
@@ -83,6 +85,61 @@ export const PreventUncommittedChanges = () => {
           </Wizard.Step>
         </Wizard.Container>
       </Form.Handler>
+    </ComponentBox>
+  )
+}
+
+export const AsyncOnDone = () => {
+  return (
+    <ComponentBox>
+      {() => {
+        const formId = 'async-on-done'
+
+        const Example = () => {
+          const [error, setError] = useState<string>()
+
+          const saveSection = async () => {
+            setError(undefined)
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+
+            const { getValue } = Form.getData(formId)
+            if (getValue('/simulateError')) {
+              setError('The section could not be saved. Try again.')
+              throw new Error('The section could not be saved')
+            }
+          }
+
+          return (
+            <Form.Handler
+              id={formId}
+              defaultData={{
+                profile: { firstName: 'Nora' },
+                simulateError: true,
+              }}
+            >
+              <Form.Card>
+                <Form.Section path="/profile" containerMode="edit">
+                  <Form.Section.EditContainer onDone={saveSection}>
+                    <Field.Name.First path="/firstName" />
+                    <Field.Boolean
+                      path="//simulateError"
+                      label="Simulate save error"
+                      variant="button"
+                    />
+                    {error && <FormStatus>{error}</FormStatus>}
+                  </Form.Section.EditContainer>
+
+                  <Form.Section.ViewContainer>
+                    <Value.Name.First path="/firstName" />
+                  </Form.Section.ViewContainer>
+                </Form.Section>
+              </Form.Card>
+            </Form.Handler>
+          )
+        }
+
+        return <Example />
+      }}
     </ComponentBox>
   )
 }

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
@@ -18,3 +18,11 @@ This demo shows the edit container opened by default by using the `containerMode
 With `preventUncommittedChanges`, the user must select "Done" or "Cancel" before continuing to the next Wizard step, even when no values have changed.
 
 <Examples.PreventUncommittedChanges />
+
+### Async onDone
+
+When `onDone` returns a Promise, the section stays in edit mode while it is pending. It switches to view mode when the Promise resolves and stays in edit mode when it rejects.
+
+The demo starts with a simulated save error. Change the first name and select **Done** to verify that the input remains. Turn off **Simulate save error** and try again to complete the save.
+
+<Examples.AsyncOnDone />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/CancelButton.tsx
@@ -17,7 +17,8 @@ export default function CancelButton({
   showConfirmDialog = true,
   ...buttonProps
 }: Props) {
-  const { onCancel, setShowError } = useContext(ToolbarContext) || {}
+  const { onCancel, setShowError, isPending } =
+    useContext(ToolbarContext) || {}
   const editContainerContext = useContext(EditContainerContext)
   const fallbackDataStore = useContainerDataStore({
     enabled: !editContainerContext,
@@ -68,6 +69,7 @@ export default function CancelButton({
     iconPosition: 'left',
     text: cancelButton,
     ...buttonProps,
+    disabled: isPending || buttonProps.disabled,
   }
 
   if (showConfirmDialog) {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -5,16 +5,21 @@ import { useTranslation } from '../../../hooks'
 import { Button } from '../../../../../components'
 import { check } from '../../../../../icons'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
+import SubmitIndicator from '../../SubmitIndicator'
 
 export default function DoneEditButton() {
-  const { onDone, setShowError } = useContext(ToolbarContext) || {}
+  const { onDone, setShowError, isPending, setIsPending } =
+    useContext(ToolbarContext) || {}
 
   const { switchContainerMode } = useContext(SectionContainerContext) || {}
   const { hasError, hasVisibleError, setShowBoundaryErrors } =
     useContext(FieldBoundaryContext) || {}
-
   const translation = useTranslation().SectionEditContainer
   const doneHandler = useCallback(() => {
+    if (isPending) {
+      return
+    }
+
     if (hasError) {
       setShowBoundaryErrors?.(true)
       if (hasVisibleError) {
@@ -23,15 +28,31 @@ export default function DoneEditButton() {
     } else {
       setShowError(false)
       setShowBoundaryErrors?.(false)
-      switchContainerMode?.('view')
-      onDone?.()
+
+      const result = onDone?.()
+      if (result) {
+        setIsPending?.(true)
+        void result.then(
+          () => {
+            setIsPending?.(false)
+            switchContainerMode?.('view')
+          },
+          () => {
+            setIsPending?.(false)
+          }
+        )
+      } else {
+        switchContainerMode?.('view')
+      }
     }
   }, [
     hasError,
     hasVisibleError,
+    isPending,
     onDone,
     setShowBoundaryErrors,
     setShowError,
+    setIsPending,
     switchContainerMode,
   ])
 
@@ -41,8 +62,10 @@ export default function DoneEditButton() {
       icon={check}
       iconPosition="left"
       onClick={doneHandler}
+      disabled={isPending}
     >
       {translation.doneButton}
+      {isPending && <SubmitIndicator state="pending" />}
     </Button>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -30,7 +30,7 @@ import SectionContext from '../SectionContext'
 
 export type FormSectionEditContainerProps = {
   title?: ReactNode
-  onDone?: () => void
+  onDone?: () => void | Promise<unknown>
   onCancel?: () => void
   /**
    * Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected. Requires Form.Section to have a path.

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
@@ -26,8 +26,8 @@ export const EditContainerProperties: PropertiesTableProps = {
 
 export const EditContainerEvents: PropertiesTableProps = {
   onDone: {
-    doc: 'Callback for the done button.',
-    type: 'function',
+    doc: 'Callback for the done button. When it returns a Promise, the section stays in edit mode until the Promise resolves. If it rejects, the section stays in edit mode.',
+    type: '() => void | Promise<unknown>',
     status: 'optional',
   },
   onCancel: {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -1253,6 +1253,111 @@ describe('EditContainer and ViewContainer', () => {
     expect(onDone).toHaveBeenCalledTimes(1)
   })
 
+  it('should stay in edit mode while async onDone is pending and switch to view mode on resolve', async () => {
+    let resolveOnDone!: () => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOnDone = resolve
+        })
+    )
+    let containerMode = null
+
+    const ContextConsumer = () => {
+      const context = useContext(SectionContainerContext)
+      containerMode = context.containerMode
+
+      return null
+    }
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+
+        <ContextConsumer />
+      </Form.Section>
+    )
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+    await userEvent.click(doneButton)
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(containerMode).toBe('edit')
+    expect(doneButton).toBeDisabled()
+    expect(
+      document.querySelectorAll('.dnb-forms-section-edit-block button')[1]
+    ).toBeDisabled()
+    expect(
+      doneButton.querySelector(
+        '.dnb-forms-submit-indicator [aria-busy="true"]'
+      )
+    ).toHaveAttribute('aria-busy', 'true')
+
+    await userEvent.click(doneButton)
+    expect(onDone).toHaveBeenCalledTimes(1)
+
+    resolveOnDone()
+
+    await waitFor(() => {
+      expect(containerMode).toBe('view')
+    })
+  })
+
+  it('should stay in edit mode with user input intact when async onDone rejects', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+    let containerMode = null
+
+    const ContextConsumer = () => {
+      const context = useContext(SectionContainerContext)
+      containerMode = context.containerMode
+
+      return null
+    }
+
+    render(
+      <Form.Section defaultData={{ name: 'Ada' }} containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+
+        <ContextConsumer />
+      </Form.Section>
+    )
+
+    const input = document.querySelector('input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Grace')
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+    await userEvent.click(doneButton)
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(
+      document.querySelectorAll('.dnb-forms-section-edit-block button')[1]
+    ).not.toBeDisabled()
+    expect(containerMode).toBe('edit')
+    expect(input).toHaveValue('Grace')
+  })
+
   it('should emit "onCancel" event when cancel button is clicked', async () => {
     const onCancel = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
@@ -10,7 +10,7 @@ import Space from '../../../../../components/Space'
 
 export type FormSectionToolbarProps = SpaceAllProps & {
   onEdit?: () => void
-  onDone?: () => void
+  onDone?: () => void | Promise<unknown>
   onCancel?: () => void
 }
 
@@ -21,6 +21,7 @@ export default function Toolbar(props: FormSectionToolbarProps) {
   const { hasError, hasVisibleError } =
     useContext(FieldBoundaryContext) || {}
   const [showError, setShowError] = useState(false)
+  const [isPending, setIsPending] = useState(false)
 
   useEffect(() => {
     if (showError && !hasError) {
@@ -35,7 +36,16 @@ export default function Toolbar(props: FormSectionToolbarProps) {
     >
       <Hr space={0} />
 
-      <ToolbarContext value={{ setShowError, onEdit, onDone, onCancel }}>
+      <ToolbarContext
+        value={{
+          setShowError,
+          isPending,
+          setIsPending,
+          onEdit,
+          onDone,
+          onCancel,
+        }}
+      >
         <Flex.Horizontal layoutEngine="css" top="x-small" gap="large">
           {children}
         </Flex.Horizontal>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarContext.ts
@@ -1,8 +1,10 @@
 import { createContext } from 'react'
 export type ToolbarContextState = {
   setShowError: (showError: boolean) => void
+  isPending?: boolean
+  setIsPending?: (isPending: boolean) => void
   onEdit?: () => void
-  onDone?: () => void
+  onDone?: () => void | Promise<unknown>
   onCancel?: () => void
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
@@ -15,8 +15,8 @@ export const ToolbarEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onDone: {
-    doc: 'Callback for the done button.',
-    type: 'function',
+    doc: 'Callback for the done button. When it returns a Promise, the section stays in edit mode until the Promise resolves. If it rejects, the section stays in edit mode.',
+    type: '() => void | Promise<unknown>',
     status: 'optional',
   },
   onCancel: {


### PR DESCRIPTION
Allow EditContainer's onDone callback to return a Promise so API-backed saves stay in edit mode until they succeed. Rejected saves keep the edited values available for retry and error feedback.

Motivation: [Slack discussion](https://dnb-it.slack.com/archives/CMXABCHEY/p1788184722094539)

Preview: [Async onDone example](https://feat-form-section-async-on-d.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Section/EditContainer/demos/#async-ondone)