### PR TITLE
chore(Portal): remove orphaned theme tag link from theming guide

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
@@ -16,7 +16,6 @@ You may also check out the section about [how to use a theme in your application
   - [Main theming file](#main-theming-file)
     - [Creating a new main theme](#creating-a-new-main-theme)
     - [Run the Portal with a different theme](#run-the-portal-with-a-different-theme)
-    - [Show theme tag in Portal](#show-theme-tag-in-portal)
   - [Component theming](#component-theming)
     - [Button as an example](#button-as-an-example)
     - [CSS custom properties and :root](#css-custom-properties-and-root)


### PR DESCRIPTION
Follow-up to the discussion in #9215 about removing the now-unused `theme` frontmatter (https://github.com/dnbexperience/eufemia/pull/9215#discussion_r3914659087).

#9215 already removed all `theme` readiness frontmatter from the MDX pages, the sidebar `ThemeBadge` (component, styles and GraphQL query field), and the "Show theme tag in Portal" authoring guide section. The only thing left behind was the table-of-contents link in the theming style guide, which still pointed to the deleted section.

This removes that orphaned link so the guide's contents list matches its headings again.
