### PR TITLE
chore(Theme): keep size and density in sync in useTheme

### DIFF
--- a/packages/dnb-eufemia/src/shared/__tests__/useTheme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/useTheme.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import Theme from '../Theme'
+import { Provider } from '../'
 import useTheme from '../useTheme'
 
 describe('useTheme', () => {
@@ -51,6 +52,28 @@ describe('useTheme', () => {
 
     expect(result.current).toEqual(
       expect.objectContaining({ brand: 'sbanken', name: 'sbanken' })
+    )
+  })
+
+  it('resolves density from the deprecated size when set via Provider', () => {
+    const wrapper = ({ children }) => (
+      <Provider theme={{ size: 'basis' }}>{children}</Provider>
+    )
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    expect(result.current).toEqual(
+      expect.objectContaining({ density: 'basis', size: 'basis' })
+    )
+  })
+
+  it('resolves the deprecated size from density when set via Provider', () => {
+    const wrapper = ({ children }) => (
+      <Provider theme={{ density: 'basis' }}>{children}</Provider>
+    )
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    expect(result.current).toEqual(
+      expect.objectContaining({ density: 'basis', size: 'basis' })
     )
   })
 

--- a/packages/dnb-eufemia/src/shared/useTheme.ts
+++ b/packages/dnb-eufemia/src/shared/useTheme.ts
@@ -21,10 +21,13 @@ export default function useTheme(): UseThemeReturn {
 
   if (theme) {
     const brand = theme.brand ?? theme.name
+    const density = theme.density ?? theme.size
     return {
       ...theme,
       brand,
       name: brand,
+      density,
+      size: density,
       isUi: brand === 'ui',
       isSbanken: brand === 'sbanken',
       isEiendom: brand === 'eiendom',


### PR DESCRIPTION
Follow-up to #9191, which deprecated Theme `size` in favor of `density`.

`useTheme` already resolves `brand` from the deprecated `name` and returns both. #9191 mirrored `size`/`density` everywhere the theme is normalized — the `Theme` component, `getThemeClasses`, `ThemeWrapper`, and `getTheme`/`setTheme` — but not in `useTheme`. So when a theme is set via `Provider theme={{ size }}` (which stores the prop without normalization), `useTheme().density` was `undefined`, and `density` → `size` had the same gap.

This adds the same one-line resolution for `density`/`size` that already exists for `brand`/`name`, so both are always populated.

Not a breaking change: a set `size` is never dropped, so existing `size` users are unaffected, and nothing reads `useTheme().density` yet. It is a consistency follow-up that completes the `size` → `density` mirroring so `density` behaves like `brand` before consumers adopt it.
