### PR TITLE
fix(Icon): preserve inferred size after minification

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -228,17 +228,16 @@ export function calcSize(props: IconProps) {
 
     const nameParts = String(name || '').split('_')
 
-    if (nameParts.length > 1) {
-      const lastPartOfIconName = nameParts.reverse()[0] as ValidIconType
+    const lastPartOfIconName = nameParts.at(-1) as ValidIconType
+
+    if (ValidIconType.includes(lastPartOfIconName)) {
       const potentialSize = ListDefaultIconSizes.filter(
         ([key]) => key === lastPartOfIconName
       )?.[0]?.[1]
       if (potentialSize) {
         sizeAsInt = potentialSize
       }
-      if (ValidIconType.includes(lastPartOfIconName)) {
-        sizeAsString = lastPartOfIconName
-      }
+      sizeAsString = lastPartOfIconName
     } else {
       // Resolve the icon function — either directly or from a React element's type.
       // This handles minified builds where Function.name no longer contains

--- a/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/Icon.test.tsx
@@ -238,6 +238,25 @@ describe('Icon component', () => {
     )
   })
 
+  it('should detect medium size from a minified icon name containing an underscore', () => {
+    const _t = (props?: SVGProps<SVGSVGElement>) => (
+      <svg
+        width={24}
+        height={24}
+        viewBox="0 0 24 24"
+        fill="none"
+        {...props}
+      >
+        <path d="M12 2a10 10 0 100 20 10 10 0 000-20z" />
+      </svg>
+    )
+
+    render(<Icon icon={_t} />)
+    expect(document.querySelector('span.dnb-icon').classList).toContain(
+      'dnb-icon--medium'
+    )
+  })
+
   it('should validate with ARIA rules', async () => {
     const Comp = render(<Icon {...props} />)
     expect(await axeComponent(Comp)).toHaveNoViolations()


### PR DESCRIPTION
The production bundle can minify icon function names to underscore-prefixed identifiers such as `_t`. `Icon.calcSize` treated any underscore as a size suffix, skipped its SVG-width fallback, and rendered medium icons at the default 16px size. This also reduced the height of confirmation dialogs and caused the seven visual regressions on `main`.

Only recognized size suffixes now bypass the fallback. No screenshot baselines are changed.