### PR TITLE
chore(analytics): alarm on empty dashboard snapshots

### DIFF
--- a/tools/analytics/README.md
+++ b/tools/analytics/README.md
@@ -96,7 +96,7 @@ For the same reason, an admin must pre-create the read-only dashboard-read execu
 - **Glue database + table** with JSON SerDe and partition projection on `dt`.
 - **Athena workgroup** for the retrieve queries.
 - **Lambda function** (`nodejs22.x`) — its execution role is pre-created out-of-band, because the OIDC deploy role's permissions boundary forbids `iam:CreateRole` (ADR 0004); it is only referenced here.
-- **Dashboard-read Lambda** (`nodejs22.x`) serving `GET /data` under the read-only `eufemia-<env>-dashboard-role`, plus a **scheduled snapshot generator** Lambda (hourly EventBridge rule) that runs under `eufemia-<env>-analytics-role` and refreshes `records/dashboard-snapshot.json` off the request path. Two CloudWatch alarms flag a failed generator run (`Errors`) or a generator that has stopped firing (missing `Invocations`).
+- **Dashboard-read Lambda** (`nodejs22.x`) serving `GET /data` under the read-only `eufemia-<env>-dashboard-role`, plus a **scheduled snapshot generator** Lambda (hourly EventBridge rule) that runs under `eufemia-<env>-analytics-role` and refreshes `records/dashboard-snapshot.json` off the request path. Three CloudWatch alarms flag a failed generator run (`Errors`), a generator that has stopped firing (missing `Invocations`), and a run that succeeds but writes an empty snapshot (the `SnapshotRecordCount` EMF metric stays below 1). The empty-snapshot metric is emitted as an Embedded Metric Format log line, so it needs no extra role permissions.
 - **API Gateway HTTP API** with the two `/records` routes and throttling.
 
 The dashboard is hosted separately as a static site:

--- a/tools/analytics/__tests__/snapshot.test.ts
+++ b/tools/analytics/__tests__/snapshot.test.ts
@@ -37,15 +37,21 @@ function putCalls() {
   )
 }
 
+// Silence and capture the EMF metric line the handler logs, so it neither spams
+// test output nor needs a per-suite spy; assertions read logSpy.mock.calls.
+let logSpy: ReturnType<typeof vi.spyOn>
+
 beforeEach(() => {
   send.mockReset()
   retrievePageViews.mockReset()
   send.mockResolvedValue({})
   process.env.DATA_BUCKET = 'my-bucket'
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
 })
 
 afterEach(() => {
   delete process.env.DATA_BUCKET
+  logSpy.mockRestore()
 })
 
 describe('snapshot generator handler', () => {
@@ -83,10 +89,8 @@ describe('snapshot generator handler', () => {
 })
 
 describe('snapshot record-count metric', () => {
-  let log: ReturnType<typeof vi.spyOn>
-
   function findEmfMetric() {
-    const line = log.mock.calls
+    const line = logSpy.mock.calls
       .map((call: unknown[]) => call[0])
       .find(
         (arg: unknown): arg is string =>
@@ -96,12 +100,7 @@ describe('snapshot record-count metric', () => {
     return line ? JSON.parse(line) : null
   }
 
-  beforeEach(() => {
-    log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
-  })
-
   afterEach(() => {
-    log.mockRestore()
     delete process.env.AWS_LAMBDA_FUNCTION_NAME
   })
 
@@ -132,6 +131,8 @@ describe('snapshot record-count metric', () => {
     const result = await handler()
 
     expect(result.count).toBe(0)
-    expect(findEmfMetric().SnapshotRecordCount).toBe(0)
+    const emf = findEmfMetric()
+    expect(emf).not.toBeNull()
+    expect(emf.SnapshotRecordCount).toBe(0)
   })
 })

--- a/tools/analytics/__tests__/snapshot.test.ts
+++ b/tools/analytics/__tests__/snapshot.test.ts
@@ -81,3 +81,57 @@ describe('snapshot generator handler', () => {
     expect(retrievePageViews).not.toHaveBeenCalled()
   })
 })
+
+describe('snapshot record-count metric', () => {
+  let log: ReturnType<typeof vi.spyOn>
+
+  function findEmfMetric() {
+    const line = log.mock.calls
+      .map((call: unknown[]) => call[0])
+      .find(
+        (arg: unknown): arg is string =>
+          typeof arg === 'string' && arg.includes('SnapshotRecordCount')
+      )
+
+    return line ? JSON.parse(line) : null
+  }
+
+  beforeEach(() => {
+    log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME
+  })
+
+  it('emits the record count as an EMF metric after a successful run', async () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'eufemia-dev-analytics-snapshot'
+    retrievePageViews.mockResolvedValue([
+      { type: 'pageview', path: '/', env: 'prod', timestamp: 't' },
+    ])
+
+    await handler()
+
+    const emf = findEmfMetric()
+    expect(emf).not.toBeNull()
+    expect(emf.SnapshotRecordCount).toBe(1)
+    expect(emf.FunctionName).toBe('eufemia-dev-analytics-snapshot')
+    expect(emf._aws.CloudWatchMetrics[0].Namespace).toBe(
+      'Eufemia/Analytics'
+    )
+    expect(emf._aws.CloudWatchMetrics[0].Metrics[0]).toEqual({
+      Name: 'SnapshotRecordCount',
+      Unit: 'Count',
+    })
+  })
+
+  it('emits a zero count when the snapshot is empty', async () => {
+    retrievePageViews.mockResolvedValue([])
+
+    const result = await handler()
+
+    expect(result.count).toBe(0)
+    expect(findEmfMetric().SnapshotRecordCount).toBe(0)
+  })
+})

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -512,8 +512,10 @@ resource "aws_cloudwatch_metric_alarm" "snapshot_not_running" {
 # count as an EMF metric (SnapshotRecordCount), so a snapshot that stays empty is
 # caught here — the Lambda alarms above only see the run, not its content. The
 # not-running alarm owns the "stopped firing" case, so missing data here does not
-# breach. No alarm actions yet (state is visible in CloudWatch); wire an
-# SNS/notification target here when one exists.
+# breach. The namespace/metric/dimension must match those emitted in
+# src/lambda/snapshot.ts. No alarm actions yet (state is visible in CloudWatch);
+# wire an SNS/notification target here when one exists — and note a genuinely
+# idle environment (no traffic) can sit at 0 and trip this.
 resource "aws_cloudwatch_metric_alarm" "snapshot_empty" {
   alarm_name          = "eufemia-${var.environment}-analytics-snapshot-empty"
   alarm_description   = "Dashboard snapshot generator wrote an empty snapshot (no records)"

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -507,6 +507,27 @@ resource "aws_cloudwatch_metric_alarm" "snapshot_not_running" {
   treat_missing_data  = "breaching"
 }
 
+# A run can succeed (Invocations >= 1, Errors = 0) yet write an empty snapshot,
+# e.g. the Athena query stops matching partitions. The generator emits the row
+# count as an EMF metric (SnapshotRecordCount), so a snapshot that stays empty is
+# caught here — the Lambda alarms above only see the run, not its content. The
+# not-running alarm owns the "stopped firing" case, so missing data here does not
+# breach. No alarm actions yet (state is visible in CloudWatch); wire an
+# SNS/notification target here when one exists.
+resource "aws_cloudwatch_metric_alarm" "snapshot_empty" {
+  alarm_name          = "eufemia-${var.environment}-analytics-snapshot-empty"
+  alarm_description   = "Dashboard snapshot generator wrote an empty snapshot (no records)"
+  namespace           = "Eufemia/Analytics"
+  metric_name         = "SnapshotRecordCount"
+  dimensions          = { FunctionName = aws_lambda_function.snapshot.function_name }
+  statistic           = "Maximum"
+  period              = 3600
+  evaluation_periods  = 6
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "notBreaching"
+}
+
 # ---------------------------------------------------------------------------
 # Custom domain (origin for Akamai)
 # ---------------------------------------------------------------------------

--- a/tools/analytics/src/lambda/snapshot.ts
+++ b/tools/analytics/src/lambda/snapshot.ts
@@ -16,6 +16,10 @@ const METRIC_NAMESPACE = 'Eufemia/Analytics'
  * be granted cloudwatch:PutMetricData in Terraform, ADR 0004). A sustained count
  * of 0 catches a run that succeeds but writes an empty snapshot — a state the
  * generator's Errors/Invocations alarms cannot see.
+ *
+ * The namespace, metric name, and FunctionName dimension below must stay in sync
+ * with the `snapshot_empty` alarm in infra/main.tf; a mismatch silently leaves
+ * the alarm at INSUFFICIENT_DATA.
  */
 function emitRecordCountMetric(count: number): void {
   const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME ?? 'unknown'

--- a/tools/analytics/src/lambda/snapshot.ts
+++ b/tools/analytics/src/lambda/snapshot.ts
@@ -7,6 +7,38 @@ import {
 
 const SNAPSHOT_LIMIT = 1000
 
+const METRIC_NAMESPACE = 'Eufemia/Analytics'
+
+/**
+ * Emit the snapshot record count as a CloudWatch metric using the Embedded
+ * Metric Format (a structured log line). EMF needs only the Lambda's existing
+ * log permissions, so the pre-provisioned execution role stays as-is (it cannot
+ * be granted cloudwatch:PutMetricData in Terraform, ADR 0004). A sustained count
+ * of 0 catches a run that succeeds but writes an empty snapshot — a state the
+ * generator's Errors/Invocations alarms cannot see.
+ */
+function emitRecordCountMetric(count: number): void {
+  const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME ?? 'unknown'
+
+  // eslint-disable-next-line no-console -- EMF metric emission to CloudWatch Logs
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: METRIC_NAMESPACE,
+            Dimensions: [['FunctionName']],
+            Metrics: [{ Name: 'SnapshotRecordCount', Unit: 'Count' }],
+          },
+        ],
+      },
+      FunctionName: functionName,
+      SnapshotRecordCount: count,
+    })
+  )
+}
+
 /**
  * Scheduled dashboard snapshot generator (EventBridge, off the request path).
  *
@@ -26,6 +58,8 @@ export async function handler(): Promise<{
   }
 
   await writeSnapshot(bucket, snapshot)
+
+  emitRecordCountMetric(snapshot.records.length)
 
   return {
     generatedAt: snapshot.generatedAt,


### PR DESCRIPTION
## Motivation

The scheduled dashboard snapshot generator already alarms on a failed run (`Errors`) and on a generator that stops firing (missing `Invocations`). Neither catches a run that succeeds but writes an *empty* snapshot — for example when the Athena query stops matching partitions. Both alarms stay green while the dashboard silently serves "No data".

This closes that gap: the generator reports its row count and an alarm fires when the snapshot stays empty. Record count is the right signal because the snapshot holds the latest 1000 page views, so once the pipeline has data the count stays positive — dropping to 0 means the data is broken, not quiet.
