### PR TITLE
fix(Anchor): shorten external link tooltip hide delay

### DIFF
--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -256,6 +256,7 @@ export function AnchorComponent(localProps: AnchorAllProps) {
           id={internalId + '-tooltip'}
           targetElement={tooltipRef}
           tooltip={tooltip}
+          {...(_opensNewTab && { hideDelay: 0 })}
         >
           {allProps.title || targetBlankTitle}
         </Tooltip>

--- a/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
+++ b/packages/dnb-eufemia/src/components/anchor/Anchor.tsx
@@ -256,7 +256,7 @@ export function AnchorComponent(localProps: AnchorAllProps) {
           id={internalId + '-tooltip'}
           targetElement={tooltipRef}
           tooltip={tooltip}
-          {...(_opensNewTab && { hideDelay: 0 })}
+          {...(_opensNewTab && { hideDelay: 100 })}
         >
           {allProps.title || targetBlankTitle}
         </Tooltip>

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -1070,6 +1070,34 @@ describe('Tooltip', () => {
       )
     })
 
+    it('hides without delay when hover ends', async () => {
+      render(
+        <Anchor href="/url" target="_blank" lang="en-GB">
+          text
+        </Anchor>
+      )
+
+      const anchorElement = document.querySelector('a')
+
+      fireEvent.mouseEnter(anchorElement)
+
+      await waitFor(() =>
+        expect(document.querySelector('.dnb-tooltip')).toHaveClass(
+          'dnb-tooltip--active'
+        )
+      )
+
+      fireEvent.mouseLeave(anchorElement)
+
+      await waitFor(
+        () =>
+          expect(document.querySelector('.dnb-tooltip')).not.toHaveClass(
+            'dnb-tooltip--active'
+          ),
+        { timeout: 100 }
+      )
+    })
+
     it('has to be visible on focus event dispatch', async () => {
       render(
         <Anchor href="/url" target="_blank" lang="en-GB">

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -1070,7 +1070,7 @@ describe('Tooltip', () => {
       )
     })
 
-    it('hides without delay when hover ends', async () => {
+    it('hides after a short delay when hover ends', async () => {
       render(
         <Anchor href="/url" target="_blank" lang="en-GB">
           text
@@ -1089,12 +1089,22 @@ describe('Tooltip', () => {
 
       fireEvent.mouseLeave(anchorElement)
 
+      expect(document.querySelector('.dnb-tooltip')).toHaveClass(
+        'dnb-tooltip--active'
+      )
+
+      await wait(50)
+
+      expect(document.querySelector('.dnb-tooltip')).toHaveClass(
+        'dnb-tooltip--active'
+      )
+
       await waitFor(
         () =>
           expect(document.querySelector('.dnb-tooltip')).not.toHaveClass(
             'dnb-tooltip--active'
           ),
-        { timeout: 100 }
+        { timeout: 250 }
       )
     })
 


### PR DESCRIPTION
External-link tooltips use the default 500 ms hide delay after the pointer leaves the anchor. This can make the tooltip overlap underlying content while the user has already moved on.

Use a shorter 100 ms hide delay for these tooltips. This preserves a brief delay while substantially reducing how long they cover nearby content.