### PR TITLE
fix: preserve URLs when validating MCP configuration

### DIFF
--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -839,7 +839,7 @@ describe('MCP dependency configuration', () => {
 
     // Strip JSONC comments (mcp.json may have config commented out)
     const jsonContent = rawContent
-      .replace(/\/\/.*$/gm, '')
+      .replace(/^\s*\/\/.*$/gm, '')
       .replace(/\n\s*\n/g, '\n')
     const mcpConfig = JSON.parse(jsonContent)
 


### PR DESCRIPTION
The MCP configuration test treated URL delimiters as JSONC comments, causing the main branch verification to fail after adding the Figma HTTP endpoint. Restrict comment removal to full comment lines so configured URLs remain valid JSON.