### PR TITLE
chore(Form.Section): document the disabled state during an async onDone

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
@@ -23,6 +23,8 @@ With `preventUncommittedChanges`, the user must select "Done" or "Cancel" before
 
 When `onDone` returns a Promise, the section stays in edit mode while it is pending. It switches to view mode when the Promise resolves and stays in edit mode when it rejects.
 
+While the Promise is pending, the fields inside the section and its "Done" and "Cancel" buttons are disabled. This keeps the submitted values from changing while the save is in flight. Make sure the returned Promise always settles, because one that never resolves or rejects leaves the section disabled.
+
 The demo starts with a simulated save error. Change the first name and select **Done** to verify that the input remains. Turn off **Simulate save error** and try again to complete the save.
 
 <Examples.AsyncOnDone />

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
@@ -135,4 +135,49 @@ describe('EditContainer async onDone', () => {
 
     expect(document.querySelector('input')).toBeDisabled()
   })
+
+  it('should disable the toolbar buttons while an async onDone is pending', async () => {
+    let resolveOnDone!: () => void
+
+    const onDone = () =>
+      new Promise<void>((resolve) => {
+        resolveOnDone = resolve
+      })
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.String path="/name" />
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+      </Form.Section>
+    )
+
+    // The EditContainer renders its Done button before the Cancel button
+    const buttons = document.querySelectorAll(
+      '.dnb-forms-section-edit-block button'
+    )
+    expect(buttons).toHaveLength(2)
+
+    const [doneButton, cancelButton] = Array.from(buttons)
+    expect(doneButton).not.toBeDisabled()
+    expect(cancelButton).not.toBeDisabled()
+
+    await userEvent.click(doneButton)
+
+    // Cancel restores the original data and leaves edit mode, which would
+    // discard the values a pending save is still writing. Both buttons
+    // stay disabled until the Promise settles.
+    expect(doneButton).toBeDisabled()
+    expect(cancelButton).toBeDisabled()
+
+    resolveOnDone()
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-forms-section-view-block')
+      ).not.toHaveAttribute('aria-hidden', 'true')
+    })
+  })
 })


### PR DESCRIPTION
Follow-up to #9197 / #9211. Those shipped the behaviour; this documents it.

## Why

The `Async onDone` docs explain how the container mode changes, but not that the section is **locked** while the Promise is pending. #9211 disables the fields and the toolbar buttons during the save, which is a useful guarantee — consumers do not need to guard their own fields — and it was not written down anywhere.

It also carries one obligation that was undocumented. `isPending` is only cleared in the Promise handlers:

```
void result.then(
  () => { setIsPending?.(false); switchContainerMode?.("view") },
  () => { restoreFocusRef.current = true; setIsPending?.(false) }
)
```

So a Promise that never settles leaves the section disabled with no way out — the fields, **Done** and **Cancel** are all disabled at that point. Worth stating as a contract rather than leaving it to be discovered.

## What changed

- One paragraph in the `Async onDone` section of the EditContainer demos page.
- A test pinning the toolbar half of the behaviour.

## Why the test

The existing `AsyncOnDone` tests assert the **fields** are disabled, but nothing asserted that **Cancel** is. Since the docs now promise it, an untested claim could rot. I mutation-tested it — removing `isPending ||` from `CancelButton` fails the new test at exactly `expect(cancelButton).toBeDisabled()`, so it can fail and it fails for the right reason.

Cancel is worth disabling on purpose: it calls `restoreOriginalData()` and leaves edit mode, so allowing it mid-save would discard the values the pending request is still writing.

## Verification

- `Form/Section` suite: 10/10 files, run twice
- `test:types`: no errors
- `lint:ci` and Prettier: clean
- No source behaviour changed — docs plus one test

## Note

I deliberately left the `onDone` property descriptions in `EditContainerDocs.ts` / `ToolbarDocs.ts` alone, because #9206 is currently rewording exactly those lines. Once it lands, the same sentence could be added there if wanted.