### PR TITLE
docs(Portal): add guided content suggestions via AI

### DIFF
--- a/packages/dnb-design-system-portal/src/core/PortalLayout.tsx
+++ b/packages/dnb-design-system-portal/src/core/PortalLayout.tsx
@@ -15,9 +15,8 @@ import tags from '../shared/tags'
 import { resetLevels } from '@dnb/eufemia/src/components/Heading'
 import { setPortalHeadData, usePortalHead } from './PortalHead'
 import { Breadcrumb, Button } from '@dnb/eufemia/src'
-import GithubLogo from '../docs/contribute/assets/github-logo'
 import { resolveEditSourcePath } from './editSourcePath'
-import { getGitHubEditTitle, getGitHubEditUrl } from './githubSource'
+import { getSuggestEditUrl } from './suggestEdit'
 
 const ContentWrapper = TabBar.ContentWrapper
 
@@ -25,6 +24,7 @@ type Frontmatter = {
   title?: string
   showTabs?: boolean
   fullscreen?: boolean
+  hideEditLink?: boolean
 }
 type Fields = {
   slug: string
@@ -57,6 +57,7 @@ export default function PortalLayout(props: PortalLayoutProps) {
               description
               fullscreen
               showTabs
+              hideEditLink
               breadcrumb {
                 text
                 href
@@ -80,6 +81,7 @@ export default function PortalLayout(props: PortalLayoutProps) {
                 description
                 fullscreen
                 showTabs
+                hideEditLink
                 breadcrumb {
                   text
                   href
@@ -200,7 +202,8 @@ export default function PortalLayout(props: PortalLayoutProps) {
       <Content
         showTabs={currentFm.showTabs}
         sourcePath={editSourcePath}
-        showEditLink={!codeFocusMode}
+        pagePath={`${location.pathname}${location.hash || ''}`}
+        showEditLink={!codeFocusMode && !fmData.hideEditLink}
       >
         {children}
       </Content>
@@ -208,7 +211,13 @@ export default function PortalLayout(props: PortalLayoutProps) {
   )
 }
 
-function Content({ showTabs, sourcePath, showEditLink, children }) {
+function Content({
+  showTabs,
+  sourcePath,
+  pagePath,
+  showEditLink,
+  children,
+}) {
   if (showTabs) {
     resetLevels(2)
   }
@@ -220,13 +229,10 @@ function Content({ showTabs, sourcePath, showEditLink, children }) {
       {showEditLink && (
         <Button
           variant="secondary"
-          text="Edit on GitHub"
-          title={getGitHubEditTitle()}
-          icon={GithubLogo}
+          text="Suggest an edit"
+          icon="edit"
           iconPosition="left"
-          href={getGitHubEditUrl(sourcePath)}
-          target="_blank"
-          rel="noopener noreferrer"
+          href={getSuggestEditUrl(pagePath, sourcePath)}
           top="large"
           bottom="large"
         />

--- a/packages/dnb-design-system-portal/src/core/__tests__/suggestEdit.test.ts
+++ b/packages/dnb-design-system-portal/src/core/__tests__/suggestEdit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { createSuggestEditPrompt, getSuggestEditUrl } from '../suggestEdit'
+
+describe('suggestEdit', () => {
+  const source = {
+    repository: 'dnbexperience/eufemia',
+    editRef: 'main',
+    commitSha: 'abcdef123456',
+  }
+
+  it('creates a link with the page, anchor and source path', () => {
+    expect(
+      getSuggestEditUrl(
+        '/uilib/components/button/#events',
+        'packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx'
+      )
+    ).toBe(
+      '/contribute/suggest-edit/?page=%2Fuilib%2Fcomponents%2Fbutton%2F%23events&source=packages%2Fdnb-design-system-portal%2Fsrc%2Fdocs%2Fuilib%2Fcomponents%2Fbutton%2Finfo.mdx'
+    )
+  })
+
+  it('creates a complete portal-content prompt', () => {
+    expect(
+      createSuggestEditPrompt({
+        pageUrl: 'https://eufemia.dnb.no/uilib/components/button/#events',
+        sourcePath:
+          'packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx',
+        requestedChange: 'Clarify when the click event fires.',
+        proposedWording: 'The event fires after activation.',
+        includeInReleaseNotes: false,
+        deployment: 'regular',
+        source,
+      })
+    )
+      .toBe(`Use the eufemia-portal-content skill to update this Eufemia portal page and create or update the pull request. If the skill is not available, follow the instructions below directly. Use the Eufemia MCP server for current documentation if it is configured.
+
+Page: https://eufemia.dnb.no/uilib/components/button/#events
+Source: https://github.com/dnbexperience/eufemia/blob/main/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx
+
+Requested change:
+Clarify when the click event fires.
+
+Proposed wording:
+The event fires after activation.
+
+Release notes: Do not include this change in the next release notes.
+Deployment: This can wait for the next regular release.
+
+Keep the change focused, preserve the page's MDX structure and formatting, run or inspect the appropriate checks, and give me the pull request and exact page preview. Do not merge it.`)
+  })
+
+  it('includes portal-only deployment details', () => {
+    const prompt = createSuggestEditPrompt({
+      pageUrl: 'https://eufemia.dnb.no/design-system/about/',
+      sourcePath:
+        'packages/dnb-design-system-portal/src/docs/design-system/about.mdx',
+      requestedChange: 'Correct the team list.',
+      proposedWording: '',
+      includeInReleaseNotes: true,
+      deployment: 'portal-only',
+      deadline: '2026-09-04',
+      urgencyReason: 'The published names are outdated.',
+      source,
+    })
+
+    expect(prompt).toContain(
+      'This needs a portal-only deployment by 2026-09-04 because The published names are outdated.'
+    )
+  })
+})

--- a/packages/dnb-design-system-portal/src/core/__tests__/suggestEdit.test.ts
+++ b/packages/dnb-design-system-portal/src/core/__tests__/suggestEdit.test.ts
@@ -67,4 +67,15 @@ Keep the change focused, preserve the page's MDX structure and formatting, run o
       'This needs a portal-only deployment by 2026-09-04 because The published names are outdated.'
     )
   })
+
+  it('handles optional values omitted by Eufemia Forms', () => {
+    expect(
+      createSuggestEditPrompt({
+        pageUrl: 'https://eufemia.dnb.no/design-system/about/',
+        sourcePath:
+          'packages/dnb-design-system-portal/src/docs/design-system/about.mdx',
+        source,
+      })
+    ).toContain('Requested change:\n[Describe the change]')
+  })
 })

--- a/packages/dnb-design-system-portal/src/core/suggestEdit.ts
+++ b/packages/dnb-design-system-portal/src/core/suggestEdit.ts
@@ -1,0 +1,65 @@
+import type { GitHubSource } from './githubSource'
+import { githubSource } from './githubSource'
+
+export type SuggestEditDeployment = 'regular' | 'portal-only'
+
+export function getSuggestEditUrl(
+  page: string,
+  sourcePath: string
+): string {
+  const params = new URLSearchParams({ page, source: sourcePath })
+
+  return `/contribute/suggest-edit/?${params}`
+}
+
+type SuggestEditPrompt = {
+  pageUrl: string
+  sourcePath: string
+  requestedChange: string
+  proposedWording: string
+  includeInReleaseNotes: boolean
+  deployment: SuggestEditDeployment
+  deadline?: string
+  urgencyReason?: string
+  source?: GitHubSource
+}
+
+export function createSuggestEditPrompt({
+  pageUrl,
+  sourcePath,
+  requestedChange,
+  proposedWording,
+  includeInReleaseNotes,
+  deployment,
+  deadline,
+  urgencyReason,
+  source = githubSource,
+}: SuggestEditPrompt): string {
+  const sourceUrl = `https://github.com/${source.repository}/blob/${source.editRef}/${sourcePath}`
+  const proposedWordingSection = proposedWording.trim()
+    ? `\n\nProposed wording:\n${proposedWording.trim()}`
+    : ''
+  const deploymentText =
+    deployment === 'portal-only'
+      ? `This needs a portal-only deployment by ${
+          deadline || '[desired date]'
+        } because ${urgencyReason?.trim() || '[reason]'}.`
+      : 'This can wait for the next regular release.'
+
+  return `Use the eufemia-portal-content skill to update this Eufemia portal page and create or update the pull request. If the skill is not available, follow the instructions below directly. Use the Eufemia MCP server for current documentation if it is configured.
+
+Page: ${pageUrl}
+Source: ${sourceUrl}
+
+Requested change:
+${requestedChange.trim() || '[Describe the change]'}${proposedWordingSection}
+
+Release notes: ${
+    includeInReleaseNotes
+      ? 'Include this change in the next release notes.'
+      : 'Do not include this change in the next release notes.'
+  }
+Deployment: ${deploymentText}
+
+Keep the change focused, preserve the page's MDX structure and formatting, run or inspect the appropriate checks, and give me the pull request and exact page preview. Do not merge it.`
+}

--- a/packages/dnb-design-system-portal/src/core/suggestEdit.ts
+++ b/packages/dnb-design-system-portal/src/core/suggestEdit.ts
@@ -15,10 +15,10 @@ export function getSuggestEditUrl(
 type SuggestEditPrompt = {
   pageUrl: string
   sourcePath: string
-  requestedChange: string
-  proposedWording: string
-  includeInReleaseNotes: boolean
-  deployment: SuggestEditDeployment
+  requestedChange?: string
+  proposedWording?: string
+  includeInReleaseNotes?: boolean
+  deployment?: SuggestEditDeployment
   deadline?: string
   urgencyReason?: string
   source?: GitHubSource
@@ -36,7 +36,7 @@ export function createSuggestEditPrompt({
   source = githubSource,
 }: SuggestEditPrompt): string {
   const sourceUrl = `https://github.com/${source.repository}/blob/${source.editRef}/${sourcePath}`
-  const proposedWordingSection = proposedWording.trim()
+  const proposedWordingSection = proposedWording?.trim()
     ? `\n\nProposed wording:\n${proposedWording.trim()}`
     : ''
   const deploymentText =
@@ -52,7 +52,7 @@ Page: ${pageUrl}
 Source: ${sourceUrl}
 
 Requested change:
-${requestedChange.trim() || '[Describe the change]'}${proposedWordingSection}
+${requestedChange?.trim() || '[Describe the change]'}${proposedWordingSection}
 
 Release notes: ${
     includeInReleaseNotes

--- a/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Suggest an edit'
+description: 'Create a ready-to-use prompt for improving an Eufemia portal page.'
+hideInMenu: true
+hideEditLink: true
+---
+
+import SuggestEdit from './suggest-edit/SuggestEdit'
+
+# Suggest an edit
+
+Describe what should change. We will prepare a prompt with the page and source
+details needed to make a small, correctly formatted pull request.
+
+<SuggestEdit />

--- a/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit/SuggestEdit.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit/SuggestEdit.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from 'react'
+import {
+  Accordion,
+  Anchor,
+  Button,
+  Flex,
+  FormStatus,
+  Textarea,
+} from '@dnb/eufemia/src'
+import { Field, Form } from '@dnb/eufemia/src/extensions/forms'
+import { copyToClipboard } from '@dnb/eufemia/src/shared/helpers'
+import { getGitHubEditUrl } from '../../../core/githubSource'
+import {
+  createSuggestEditPrompt,
+  type SuggestEditDeployment,
+} from '../../../core/suggestEdit'
+
+export default function SuggestEdit() {
+  const params =
+    typeof window === 'undefined'
+      ? new URLSearchParams()
+      : new URLSearchParams(window.location.search)
+  const page = params.get('page') || '/'
+  const sourcePath = params.get('source') || ''
+  const pageUrl = new URL(page, 'https://eufemia.dnb.no').toString()
+
+  const defaultData: SuggestEditData = {
+    requestedChange: '',
+    proposedWording: '',
+    includeInReleaseNotes: false,
+    deployment: 'regular',
+    deadline: '',
+    urgencyReason: '',
+  }
+  const [data, setData] = useState(defaultData)
+  const [copied, setCopied] = useState(false)
+
+  const prompt = useMemo(() => {
+    return createSuggestEditPrompt({
+      pageUrl,
+      sourcePath,
+      ...data,
+    })
+  }, [data, pageUrl, sourcePath])
+
+  const handleCopy = async (submittedData: SuggestEditData) => {
+    const submittedPrompt = createSuggestEditPrompt({
+      pageUrl,
+      sourcePath,
+      ...submittedData,
+    })
+    setCopied(await copyToClipboard(submittedPrompt))
+  }
+
+  return (
+    <Flex.Stack gap="large" top="medium" bottom="large">
+      <FormStatus state="information">
+        Page: <Anchor href={page}>{page}</Anchor>
+      </FormStatus>
+
+      <Form.Handler
+        defaultData={defaultData}
+        onChange={(data) => {
+          setData(data)
+          setCopied(false)
+        }}
+        onSubmit={handleCopy}
+      >
+        <Flex.Stack gap="large">
+          <Field.String
+            path="/requestedChange"
+            label="What should change?"
+            labelDescription="Describe what is wrong or outdated, and what the page should communicate instead."
+            width="stretch"
+            multiline
+            rows={4}
+            autoResize={false}
+            required
+          />
+
+          <Field.String
+            path="/proposedWording"
+            label="Proposed wording (optional)"
+            labelDescription="Paste the exact replacement text if you already know it."
+            width="stretch"
+            multiline
+            rows={5}
+            autoResize={false}
+          />
+
+          <Field.Boolean
+            path="/includeInReleaseNotes"
+            variant="checkbox"
+            label="Mention this in the release notes"
+            labelDescription="Choose this when the change should be visible in the next Eufemia release summary."
+          />
+
+          <Field.Selection
+            path="/deployment"
+            variant="radio"
+            label="When should it be published?"
+          >
+            <Field.Option
+              value="regular"
+              title="With the next regular release"
+            />
+            <Field.Option
+              value="portal-only"
+              title="Earlier than the next release"
+            />
+          </Field.Selection>
+
+          <Form.Visibility
+            visibleWhen={{
+              path: '/deployment',
+              hasValue: 'portal-only',
+            }}
+            animate
+          >
+            <Flex.Stack gap="small">
+              <Field.Date
+                path="/deadline"
+                label="Desired publication date"
+                required
+              />
+              <Field.String
+                path="/urgencyReason"
+                label="Why is the earlier publication needed?"
+                labelDescription="Give maintainers the context they need to evaluate a portal-only deployment."
+                width="stretch"
+                multiline
+                rows={3}
+                autoResize={false}
+                required
+              />
+            </Flex.Stack>
+          </Form.Visibility>
+
+          <p>
+            Paste the prompt into your coding agent. You can{' '}
+            <Anchor href="/uilib/usage/first-steps/tools/#install-project-skills">
+              install the Eufemia skills
+            </Anchor>
+            {' or '}
+            <Anchor href="/uilib/usage/first-steps/tools/#hosted-mcp-server">
+              connect the hosted Eufemia MCP server
+            </Anchor>{' '}
+            to give the agent Eufemia guidance.
+          </p>
+
+          <Accordion title="Preview prompt" variant="filled">
+            <Textarea
+              label="Generated prompt"
+              labelSrOnly
+              rows={14}
+              stretch
+              readOnly
+              value={prompt}
+            />
+          </Accordion>
+
+          <Form.ButtonRow>
+            <Form.SubmitButton
+              text={copied ? 'Prompt copied' : 'Copy prompt'}
+              icon={copied ? 'check' : 'copy'}
+            />
+          </Form.ButtonRow>
+
+          {sourcePath && (
+            <Accordion title="For developers">
+              <Button
+                variant="tertiary"
+                text="Edit source on GitHub"
+                href={getGitHubEditUrl(sourcePath)}
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            </Accordion>
+          )}
+        </Flex.Stack>
+      </Form.Handler>
+    </Flex.Stack>
+  )
+}
+
+type SuggestEditData = {
+  requestedChange: string
+  proposedWording: string
+  includeInReleaseNotes: boolean
+  deployment: SuggestEditDeployment
+  deadline: string
+  urgencyReason: string
+}

--- a/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit/SuggestEdit.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit/SuggestEdit.tsx
@@ -134,15 +134,15 @@ export default function SuggestEdit() {
           </Form.Visibility>
 
           <p>
-            Paste the prompt into your coding agent. You can{' '}
+            Paste the prompt into your coding agent. For Eufemia guidance,{' '}
             <Anchor href="/uilib/usage/first-steps/tools/#install-project-skills">
               install the Eufemia skills
             </Anchor>
             {' or '}
             <Anchor href="/uilib/usage/first-steps/tools/#hosted-mcp-server">
               connect the hosted Eufemia MCP server
-            </Anchor>{' '}
-            to give the agent Eufemia guidance.
+            </Anchor>
+            .
           </p>
 
           <Accordion title="Preview prompt" variant="filled">
@@ -164,15 +164,13 @@ export default function SuggestEdit() {
           </Form.ButtonRow>
 
           {sourcePath && (
-            <Accordion title="For developers">
-              <Button
-                variant="tertiary"
-                text="Edit source on GitHub"
-                href={getGitHubEditUrl(sourcePath)}
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            </Accordion>
+            <Button
+              variant="tertiary"
+              text="Edit source on GitHub"
+              href={getGitHubEditUrl(sourcePath)}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
           )}
         </Flex.Stack>
       </Form.Handler>

--- a/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit/SuggestEdit.tsx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/suggest-edit/SuggestEdit.tsx
@@ -74,7 +74,6 @@ export default function SuggestEdit() {
             width="stretch"
             multiline
             rows={4}
-            autoResize={false}
             required
           />
 
@@ -85,7 +84,6 @@ export default function SuggestEdit() {
             width="stretch"
             multiline
             rows={5}
-            autoResize={false}
           />
 
           <Field.Boolean
@@ -130,7 +128,6 @@ export default function SuggestEdit() {
                 width="stretch"
                 multiline
                 rows={3}
-                autoResize={false}
                 required
               />
             </Flex.Stack>

--- a/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/pageNavigation.spec.ts
@@ -132,28 +132,16 @@ test.describe('Page Navigation', () => {
       expect(title).toContain('Button | Eufemia')
     })
 
-    test('should contain an Edit on GitHub link', async ({ page }) => {
+    test('should contain a Suggest an edit link', async ({ page }) => {
       await page.goto('/uilib/components/button/')
       await waitForApp(page)
 
-      const repository =
-        process.env.VITE_GITHUB_REPOSITORY || 'dnbexperience/eufemia'
-      const editRef = process.env.VITE_GITHUB_EDIT_REF || 'main'
-      const commitSha = process.env.VITE_GITHUB_COMMIT_SHA
-      const editLink = page.getByRole('link', { name: 'Edit on GitHub' })
+      const editLink = page.getByRole('link', { name: 'Suggest an edit' })
 
       await expect(editLink).toHaveAttribute(
         'href',
-        `https://github.com/${repository}/edit/${editRef}/packages/dnb-design-system-portal/src/docs/uilib/components/button/info.mdx`
+        '/contribute/suggest-edit/?page=%2Fuilib%2Fcomponents%2Fbutton%2F&source=packages%2Fdnb-design-system-portal%2Fsrc%2Fdocs%2Fuilib%2Fcomponents%2Fbutton%2Finfo.mdx'
       )
-      await expect(editLink).toHaveAttribute('target', '_blank')
-
-      if (commitSha) {
-        await expect(editLink).toHaveAttribute(
-          'title',
-          `Edit source from preview commit ${commitSha.slice(0, 7)} on GitHub`
-        )
-      }
     })
 
     test('click on first main menu card should open /design-system', async ({


### PR DESCRIPTION
Replaces the direct GitHub editor link with a guided content suggestion flow. Contributors can describe a change using Eufemia Forms, choose release timing, and copy a prompt containing the exact Portal page and source context.

Example: https://chore-portal-suggest-edit.eufemia-e25.pages.dev/contribute/suggest-edit/?page=%2Fdesign-system%2Fcontact&source=packages%2Fdnb-design-system-portal%2Fsrc%2Fdocs%2Fdesign-system%2Fcontact.mdx