### PR TITLE
chore(analytics): show snapshot freshness in the dashboard empty state

### DIFF
--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -6,7 +6,7 @@ import {
   clearSession,
   readSession,
 } from '../dashboard/auth.js'
-import { loadDashboardData } from '../dashboard/app.js'
+import { loadDashboardData, snapshotMeta } from '../dashboard/app.js'
 
 class MemoryStorage {
   store = new Map()
@@ -256,5 +256,32 @@ describe('loadDashboardData', () => {
     ).toEqual({
       kind: 'empty',
     })
+  })
+})
+
+describe('snapshotMeta', () => {
+  const generatedAt = '2026-09-02T10:00:00.000Z'
+
+  it('reports the snapshot time when there are records', () => {
+    const text = snapshotMeta({ generatedAt }, 3)
+
+    expect(text.startsWith('Snapshot generated ')).toBe(true)
+    expect(text).toContain(new Date(generatedAt).toLocaleString())
+  })
+
+  it('surfaces the snapshot time in the empty state', () => {
+    const text = snapshotMeta({ generatedAt, records: [] }, 0)
+
+    expect(text.startsWith('No data yet (snapshot generated ')).toBe(true)
+    expect(text).toContain(new Date(generatedAt).toLocaleString())
+  })
+
+  it('falls back to a plain empty message without a snapshot time', () => {
+    expect(snapshotMeta({}, 0)).toBe('No data yet.')
+    expect(snapshotMeta(null, 0)).toBe('No data yet.')
+  })
+
+  it('returns nothing when records exist but no snapshot time is present', () => {
+    expect(snapshotMeta({}, 5)).toBe('')
   })
 })

--- a/tools/analytics/__tests__/dashboard.test.js
+++ b/tools/analytics/__tests__/dashboard.test.js
@@ -270,7 +270,7 @@ describe('snapshotMeta', () => {
   })
 
   it('surfaces the snapshot time in the empty state', () => {
-    const text = snapshotMeta({ generatedAt, records: [] }, 0)
+    const text = snapshotMeta({ generatedAt }, 0)
 
     expect(text.startsWith('No data yet (snapshot generated ')).toBe(true)
     expect(text).toContain(new Date(generatedAt).toLocaleString())

--- a/tools/analytics/dashboard/app.js
+++ b/tools/analytics/dashboard/app.js
@@ -35,6 +35,24 @@ function toRecords(payload) {
 }
 
 /**
+ * Freshness line for the meta row. Surfaces the snapshot time even when there
+ * are no records, so a viewer can tell the pipeline ran and the data is empty
+ * rather than stale.
+ */
+export function snapshotMeta(payload, count) {
+  const generated = payload && payload.generatedAt
+  const when = generated ? new Date(generated).toLocaleString() : ''
+
+  if (count === 0) {
+    return when
+      ? `No data yet (snapshot generated ${when}).`
+      : 'No data yet.'
+  }
+
+  return when ? `Snapshot generated ${when}` : ''
+}
+
+/**
  * Fetch dashboard records from the protected API. Returns a discriminated
  * result so the caller owns DOM and navigation; this function only manages the
  * sign-in retry marker:
@@ -270,16 +288,13 @@ async function main() {
   const payload = result.kind === 'data' ? result.payload : null
   const all = toRecords(payload).map(normalise)
 
+  document.getElementById('meta').textContent = snapshotMeta(
+    payload,
+    all.length
+  )
+
   if (all.length === 0) {
-    document.getElementById('meta').textContent = 'No data yet.'
-
     return
-  }
-
-  const generated = payload && payload.generatedAt
-  if (generated) {
-    document.getElementById('meta').textContent =
-      `Snapshot generated ${new Date(generated).toLocaleString()}`
   }
 
   const apply = (env) =>


### PR DESCRIPTION
The dashboard empty state previously showed only "No data yet." and discarded the snapshot timestamp, so a viewer could not tell whether the pipeline had run or the data was simply stale. It now surfaces the snapshot time in the empty state too ("No data yet (snapshot generated <time>).").