### PR TITLE
chore(Form.Section): keep onDone compatible with value-returning callbacks

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -51,8 +51,15 @@ export default function DoneEditButton() {
       setShowError(false)
       setShowBoundaryErrors?.(false)
 
-      const result = onDone?.()
-      if (result) {
+      // "onDone" is typed as `() => void`, which is what makes it accept
+      // both async and value-returning callbacks. Widening the result to
+      // unknown is what allows it to be inspected at all.
+      const result: unknown = onDone?.()
+
+      // Only a returned Promise defers the mode switch. Any other return
+      // value is ignored, because "onDone" has always allowed callbacks
+      // that return something (e.g. `onDone={() => list.push(value)}`).
+      if (result instanceof Promise) {
         setIsPending?.(true)
         void result.then(
           () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -56,9 +56,6 @@ export default function DoneEditButton() {
       // unknown is what allows it to be inspected at all.
       const result: unknown = onDone?.()
 
-      // Only a returned Promise defers the mode switch. Any other return
-      // value is ignored, because "onDone" has always allowed callbacks
-      // that return something (e.g. `onDone={() => list.push(value)}`).
       if (result instanceof Promise) {
         setIsPending?.(true)
         void result.then(

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -32,13 +32,6 @@ import SectionContext from '../SectionContext'
 
 export type FormSectionEditContainerProps = {
   title?: ReactNode
-  /**
-   * Callback for the done button.
-   * Return a Promise to keep the section in edit mode until it settles:
-   * it switches to view mode when the Promise resolves,
-   * and stays in edit mode when it rejects.
-   * Any other return value is ignored.
-   */
   onDone?: () => void
   onCancel?: () => void
   /**

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -32,7 +32,14 @@ import SectionContext from '../SectionContext'
 
 export type FormSectionEditContainerProps = {
   title?: ReactNode
-  onDone?: () => void | Promise<unknown>
+  /**
+   * Callback for the done button.
+   * Return a Promise to keep the section in edit mode until it settles:
+   * it switches to view mode when the Promise resolves,
+   * and stays in edit mode when it rejects.
+   * Any other return value is ignored.
+   */
+  onDone?: () => void
   onCancel?: () => void
   /**
    * Prevents form submission and Wizard navigation while the section is in edit mode, until the Done or Cancel button is selected. Requires Form.Section to have a path.

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
@@ -26,8 +26,8 @@ export const EditContainerProperties: PropertiesTableProps = {
 
 export const EditContainerEvents: PropertiesTableProps = {
   onDone: {
-    doc: 'Callback for the done button. When it returns a Promise, the section stays in edit mode until the Promise resolves. If it rejects, the section stays in edit mode.',
-    type: '() => void | Promise<unknown>',
+    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored.',
+    type: 'function',
     status: 'optional',
   },
   onCancel: {

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -1358,6 +1358,42 @@ describe('EditContainer and ViewContainer', () => {
     expect(input).toHaveValue('Grace')
   })
 
+  it('should switch to view mode when onDone returns a non-Promise value', async () => {
+    // "onDone" was typed as `() => void`, which lets TypeScript accept
+    // callbacks that return a value. Those return values have always been
+    // ignored, and must not be mistaken for a Promise.
+    const onDone = vi.fn(() => 'saved-id')
+    let containerMode = null
+
+    const ContextConsumer = () => {
+      const context = useContext(SectionContainerContext)
+      containerMode = context.containerMode
+
+      return null
+    }
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+
+        <ContextConsumer />
+      </Form.Section>
+    )
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+    await userEvent.click(doneButton)
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(containerMode).toBe('view')
+    expect(doneButton).not.toBeDisabled()
+  })
+
   it('should emit "onCancel" event when cancel button is clicked', async () => {
     const onCancel = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
@@ -11,13 +11,6 @@ import Space from '../../../../../components/Space'
 
 export type FormSectionToolbarProps = SpaceAllProps & {
   onEdit?: () => void
-  /**
-   * Callback for the done button.
-   * Return a Promise to keep the section in edit mode until it settles:
-   * it switches to view mode when the Promise resolves,
-   * and stays in edit mode when it rejects.
-   * Any other return value is ignored.
-   */
   onDone?: () => void
   onCancel?: () => void
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
@@ -11,7 +11,14 @@ import Space from '../../../../../components/Space'
 
 export type FormSectionToolbarProps = SpaceAllProps & {
   onEdit?: () => void
-  onDone?: () => void | Promise<unknown>
+  /**
+   * Callback for the done button.
+   * Return a Promise to keep the section in edit mode until it settles:
+   * it switches to view mode when the Promise resolves,
+   * and stays in edit mode when it rejects.
+   * Any other return value is ignored.
+   */
+  onDone?: () => void
   onCancel?: () => void
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarContext.ts
@@ -4,7 +4,7 @@ export type ToolbarContextState = {
   isPending?: boolean
   setIsPending?: (isPending: boolean) => void
   onEdit?: () => void
-  onDone?: () => void | Promise<unknown>
+  onDone?: () => void
   onCancel?: () => void
 }
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
@@ -15,8 +15,8 @@ export const ToolbarEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onDone: {
-    doc: 'Callback for the done button. When it returns a Promise, the section stays in edit mode until the Promise resolves. If it rejects, the section stays in edit mode.',
-    type: '() => void | Promise<unknown>',
+    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored.',
+    type: 'function',
     status: 'optional',
   },
   onCancel: {


### PR DESCRIPTION
Follow-up to #9197.

Continues #9204, which was closed and cannot be reopened — GitHub blocks reopening once the branch has been force-pushed. This is the same work, narrowed to the breaking change only.

#9197 narrowed a published prop type, which breaks consumer builds on a minor release. Every claim below was measured against three checkouts: the commit before #9197 (`d6d2401`), current `main`, and this branch.

## The problem

`onDone` was typed `() => void`. TypeScript's void-return rule makes that the **most permissive callback shape there is** — a prop typed `() => void` accepts a callback returning anything, including a Promise. Narrowing it to `() => void | Promise<unknown>` removes that, because a union containing `void` does not get the rule.

So callbacks that exist in consumer code today stop compiling:

```tsx
onDone={() => list.push(value)}      // () => number
onDone={() => trackEvent('done')}    // () => boolean
onDone={() => saveToStore()}         // () => { id: string }
```

One probe file, one set of compiler flags, against the real exported component:

| Callback shape | Before #9197 | `main` | This PR |
| --- | --- | --- | --- |
| `() => boolean` | compiles | **TS2322** | compiles |
| `() => { id: string }` | compiles | **TS2322** | compiles |
| `() => number` | compiles | **TS2322** | compiles |
| `() => void` (control) | compiles | compiles | compiles |
| `async () => …` (control) | compiles | compiles | compiles |

The controls compiling in all three columns are what make the middle column meaningful.

## The change

Per review, the public type goes back to `() => void`, **unchanged from before #9197**. No public API change at all — which is a stronger compatibility guarantee than introducing `() => unknown`, and it needs no explanation to consumers.

That does require one internal adjustment. `instanceof` cannot be used on a `void` typed value:

```
error TS2358: The left-hand side of an 'instanceof' expression must be of
type 'any', an object type or a type parameter.
```

So the result is assigned to `unknown` before it is inspected:

```ts
const result: unknown = onDone?.()

if (result instanceof Promise) {
  …
}
```

I verified both halves of that in isolation: the same check without the `unknown` assignment fails with TS2358, and with it, compiles.

`instanceof Promise` matches how `useFieldValidation` already decides whether a callback result should be awaited. A non-native thenable is therefore treated as synchronous — the same as before #9197, when nothing was awaited at all, so no consumer regresses.

## Why the runtime check ships with the type

Relaxing the type on its own would be **worse than leaving `main` alone**, so the two cannot be separated.

The pending state is entered for any truthy return value:

```js
const result = onDone?.()
if (result) {
  setIsPending?.(true)
  void result.then(…)   // ← not a Promise
```

So the very callbacks that compilation would permit again reach `TypeError: result.then is not a function`. The Done button stops working and the section never leaves edit mode. I built a type-change-only variant to confirm this rather than assume it: `onDone={() => trackEvent('done')}` compiled fine and then died at runtime, leaving the section stuck in `edit`.

That is the trap — fixing the type alone converts a **loud build error into a silently dead button**. Both halves belong in one change.

## Test

One test added — `should switch to view mode when onDone returns a non-Promise value`. It fails on `main` and passes here.

Verified after the review change: 4/4 test files in `EditContainer`; 14/14 across every suite that renders `Section.EditContainer`, `Section.Toolbar` or `Iterate.EditContainer`; six callback shapes compile against the real component, including a standalone `Form.Section.Toolbar`; `lint:ci` and portal lint clean; `test:types` produces a byte-identical error set to `main`. Nothing in the rendered output changed, so the `Form.Section` visual tests are unaffected.

One trade-off worth naming: with `() => void`, a consumer who enables `@typescript-eslint/no-misused-promises` will see `onDone={async () => …}` flagged as a Promise passed where a void return is expected. That is not a regression — it was equally true before #9197 — and the rule is not enabled anywhere in this repo. `() => unknown` would silence it, at the cost of an actual API change. Flagging it only so the choice is deliberate.

Worth a line in the release notes either way: `async` callbacks already compiled before #9197, so anyone passing one today gets a behaviour change from fire-and-forget to awaited.

## Not included

Findings from the same review that are behaviour or policy decisions rather than a compatibility break:

- **Keyboard focus is dropped and never restored** after a failed save — now #9212.
- **Fields stay editable while saving,** so the section can commit a value the save never sent — now #9211.
- **No timeout.** Done and Cancel are both disabled while pending and there is no timer, so a request that never settles leaves the section with no way forward or back. `Form.Handler` solves this for submits with `asyncSubmitTimeout` (default 30s).
- **No minimum indicator time.** A fast save flashes the dots and the disabled state. `minimumAsyncBehaviorTime` (default 1s) exists for this.
- **The pending indicator is rendered conditionally,** so the `role="status"` live region and its content appear in the same instant; `Form.SubmitButton` renders it unconditionally. Changing this alters the non-pending DOM, so it should go through the visual tests deliberately.
