### PR TITLE
fix(Heading): recalculate dynamic levels

### DIFF
--- a/packages/dnb-eufemia/src/components/heading/Heading.tsx
+++ b/packages/dnb-eufemia/src/components/heading/Heading.tsx
@@ -167,22 +167,28 @@ export default function Heading(props: HeadingAllProps) {
     ...rest
   } = useTypography(props)
 
+  type State = {
+    level: InternalHeadingLevel
+    counter: HeadingCounter
+    context: HeadingContextValue
+    contextRevision?: number
+    headingContext?: HeadingContextValue
+    id: string
+    notifyScopeRevision?: number
+    prevLevel?: InternalHeadingLevel
+    recalculate?: () => void
+    ref: HeadingAllProps
+  }
+
   const [currentState, setState] = useState(() => {
-    type State = {
-      level: InternalHeadingLevel
-      prevLevel?: InternalHeadingLevel | HeadingProps['level']
-      counter: HeadingCounter
-      context: HeadingContextValue
-      headingContext?: HeadingContextValue
-      id: string
-      ref: HeadingAllProps
-    }
     const state: State = {
       level: null,
       counter: null,
       context,
+      contextRevision: headingContext.heading?.revision,
       headingContext,
       id,
+      recalculate: headingContext.heading?.recalculate,
       ref: props,
     }
 
@@ -220,11 +226,46 @@ export default function Heading(props: HeadingAllProps) {
 
     return state
   })
+
   let state = currentState
 
   const level = parseFloat(String(props.level))
-  if (
-    state.prevLevel !== props.level &&
+  const contextRevision = headingContext.heading?.revision
+
+  const recalculateLevel = (level: InternalHeadingLevel) => {
+    state.counter.restart()
+    const { level: newLevel } = correctInternalHeadingLevel({
+      counter: state.counter,
+      level,
+      inherit: props.inherit,
+      reset: props.reset,
+      increase: props.increase || props.up,
+      decrease: props.decrease || props.down,
+      bypassChecks:
+        props.skipCorrection || headingContext.heading?.skipCorrection,
+      source: props.text || props.children,
+      debug: props.debug || headingContext.heading?.debug,
+    })
+    globalSyncCounter.current = state.counter
+    return newLevel
+  }
+
+  if (state.contextRevision !== contextRevision) {
+    state = {
+      ...state,
+      level: recalculateLevel(
+        Number.isNaN(level) && headingContext.heading?.preserveLevels
+          ? state.level
+          : level
+      ),
+      contextRevision,
+      headingContext,
+      prevLevel: level,
+      recalculate: headingContext.heading?.recalculate,
+    }
+    setState(state)
+  } else if (
+    state.prevLevel !== level &&
     level > 0 &&
     level !== state.level
   ) {
@@ -233,29 +274,44 @@ export default function Heading(props: HeadingAllProps) {
       isRerender: true,
       level,
       bypassChecks:
-        props.skipCorrection ||
-        state.headingContext?.heading?.skipCorrection,
+        props.skipCorrection || headingContext.heading?.skipCorrection,
       source: props.text || props.children,
-      debug: props.debug || state.headingContext?.heading?.debug,
+      debug: props.debug || headingContext.heading?.debug,
     })
-    state = { ...state, level: newLevel, prevLevel: props.level }
+    state = {
+      ...state,
+      level: newLevel,
+      notifyScopeRevision: (state.notifyScopeRevision || 0) + 1,
+      prevLevel: level,
+    }
     setState(state)
   }
 
+  const {
+    counter,
+    id: counterId,
+    notifyScopeRevision,
+    recalculate,
+    ref: counterRef,
+  } = currentState
+
+  useEffect(() => {
+    if (notifyScopeRevision) {
+      recalculate?.()
+    }
+  }, [notifyScopeRevision, recalculate])
+
   useEffect(() => {
     windupHeadings()
-    currentState.counter.windup()
+    counter.windup()
 
     return () => {
-      releaseHeadingLevel(
-        currentState.ref,
-        currentState.id,
-        currentState.counter
-      )
+      releaseHeadingLevel(counterRef, counterId, counter)
       teardownHeadings()
-      currentState.counter.teardown()
+      counter.teardown()
+      recalculate?.()
     }
-  }, [currentState.counter, currentState.id, currentState.ref])
+  }, [counter, counterId, counterRef, recalculate])
 
   const theme = useTheme()
 

--- a/packages/dnb-eufemia/src/components/heading/HeadingContext.ts
+++ b/packages/dnb-eufemia/src/components/heading/HeadingContext.ts
@@ -8,7 +8,11 @@ import type { SkeletonContextValue } from '../skeleton/SkeletonHelper'
 import type { HeadingProps } from './Heading'
 
 export type HeadingContextValue = {
-  heading?: HeadingProps
+  heading?: HeadingProps & {
+    preserveLevels?: boolean
+    revision?: number
+    recalculate?: () => void
+  }
 } & SkeletonContextValue
 
 const HeadingContext = createContext<HeadingContextValue>({

--- a/packages/dnb-eufemia/src/components/heading/HeadingCounter.ts
+++ b/packages/dnb-eufemia/src/components/heading/HeadingCounter.ts
@@ -268,6 +268,15 @@ export class Counter {
     this.setLevel(this.level - 1, 'decrement')
   }
 
+  restart() {
+    this.level = 0
+  }
+
+  restartContext() {
+    this.level = this.entry
+    this._isReady = false
+  }
+
   force(level = 1) {
     this.bypassChecks = true
     this.setLevel(level)

--- a/packages/dnb-eufemia/src/components/heading/HeadingProvider.tsx
+++ b/packages/dnb-eufemia/src/components/heading/HeadingProvider.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import { useContext, useEffect, useId, useState } from 'react'
+import { useContext, useEffect, useId, useReducer, useState } from 'react'
 import type { HTMLProps } from 'react'
 
 import HeadingContext from './HeadingContext'
@@ -31,17 +31,35 @@ export default function HeadingProvider(props: HeadingProviderAllProps) {
   const newProps = existingContext
     ? { ...existingContext, ...props }
     : props
+  const [scopeRevision, recalculate] = useReducer(
+    (revision) => revision + 1,
+    0
+  )
+
+  type State = {
+    level?: InternalHeadingLevel
+    counter?: HeadingCounter
+    contextRevision?: number
+    notifyParentRevision?: number
+    preserveLevels: boolean
+    prevLevel?: InternalHeadingLevel
+    recalculate?: () => void
+    revision: number
+    scopeRevision: number
+    id?: string
+    ref?: HeadingProviderAllProps
+  }
 
   const [currentState, setState] = useState(() => {
-    type State = {
-      level?: InternalHeadingLevel
-      prevLevel?: InternalHeadingLevel
-      counter?: HeadingCounter
-      id?: string
-      ref?: HeadingProviderAllProps
+    const state: State = {
+      preserveLevels: false,
+      contextRevision: existingContext?.revision,
+      recalculate: existingContext?.recalculate,
+      revision: 0,
+      scopeRevision,
+      id,
+      ref: props,
     }
-
-    const state: State = { id, ref: props }
 
     // Here we create a new counter, but use the last global level
     state.counter = initCounter(props) // in here we use isContext prop
@@ -77,10 +95,46 @@ export default function HeadingProvider(props: HeadingProviderAllProps) {
       parseFloat(String(newProps.level)) || state.counter.level
     return state
   })
+
   let state = currentState
 
   const level = parseFloat(String(props.level))
-  if (state.prevLevel !== level && level > 0 && level !== state.level) {
+  const levelChanged =
+    state.prevLevel !== level && level > 0 && level !== state.level
+  const contextChanged =
+    state.contextRevision !== existingContext?.revision
+
+  if (state.scopeRevision !== scopeRevision || contextChanged) {
+    const preserveLevels =
+      state.scopeRevision !== scopeRevision ||
+      existingContext?.preserveLevels
+    state.counter.restartContext()
+    if (contextChanged && !existingContext?.preserveLevels) {
+      state.counter = correctInternalHeadingLevel({
+        counter: state.counter,
+        level: parseFloat(String(props.level)),
+        inherit: props.inherit,
+        reset: props.reset,
+        increase: props.increase || props.up,
+        decrease: props.decrease || props.down,
+        bypassChecks: newProps.skipCorrection,
+        source: props.text || props.children,
+        debug: newProps.debug,
+      })
+    }
+    globalSyncCounter.current = state.counter
+    state = {
+      ...state,
+      contextRevision: existingContext?.revision,
+      level: state.counter.level,
+      preserveLevels,
+      prevLevel: level || state.counter.level,
+      recalculate: existingContext?.recalculate,
+      revision: state.revision + 1,
+      scopeRevision,
+    }
+    setState(state)
+  } else if (levelChanged) {
     const { level: newLevel } = correctInternalHeadingLevel({
       counter: state.counter,
       level,
@@ -88,22 +142,40 @@ export default function HeadingProvider(props: HeadingProviderAllProps) {
       source: props.text || props.children,
       debug: newProps.debug,
     })
-    state = { ...state, level: newLevel, prevLevel: level }
+    state = {
+      ...state,
+      level: newLevel,
+      notifyParentRevision: (state.notifyParentRevision || 0) + 1,
+      preserveLevels: false,
+      prevLevel: level,
+      revision: state.revision + 1,
+    }
     setState(state)
   }
+
+  const {
+    counter,
+    id: counterId,
+    notifyParentRevision,
+    recalculate: recalculateParent,
+    ref: counterRef,
+  } = currentState
+
+  useEffect(() => {
+    if (notifyParentRevision) {
+      recalculateParent?.()
+    }
+  }, [notifyParentRevision, recalculateParent])
 
   useEffect(() => {
     windupHeadings()
 
     return () => {
-      releaseHeadingLevel(
-        currentState.ref,
-        currentState.id,
-        currentState.counter
-      )
+      releaseHeadingLevel(counterRef, counterId, counter)
       teardownHeadings()
+      recalculateParent?.()
     }
-  }, [currentState.counter, currentState.id, currentState.ref])
+  }, [counter, counterId, counterRef, recalculateParent])
 
   return (
     <HeadingContext
@@ -112,6 +184,9 @@ export default function HeadingProvider(props: HeadingProviderAllProps) {
           ...newProps,
           level: state.level as HeadingProps['level'],
           counter: state.counter,
+          preserveLevels: state.preserveLevels,
+          revision: state.revision,
+          recalculate,
         },
       }}
     >

--- a/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
+++ b/packages/dnb-eufemia/src/components/heading/__tests__/Heading.test.tsx
@@ -148,11 +148,14 @@ describe('Heading component', () => {
     expect(elem[i + 1].textContent).toBe('[h2] Heading #12')
   })
 
-  it('should preserve string level correction behavior', () => {
-    render(<Heading level="2">Heading</Heading>)
+  it.each([2, '2'] as const)(
+    'should correct Heading level %s at the document root',
+    (level) => {
+      render(<Heading level={level}>Heading</Heading>)
 
-    expect(document.querySelector('.dnb-heading')?.tagName).toBe('H2')
-  })
+      expect(document.querySelector('.dnb-heading')?.tagName).toBe('H1')
+    }
+  )
 
   it('should settle repeated string levels', () => {
     render(
@@ -316,6 +319,67 @@ describe('Heading component', () => {
       '[h1] Heading'
     )
   })
+
+  it('should update mounted headings when Heading.Level changes', () => {
+    const App = ({ level }: { level: HeadingLevel }) => (
+      <Heading.Level level={level} skipCorrection>
+        <Heading>Heading</Heading>
+      </Heading.Level>
+    )
+    const { rerender } = render(<App level={2} />)
+
+    expect(document.querySelector('.dnb-heading')?.tagName).toBe('H2')
+
+    rerender(<App level={3} />)
+
+    expect(document.querySelector('.dnb-heading')?.tagName).toBe('H3')
+  })
+
+  it.each([
+    [
+      'heading',
+      <Heading key="middle" level={2}>
+        Middle
+      </Heading>,
+    ],
+    [
+      'level provider',
+      <Heading.Level key="middle" reset={2}>
+        <Heading level={2}>Middle</Heading>
+      </Heading.Level>,
+    ],
+  ])(
+    'should recalculate after a preceding %s is removed',
+    (_name, middle) => {
+      const App = ({ showMiddle = true }) => (
+        <Heading.Level reset={1}>
+          <Heading key="first" level={1}>
+            First
+          </Heading>
+          {showMiddle && middle}
+          <Heading key="last" level={3}>
+            Last
+          </Heading>
+        </Heading.Level>
+      )
+      const { rerender } = render(<App />)
+
+      let headings = document.querySelectorAll('.dnb-heading')
+      expect(Array.from(headings, ({ tagName }) => tagName)).toEqual([
+        'H1',
+        'H2',
+        'H3',
+      ])
+
+      rerender(<App showMiddle={false} />)
+
+      headings = document.querySelectorAll('.dnb-heading')
+      expect(Array.from(headings, ({ tagName }) => tagName)).toEqual([
+        'H1',
+        'H2',
+      ])
+    }
+  )
 
   it('should match level correction with manual heading', () => {
     render(


### PR DESCRIPTION
Stacked on #9181 and intended to be reviewed after it.

Headings inside `Heading.Level` kept stale levels when an earlier heading or nested level provider was removed, and mounted children did not react when their provider level changed. This recalculates the affected scope while preserving mounted child state, and makes string and numeric level values behave consistently.