### PR TITLE
refactor(VisibilityByTheme): add `Brand` and deprecate `Name`

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/eufemia/v13-info.mdx
@@ -72,6 +72,13 @@ The deprecated `size` property, `ThemeSizes` type, `data-size` attribute, and `e
 +<Theme density="basis">
 ```
 
+The deprecated `VisibilityByTheme.Name` component has been removed. Use `VisibilityByTheme.Brand` instead.
+
+```diff
+-<VisibilityByTheme.Name />
++<VisibilityByTheme.Brand />
+```
+
 ### [Flex](/uilib/layout/flex/)
 
 Flex now uses native CSS gap and renders React children unchanged. The following legacy migration APIs are deprecated:

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -6,7 +6,7 @@ order: 3
 import { GetPropValue, GetPropAsPx } from './_helpers.tsx'
 import ChangeStyleTheme from '../../../core/ChangeStyleTheme'
 
-# Font Size for <VisibilityByTheme.Name />
+# Font Size for <VisibilityByTheme.Brand />
 
 <ChangeStyleTheme label="Change the brand:" bottom="large" />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-weight.mdx
@@ -7,7 +7,7 @@ import { FontWeightByThemeExample } from 'Docs/uilib/typography/Examples'
 import { GetPropValue } from './_helpers.tsx'
 import ChangeStyleTheme from '../../../core/ChangeStyleTheme'
 
-# Font Weights for <VisibilityByTheme.Name />
+# Font Weights for <VisibilityByTheme.Brand />
 
 <ChangeStyleTheme label="Change the brand:" bottom="large" />
 
@@ -54,6 +54,6 @@ p {
 <span class="dnb-t__weight--bold">Third Tag</span>
 ```
 
-## <VisibilityByTheme.Name /> weight examples
+## <VisibilityByTheme.Brand /> weight examples
 
 <FontWeightByThemeExample />

--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/line-height.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/line-height.mdx
@@ -6,7 +6,7 @@ order: 4
 import { GetPropValue, GetPropAsPx } from './_helpers.tsx'
 import ChangeStyleTheme from '../../../core/ChangeStyleTheme'
 
-# Line Height for <VisibilityByTheme.Name />
+# Line Height for <VisibilityByTheme.Brand />
 
 <ChangeStyleTheme label="Change the brand:" bottom="large" />
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/usage/customisation/theming/theme/info.mdx
@@ -274,6 +274,20 @@ render(
 )
 ```
 
+### Show the inherited brand name
+
+`VisibilityByTheme.Brand` renders the display name of the inherited theme brand – `DNB`, `Sbanken`, `Eiendom` or `Carnegie`. It renders nothing when no theme was inherited.
+
+```tsx
+import { Theme, VisibilityByTheme } from '@dnb/eufemia/shared'
+
+render(
+  <Theme brand="sbanken">
+    Colors for <VisibilityByTheme.Brand />
+  </Theme>
+)
+```
+
 ### Integrations
 
 When integrating runtime theme switching, your app can be wrapped with this theme component.

--- a/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
+++ b/packages/dnb-eufemia/src/shared/VisibilityByTheme.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import useTheme from './useTheme'
+import type { UseThemeReturn } from './useTheme'
 import type { ThemeNames, ThemeProps } from './Theme'
 
 type VisibilityByThemeProps = {
@@ -47,8 +48,12 @@ export default function VisibilityByTheme({
 
   return children
 
-  function match(theme: ThemeProps) {
+  function match(theme: UseThemeReturn) {
     return (themeItem: ThemeItem) => {
+      if (!theme) {
+        return false
+      }
+
       return typeof themeItem === 'string'
         ? theme.brand === themeItem
         : matchObject(theme, themeItem)
@@ -64,19 +69,30 @@ export default function VisibilityByTheme({
   }
 }
 
-VisibilityByTheme.Name = function ThemeName() {
+/**
+ * Renders the display name of the inherited theme brand,
+ * such as "DNB", "Sbanken", "Eiendom" or "Carnegie".
+ * Renders nothing when the brand is unknown or no theme was inherited.
+ */
+VisibilityByTheme.Brand = function ThemeBrand() {
   const theme = useTheme()
   if (theme?.isCarnegie) {
     return 'Carnegie'
   }
-  if (theme.isEiendom) {
+  if (theme?.isEiendom) {
     return 'Eiendom'
   }
-  if (theme.isSbanken) {
+  if (theme?.isSbanken) {
     return 'Sbanken'
   }
-  if (theme.isUi) {
+  if (theme?.isUi) {
     return 'DNB'
   }
   return undefined
 }
+
+/**
+ * Deprecated. Use `VisibilityByTheme.Brand` instead.
+ * @deprecated Use `VisibilityByTheme.Brand` instead. This will be removed in v13.
+ */
+VisibilityByTheme.Name = VisibilityByTheme.Brand

--- a/packages/dnb-eufemia/src/shared/__tests__/VisibilityByTheme.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/VisibilityByTheme.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
 import Theme from '../Theme'
+import type { ThemeNames } from '../Theme'
 import VisibilityByTheme from '../VisibilityByTheme'
 
 describe('VisibilityByTheme', () => {
@@ -152,6 +153,117 @@ describe('VisibilityByTheme', () => {
     expect(document.body.textContent).toBe("I'm visible")
 
     rerender(<Component name="sbanken" variant="red" />)
+
+    expect(document.body.textContent).toBe('')
+  })
+
+  describe('without a theme context', () => {
+    it('renders content if not visible or hidden was given', () => {
+      render(
+        <VisibilityByTheme>
+          <p>I'm visible</p>
+        </VisibilityByTheme>
+      )
+
+      expect(document.body.textContent).toBe("I'm visible")
+    })
+
+    it('skips render when visible was given as a brand', () => {
+      render(
+        <VisibilityByTheme visible="sbanken">
+          <p>I'm visible</p>
+        </VisibilityByTheme>
+      )
+
+      expect(document.body.textContent).toBe('')
+    })
+
+    it('skips render when visible was given as an object', () => {
+      render(
+        <VisibilityByTheme visible={[{ brand: 'sbanken' }]}>
+          <p>I'm visible</p>
+        </VisibilityByTheme>
+      )
+
+      expect(document.body.textContent).toBe('')
+    })
+
+    it('renders content when hidden was given', () => {
+      render(
+        <VisibilityByTheme hidden="sbanken">
+          <p>I'm visible</p>
+        </VisibilityByTheme>
+      )
+
+      expect(document.body.textContent).toBe("I'm visible")
+    })
+  })
+})
+
+describe('VisibilityByTheme.Brand', () => {
+  it.each([
+    ['ui', 'DNB'],
+    ['sbanken', 'Sbanken'],
+    ['eiendom', 'Eiendom'],
+    ['carnegie', 'Carnegie'],
+  ] as const)('renders the label of the %s brand', (brand, label) => {
+    render(
+      <Theme brand={brand}>
+        <VisibilityByTheme.Brand />
+      </Theme>
+    )
+
+    expect(document.body.textContent).toBe(label)
+  })
+
+  it('renders nothing when the brand is unknown', () => {
+    render(
+      <Theme brand={'unknown' as ThemeNames}>
+        <VisibilityByTheme.Brand />
+      </Theme>
+    )
+
+    expect(document.body.textContent).toBe('')
+  })
+
+  it('renders nothing without a theme context', () => {
+    render(<VisibilityByTheme.Brand />)
+
+    expect(document.body.textContent).toBe('')
+  })
+})
+
+describe('VisibilityByTheme.Name', () => {
+  it.each([
+    ['ui', 'DNB'],
+    ['sbanken', 'Sbanken'],
+    ['eiendom', 'Eiendom'],
+    ['carnegie', 'Carnegie'],
+  ] as const)(
+    'renders the same label as Brand for the %s brand',
+    (brand, label) => {
+      const { unmount } = render(
+        <Theme brand={brand}>
+          <VisibilityByTheme.Name />
+        </Theme>
+      )
+
+      expect(document.body.textContent).toBe(label)
+
+      unmount()
+
+      render(
+        <Theme brand={brand}>
+          <VisibilityByTheme.Brand />
+        </Theme>
+      )
+
+      expect(document.body.textContent).toBe(label)
+    }
+  )
+
+  it('renders nothing without a theme context', () => {
+    render(<VisibilityByTheme.Name />)
 
     expect(document.body.textContent).toBe('')
   })


### PR DESCRIPTION
`VisibilityByTheme.Name` renders the display name of the inherited theme brand. Its implementation has read `brand`-derived flags since the `name` → `brand` rename, so only the API name was stale — and unlike `ThemeProps.name`, `size`, `ThemeSizes` and `data-name`, it carried no deprecation marker. It was the last public API still calling a brand a "name".

`VisibilityByTheme.Brand` is added, and `Name` becomes an alias of it — literally the same function reference, so there is one implementation and existing usages render identically until the alias is removed in v13.

## The null-theme crash

`Name` had no test coverage. Adding it surfaced a bug: the component throws without a theme context. `useTheme()` returns `null` outside a themed `Provider`, and only the first of the four brand checks was guarded (`theme?.isCarnegie`). The same applies to `visible` and `hidden`, which both dereference the theme when resolving a match.

Reproduced on `main`, with a passing control:

| case | on `main` |
|---|---|
| inside `<Theme brand="sbanken">` (**control**) | renders `Sbanken` ✅ |
| `<VisibilityByTheme>` with no `visible`/`hidden`, no theme (**control**) | renders children ✅ |
| `.Name`, no theme | ❌ `TypeError: Cannot read properties of null (reading 'isEiendom')` |
| `visible="sbanken"`, no theme | ❌ `TypeError: ... (reading 'brand')` |
| `visible={[{ brand: 'sbanken' }]}`, no theme | ❌ `TypeError: ... (reading 'brand')` |
| `hidden="sbanken"`, no theme | ❌ `TypeError: ... (reading 'brand')` |

All three entry points now treat a missing theme as "no brand to match": `visible` renders nothing, `hidden` renders its children, and `Brand` renders nothing — consistent with `Brand` already returning `undefined` for an unrecognised brand.