### PR TITLE
chore(analytics): support custom dashboard domain (dashboard.eufemia.dnb.no)

### DIFF
--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -111,7 +111,7 @@ jobs:
           cd infra
           ENDPOINT=$(terraform output -raw api_endpoint)
           BUCKET=$(terraform output -raw data_bucket)
-          DASHBOARD_URL=$(terraform output -raw dashboard_url)
+          DASHBOARD_URL=$(terraform output -raw dashboard_public_url)
           echo "## Analytics Lambda deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Endpoint:** \`${ENDPOINT}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/tools/analytics/ghe-deploy-workflow.yml
+++ b/tools/analytics/ghe-deploy-workflow.yml
@@ -56,6 +56,7 @@ jobs:
           TF_VAR_entra_client_id: ${{ vars.ENTRA_CLIENT_ID }}
           TF_VAR_entra_tenant_id: ${{ vars.ENTRA_TENANT_ID }}
           TF_VAR_dashboard_origins: ${{ vars.DASHBOARD_ORIGINS }}
+          TF_VAR_dashboard_public_url: ${{ vars.DASHBOARD_PUBLIC_URL }}
         run: |
           set -euo pipefail
           cd infra
@@ -71,13 +72,15 @@ jobs:
           cd infra
           BUCKET=$(terraform output -raw dashboard_bucket)
           DIST=$(terraform output -raw dashboard_distribution_id)
-          URL=$(terraform output -raw dashboard_url)
+          URL=$(terraform output -raw dashboard_public_url)
           API_BASE_URL=$(terraform output -raw dashboard_api_endpoint)
 
           # Generate the per-host runtime config from the deploy variables. It
           # holds only non-secret public identifiers, so it is safe to serve.
-          # The redirect URI must be the CloudFront URL registered on the app;
-          # apiScope is the app registration's exposed "Dashboard.Read" scope.
+          # The redirect URI is the canonical public dashboard URL (custom
+          # domain when DASHBOARD_PUBLIC_URL is set, else the CloudFront URL) and
+          # must be registered on the app registration; apiScope is the app
+          # registration's exposed "Dashboard.Read" scope.
           jq -n \
             --arg clientId "$ENTRA_CLIENT_ID" \
             --arg tenantId "$ENTRA_TENANT_ID" \

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -319,10 +319,15 @@ resource "aws_apigatewayv2_api" "dashboard" {
   cors_configuration {
     # Always include the live dashboard origin so CORS works on the first deploy
     # (no chicken-and-egg); dashboard_origins adds any extra, e.g. local dev.
-    allow_origins = concat(
+    # dashboard_public_url adds the custom domain once it is configured; compact
+    # drops it while it is still empty.
+    allow_origins = compact(concat(
       var.dashboard_origins,
-      ["https://${aws_cloudfront_distribution.dashboard.domain_name}"],
-    )
+      [
+        "https://${aws_cloudfront_distribution.dashboard.domain_name}",
+        var.dashboard_public_url,
+      ],
+    ))
     allow_methods = ["GET"]
     allow_headers = ["authorization"]
     max_age       = 3600

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -320,14 +320,15 @@ resource "aws_apigatewayv2_api" "dashboard" {
     # Always include the live dashboard origin so CORS works on the first deploy
     # (no chicken-and-egg); dashboard_origins adds any extra, e.g. local dev.
     # dashboard_public_url adds the custom domain once it is configured; compact
-    # drops it while it is still empty.
-    allow_origins = compact(concat(
+    # drops it while it is still empty, distinct dedupes an overlap with
+    # dashboard_origins.
+    allow_origins = distinct(compact(concat(
       var.dashboard_origins,
       [
         "https://${aws_cloudfront_distribution.dashboard.domain_name}",
         var.dashboard_public_url,
       ],
-    ))
+    )))
     allow_methods = ["GET"]
     allow_headers = ["authorization"]
     max_age       = 3600

--- a/tools/analytics/infra/outputs.tf
+++ b/tools/analytics/infra/outputs.tf
@@ -41,6 +41,11 @@ output "dashboard_url" {
   value       = "https://${aws_cloudfront_distribution.dashboard.domain_name}"
 }
 
+output "dashboard_public_url" {
+  description = "Canonical public dashboard URL (custom domain when set, else the CloudFront URL)"
+  value       = coalesce(var.dashboard_public_url, "https://${aws_cloudfront_distribution.dashboard.domain_name}")
+}
+
 output "dashboard_distribution_id" {
   description = "CloudFront distribution id (used for cache invalidation on publish)"
   value       = aws_cloudfront_distribution.dashboard.id

--- a/tools/analytics/infra/variables.tf
+++ b/tools/analytics/infra/variables.tf
@@ -88,6 +88,14 @@ variable "dashboard_origins" {
 # becomes an allowed CORS origin and the OIDC redirect URI; empty falls back to
 # the raw CloudFront URL, preserving the pre-custom-domain behaviour.
 variable "dashboard_public_url" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
+  description = "Canonical public dashboard URL (e.g. https://dashboard.eufemia.dnb.no). Becomes a CORS origin and the OIDC redirect URI; empty falls back to the CloudFront URL."
+
+  # Entra matches redirect URIs exactly, so a trailing slash or missing scheme
+  # would break sign-in while the deploy still succeeds. Allow empty (default).
+  validation {
+    condition     = var.dashboard_public_url == "" || can(regex("^https://[^/]+$", var.dashboard_public_url))
+    error_message = "dashboard_public_url must be an https:// origin with no trailing slash (e.g. https://dashboard.eufemia.dnb.no)."
+  }
 }

--- a/tools/analytics/infra/variables.tf
+++ b/tools/analytics/infra/variables.tf
@@ -82,3 +82,12 @@ variable "dashboard_origins" {
     error_message = "dashboard_origins must list at least one allowed origin."
   }
 }
+
+# Canonical public URL the dashboard is served from once it is fronted by a
+# custom domain (e.g. https://dashboard.eufemia.dnb.no via Akamai). When set it
+# becomes an allowed CORS origin and the OIDC redirect URI; empty falls back to
+# the raw CloudFront URL, preserving the pre-custom-domain behaviour.
+variable "dashboard_public_url" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
## Motivation

Prepares the analytics dashboard to be served at a human-readable **https://dashboard.eufemia.dnb.no** (fronted by Akamai) instead of the raw `*.cloudfront.net` URL. Jira: EDS-963.

## What

- New `dashboard_public_url` variable (default `""`, validated as an `https://` origin with no trailing slash), threaded through the deploy workflow as `TF_VAR_dashboard_public_url`.
- When set, it is added to the dashboard API's CORS `allow_origins` and used as the OIDC `redirectUri` written into the deployed `config.json`.
- Empty by default, so nothing changes until the GHE variable `DASHBOARD_PUBLIC_URL` is set — the dashboard keeps using the CloudFront URL. On the empty default this plans to essentially nothing (an in-place CORS update, no resource churn).

## Go-live prerequisite (do not skip)

Flipping `DASHBOARD_PUBLIC_URL` changes the `redirect_uri` sent to Entra. **Register `https://dashboard.eufemia.dnb.no` as a redirect URI on the Entra app registration first** (exact match, no trailing slash) — otherwise sign-in on the custom domain breaks. The CloudFront path is unaffected until DNS cuts over, so sequence: register the redirect URI (and confirm the host is live) → then set the GHE variable.

Backward-compatible and independently mergeable; the Akamai property lives in a separate repo (`akamai_delivery_eufemia`) and the GHE variable is flipped only once the host is live.
