### PR TITLE
fix(AI): support remote-only content edits via skill

### DIFF
--- a/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
+++ b/packages/dnb-eufemia/agent-skills-evals/eufemia-portal-content/evals.json
@@ -23,6 +23,18 @@
         "The promotion has the same affected paths and resulting content patch as the approved main change with no extras",
         "The response distinguishes the full main review from the short release deployment gate, requires a squash merge for the promotion, and requires explicit permission before either merge"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "I used Edit on GitHub to correct a few lines of prose on an existing Eufemia portal page and opened a pull request. Please take care of the formatting and pull request setup. Do I need to install the repository dependencies first?",
+      "expected_output": "A GitHub-only repair of the existing small prose pull request, with repository formatting and pull request conventions verified by CI and a working page preview, without requiring a local checkout or dependency installation.",
+      "assertions": [
+        "The response continues the contributor's existing branch and pull request after inspecting the complete diff",
+        "The response does not require a local checkout or dependency installation when the complete change is only existing Markdown or MDX prose",
+        "The response updates the title and motivation-focused description according to the release-note and deployment choices",
+        "The response waits for required CI checks, fixes unambiguous formatting failures through GitHub, and switches to local work if a failure cannot be corrected confidently",
+        "The response verifies the exact route and anchor on the stable branch preview and reports that validation came from CI rather than local checks"
+      ]
     }
   ]
 }

--- a/packages/dnb-eufemia/agent-skills-evals/trigger-cases.json
+++ b/packages/dnb-eufemia/agent-skills-evals/trigger-cases.json
@@ -49,6 +49,10 @@
       "expected_skill": "eufemia-portal-content"
     },
     {
+      "prompt": "I edited a few lines on an Eufemia portal page with Edit on GitHub. Please fix the formatting and pull request for me.",
+      "expected_skill": "eufemia-portal-content"
+    },
+    {
       "prompt": "Optimize this SQL query and propose a database index.",
       "expected_skill": null
     },

--- a/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
+++ b/packages/dnb-eufemia/agent-skills/eufemia-portal-content/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eufemia-portal-content
-description: Edit content in the official Eufemia portal and deliver small, reviewable pull requests with working page previews. Use when a non-technical contributor asks AI to change portal copy, guidance, or other editorial content.
-compatibility: Requires the Eufemia repository and permission to create GitHub pull requests.
+description: Edit content in the official Eufemia portal and deliver small, reviewable pull requests with working page previews. Use when a non-technical contributor asks AI to change portal copy, guidance, or other editorial content, or repair a pull request created with Edit on GitHub.
+compatibility: Requires access to the Eufemia repository and permission to create or update GitHub pull requests.
 metadata:
   owner: dnbexperience/eufemia
   manifest-version: '1'
@@ -21,9 +21,24 @@ commands, files, or validation steps.
    regular portal deployment or needs a portal-only deployment. For an urgent
    change, also ask for the desired deadline and a short reason that maintainers
    can evaluate.
-3. Fetch current refs and create the content branch from `origin/main`. `main`
-   is the source for new work; `release` is the exact source deployed to the
-   production portal.
+3. Choose the lightest delivery path that can verify the change:
+   - Work only through GitHub when the complete diff is a small prose edit to
+     existing Markdown or MDX and does not change imports, frontmatter, JSX,
+     code examples, assets, navigation, or behavior. Read the complete file and
+     nearby content through GitHub before editing. This path does not require a
+     local checkout, dependency installation, or local test run.
+   - Use a local checkout for broader or structural MDX changes, generated
+     content, behavior, or failures that cannot be diagnosed and corrected
+     confidently from GitHub and CI. Fetch current refs and create the content
+     branch from `origin/main`.
+   - When the contributor already used Edit on GitHub, inspect and continue
+     their branch and pull request instead of making them start again. Review
+     the complete diff and repair its formatting, title, description, and base
+     branch as needed.
+
+   `main` is the source for new work; `release` is the exact source deployed to
+   the production portal.
+
 4. Keep one independently understandable content outcome per pull request.
    Split changes that cover different topics, audiences, navigation areas, or
    reviewer decisions. Keep tightly coupled edits together when separating them
@@ -33,9 +48,14 @@ commands, files, or validation steps.
 5. Preserve the page's MDX structure, imports, links, terminology, tone, and
    heading hierarchy. Do not turn an editorial request into component, API, or
    layout work without explaining the additional scope and receiving approval.
-6. Format changed files with the workspace tools, run focused checks, inspect
-   the complete diff, and verify the affected route and anchor. Add or update
-   tests only when behavior rather than prose changes.
+6. Inspect the complete diff and verify the affected route and anchor. For
+   local work, format changed files with the workspace tools and run focused
+   checks. For GitHub-only work, preserve the surrounding formatting, wait for
+   the required formatting and build checks, and inspect any failures. Apply an
+   unambiguous formatting correction through GitHub; switch to a local checkout
+   when the correction or failure needs local reproduction. State explicitly
+   that validation came from CI rather than claiming local checks. Add or
+   update tests only when behavior rather than prose changes.
 7. Choose the pull request title from the contributor's release-note intent:
    - Use `docs(Portal): ...` when the change should be listed under
      Documentation in the next Eufemia release notes.
@@ -43,11 +63,12 @@ commands, files, or validation steps.
      Confirm the choice in plain language. Neither type should publish a package
      version by itself, but verify the current semantic-release configuration
      before promising release behavior.
-8. Open the pull request against `main` with a short motivation-focused
-   description. After the preview workflow finishes, read its stable Branch
-   Preview URL, append the affected page path and anchor, verify that exact link,
-   and update the description. Include a short release-priority line. Do not list
-   changed files or validation steps. A suitable shape is:
+8. Open or update the pull request against `main` with a short
+   motivation-focused description. After the preview workflow finishes, read
+   its stable Branch Preview URL, append the affected page path and anchor,
+   verify that exact link, and update the description. Include a short
+   release-priority line. Do not list changed files or validation steps. A
+   suitable shape is:
 
    ```markdown
    Explains the problem and why the content change matters.

--- a/packages/dnb-eufemia/agent-skills/manifest.json
+++ b/packages/dnb-eufemia/agent-skills/manifest.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "eufemia-portal-content",
-      "description": "Edit content in the official Eufemia portal and deliver small, reviewable pull requests with working page previews. Use when a non-technical contributor asks AI to change portal copy, guidance, or other editorial content.",
+      "description": "Edit content in the official Eufemia portal and deliver small, reviewable pull requests with working page previews. Use when a non-technical contributor asks AI to change portal copy, guidance, or other editorial content, or repair a pull request created with Edit on GitHub.",
       "path": "eufemia-portal-content/SKILL.md",
       "requiredTools": []
     }


### PR DESCRIPTION
Allows contributors to use the existing GitHub editing flow for small prose changes without installing the repository locally. The portal-content skill can now repair an existing web-created pull request and rely on CI for formatting and build validation, while retaining the local workflow for structural or unclear changes.