### PR TITLE
fix(Form.Section): restore focus after a failed async EditContainer save

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useRef } from 'react'
 import SectionContainerContext from '../containers/SectionContainerContext'
 import ToolbarContext from '../Toolbar/ToolbarContext'
 import { useTranslation } from '../../../hooks'
@@ -6,6 +6,7 @@ import { Button } from '../../../../../components'
 import { check } from '../../../../../icons'
 import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBoundaryContext'
 import SubmitIndicator from '../../SubmitIndicator'
+import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../../shared/helpers/useIsomorphicLayoutEffect'
 
 export default function DoneEditButton() {
   const { onDone, setShowError, isPending, setIsPending } =
@@ -15,6 +16,27 @@ export default function DoneEditButton() {
   const { hasError, hasVisibleError, setShowBoundaryErrors } =
     useContext(FieldBoundaryContext) || {}
   const translation = useTranslation().SectionEditContainer
+  const buttonRef = useRef<HTMLElement>(null)
+  const restoreFocusRef = useRef(false)
+
+  // Disabling the button while it is pending removes it from the focus
+  // order, which makes browsers move focus to the document body. When the
+  // section stays in edit mode (rejected Promise), move focus back so the
+  // user keeps their place. Focus is only reclaimed when it was actually
+  // lost, to avoid taking it away from somewhere the user moved it to.
+  // On a resolved Promise, SectionContainer handles focus when the view
+  // container opens. A layout effect restores focus in the same commit
+  // that enables the button again.
+  useLayoutEffect(() => {
+    if (!isPending && restoreFocusRef.current) {
+      restoreFocusRef.current = false
+
+      if (document.activeElement === document.body) {
+        buttonRef.current?.focus?.()
+      }
+    }
+  }, [isPending])
+
   const doneHandler = useCallback(() => {
     if (isPending) {
       return
@@ -38,6 +60,7 @@ export default function DoneEditButton() {
             switchContainerMode?.('view')
           },
           () => {
+            restoreFocusRef.current = true
             setIsPending?.(false)
           }
         )
@@ -63,6 +86,7 @@ export default function DoneEditButton() {
       iconPosition="left"
       onClick={doneHandler}
       disabled={isPending}
+      ref={buttonRef}
     >
       {translation.doneButton}
       {isPending && <SubmitIndicator state="pending" />}

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/DoneButtonFocus.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/DoneButtonFocus.test.tsx
@@ -1,0 +1,85 @@
+import { render, waitFor } from '@testing-library/react'
+import { Field, Form } from '../../../..'
+import userEvent from '@testing-library/user-event'
+
+describe('EditContainer done button focus', () => {
+  const renderSection = (onDone: () => void | Promise<unknown>) =>
+    render(
+      <>
+        {/* Focus target outside the section, so it stays focusable while
+        the section is pending */}
+        <button type="button" data-testid="outside">
+          outside
+        </button>
+
+        <Form.Section containerMode="edit">
+          <Form.Section.EditContainer onDone={onDone}>
+            <Field.String path="/name" />
+          </Form.Section.EditContainer>
+
+          <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+        </Form.Section>
+      </>
+    )
+
+  const getDoneButton = () =>
+    document.querySelector('.dnb-forms-section-edit-block button')
+
+  const getOutsideButton = () =>
+    document.querySelector('[data-testid="outside"]') as HTMLButtonElement
+
+  it('should move focus back to the done button when async onDone rejects', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+
+    renderSection(onDone)
+
+    const doneButton = getDoneButton()
+    await userEvent.click(doneButton)
+    expect(doneButton).toBeDisabled()
+
+    // Browsers move focus to the document body when the focused element
+    // becomes disabled, while jsdom keeps the focus. Reproduce the browser
+    // behavior, so the focus can be verified as restored.
+    getOutsideButton().focus()
+    getOutsideButton().blur()
+    expect(document.body).toHaveFocus()
+
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(doneButton).toHaveFocus()
+  })
+
+  it('should not move focus when the user moved it elsewhere while async onDone was pending', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+
+    renderSection(onDone)
+
+    const doneButton = getDoneButton()
+    await userEvent.click(doneButton)
+
+    getOutsideButton().focus()
+    expect(getOutsideButton()).toHaveFocus()
+
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(getOutsideButton()).toHaveFocus()
+  })
+})


### PR DESCRIPTION
Follow-up to #9197.

Deploy preview: https://fix-form-section-restore-foc.eufemia-e25.pages.dev/uilib/extensions/forms/Form/Section/EditContainer/demos/#async-ondone

Select "Ja" for Simulate save error.

## The problem

#9197 disables the Done button while a Promise returned from `onDone` is pending. Browsers blur a focused element that becomes `disabled`, so activating Done drops focus to the document body — and nothing puts it back when the save fails.

Measured in Chromium against the #9197 preview build, focusing Done and pressing <kbd>Enter</kbd>:

| Moment | `document.activeElement` |
| --- | --- |
| Before activating | the Done button |
| While the save is pending | `<body>` |
| After the save fails | `<body>` |

A keyboard or screen-reader user is left with no focus position next to the error they need to act on. The error itself is announced (`role="alert"`), and <kbd>Tab</kbd> resumes at Cancel rather than the top of the page, so this is about losing your place rather than being stranded — but it is still a focus-management defect in a state the component created.

jsdom keeps focus on a disabled element, which is why the existing tests looked clean. The test added here reproduces the browser behaviour explicitly.

## The change

Focus returns to the Done button when the Promise rejects — but only when it was **actually lost**:

```tsx
if (document.activeElement === document.body) {
  buttonRef.current?.focus?.()
}
```

Without that condition the fix would *steal* focus from a user who moved it elsewhere while the save was in flight. That was a real flaw in my first attempt; the `should not move focus when the user moved it elsewhere` test fails if the condition is removed, which I verified by removing it.

A layout effect is used rather than a passive effect, so focus is restored in the same commit that re-enables the button. With a passive effect, `waitFor` can observe the button enabled *before* focus is restored — which made the test pass alone and fail in a larger run. `useIsomorphicLayoutEffect` is the repo's own SSR-safe helper, already used in `SubmitIndicator` and `Section`.

Nothing changes on the resolved path: `SectionContainer` already moves focus when the view container opens.

## Tests

Two tests added:

- `should move focus back to the done button when async onDone rejects` — **fails on `main`** (reproduced twice)
- `should not move focus when the user moved it elsewhere while async onDone was pending` — guard; verified it fails when the "focus was actually lost" condition is removed

I also wrote a third test asserting focus is *not* reclaimed on the resolved path, then deleted it: I could not make it fail. Setting the restore flag on the resolve path too still passes, because the view container's own focus management takes over and masks the difference. It could not fail, so it would only have implied coverage it did not provide.

Verified: 15/15 test files across every suite that renders `Section.EditContainer`, `Section.Toolbar` or `Iterate.EditContainer`; the `Form/Section` tree run five times to confirm the focus test is not flaky; lint clean; `test:types` produces a byte-identical error set to `main`.

The rendered output is unchanged in the non-pending state (a `ref` and an effect only), so the `Form.Section` visual tests are unaffected.

## Merge order

Touches `DoneButton.tsx`, which #9206 also touches (a different hunk — the `instanceof Promise` check). Independent in intent; whichever lands second may need a trivial rebase.
