### PR TITLE
feat(Switch): add fast bounce motion

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -17,19 +17,17 @@ All the [components](/uilib/components) share a couple of commonly used helpers.
 
 ### Animation easing
 
-You can use the internal Eufemia easing function.
+Eufemia provides reusable easing curves for consistent motion:
+
+- `--easing-default` for standard transitions.
+- `--easing-fast-bounce` for short interactions that should settle with a subtle overshoot.
 
 ```css
 .animation-element {
   transition: transform 400ms var(--easing-default);
 }
-```
 
-For short interactions that should settle with a subtle overshoot, use the
-faster bounce curve.
-
-```css
-.animation-element {
+.bouncing-animation-element {
   transition: transform 180ms var(--easing-fast-bounce);
 }
 ```

--- a/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/helpers/info.mdx
@@ -25,6 +25,15 @@ You can use the internal Eufemia easing function.
 }
 ```
 
+For short interactions that should settle with a subtle overshoot, use the
+faster bounce curve.
+
+```css
+.animation-element {
+  transition: transform 180ms var(--easing-fast-bounce);
+}
+```
+
 ## CSS classes
 
 - [dnb-core-style](/uilib/helpers/classes#core-style): A CSS-reset and core styling, including font, line-height and color.

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/__snapshots__/makePropertiesFile.test.ts.snap
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/__snapshots__/makePropertiesFile.test.ts.snap
@@ -186,6 +186,7 @@ export default {
   '--shadow-sharp-blur-radius': '6px',
   '--shadow-sharp-color': 'rgb(0 0 0 / 16%)',
   '--easing-default': 'cubic-bezier(0.42, 0, 0, 1)',
+  '--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
   '--focus-ring-width': '0.25rem'
 }; // prettier-ignore
 "
@@ -377,6 +378,7 @@ export default {
   '--shadow-sharp-blur-radius': '6px',
   '--shadow-sharp-color': 'rgb(0 0 0 / 16%)',
   '--easing-default': 'cubic-bezier(0.42, 0, 0, 1)',
+  '--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
   '--focus-ring-width': '0.25rem'
 }; // prettier-ignore
 "

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makePropertiesFile.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makePropertiesFile.test.ts
@@ -565,6 +565,9 @@ describe('makePropertiesFile', () => {
       expect(global.ui).toMatchSnapshot()
       expect(global.ui).toContain(`'--font-size-large': '1.625rem'`)
       expect(global.ui).toContain(
+        `'--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)'`
+      )
+      expect(global.ui).toContain(
         `'--font-family-default': "'DNB', sans-serif"`
       )
     })

--- a/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -305,7 +305,12 @@ button .dnb-form-status__text {
   height: var(--switch-button-size-off--medium);
   color: var(--switch-checked-icon);
   background-color: var(--switch-button-background);
-  transition: transform 160ms ease-out 125ms;
+  transition: transform 180ms var(--easing-fast-bounce);
+}
+@media (prefers-reduced-motion: reduce) {
+  .dnb-switch__button {
+    transition-duration: 0.01ms;
+  }
 }
 .dnb-switch--large .dnb-switch__button {
   width: var(--switch-button-size-off--large);

--- a/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
+++ b/packages/dnb-eufemia/src/components/switch/style/dnb-switch.scss
@@ -119,7 +119,11 @@
     color: var(--switch-checked-icon);
     background-color: var(--switch-button-background);
 
-    transition: transform 160ms ease-out 125ms;
+    transition: transform 180ms var(--easing-fast-bounce);
+
+    @include utilities.reducedMotion() {
+      transition-duration: 0.01ms;
+    }
 
     .dnb-switch--large & {
       width: var(--switch-button-size-off--large);

--- a/packages/dnb-eufemia/src/style/themes/carnegie/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/carnegie/properties-tailwind.css
@@ -185,5 +185,6 @@
   --shadow-sharp-blur-radius: 6px;
   --shadow-sharp-color: rgb(0 0 0 / 16%);
   --ease-default: cubic-bezier(0.42, 0, 0, 1);
+  --ease-fast-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
   --focus-ring-width: 0.25rem;
 }

--- a/packages/dnb-eufemia/src/style/themes/carnegie/properties.ts
+++ b/packages/dnb-eufemia/src/style/themes/carnegie/properties.ts
@@ -183,5 +183,6 @@ export default {
   '--shadow-sharp-blur-radius': '6px',
   '--shadow-sharp-color': 'rgb(0 0 0 / 16%)',
   '--easing-default': 'cubic-bezier(0.42, 0, 0, 1)',
+  '--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
   '--focus-ring-width': '0.25rem'
 }; // prettier-ignore

--- a/packages/dnb-eufemia/src/style/themes/eiendom/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/eiendom/properties-tailwind.css
@@ -185,5 +185,6 @@
   --shadow-sharp-blur-radius: 6px;
   --shadow-sharp-color: rgb(0 0 0 / 16%);
   --ease-default: cubic-bezier(0.42, 0, 0, 1);
+  --ease-fast-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
   --focus-ring-width: 0.25rem;
 }

--- a/packages/dnb-eufemia/src/style/themes/eiendom/properties.ts
+++ b/packages/dnb-eufemia/src/style/themes/eiendom/properties.ts
@@ -183,5 +183,6 @@ export default {
   '--shadow-sharp-blur-radius': '6px',
   '--shadow-sharp-color': 'rgb(0 0 0 / 16%)',
   '--easing-default': 'cubic-bezier(0.42, 0, 0, 1)',
+  '--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
   '--focus-ring-width': '0.25rem'
 }; // prettier-ignore

--- a/packages/dnb-eufemia/src/style/themes/sbanken/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/properties-tailwind.css
@@ -185,5 +185,6 @@
   --shadow-sharp-blur-radius: 6px;
   --shadow-sharp-color: rgb(0 0 0 / 16%);
   --ease-default: cubic-bezier(0.42, 0, 0, 1);
+  --ease-fast-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
   --focus-ring-width: 0.25rem;
 }

--- a/packages/dnb-eufemia/src/style/themes/sbanken/properties.ts
+++ b/packages/dnb-eufemia/src/style/themes/sbanken/properties.ts
@@ -183,5 +183,6 @@ export default {
   '--shadow-sharp-blur-radius': '6px',
   '--shadow-sharp-color': 'rgb(0 0 0 / 16%)',
   '--easing-default': 'cubic-bezier(0.42, 0, 0, 1)',
+  '--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
   '--focus-ring-width': '0.25rem'
 }; // prettier-ignore

--- a/packages/dnb-eufemia/src/style/themes/ui/properties-tailwind.css
+++ b/packages/dnb-eufemia/src/style/themes/ui/properties-tailwind.css
@@ -185,5 +185,6 @@
   --shadow-sharp-blur-radius: 6px;
   --shadow-sharp-color: rgb(0 0 0 / 16%);
   --ease-default: cubic-bezier(0.42, 0, 0, 1);
+  --ease-fast-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
   --focus-ring-width: 0.25rem;
 }

--- a/packages/dnb-eufemia/src/style/themes/ui/properties.scss
+++ b/packages/dnb-eufemia/src/style/themes/ui/properties.scss
@@ -104,6 +104,7 @@
 
   // Easing
   --easing-default: cubic-bezier(0.42, 0, 0, 1);
+  --easing-fast-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
 
   // Width
   --prose-max-width: 60ch;

--- a/packages/dnb-eufemia/src/style/themes/ui/properties.ts
+++ b/packages/dnb-eufemia/src/style/themes/ui/properties.ts
@@ -183,5 +183,6 @@ export default {
   '--shadow-sharp-blur-radius': '6px',
   '--shadow-sharp-color': 'rgb(0 0 0 / 16%)',
   '--easing-default': 'cubic-bezier(0.42, 0, 0, 1)',
+  '--easing-fast-bounce': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
   '--focus-ring-width': '0.25rem'
 }; // prettier-ignore


### PR DESCRIPTION
Adds a reusable fast-bounce easing curve for short interactions and applies it to the Switch thumb. This removes the existing delay so state changes feel faster while retaining reduced-motion behavior. Stacked on #9214.


Motivation: https://dnb-it.slack.com/archives/C081G91GCT0/p1788271813754589
Preview: https://feat-switch-fast-bounce-easi.eufemia-e25.pages.dev/uilib/components/switch/demos