### PR TITLE
chore: correct the @babel/runtime-corejs3 dependency comment

### DIFF
--- a/packages/dnb-eufemia/babel.config.js
+++ b/packages/dnb-eufemia/babel.config.js
@@ -105,6 +105,19 @@ const basePlugins = [
   '@babel/plugin-transform-nullish-coalescing-operator',
 ]
 
+// Polyfill / runtime-helper strategy (why @babel/runtime-corejs3 is a dependency):
+// - Polyfills are injected from "core-js-pure" via babel-plugin-polyfill-corejs3
+//   (method "usage-pure") — the plugin below.
+// - Runtime helpers are extracted to "@babel/runtime" by
+//   @babel/plugin-transform-runtime (see the env configs). We intentionally do
+//   NOT pass `corejs` there, so it never emits "@babel/runtime-corejs3/*" imports.
+// "@babel/runtime-corejs3" is nonetheless kept as a published runtime dependency:
+// it is the core-js-3 helper runtime that transform-runtime would emit under
+// `corejs: 3`, and consumers must then be able to resolve those imports. A prior
+// removal (#7994) broke consumer bundling and was reverted (#8016). A clean build
+// currently emits no imports of it, so do not assume it is unused from a grep
+// (the local build/ dir can also be stale). The postbuild dependency tests
+// enforce that it stays declared.
 const polyfillPlugin = [
   'polyfill-corejs3',
   {

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -1074,13 +1074,10 @@ describe('review rule metadata build', () => {
 
 describe('package.json dependencies', () => {
   it('includes @babel/runtime-corejs3 as a runtime dependency', () => {
-    // The published build artifacts contain imports from
-    // "@babel/runtime-corejs3/helpers/esm/*" because they were compiled with
-    // @babel/plugin-transform-runtime using corejs: 3. Consumers bundling with
-    // tools like esbuild or Vite will get a build error if this package is not
-    // listed as a dependency in the published package.json.
-    // See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
-    //      https://github.com/dnbexperience/eufemia/pull/8016 (re-added)
+    // @babel/runtime-corejs3 must stay a declared runtime dependency. See
+    // babel.config.js (polyfill/runtime strategy) for why it is required even
+    // though a clean build currently emits no imports of it. Removing it broke
+    // consumer bundling before: #7994 (removed) -> #8016 (reverted).
     const packageJson = fs.readJsonSync(
       path.resolve(PKG_ROOT, 'package.json')
     )

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
@@ -32,13 +32,10 @@ describe('cleanupPackage', () => {
   })
 
   it('includes @babel/runtime-corejs3 as a runtime dependency', async () => {
-    // The published build artifacts contain imports from
-    // "@babel/runtime-corejs3/helpers/esm/*" because they were compiled with
-    // @babel/plugin-transform-runtime using corejs: 3. Consumers bundling with
-    // tools like esbuild or Vite will get a build error if this package is not
-    // listed as a dependency in the published package.json.
-    // See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
-    //      https://github.com/dnbexperience/eufemia/pull/8016 (re-added)
+    // @babel/runtime-corejs3 must stay a declared runtime dependency. See
+    // babel.config.js (polyfill/runtime strategy) for why it is required even
+    // though a clean build currently emits no imports of it. Removing it broke
+    // consumer bundling before: #7994 (removed) -> #8016 (reverted).
     const filepath = path.resolve(PKG_ROOT, 'package.json')
     const packageString = await fs.readFile(filepath, 'utf-8')
     const cleanedPackage = await cleanupPackage({
@@ -173,12 +170,10 @@ describe('package.json', () => {
   })
 
   it('has @babel/runtime-corejs3 as a dependency', () => {
-    // The published build artifacts (e.g. build/shared/useTranslation.js) contain
-    // imports from "@babel/runtime-corejs3/helpers/esm/*" because they were compiled
-    // with @babel/plugin-transform-runtime using corejs: 3. Consumers who do not have
-    // this package installed (e.g. via bundlers like esbuild or Vite) will get a
-    // build error if this runtime dependency is missing from the published package.
-    // See: https://github.com/dnbexperience/eufemia/issues/7994
+    // @babel/runtime-corejs3 must stay a declared runtime dependency. See
+    // babel.config.js (polyfill/runtime strategy) for why it is required even
+    // though a clean build currently emits no imports of it. Removing it broke
+    // consumer bundling before: #7994 (removed) -> #8016 (reverted).
     expect(
       (packageJson as { dependencies?: Record<string, string> })
         .dependencies


### PR DESCRIPTION
The tests guarding `@babel/runtime-corejs3` claimed the compiled output imports `@babel/runtime-corejs3/helpers/esm/*` because it is built with `corejs: 3`. That is inaccurate: the Babel config does not set `corejs` on `@babel/plugin-transform-runtime` (polyfills come from `core-js-pure`), and a clean build emits no such imports.

This corrects the comment so it no longer states a wrong reason, while keeping the #7994 (removed) → #8016 (reverted) history that explains why the dependency is intentionally kept.
