### PR TITLE
chore(security): cover the artifact root in the non-regular entry check

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/writeReleaseConfig.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/writeReleaseConfig.test.ts
@@ -325,7 +325,7 @@ describe('writeReleaseConfig', () => {
     symlinkSync('../../../outside.md', path.join(dir, 'CHANGELOG.md'))
 
     expect(() => writeReleaseConfig(sourcePackageJson, dir)).toThrow(
-      'neither a regular file nor a directory'
+      'neither regular files nor directories'
     )
     expect(existsSync(path.join(dir, TRUSTED_CONFIG_FILE))).toBe(false)
   })
@@ -343,7 +343,7 @@ describe('writeReleaseConfig', () => {
     symlinkSync('elsewhere.json', path.join(dir, 'package.json'))
 
     expect(() => writeReleaseConfig(sourcePackageJson, dir)).toThrow(
-      'neither a regular file nor a directory'
+      'neither regular files nor directories'
     )
     expect(existsSync(path.join(dir, TRUSTED_CONFIG_FILE))).toBe(false)
   })
@@ -520,6 +520,20 @@ describe('findNonRegularArtifactEntries', () => {
     execFileSync('mkfifo', [path.join(dir, 'pipe')])
 
     expect(findNonRegularArtifactEntries(dir)).toEqual(['pipe (FIFO)'])
+  })
+
+  // tar restores a symlinked archive root as a symlink too, so the artifact can
+  // arrive as a link to somewhere else entirely. Walking its contents would then
+  // report nothing unusual, which is why the directory itself is checked.
+  it('flags the build directory itself when it is a symlink', () => {
+    mkdirSync(path.join(dir, 'elsewhere'))
+    writeFileSync(path.join(dir, 'elsewhere', 'package.json'), '{}')
+    const link = path.join(dir, 'build')
+    symlinkSync('elsewhere', link)
+
+    expect(findNonRegularArtifactEntries(link)).toEqual([
+      'build (symbolic link)',
+    ])
   })
 })
 

--- a/packages/dnb-eufemia/scripts/postbuild/writeReleaseConfig.mjs
+++ b/packages/dnb-eufemia/scripts/postbuild/writeReleaseConfig.mjs
@@ -104,6 +104,7 @@
 
 import {
   existsSync,
+  lstatSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -407,9 +408,12 @@ function describeEntryType(entry) {
 }
 
 /**
- * Return every entry in the build directory that is neither a regular file nor a
- * directory, relative to that directory. A faithful build writes only files and
- * directories, so anything else is unexpected.
+ * Return every entry at or under the build directory that is neither a regular
+ * file nor a directory, relative to that directory. A faithful build writes only
+ * files and directories, so anything else is unexpected. The directory itself is
+ * included in the check: `tar` restores a symlinked archive root as a symlink
+ * too, so a link there would otherwise leave the whole walk looking at somewhere
+ * else entirely.
  *
  * Symlinks are the reason this exists. They survive the artifact: it travels as
  * a tar archive, which stores a symlink as a symlink, and the publish job
@@ -433,6 +437,10 @@ function describeEntryType(entry) {
  * over, so the walk here is deliberately hand-rolled.
  */
 export function findNonRegularArtifactEntries(buildDir) {
+  if (lstatSync(buildDir).isSymbolicLink()) {
+    return [`${path.basename(buildDir)} (symbolic link)`]
+  }
+
   const found = []
 
   const walk = (dir) => {
@@ -501,17 +509,14 @@ export function writeReleaseConfig(sourcePackageJsonPath, buildDir) {
       nonRegular.length > 10 ? ` (and ${nonRegular.length - 10} more)` : ''
 
     throw new Error(
-      `Refusing to publish: the build directory carries ${nonRegular.length} ` +
-        `entr${nonRegular.length === 1 ? 'y' : 'ies'} that ${
-          nonRegular.length === 1 ? 'is' : 'are'
-        } neither a regular file nor a ` +
-        `directory: ${listed}${rest}. A symlink here is followed by whatever ` +
-        `reads or writes that path in this credentialed job — the changelog is ` +
-        `written through it, and the release commit stages the link itself, so ` +
-        `it persists into the trusted checkout for later releases. npm pack ` +
-        `omits symlinks from the tarball, so content validation cannot reveal ` +
-        `them. prepareForRelease writes only files, so treat the build artifact ` +
-        `as untrusted.`
+      `Refusing to publish: the restored build artifact includes paths that ` +
+        `are neither regular files nor directories: ${listed}${rest}. A ` +
+        `symlink is followed by whatever reads or writes that path in this ` +
+        `credentialed job — the changelog is written through it, and the ` +
+        `release commit stages the link itself, so it persists into the ` +
+        `trusted checkout for later releases. npm pack omits symlinks from the ` +
+        `tarball, so content validation cannot reveal them. prepareForRelease ` +
+        `writes only files, so treat the build artifact as untrusted.`
     )
   }
 


### PR DESCRIPTION
Self-review of #9221, which merged before I could push this. Two things, on top of the current #8949 head.

### The check missed the one path that matters most

`findNonRegularArtifactEntries` walked every entry **inside** the restored artifact, but never checked the artifact directory itself — and `tar` restores a symlinked archive root as a symlink exactly as it does any other member (verified: staged a `build -> target` link, archived and extracted it, and the link came back a link).

So an artifact whose root is a link would have left the walk inspecting somewhere else entirely and reporting nothing unusual. The rule #9221 established — "everything the artifact carries is a regular file or a directory" — did not actually hold for the root.

`lstat` on the directory now covers it, with a test that fails without it.

Severity: this is not an escalation on its own, since whoever can point the root elsewhere can equally write into the real one, and a redirected root carrying the *trusted checkout's* manifest is still refused by the whole-manifest comparison. It is the invariant being one step short of what it claims, which is worth closing while the code is fresh.

### The refusal message was over-clever and would have misdescribed that case

It derived its own singular/plural grammar from the entry count through nested ternaries, and opened with "the build directory carries" — wording that reads wrong for precisely the root case above. It now states the invariant plainly and covers both shapes.

### Verification

- 119 tests pass in the two touched suites; Prettier and ESLint clean.
- The new case fails with the root check removed.
- End-to-end against a real prepared artifact: accepted as built → refused with a symlinked build root → accepted again once restored.
- Still no false positives: three independently produced build trees, ~28,000 entries each, zero non-regular entries, ~0.4s per walk.