### PR TITLE
chore(deps): bump fast-uri to 3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "ttf2woff2@npm:^6.0.1": "npm:8.0.1",
-    "fast-uri@npm:^3.0.1": "npm:3.1.5",
+    "fast-uri@npm:^3.0.1": "npm:3.1.6",
     "@babel/core": "7.29.7",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "@babel/runtime": "7.26.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10135,10 +10135,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.5":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
+"fast-uri@npm:3.1.6":
+  version: 3.1.6
+  resolution: "fast-uri@npm:3.1.6"
+  checksum: 10/de34fceafd3a1d917989a1116b092d9b6ebe6fa3c9e908a308b988a6455449fa0a0256b6ef628aa7da80f1f84031d704c290d6ba0ea4c6f4c42b7974a3bd43ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates the existing transitive fast-uri resolution to the patched release, addressing the current high-severity URL normalization and SSRF advisories.

Advisories:
- https://github.com/advisories/GHSA-5jgf-p345-68v8
- https://github.com/advisories/GHSA-f65p-4m7j-42xc
- https://github.com/advisories/GHSA-fph4-wmhf-6fwf
- https://github.com/advisories/GHSA-jqff-g426-hqxp