### PR TITLE
chore(Portal): correct theme-switching description in guide and comments

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/style-guides/theming.mdx
@@ -83,7 +83,7 @@ and run `yarn build`. All the related component theme file will then be created 
 
 ### Run the Portal with a different theme
 
-Theme switching in the Portal is handled by the Vite theme handler shim (`vite/client/shims/theme-handler.ts`), which manages theme CSS via the `data-dnb-theme` attribute on `<html>`.
+Theme switching in the Portal is handled by the Vite theme handler shim (`vite/client/shims/theme-handler.ts`) together with `vite-plugin-eufemia-theme`. Switching enables the selected theme's stylesheet and disables the others — each theme is a separate `<style>` (dev) or lazy-loaded `<link data-eufemia-theme="<name>">` (production) element — and sets an `eufemia-theme__<brand>` class on `<body>`.
 
 - In the Portal Tools you can switch to a different theme (runtime).
 - You can also define a different theme in the URL itself `path/?eufemia-theme=eiendom` (runtime).

--- a/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
+++ b/packages/dnb-design-system-portal/vite/client/plugins/eufemia-theme.ts
@@ -6,8 +6,10 @@
  * 2. Generates a virtual module (`virtual:eufemia-theme-styles`) with imports
  * 3. Exports a `useThemeHandler` hook for runtime theme switching
  *
- * The theme switching works via CSS attribute selectors
- * (data-dnb-theme="<name>") that Eufemia's SCSS already supports.
+ * Theme switching enables the selected theme's stylesheet and disables the
+ * others — each theme is a separate `<style>` (dev) or lazy-loaded
+ * `<link data-eufemia-theme="<name>">` (build) element — and sets an
+ * `eufemia-theme__<brand>` class on <body> for theme-scoped CSS properties.
  */
 
 import { type Plugin } from 'vite'

--- a/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
+++ b/packages/dnb-design-system-portal/vite/client/shims/theme-handler.ts
@@ -2,11 +2,12 @@
  * Runtime theme handler used by the portal.
  *
  * Provides the same runtime API: useThemeHandler, getTheme, setTheme, etc.
- * Theme switching works via the `data-dnb-theme` attribute on <html>,
- * which Eufemia's SCSS theme files already respond to.
- *
- * All theme CSS is already loaded by vite-plugin-eufemia-theme,
- * so switching only requires updating localStorage + the HTML attribute.
+ * Theme switching is handled by vite-plugin-eufemia-theme: it enables the
+ * selected theme's stylesheet and disables the others — each theme is a
+ * separate `<style>` (dev) or `<link data-eufemia-theme="<name>">` (build)
+ * element — and sets an `eufemia-theme__<brand>` class on <body> so the
+ * theme's scoped CSS custom properties resolve. In build mode the theme CSS
+ * is lazy-loaded on first use before the active stylesheet is swapped.
  *
  * Shares the `eufemia-theme` localStorage key with Eufemia's getTheme/setTheme
  * (shared/Theme.tsx). The payload contract is kept in sync by hand — `brand`


### PR DESCRIPTION
The theming style guide and the `theme-handler.ts` / `eufemia-theme.ts` header comments described portal theme switching as working via a `data-dnb-theme` attribute on `<html>`. That attribute is never set anywhere in the codebase — it appears to be a leftover from an earlier implementation.

The portal actually switches themes by enabling the selected theme's stylesheet and disabling the others — each theme is a separate `<style>` element in dev, or a lazy-loaded `<link data-eufemia-theme="<name>">` in production builds — and by adding an `eufemia-theme__<brand>` class to `<body>` so the theme's scoped CSS custom properties resolve (the same class the PostCSS theme-scope plugin targets).

This updates the guide and the two comments to match the implementation. Documentation/comments only — no behavior change.
