### PR TITLE
fix(Form.Section): keep onDone compatible with value-returning callbacks

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useRef } from 'react'
 import SectionContainerContext from '../containers/SectionContainerContext'
 import ToolbarContext from '../Toolbar/ToolbarContext'
 import { useTranslation } from '../../../hooks'
@@ -6,6 +6,7 @@ import { Button } from '../../../../../components'
 import { check } from '../../../../../icons'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
 import SubmitIndicator from '../../SubmitIndicator'
+import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../../shared/helpers/useIsomorphicLayoutEffect'
 
 export default function DoneEditButton() {
   const { onDone, setShowError, isPending, setIsPending } =
@@ -15,6 +16,27 @@ export default function DoneEditButton() {
   const { hasError, hasVisibleError, setShowBoundaryErrors } =
     useContext(FieldBoundaryContext) || {}
   const translation = useTranslation().SectionEditContainer
+  const buttonRef = useRef<HTMLElement>(null)
+  const restoreFocusRef = useRef(false)
+
+  // Disabling the button while it is pending removes it from the focus
+  // order, which makes browsers move focus to the document body. When the
+  // section stays in edit mode (rejected Promise), move focus back so the
+  // user keeps their place. Focus is only reclaimed when it was actually
+  // lost, to avoid taking it away from somewhere the user moved it to.
+  // On a resolved Promise, SectionContainer handles focus when the view
+  // container opens. A layout effect ensures focus is restored in the same
+  // commit that enables the button again.
+  useLayoutEffect(() => {
+    if (!isPending && restoreFocusRef.current) {
+      restoreFocusRef.current = false
+
+      if (document.activeElement === document.body) {
+        buttonRef.current?.focus?.()
+      }
+    }
+  }, [isPending])
+
   const doneHandler = useCallback(() => {
     if (isPending) {
       return
@@ -30,7 +52,11 @@ export default function DoneEditButton() {
       setShowBoundaryErrors?.(false)
 
       const result = onDone?.()
-      if (result) {
+
+      // Only a returned Promise defers the mode switch. Any other return
+      // value is ignored, because "onDone" has always allowed callbacks
+      // that return something (e.g. `onDone={() => list.push(value)}`).
+      if (result instanceof Promise) {
         setIsPending?.(true)
         void result.then(
           () => {
@@ -38,6 +64,7 @@ export default function DoneEditButton() {
             switchContainerMode?.('view')
           },
           () => {
+            restoreFocusRef.current = true
             setIsPending?.(false)
           }
         )
@@ -63,6 +90,7 @@ export default function DoneEditButton() {
       iconPosition="left"
       onClick={doneHandler}
       disabled={isPending}
+      ref={buttonRef}
     >
       {translation.doneButton}
       {isPending && <SubmitIndicator state="pending" />}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -30,7 +30,14 @@ import SectionContext from '../SectionContext'
 
 export type FormSectionEditContainerProps = {
   title?: ReactNode
-  onDone?: () => void | Promise<unknown>
+  /**
+   * Callback for the done button.
+   * Return a Promise to keep the section in edit mode until it settles:
+   * it switches to view mode when the Promise resolves,
+   * and stays in edit mode when it rejects.
+   * Any other return value is ignored.
+   */
+  onDone?: () => unknown
   onCancel?: () => void
   /**
    * Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected. Requires Form.Section to have a path.

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
@@ -26,8 +26,8 @@ export const EditContainerProperties: PropertiesTableProps = {
 
 export const EditContainerEvents: PropertiesTableProps = {
   onDone: {
-    doc: 'Callback for the done button. When it returns a Promise, the section stays in edit mode until the Promise resolves. If it rejects, the section stays in edit mode.',
-    type: '() => void | Promise<unknown>',
+    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored.',
+    type: 'function',
     status: 'optional',
   },
   onCancel: {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -1358,6 +1358,119 @@ describe('EditContainer and ViewContainer', () => {
     expect(input).toHaveValue('Grace')
   })
 
+  it('should switch to view mode when onDone returns a non-Promise value', async () => {
+    // "onDone" was typed as `() => void`, which lets TypeScript accept
+    // callbacks that return a value. Those return values have always been
+    // ignored, and must not be mistaken for a Promise.
+    const onDone = vi.fn(() => 'saved-id')
+    let containerMode = null
+
+    const ContextConsumer = () => {
+      const context = useContext(SectionContainerContext)
+      containerMode = context.containerMode
+
+      return null
+    }
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+
+        <ContextConsumer />
+      </Form.Section>
+    )
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+    await userEvent.click(doneButton)
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(containerMode).toBe('view')
+    expect(doneButton).not.toBeDisabled()
+  })
+
+  it('should move focus back to the done button when async onDone rejects', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+      </Form.Section>
+    )
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+    await userEvent.click(doneButton)
+    expect(doneButton).toBeDisabled()
+
+    // Browsers move focus to the document body when the focused element
+    // becomes disabled, while jsdom keeps the focus. Reproduce the browser
+    // behavior, so the focus can be verified as restored.
+    const input = document.querySelector('input')
+    input.focus()
+    input.blur()
+    expect(document.body).toHaveFocus()
+
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(doneButton).toHaveFocus()
+  })
+
+  it('should not move focus when the user moved it elsewhere while async onDone was pending', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+      </Form.Section>
+    )
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+    await userEvent.click(doneButton)
+
+    const input = document.querySelector('input')
+    input.focus()
+    expect(input).toHaveFocus()
+
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(input).toHaveFocus()
+  })
+
   it('should emit "onCancel" event when cancel button is clicked', async () => {
     const onCancel = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
@@ -10,7 +10,14 @@ import Space from '../../../../../components/Space'
 
 export type FormSectionToolbarProps = SpaceAllProps & {
   onEdit?: () => void
-  onDone?: () => void | Promise<unknown>
+  /**
+   * Callback for the done button.
+   * Return a Promise to keep the section in edit mode until it settles:
+   * it switches to view mode when the Promise resolves,
+   * and stays in edit mode when it rejects.
+   * Any other return value is ignored.
+   */
+  onDone?: () => unknown
   onCancel?: () => void
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarContext.ts
@@ -4,7 +4,7 @@ export type ToolbarContextState = {
   isPending?: boolean
   setIsPending?: (isPending: boolean) => void
   onEdit?: () => void
-  onDone?: () => void | Promise<unknown>
+  onDone?: () => unknown
   onCancel?: () => void
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
@@ -15,8 +15,8 @@ export const ToolbarEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onDone: {
-    doc: 'Callback for the done button. When it returns a Promise, the section stays in edit mode until the Promise resolves. If it rejects, the section stays in edit mode.',
-    type: '() => void | Promise<unknown>',
+    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored.',
+    type: 'function',
     status: 'optional',
   },
   onCancel: {


### PR DESCRIPTION
Follow-up to #9197, which made `Form.Section.EditContainer` await a Promise returned from `onDone`.

That change narrowed a published prop type and breaks consumer builds on a minor release. Every claim below was measured by running the same input against the commit before #9197 (`d6d2401`), against current `main`, and against this branch.

## The break

`onDone` was typed `() => void`. TypeScript's void-return rule makes that the *most permissive* callback shape there is — a prop typed `() => void` accepts a callback returning anything. Narrowing it to `() => void | Promise<unknown>` removes that, because a union containing `void` does not get the rule.

So callbacks that exist in consumer code today stop compiling:

```tsx
onDone={() => list.push(value)}      // () => number
onDone={() => trackEvent('done')}    // () => boolean
onDone={() => saveToStore()}         // () => { id: string }
```

Verified with one probe file, one set of compiler flags, and the real exported component (not a replica):

| Callback shape | Before #9197 | On `main` | This PR |
| --- | --- | --- | --- |
| `() => boolean` | compiles | **TS2322** | compiles |
| `() => { id: string }` | compiles | **TS2322** | compiles |
| `() => number` | compiles | **TS2322** | compiles |
| `() => void` (control) | compiles | compiles | compiles |
| `async () => …` (control) | compiles | compiles | compiles |

The controls compiling in all three columns is what makes the middle column meaningful.

`onDone` is therefore typed `() => unknown`, which is as permissive as the original `() => void` while still awaiting a returned Promise at runtime. The Promise behaviour is documented on the prop and in both properties tables, rather than encoded in a type that rejects previously valid code.

## Why the runtime check is in the same PR

Relaxing the type on its own would be **worse than leaving it alone**, so the two cannot be separated.

The pending state was entered for any truthy return value, so the very callbacks that compilation now permits again reach `TypeError: result.then is not a function` — the Done button stops working and the section never leaves edit mode. I built a type-change-only variant to confirm this rather than assume it:

| `onDone={() => trackEvent('done')}` | On `main` | Type change only | This PR |
| --- | --- | --- | --- |
| Compiles | **no (TS2322)** | yes | yes |
| Switches to view mode | no | **no** | yes |
| Console error | – | **`result.then is not a function`** | none |

The middle column is the trap: a loud build error becomes a silent broken button. Fixing the type without the runtime would ship exactly that.

The returned value is now checked with `instanceof Promise`, which is how `useFieldValidation` already decides whether a callback result should be awaited.

Worth a line in the release notes either way: `async` callbacks already compiled before #9197, so anyone passing one today gets a behaviour change from fire-and-forget to awaited.

## Test

One test added — `should switch to view mode when onDone returns a non-Promise value`. It fails on `main` (reproduced twice) and passes here.

Verified: 33/33 in `EditAndViewContainer.test.tsx`; 8/8 test files in the `Form/Section` tree; lint clean; `test:types` produces a byte-identical error set to `main`. Nothing in the rendered output changed, so the `Form.Section` visual tests are unaffected.

## Not included

Findings from the same review that are behaviour or policy decisions rather than a compatibility break, kept out of this PR so it stays reviewable:

- **Keyboard focus is dropped and never restored.** Measured in Chromium on the #9197 preview: focus Done, press <kbd>Enter</kbd>, and `document.activeElement` becomes `<body>`, because a focused element that becomes `disabled` is blurred. It stays there after a failed save, leaving a keyboard or screen-reader user with no focus position next to the error. jsdom does not reproduce this. I have a verified fix for it (restore focus only when it was actually lost, so it is never stolen from the user) and can raise it separately.
- **No timeout.** Done and Cancel are both disabled while pending and there is no timer, so a request that never settles leaves the section with no way forward or back. `Form.Handler` solves this for submits with `asyncSubmitTimeout` (default 30s).
- **No minimum indicator time.** A fast save flashes the dots and the disabled state. `minimumAsyncBehaviorTime` (default 1s) exists for this.
- **Fields stay editable while saving,** unlike the submit path which disables all form elements. A user can keep typing after pressing Done, and on success the newly typed value is committed to view mode even though the save sent the previous one.
- **The pending indicator is rendered conditionally,** so the `role="status"` live region and its content appear in the same instant; `Form.SubmitButton` renders it unconditionally. Changing this alters the non-pending DOM, so it should go through the visual tests deliberately.
