### PR TITLE
docs(AI): recommend building AI tooling on Eufemia

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
@@ -34,6 +34,29 @@ retrieve. Component APIs, tokens, theme support, and other version-sensitive
 facts remain in Eufemia's packaged documentation and MCP server rather than
 being copied into the skills.
 
+### Build AI tools on Eufemia
+
+Treat Eufemia as the source of truth for shared design-system functionality and
+guidance when creating AI instructions, skills, plugins, MCP tools, or generated
+code.
+
+Before adding local components, tokens, themes, patterns, or Eufemia guidance:
+
+- Check the current, version-matched Eufemia documentation and supported APIs.
+- Reuse or compose existing Eufemia capabilities where possible.
+- If a generally useful capability is missing, consider contributing it to
+  Eufemia so it becomes available to everyone.
+- Keep product-specific business logic, integrations, and workflows in the
+  product's own tooling.
+- Avoid copying Eufemia documentation or API details into local AI instructions.
+  Retrieve current information through Eufemia's documentation and MCP server.
+
+Local solutions are appropriate for genuinely product-specific needs and
+temporary migration work. Keep the boundary explicit so local guidance is not
+mistaken for an Eufemia standard. See
+[where a component change belongs](/contribute/rules#where-a-component-change-belongs)
+for the general ownership guidance.
+
 ### Install project skills
 
 In a project that depends on `@dnb/eufemia`, use the CLI provided by the same

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
@@ -34,29 +34,6 @@ retrieve. Component APIs, tokens, theme support, and other version-sensitive
 facts remain in Eufemia's packaged documentation and MCP server rather than
 being copied into the skills.
 
-### Build AI tools on Eufemia
-
-Treat Eufemia as the source of truth for shared design-system functionality and
-guidance when creating AI instructions, skills, plugins, MCP tools, or generated
-code.
-
-Before adding local components, tokens, themes, patterns, or Eufemia guidance:
-
-- Check the current, version-matched Eufemia documentation and supported APIs.
-- Reuse or compose existing Eufemia capabilities where possible.
-- If a generally useful capability is missing, consider contributing it to
-  Eufemia so it becomes available to everyone.
-- Keep product-specific business logic, integrations, and workflows in the
-  product's own tooling.
-- Avoid copying Eufemia documentation or API details into local AI instructions.
-  Retrieve current information through Eufemia's documentation and MCP server.
-
-Local solutions are appropriate for genuinely product-specific needs and
-temporary migration work. Keep the boundary explicit so local guidance is not
-mistaken for an Eufemia standard. See
-[where a component change belongs](/contribute/rules#where-a-component-change-belongs)
-for the general ownership guidance.
-
 ### Install project skills
 
 In a project that depends on `@dnb/eufemia`, use the CLI provided by the same
@@ -167,6 +144,29 @@ Install the Agent Skills and configure one of the MCP options below. Skills are
 the reusable workflow; MCP provides the current Eufemia facts. If MCP is not
 available, the skills should say that the relevant information could not be
 verified instead of guessing.
+
+### Build AI tools on Eufemia
+
+Treat Eufemia as the source of truth for shared design-system functionality and
+guidance when creating AI instructions, skills, plugins, MCP tools, or generated
+code.
+
+Before adding local components, tokens, themes, patterns, or Eufemia guidance:
+
+- Check the current, version-matched Eufemia documentation and supported APIs.
+- Reuse or compose existing Eufemia capabilities where possible.
+- If a generally useful capability is missing, consider contributing it to
+  Eufemia so it becomes available to everyone.
+- Keep product-specific business logic, integrations, and workflows in the
+  product's own tooling.
+- Avoid copying Eufemia documentation or API details into local AI instructions.
+  Retrieve current information through Eufemia's documentation and MCP server.
+
+Local solutions are appropriate for genuinely product-specific needs and
+temporary migration work. Keep the boundary explicit so local guidance is not
+mistaken for an Eufemia standard. See
+[where a component change belongs](/contribute/rules#where-a-component-change-belongs)
+for the general ownership guidance.
 
 ## AI Assistance and MCP Server
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/first-steps/tools.mdx
@@ -145,29 +145,6 @@ the reusable workflow; MCP provides the current Eufemia facts. If MCP is not
 available, the skills should say that the relevant information could not be
 verified instead of guessing.
 
-### Build AI tools on Eufemia
-
-Treat Eufemia as the source of truth for shared design-system functionality and
-guidance when creating AI instructions, skills, plugins, MCP tools, or generated
-code.
-
-Before adding local components, tokens, themes, patterns, or Eufemia guidance:
-
-- Check the current, version-matched Eufemia documentation and supported APIs.
-- Reuse or compose existing Eufemia capabilities where possible.
-- If a generally useful capability is missing, consider contributing it to
-  Eufemia so it becomes available to everyone.
-- Keep product-specific business logic, integrations, and workflows in the
-  product's own tooling.
-- Avoid copying Eufemia documentation or API details into local AI instructions.
-  Retrieve current information through Eufemia's documentation and MCP server.
-
-Local solutions are appropriate for genuinely product-specific needs and
-temporary migration work. Keep the boundary explicit so local guidance is not
-mistaken for an Eufemia standard. See
-[where a component change belongs](/contribute/rules#where-a-component-change-belongs)
-for the general ownership guidance.
-
 ## AI Assistance and MCP Server
 
 **NB:** This feature is experimental and may change in the future. Please give us feedback on your experience with it!
@@ -265,6 +242,29 @@ raicode mcp add --transport stdio eufemia -- node node_modules/@dnb/eufemia/mcp/
 - The MCP server provides documentation context only; it does not execute code or access the network.
 - Ask your AI tool to search or summarize Eufemia docs, e.g. "Find the spacing system rules in Eufemia."
 - If the server fails to start, confirm `@dnb/eufemia` is installed and the path points to `node_modules/@dnb/eufemia/mcp/mcp-docs-server.js`.
+
+## Build AI tools on Eufemia
+
+Treat Eufemia as the source of truth for shared design-system functionality and
+guidance when creating AI instructions, skills, plugins, MCP tools, or generated
+code.
+
+Before adding local components, tokens, themes, patterns, or Eufemia guidance:
+
+- Check the current, version-matched Eufemia documentation and supported APIs.
+- Reuse or compose existing Eufemia capabilities where possible.
+- If a generally useful capability is missing, consider contributing it to
+  Eufemia so it becomes available to everyone.
+- Keep product-specific business logic, integrations, and workflows in the
+  product's own tooling.
+- Avoid copying Eufemia documentation or API details into local AI instructions.
+  Retrieve current information through Eufemia's documentation and MCP server.
+
+Local solutions are appropriate for genuinely product-specific needs and
+temporary migration work. Keep the boundary explicit so local guidance is not
+mistaken for an Eufemia standard. See
+[where a component change belongs](/contribute/rules#where-a-component-change-belongs)
+for the general ownership guidance.
 
 ## Code Editor Extensions
 


### PR DESCRIPTION
Clarifies how teams can extend their AI tooling while keeping shared design-system functionality and guidance in Eufemia.

Preview: [Open the changed section](https://chore-eufemia-ai-tooling-gui.eufemia-e25.pages.dev/uilib/usage/first-steps/tools/#build-ai-tools-on-eufemia)
