### PR TITLE
chore(security): make the publish guards fail closed on drift and symlinks

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
@@ -29,6 +29,9 @@ describe('cleanupPackage', () => {
     expect(cleanedPackage).toHaveProperty('peerDependencies')
     expect(cleanedPackage.bin).toBe('./cli/eufemia.js')
     expect(cleanedPackage.license).toBe('SEE LICENSE IN LICENSE FILE')
+    // The published package is ESM; this is part of the transform the publish
+    // guard reconstructs, so it belongs in this function rather than its caller.
+    expect(cleanedPackage.type).toBe('module')
   })
 
   it('includes @babel/runtime-corejs3 as a runtime dependency', async () => {

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/validatePackageContents.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/validatePackageContents.test.ts
@@ -321,8 +321,9 @@ describe('getPackedFiles', () => {
 // writeReleaseConfig.test.ts): Node reports a symlink-resolved
 // `import.meta.url`, so comparing it with an unresolved `process.argv[1]` made
 // the validation exit 0 without validating anything whenever the invocation
-// path crossed a symlink. Pointing it at a directory with no package.json is
-// enough — it must fail, not pass silently.
+// path crossed a symlink. The fixture is a package that packs cleanly but
+// breaks the shipped rules, so the expected failure comes from the validation
+// itself — proving the checks ran rather than that something else went wrong.
 describe('the validator runs when invoked through a symlinked path', () => {
   const script = path.join(
     PKG_ROOT,
@@ -331,36 +332,42 @@ describe('the validator runs when invoked through a symlinked path', () => {
   let dir
 
   const runValidator = (scriptPath) =>
-    spawnSync(process.execPath, [scriptPath, 'empty'], {
+    spawnSync(process.execPath, [scriptPath, 'pkg'], {
       cwd: dir,
       encoding: 'utf8',
     })
 
   beforeEach(() => {
     dir = mkdtempSync(path.join(tmpdir(), 'eufemia-validate-entry-'))
-    mkdirSync(path.join(dir, 'empty'))
+    const pkg = path.join(dir, 'pkg')
+    mkdirSync(pkg)
+    writeFileSync(
+      path.join(pkg, 'package.json'),
+      JSON.stringify({ name: 'pkg', version: '1.0.0', main: './index.js' })
+    )
+    writeFileSync(path.join(pkg, 'index.js'), 'export default 1\n')
   })
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('fails through a symlink to the script', () => {
+  it('validates through a symlink to the script', () => {
     const link = path.join(dir, 'validatePackageContents.mjs')
     symlinkSync(script, link)
 
     const result = runValidator(link)
 
     expect(result.status).toBe(1)
-    expect(result.stderr).toContain('Package content validation')
+    expect(result.stderr).toContain('Package content validation FAILED')
   })
 
   // Control: identical behaviour through the real path, so the case above is
-  // about the entry point rather than about the failure itself.
-  it('fails the same way through the real path', () => {
+  // about the entry point rather than about the fixture.
+  it('reports the same violations through the real path', () => {
     const result = runValidator(script)
 
     expect(result.status).toBe(1)
-    expect(result.stderr).toContain('Package content validation')
+    expect(result.stderr).toContain('Package content validation FAILED')
   })
 })

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/validatePackageContents.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/validatePackageContents.test.ts
@@ -2,8 +2,15 @@
  * Test the package content validation logic.
  */
 
-import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { execFileSync, spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import {
@@ -14,6 +21,8 @@ import {
   getPackedFiles,
   MIN_FILE_COUNT,
 } from '../validatePackageContents.mjs'
+
+const PKG_ROOT = path.resolve(__dirname, '../../..')
 
 // Enough files to clear the real MIN_FILE_COUNT floor, so the cases below
 // exercise the shipped defaults instead of a relaxed override.
@@ -305,5 +314,53 @@ describe('getPackedFiles', () => {
     })
 
     expect(existsSync(path.join(dir, MARKER))).toBe(true)
+  })
+})
+
+// Same entry-point property as the sibling guard (see the symlink case in
+// writeReleaseConfig.test.ts): Node reports a symlink-resolved
+// `import.meta.url`, so comparing it with an unresolved `process.argv[1]` made
+// the validation exit 0 without validating anything whenever the invocation
+// path crossed a symlink. Pointing it at a directory with no package.json is
+// enough — it must fail, not pass silently.
+describe('the validator runs when invoked through a symlinked path', () => {
+  const script = path.join(
+    PKG_ROOT,
+    'scripts/postbuild/validatePackageContents.mjs'
+  )
+  let dir
+
+  const runValidator = (scriptPath) =>
+    spawnSync(process.execPath, [scriptPath, 'empty'], {
+      cwd: dir,
+      encoding: 'utf8',
+    })
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'eufemia-validate-entry-'))
+    mkdirSync(path.join(dir, 'empty'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('fails through a symlink to the script', () => {
+    const link = path.join(dir, 'validatePackageContents.mjs')
+    symlinkSync(script, link)
+
+    const result = runValidator(link)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Package content validation')
+  })
+
+  // Control: identical behaviour through the real path, so the case above is
+  // about the entry point rather than about the failure itself.
+  it('fails the same way through the real path', () => {
+    const result = runValidator(script)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Package content validation')
   })
 })

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/writeReleaseConfig.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/writeReleaseConfig.test.ts
@@ -5,11 +5,13 @@
 import { createRequire } from 'node:module'
 import { execFileSync, spawnSync } from 'node:child_process'
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -26,7 +28,7 @@ import {
   TRUSTED_CONFIG_FILE,
   writeReleaseConfig,
 } from '../writeReleaseConfig.mjs'
-import { cleanupPackage } from '../prepareForRelease'
+import prepareForRelease from '../prepareForRelease'
 
 // Load the exact cosmiconfig instance semantic-release resolves, so the
 // precedence assertions below reflect the real loader rather than an assumption
@@ -627,21 +629,43 @@ describe('expectedReleaseManifest', () => {
   // Drift + no-false-positive guard, run against the real manifest: the
   // whole-manifest comparison is only correct while expectedReleaseManifest
   // mirrors the real transform, and a faithful build must pass or the guard
-  // would block every release. prepareForRelease is cleanupPackage() followed by
-  // `type = 'module'` in its main function, so this reproduces both. If
-  // prepareForRelease changes which fields it strips, this fails until
-  // expectedReleaseManifest is brought back in sync.
-  it('matches what prepareForRelease produces from the real manifest', async () => {
-    const packageString = readFileSync(
-      path.join(PKG_ROOT, 'package.json'),
-      'utf8'
-    )
-    const cleaned = await cleanupPackage({ packageString })
-    cleaned.type = 'module'
+  // would block every release.
+  //
+  // This runs the real producer rather than reproducing its steps, so it covers
+  // the whole transform: any change to what prepareForRelease publishes — a
+  // different stripped field, an added one such as the `exports` map its TODO
+  // describes — fails here until expectedReleaseManifest is brought back in
+  // sync. Reproducing the steps instead would only cover the ones the test
+  // happens to know about.
+  it('matches what prepareForRelease actually writes', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'prepare-for-release-'))
+    try {
+      mkdirSync(path.join(root, 'build'))
+      copyFileSync(
+        path.join(PKG_ROOT, 'package.json'),
+        path.join(root, 'package.json')
+      )
+      copyFileSync(
+        path.join(PKG_ROOT, '.prettierrc'),
+        path.join(root, '.prettierrc')
+      )
 
-    expect(expectedReleaseManifest(JSON.parse(packageString))).toEqual(
-      cleaned
-    )
+      await prepareForRelease({ rootDir: root })
+
+      const written = JSON.parse(
+        readFileSync(path.join(root, 'build', 'package.json'), 'utf8')
+      )
+      const source = JSON.parse(
+        readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8')
+      )
+
+      expect(expectedReleaseManifest(source)).toEqual(written)
+      // Not vacuous: a real manifest was produced and it is not the source.
+      expect(written.name).toBe('@dnb/eufemia')
+      expect(written).not.toHaveProperty('scripts')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })
 
@@ -975,6 +999,89 @@ describe('a tampered manifest cannot change how the release is published', () =>
   it('refuses when the manifest npm would publish is missing entirely', () => {
     expect(() => writeReleaseConfig(writeSource(), dir)).toThrow(
       'Refusing to publish'
+    )
+  })
+})
+
+// The CLI entry-point check decides whether main() runs. Node reports a
+// symlink-resolved `import.meta.url`, so comparing it with an unresolved
+// `process.argv[1]` skipped main() whenever the invocation path crossed a
+// symlink — the guard then exited 0, printed nothing, checked nothing and left
+// the artifact's own .releaserc.json in place. A security control has to fail
+// closed, so this drives the real CLI through a symlink.
+describe('the guard runs when invoked through a symlinked path', () => {
+  const script = path.join(
+    PKG_ROOT,
+    'scripts/postbuild/writeReleaseConfig.mjs'
+  )
+  let dir
+
+  const runGuard = (scriptPath, buildDir) =>
+    spawnSync(
+      process.execPath,
+      [scriptPath, 'source-package.json', 'build'],
+      {
+        cwd: buildDir,
+        encoding: 'utf8',
+      }
+    )
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'eufemia-entrypoint-'))
+    mkdirSync(path.join(dir, 'build'))
+    writeFileSync(
+      path.join(dir, 'source-package.json'),
+      JSON.stringify({ name: 'pkg', release: { branches: ['release'] } })
+    )
+    // A tampered artifact manifest: the guard must refuse it however it was
+    // invoked.
+    writeFileSync(
+      path.join(dir, 'build', 'package.json'),
+      JSON.stringify({ name: 'pkg', type: 'module', tag: 'latest' })
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('refuses a tampered manifest through a symlink to the script', () => {
+    const link = path.join(dir, 'writeReleaseConfig.mjs')
+    symlinkSync(script, link)
+
+    const result = runGuard(link, dir)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Refusing to publish')
+    expect(existsSync(path.join(dir, 'build', TRUSTED_CONFIG_FILE))).toBe(
+      false
+    )
+  })
+
+  // Control: the same invocation through the real path behaves identically, so
+  // the case above is about the entry point rather than about the refusal.
+  it('refuses it the same way through the real path', () => {
+    const result = runGuard(script, dir)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Refusing to publish')
+  })
+
+  // Control: a symlinked invocation is not simply always failing — a faithful
+  // manifest still passes and the trusted config is written.
+  it('publishes a faithful manifest through the symlink', () => {
+    const link = path.join(dir, 'writeReleaseConfig.mjs')
+    symlinkSync(script, link)
+    writeFileSync(
+      path.join(dir, 'build', 'package.json'),
+      JSON.stringify({ name: 'pkg', type: 'module' })
+    )
+
+    const result = runGuard(link, dir)
+
+    expect(result.status).toBe(0)
+    expect(existsSync(path.join(dir, 'build', TRUSTED_CONFIG_FILE))).toBe(
+      true
     )
   })
 })

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/writeReleaseConfig.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/writeReleaseConfig.test.ts
@@ -640,11 +640,11 @@ describe('expectedReleaseManifest', () => {
   it('matches what prepareForRelease actually writes', async () => {
     const root = mkdtempSync(path.join(tmpdir(), 'prepare-for-release-'))
     try {
+      const sourcePath = path.join(PKG_ROOT, 'package.json')
+      const source = JSON.parse(readFileSync(sourcePath, 'utf8'))
+
       mkdirSync(path.join(root, 'build'))
-      copyFileSync(
-        path.join(PKG_ROOT, 'package.json'),
-        path.join(root, 'package.json')
-      )
+      copyFileSync(sourcePath, path.join(root, 'package.json'))
       copyFileSync(
         path.join(PKG_ROOT, '.prettierrc'),
         path.join(root, '.prettierrc')
@@ -655,13 +655,13 @@ describe('expectedReleaseManifest', () => {
       const written = JSON.parse(
         readFileSync(path.join(root, 'build', 'package.json'), 'utf8')
       )
-      const source = JSON.parse(
-        readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8')
-      )
 
       expect(expectedReleaseManifest(source)).toEqual(written)
-      // Not vacuous: a real manifest was produced and it is not the source.
+
+      // Not vacuous: the producer wrote a real manifest, and the transform it
+      // agrees on is not simply a copy of the source.
       expect(written.name).toBe('@dnb/eufemia')
+      expect(source).toHaveProperty('scripts')
       expect(written).not.toHaveProperty('scripts')
     } finally {
       rmSync(root, { recursive: true, force: true })
@@ -1016,12 +1016,12 @@ describe('the guard runs when invoked through a symlinked path', () => {
   )
   let dir
 
-  const runGuard = (scriptPath, buildDir) =>
+  const runGuard = (scriptPath) =>
     spawnSync(
       process.execPath,
       [scriptPath, 'source-package.json', 'build'],
       {
-        cwd: buildDir,
+        cwd: dir,
         encoding: 'utf8',
       }
     )
@@ -1049,7 +1049,7 @@ describe('the guard runs when invoked through a symlinked path', () => {
     const link = path.join(dir, 'writeReleaseConfig.mjs')
     symlinkSync(script, link)
 
-    const result = runGuard(link, dir)
+    const result = runGuard(link)
 
     expect(result.status).toBe(1)
     expect(result.stderr).toContain('Refusing to publish')
@@ -1061,7 +1061,7 @@ describe('the guard runs when invoked through a symlinked path', () => {
   // Control: the same invocation through the real path behaves identically, so
   // the case above is about the entry point rather than about the refusal.
   it('refuses it the same way through the real path', () => {
-    const result = runGuard(script, dir)
+    const result = runGuard(script)
 
     expect(result.status).toBe(1)
     expect(result.stderr).toContain('Refusing to publish')
@@ -1077,7 +1077,7 @@ describe('the guard runs when invoked through a symlinked path', () => {
       JSON.stringify({ name: 'pkg', type: 'module' })
     )
 
-    const result = runGuard(link, dir)
+    const result = runGuard(link)
 
     expect(result.status).toBe(0)
     expect(existsSync(path.join(dir, 'build', TRUSTED_CONFIG_FILE))).toBe(

--- a/packages/dnb-eufemia/scripts/postbuild/prepareForRelease.js
+++ b/packages/dnb-eufemia/scripts/postbuild/prepareForRelease.js
@@ -15,27 +15,41 @@ if (require.main === module) {
   prepareForRelease()
 }
 
-export default async function prepareForRelease() {
-  const filepath = path.resolve(ROOT_DIR, './package.json')
-  const dest = path.resolve(ROOT_DIR, 'build', './package.json')
+/**
+ * Write the release manifest and the semantic-release config into
+ * `<rootDir>/build`. `rootDir` defaults to this package and is only overridden
+ * by the test that runs this function for real against a temporary directory —
+ * see the drift test in writeReleaseConfig.test.ts.
+ *
+ * Every change to the published manifest belongs in cleanupPackage, not here:
+ * the publish-job guard reconstructs that transform to compare the restored
+ * artifact against it, and the drift test can only pin the reconstruction
+ * against a single producer. A mutation applied here instead would make the
+ * guard refuse a legitimate build.
+ */
+export default async function prepareForRelease({
+  rootDir = ROOT_DIR,
+} = {}) {
+  const filepath = path.resolve(rootDir, './package.json')
+  const dest = path.resolve(rootDir, 'build', './package.json')
   const packageString = await fs.readFile(filepath, 'utf-8')
   const packageJson = await cleanupPackage({
     packageString,
   })
 
-  // Ensure module type
-  packageJson.type = 'module'
-
   // Build exports map
   // TODO: In future we may enable it, or find a better solution.
   // Bundlers do not support an array of export targets yet, so we skip this for now.
   // But at the time of writing we could not confirm a speed improvement by bundlers. So what are the benefits at the end? (only silent CJS fallback?)
+  // Enabling this adds a field to the published manifest, so it belongs in
+  // cleanupPackage (which takes no buildDir today) rather than here — see the
+  // note above.
   // packageJson.exports = await buildExportsMap({
-  //   buildDir: path.resolve(ROOT_DIR, 'build'),
+  //   buildDir: path.resolve(rootDir, 'build'),
   // })
 
   const prettierrc = JSON.parse(
-    await fs.readFile(path.resolve(ROOT_DIR, '.prettierrc'), 'utf-8')
+    await fs.readFile(path.resolve(rootDir, '.prettierrc'), 'utf-8')
   )
   const formattedPackageJson = await prettier.format(
     JSON.stringify(packageJson),
@@ -50,11 +64,7 @@ export default async function prepareForRelease() {
   // Create .releaserc.json in build directory for semantic-release
   const sourcePackageJson = JSON.parse(packageString)
   if (sourcePackageJson.release) {
-    const releaseRcPath = path.resolve(
-      ROOT_DIR,
-      'build',
-      '.releaserc.json'
-    )
+    const releaseRcPath = path.resolve(rootDir, 'build', '.releaserc.json')
     const formattedReleaseRc = await prettier.format(
       JSON.stringify(sourcePackageJson.release),
       {
@@ -67,7 +77,16 @@ export default async function prepareForRelease() {
   }
 }
 
-// export for testing
+/**
+ * The complete transform from the source package.json to the manifest that gets
+ * published — the single definition of it. The publish-job guard rebuilds this
+ * transform to compare the restored build artifact against it
+ * (writeReleaseConfig.mjs -> expectedReleaseManifest), and a drift test runs
+ * this function to pin the two together, so any new change to the published
+ * manifest must be made here to stay covered.
+ *
+ * Also exported for testing.
+ */
 export async function cleanupPackage({ packageString }) {
   const packageJson = JSON.parse(packageString)
   delete packageJson.release
@@ -75,6 +94,9 @@ export async function cleanupPackage({ packageString }) {
   delete packageJson.devDependencies
   delete packageJson.resolutions
   delete packageJson.volta
+
+  // Ensure module type
+  packageJson.type = 'module'
 
   return packageJson
 }

--- a/packages/dnb-eufemia/scripts/postbuild/prepareForRelease.js
+++ b/packages/dnb-eufemia/scripts/postbuild/prepareForRelease.js
@@ -21,11 +21,12 @@ if (require.main === module) {
  * by the test that runs this function for real against a temporary directory —
  * see the drift test in writeReleaseConfig.test.ts.
  *
- * Every change to the published manifest belongs in cleanupPackage, not here:
- * the publish-job guard reconstructs that transform to compare the restored
- * artifact against it, and the drift test can only pin the reconstruction
- * against a single producer. A mutation applied here instead would make the
- * guard refuse a legitimate build.
+ * The publish job refuses to publish a build manifest that differs from the one
+ * this function produces from the trusted source (writeReleaseConfig.mjs ->
+ * expectedReleaseManifest), so a change to the published manifest has to be
+ * mirrored there. The drift test runs this function and compares, so it fails
+ * until that is done — but keeping the field changes themselves in
+ * cleanupPackage keeps the transform in one place and pure.
  */
 export default async function prepareForRelease({
   rootDir = ROOT_DIR,
@@ -41,9 +42,10 @@ export default async function prepareForRelease({
   // TODO: In future we may enable it, or find a better solution.
   // Bundlers do not support an array of export targets yet, so we skip this for now.
   // But at the time of writing we could not confirm a speed improvement by bundlers. So what are the benefits at the end? (only silent CJS fallback?)
-  // Enabling this adds a field to the published manifest, so it belongs in
-  // cleanupPackage (which takes no buildDir today) rather than here — see the
-  // note above.
+  // Note that this derives a published field from the built file tree, which the
+  // publish guard cannot reconstruct from the source manifest alone — so
+  // enabling it means deciding how that comparison should treat `exports`, not
+  // just extending expectedReleaseManifest. The drift test fails until then.
   // packageJson.exports = await buildExportsMap({
   //   buildDir: path.resolve(rootDir, 'build'),
   // })
@@ -79,11 +81,10 @@ export default async function prepareForRelease({
 
 /**
  * The complete transform from the source package.json to the manifest that gets
- * published — the single definition of it. The publish-job guard rebuilds this
- * transform to compare the restored build artifact against it
- * (writeReleaseConfig.mjs -> expectedReleaseManifest), and a drift test runs
- * this function to pin the two together, so any new change to the published
- * manifest must be made here to stay covered.
+ * published, and the single place field changes belong. The publish-job guard
+ * rebuilds this transform to compare the restored build artifact against it
+ * (writeReleaseConfig.mjs -> expectedReleaseManifest), and a drift test runs the
+ * producer to pin the two together.
  *
  * Also exported for testing.
  */

--- a/packages/dnb-eufemia/scripts/postbuild/validatePackageContents.mjs
+++ b/packages/dnb-eufemia/scripts/postbuild/validatePackageContents.mjs
@@ -20,7 +20,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -319,6 +319,13 @@ function main() {
 }
 
 const invokedPath = process.argv[1]
-if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+// Resolve the invoked path before comparing — see the same check in
+// writeReleaseConfig.mjs: `import.meta.url` is symlink-resolved, so without
+// this a symlinked invocation path skips main() and the validation silently
+// passes without validating anything.
+if (
+  invokedPath &&
+  import.meta.url === pathToFileURL(realpathSync(invokedPath)).href
+) {
   main()
 }

--- a/packages/dnb-eufemia/scripts/postbuild/writeReleaseConfig.mjs
+++ b/packages/dnb-eufemia/scripts/postbuild/writeReleaseConfig.mjs
@@ -66,7 +66,8 @@
  * produces from the trusted source. prepareForRelease derives that manifest
  * deterministically — it deletes `release`, `scripts`, `devDependencies`,
  * `resolutions` and `volta`, and sets `type: "module"` (see
- * RELEASE_STRIPPED_FIELDS and expectedReleaseManifest) — and the version is not
+ * RELEASE_STRIPPED_FIELDS and expectedReleaseManifest, pinned to the real
+ * producer by a drift test) — and the version is not
  * bumped until semantic-release runs later, so a faithful artifact manifest is
  * exactly that transform of the source. Any deviation is refused. Comparing the
  * complete manifest closes every publish-affecting field at once, including
@@ -95,7 +96,12 @@
  * Usage: node ./scripts/postbuild/writeReleaseConfig.mjs <sourcePackageJson> <buildDir>
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -255,11 +261,13 @@ function stableSerialize(value) {
 }
 
 /**
- * The fields prepareForRelease removes from the manifest before publishing (see
- * prepareForRelease.js -> cleanupPackage). Kept here so the guard can recreate
- * the exact manifest a faithful build produces and compare the whole thing,
- * rather than allow-listing individual publish-affecting fields and missing the
- * next one. A drift test pins this list against the real cleanupPackage.
+ * The fields the build removes from the manifest before publishing (see
+ * prepareForRelease.js -> cleanupPackage, the single definition of that
+ * transform). Kept here so the guard can recreate the exact manifest a faithful
+ * build produces and compare the whole thing, rather than allow-listing
+ * individual publish-affecting fields and missing the next one. A drift test
+ * runs the real producer and compares its output with this reconstruction, so a
+ * change to either side fails until both are back in sync.
  */
 export const RELEASE_STRIPPED_FIELDS = [
   'release',
@@ -272,7 +280,7 @@ export const RELEASE_STRIPPED_FIELDS = [
 /**
  * Recreate the package.json a faithful build publishes from the trusted source
  * manifest: strip RELEASE_STRIPPED_FIELDS and set `type: "module"`, exactly as
- * prepareForRelease does. The version is intentionally left untouched — it is
+ * cleanupPackage does. The version is intentionally left untouched — it is
  * not bumped until semantic-release runs, which is after this guard — so for a
  * faithful artifact this is byte-for-byte (structurally) the published manifest.
  * Pure function — no I/O — so it is easy to unit test.
@@ -458,6 +466,15 @@ function main() {
 }
 
 const invokedPath = process.argv[1]
-if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+// Resolve the invoked path before comparing: Node already reports a
+// symlink-resolved `import.meta.url`, so an invocation through a symlinked path
+// (a symlinked checkout, a temp dir such as macOS `/tmp` -> `/private/tmp`)
+// would not match and main() would silently not run — leaving a guard that
+// exits 0 without checking anything and without rewriting the trusted config.
+// Failing closed matters more here than the cost of one extra syscall.
+if (
+  invokedPath &&
+  import.meta.url === pathToFileURL(realpathSync(invokedPath)).href
+) {
   main()
 }


### PR DESCRIPTION
Follow-up to #8949, based on its branch. Two robustness gaps in the publish guards that #8949 introduced — both found while reviewing it, neither a security hole, both cheap to close.

### 1. The drift test only covered half the transform

The guard rebuilds the manifest a faithful build produces (`expectedReleaseManifest`) and refuses any deviation. That reconstruction has to track the real producer, or the guard blocks a legitimate release with an error that blames the build artifact.

`prepareForRelease` applied the transform in two places — `cleanupPackage`, plus a `type = 'module'` in its own body — and the drift test reproduced both by hand. So it could only catch a change to the half it already knew about.

The `exports` map that `prepareForRelease`'s own TODO describes is enough to show the gap. Enabling it (the function behind it is live, exported and separately tested):

- the guard **refused a completely legitimate build**
- the drift test **still passed**

So the next person to act on that TODO gets green CI and then a release that refuses to publish.

**Fix:** the whole transform now lives in `cleanupPackage`, and the drift test runs the real `prepareForRelease` against a temporary root and compares what it actually writes. Any future change to the published manifest — wherever it is applied — now fails that test until the reconstruction is brought back in sync, instead of only the changes the test happens to mirror.

`prepareForRelease` takes an optional `rootDir` so the test can run it for real without touching `build/`.

### 2. Both guards could silently skip their own checks

The CLI entry point in `writeReleaseConfig.mjs` and `validatePackageContents.mjs` compared `import.meta.url` with an unresolved `process.argv[1]`. Node reports a symlink-resolved module URL, so an invocation through a symlinked path — a symlinked checkout, or a temp dir such as macOS `/tmp` → `/private/tmp` — does not match: `main()` never runs and the script exits **0** having checked nothing, and without rewriting the trusted release config.

Not reachable on GitHub-hosted runners, where the workspace path is real — so this is robustness rather than a live hole. But a security control should not fail open and silent. Resolving the invoked path first makes both fail closed.

I found this by accident: my first attempt to test the previous guard from a temp directory produced a bogus "the guard accepts this" result, because the guard had silently done nothing.

### Verification

- `expectedReleaseManifest` still matches the real producer, and the manifest `prepareForRelease` writes is **byte-identical** to before this change (compared against the output from the base branch) — so the refactor is output-neutral.
- The real producer's output still passes the real guard end-to-end, so no release is blocked.
- Tampered manifests are still refused end-to-end (`tag`, `private`, redirected `name`/`repository`, re-added `scripts`, `publishConfig` re-enabling lifecycle scripts, an injected `exports`), with a key-reorder control still accepted.
- **Both fixes fail without them:** the drift test fails on the `exports` scenario, and the two symlink cases fail with the old entry-point comparison while their real-path controls keep passing.
- 109 tests pass in the two touched suites; lint, Prettier and type checks clean.

### Note on the base

Based on `refactor/ci-release-least-privilege-secrets` so the diff shows only these changes. If #8949 squash-merges first, this needs a rebase onto `main` — happy to do that.

Related to the remaining review item from #8949 that is **not** included here: rejecting symlinks and other non-regular entries in the restored artifact. That belongs in its own change.

---

**Second commit (self-review, no behaviour change).** The notes I first added to `prepareForRelease` asserted a rule the new drift test had just made obsolete, and pointed at `cleanupPackage` for the `exports` map — which cannot work there, since that field derives from the built file tree rather than the source manifest. Corrected. The validator's entry-point test no longer relies on `npm pack` failing for lack of a manifest; it now uses a package that packs cleanly but breaks the shipped rules, so it proves the checks *ran*. `cleanupPackage`'s own suite pins `type: "module"`, the field this change moved into it. Re-verified after the change: producer output still byte-identical, guard still accepts it, all tampered variants still refused, and each fix still fails without it.