### PR TITLE
chore(Form.Section): disable section fields while an async onDone is pending

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import type { ReactNode } from 'react'
 import { clsx } from 'clsx'
@@ -26,6 +27,7 @@ import useReportError from '../../Isolation/useReportError'
 import { useShowStatus } from '../../Isolation/useHandleStatus'
 import useContainerDataStore from './useContainerDataStore'
 import EditContainerContext from './EditContainerContext'
+import FieldPropsProvider from '../../../Field/Provider'
 import SectionContext from '../SectionContext'
 
 export type FormSectionEditContainerProps = {
@@ -67,6 +69,7 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   const dataStore = useContainerDataStore({
     enabled: true,
   })
+  const [isPending, setIsPending] = useState(false)
   const preventNavigation = preventUncommittedChanges
   const hasUncommittedChanges =
     preventNavigation && dataStore.hasUncommittedChanges
@@ -118,7 +121,9 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
   )
 
   return (
-    <EditContainerContext value={dataStore}>
+    <EditContainerContext
+      value={{ ...dataStore, isPending, setIsPending }}
+    >
       <FieldBoundaryProvider
         showErrors={validateInitially}
         onPathError={onPathError}
@@ -135,7 +140,11 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
             className="dnb-forms-section-block__content"
           >
             {title && <Lead size="basis">{title}</Lead>}
-            {children}
+            <FieldPropsProvider
+              formElement={isPending ? { disabled: true } : undefined}
+            >
+              {children}
+            </FieldPropsProvider>
             {hasToolbar ? null : (
               <Toolbar onDone={onDone} onCancel={onCancel}>
                 <DoneButton />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerContext.ts
@@ -2,6 +2,10 @@ import { createContext } from 'react'
 
 export type EditContainerContextState = {
   restoreOriginalData: () => void
+
+  /** True while an async "onDone" Promise is pending */
+  isPending?: boolean
+  setIsPending?: (isPending: boolean) => void
 }
 
 const EditContainerContext = createContext<

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
@@ -1,0 +1,138 @@
+import { render, waitFor } from '@testing-library/react'
+import { Field, Form, Value } from '../../../..'
+import userEvent from '@testing-library/user-event'
+
+describe('EditContainer async onDone', () => {
+  it('should not commit values that were changed after an async onDone started', async () => {
+    const formId = 'async-done-no-stale-commit'
+    let resolveOnDone!: () => void
+    const saved: string[] = []
+
+    const onDone = () => {
+      const { getValue } = Form.getData(formId)
+      saved.push(String(getValue('/name')))
+
+      return new Promise<void>((resolve) => {
+        resolveOnDone = resolve
+      })
+    }
+
+    render(
+      <Form.Handler id={formId} defaultData={{ name: 'Ada' }}>
+        <Form.Section containerMode="edit">
+          <Form.Section.EditContainer onDone={onDone}>
+            <Field.String path="/name" />
+          </Form.Section.EditContainer>
+
+          <Form.Section.ViewContainer>
+            <Value.String path="/name" />
+          </Form.Section.ViewContainer>
+        </Form.Section>
+      </Form.Handler>
+    )
+
+    const input = document.querySelector('input')
+    expect(input).toHaveValue('Ada')
+
+    await userEvent.click(
+      document.querySelector('.dnb-forms-section-edit-block button')
+    )
+    expect(saved).toEqual(['Ada'])
+
+    // The field is disabled while the save is pending, so typing cannot
+    // change a value the pending save will not include.
+    expect(input).toBeDisabled()
+    await userEvent.type(input, 'Grace')
+    expect(input).toHaveValue('Ada')
+
+    resolveOnDone()
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-forms-section-view-block')
+      ).not.toHaveAttribute('aria-hidden', 'true')
+    })
+
+    // What the view shows is what the save actually received
+    expect(saved).toEqual(['Ada'])
+    expect(
+      document.querySelector('.dnb-forms-section-view-block')
+    ).toHaveTextContent('Ada')
+  })
+
+  it('should enable the fields again when an async onDone rejects', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+      </Form.Section>
+    )
+
+    const input = document.querySelector('input')
+    await userEvent.click(
+      document.querySelector('.dnb-forms-section-edit-block button')
+    )
+    expect(input).toBeDisabled()
+
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(input).not.toBeDisabled()
+    })
+
+    // The user can correct the value and try again
+    await userEvent.type(input, 'Grace')
+    expect(input).toHaveValue('Grace')
+  })
+
+  it('should not disable the fields when onDone is synchronous', async () => {
+    const onDone = vi.fn()
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+      </Form.Section>
+    )
+
+    const input = document.querySelector('input')
+    expect(input).not.toBeDisabled()
+
+    await userEvent.click(
+      document.querySelector('.dnb-forms-section-edit-block button')
+    )
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(input).not.toBeDisabled()
+  })
+
+  it('should keep inheriting a form level disabled state', async () => {
+    render(
+      <Form.Handler disabled>
+        <Form.Section containerMode="edit">
+          <Form.Section.EditContainer onDone={vi.fn()}>
+            <Field.String path="/name" />
+          </Form.Section.EditContainer>
+
+          <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+        </Form.Section>
+      </Form.Handler>
+    )
+
+    expect(document.querySelector('input')).toBeDisabled()
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/Toolbar.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { useTranslation } from '../../../hooks'
 import ToolbarContext from './ToolbarContext'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
+import EditContainerContext from '../EditContainer/EditContainerContext'
 import { Hr } from '../../../../../elements'
 import { Flex, FormStatus } from '../../../../../components'
 import type { SpaceAllProps } from '../../../../../components/Space'
@@ -21,7 +22,15 @@ export default function Toolbar(props: FormSectionToolbarProps) {
   const { hasError, hasVisibleError } =
     useContext(FieldBoundaryContext) || {}
   const [showError, setShowError] = useState(false)
-  const [isPending, setIsPending] = useState(false)
+
+  // Inside an EditContainer the pending state is owned there, so the
+  // container can also disable its fields while the save is in flight.
+  // A standalone Form.Section.Toolbar keeps its own state.
+  const editContainerContext = useContext(EditContainerContext)
+  const [ownIsPending, setOwnIsPending] = useState(false)
+  const isPending = editContainerContext?.isPending ?? ownIsPending
+  const setIsPending =
+    editContainerContext?.setIsPending ?? setOwnIsPending
 
   useEffect(() => {
     if (showError && !hasError) {


### PR DESCRIPTION
Follow-up to #9197.
Deploy preview: https://fix-form-section-disable-fie.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Section/EditContainer/demos/#async-ondone

## The problem

#9197 disables the Done and Cancel buttons while a Promise returned from `onDone` is pending, but leaves the fields editable. Editing during that window makes the section commit a value the save never received:

1. the user selects **Done**; `onDone` reads `"Ada"` and starts saving
2. the user corrects the field to `"Grace"` while the save is in flight
3. the save resolves, and the section switches to view mode
4. view mode shows `"Grace"` — the server has `"Ada"`

Measured on `main`:

| | Value |
| --- | --- |
| What `onDone` sent | `"Ada"` |
| What view mode then displays | `"Grace"` |

Nothing tells the user their last edit was dropped. The section presents it as saved.

The window is short, but the failure is silent, which is what makes it worth fixing rather than documenting.

## The change

`Form.Handler` already solves this for submits — from its own `onSubmit` documentation:

> When an async function is provided, it will show an indicator on the submit button during the form submission. **All form elements will be disabled during the submit.**

This applies the same treatment, scoped to the section, by wrapping the container's children in the same `FieldPropsProvider` mechanism `DataContext` uses for that:

```tsx
<FieldPropsProvider
  formElement={isPending ? { disabled: true } : undefined}
>
  {children}
</FieldPropsProvider>
```

The pending state moves from `Toolbar` up into `EditContainer`, because the fields are **siblings** of the `Toolbar` and cannot read state owned by it. Consequences:

- A standalone `Form.Section.Toolbar` keeps its own state, so its behaviour is unchanged.
- A `Toolbar` passed as a child of `EditContainer` (the `hasToolbar` path) now shares the container's state, so both arrangements behave the same.

Note the provider passes **no `formElement` at all** when idle, rather than `disabled: false`. `SharedProvider` merges with the outer context, so an absent key inherits a form level disabled state while `disabled: false` would override it. The `should keep inheriting a form level disabled state` test fails if this is passed unconditionally — I verified that by making it so.

`FieldPropsProvider` renders only context providers, no DOM, so the rendered output is unchanged and the `Form.Section` visual tests are unaffected.

## Tests

Four tests added. Two fail on `main` and pass here:

- `should not commit values that were changed after an async onDone started` — **fails on `main`**
- `should enable the fields again when an async onDone rejects` — **fails on `main`**
- `should not disable the fields when onDone is synchronous` — guard; verified it fails if the fields are disabled unconditionally
- `should keep inheriting a form level disabled state` — guard; verified it fails if `formElement` is passed when idle

Verified: 17/17 test files across every suite that renders `Section.EditContainer`, `Section.Toolbar`, `Iterate.EditContainer` or `Field.Provider`; the `Form/Section` tree run three times for stability; lint clean; `test:types` produces a byte-identical error set to `main`.

## Merge order

Touches `EditContainer.tsx` and `Toolbar.tsx`, which #9206 also touches (different hunks — the `onDone` type declaration). Independent in intent; whichever lands second may need a trivial rebase.
