### PR TITLE
chore: correct the @babel/runtime-corejs3 dependency comment

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/postbuild.test.ts
@@ -1074,13 +1074,8 @@ describe('review rule metadata build', () => {
 
 describe('package.json dependencies', () => {
   it('includes @babel/runtime-corejs3 as a runtime dependency', () => {
-    // The published build artifacts contain imports from
-    // "@babel/runtime-corejs3/helpers/esm/*" because they were compiled with
-    // @babel/plugin-transform-runtime using corejs: 3. Consumers bundling with
-    // tools like esbuild or Vite will get a build error if this package is not
-    // listed as a dependency in the published package.json.
-    // See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
-    //      https://github.com/dnbexperience/eufemia/pull/8016 (re-added)
+    // Intentionally kept as a runtime dependency; see #7994 (removed) and
+    // #8016 (reverted).
     const packageJson = fs.readJsonSync(
       path.resolve(PKG_ROOT, 'package.json')
     )

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
@@ -32,13 +32,8 @@ describe('cleanupPackage', () => {
   })
 
   it('includes @babel/runtime-corejs3 as a runtime dependency', async () => {
-    // The published build artifacts contain imports from
-    // "@babel/runtime-corejs3/helpers/esm/*" because they were compiled with
-    // @babel/plugin-transform-runtime using corejs: 3. Consumers bundling with
-    // tools like esbuild or Vite will get a build error if this package is not
-    // listed as a dependency in the published package.json.
-    // See: https://github.com/dnbexperience/eufemia/pull/7994 (accidental removal)
-    //      https://github.com/dnbexperience/eufemia/pull/8016 (re-added)
+    // Intentionally kept as a runtime dependency; see #7994 (removed) and
+    // #8016 (reverted).
     const filepath = path.resolve(PKG_ROOT, 'package.json')
     const packageString = await fs.readFile(filepath, 'utf-8')
     const cleanedPackage = await cleanupPackage({
@@ -173,12 +168,8 @@ describe('package.json', () => {
   })
 
   it('has @babel/runtime-corejs3 as a dependency', () => {
-    // The published build artifacts (e.g. build/shared/useTranslation.js) contain
-    // imports from "@babel/runtime-corejs3/helpers/esm/*" because they were compiled
-    // with @babel/plugin-transform-runtime using corejs: 3. Consumers who do not have
-    // this package installed (e.g. via bundlers like esbuild or Vite) will get a
-    // build error if this runtime dependency is missing from the published package.
-    // See: https://github.com/dnbexperience/eufemia/issues/7994
+    // Intentionally kept as a runtime dependency; see #7994 (removed) and
+    // #8016 (reverted).
     expect(
       (packageJson as { dependencies?: Record<string, string> })
         .dependencies


### PR DESCRIPTION
The tests guarding `@babel/runtime-corejs3` claimed the compiled output imports `@babel/runtime-corejs3/helpers/esm/*` because it is built with `corejs: 3`. That is inaccurate: the Babel config does not set `corejs` on `@babel/plugin-transform-runtime` (polyfills come from `core-js-pure`), and a clean build emits no such imports.

This corrects the comment so it no longer states a wrong reason, while keeping the #7994 (removed) → #8016 (reverted) history that explains why the dependency is intentionally kept.

Supersedes #9203 (that PR was closed and could not be reopened after the branch was force-pushed).
