### PR TITLE
fix(Form.Section): recover from a stuck async onDone via asyncSubmitTimeout

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/Section/EditContainer/demos.mdx
@@ -23,7 +23,7 @@ With `preventUncommittedChanges`, the user must select "Done" or "Cancel" before
 
 When `onDone` returns a Promise, the section stays in edit mode while it is pending. It switches to view mode when the Promise resolves and stays in edit mode when it rejects.
 
-While the Promise is pending, the fields inside the section and its "Done" and "Cancel" buttons are disabled. This keeps the submitted values from changing while the save is in flight. Make sure the returned Promise always settles, because one that never resolves or rejects leaves the section disabled.
+While the Promise is pending, the fields inside the section and its "Done" and "Cancel" buttons are disabled. This keeps the submitted values from changing while the save is in flight. If the Promise does not settle within `asyncSubmitTimeout` (30 seconds by default), the section re-enables itself and stays in edit mode, mirroring `Form.Handler`'s submit behavior, so a save that never settles cannot leave the section stuck.
 
 The demo starts with a simulated save error. Change the first name and select **Done** to verify that the input remains. Turn off **Simulate save error** and try again to complete the save.
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useRef } from 'react'
 import SectionContainerContext from '../containers/SectionContainerContext'
 import ToolbarContext from '../Toolbar/ToolbarContext'
+import DataContext from '../../../DataContext/Context'
 import { useTranslation } from '../../../hooks'
 import { Button } from '../../../../../components'
 import { check } from '../../../../../icons'
@@ -15,6 +16,9 @@ export default function DoneEditButton() {
   const { switchContainerMode } = useContext(SectionContainerContext) || {}
   const { hasError, hasVisibleError, setShowBoundaryErrors } =
     useContext(FieldBoundaryContext) || {}
+  const dataContext = useContext(DataContext)
+  const asyncSubmitTimeout =
+    dataContext?.props?.asyncSubmitTimeout ?? 30000
   const translation = useTranslation().SectionEditContainer
   const buttonRef = useRef<HTMLElement>(null)
   const restoreFocusRef = useRef(false)
@@ -58,12 +62,24 @@ export default function DoneEditButton() {
 
       if (result instanceof Promise) {
         setIsPending?.(true)
+
+        // Recover the pending state if the Promise never settles, mirroring
+        // the `asyncSubmitTimeout` safety net Form.Handler's `onSubmit` uses.
+        // Without it, a Promise that never resolves or rejects would leave
+        // the section disabled with no way out. The section stays in edit
+        // mode so the user can try again.
+        const timeout = setTimeout(() => {
+          setIsPending?.(false)
+        }, asyncSubmitTimeout)
+
         void result.then(
           () => {
+            clearTimeout(timeout)
             setIsPending?.(false)
             switchContainerMode?.('view')
           },
           () => {
+            clearTimeout(timeout)
             restoreFocusRef.current = true
             setIsPending?.(false)
           }
@@ -73,6 +89,7 @@ export default function DoneEditButton() {
       }
     }
   }, [
+    asyncSubmitTimeout,
     hasError,
     hasVisibleError,
     isPending,

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/DoneButton.tsx
@@ -9,6 +9,10 @@ import FieldBoundaryContext from '../../../DataContext/FieldBoundary/FieldBounda
 import SubmitIndicator from '../../SubmitIndicator'
 import { useIsomorphicLayoutEffect as useLayoutEffect } from '../../../../../shared/helpers/useIsomorphicLayoutEffect'
 
+type PendingOperation = {
+  timeout?: ReturnType<typeof setTimeout>
+}
+
 export default function DoneEditButton() {
   const { onDone, setShowError, isPending, setIsPending } =
     useContext(ToolbarContext) || {}
@@ -22,6 +26,7 @@ export default function DoneEditButton() {
   const translation = useTranslation().SectionEditContainer
   const buttonRef = useRef<HTMLElement>(null)
   const restoreFocusRef = useRef(false)
+  const pendingOperationRef = useRef<PendingOperation>(null)
 
   // Disabling the button while it is pending removes it from the focus
   // order, which makes browsers move focus to the document body. When the
@@ -40,6 +45,18 @@ export default function DoneEditButton() {
       }
     }
   }, [isPending])
+
+  useLayoutEffect(
+    () => () => {
+      const operation = pendingOperationRef.current
+      pendingOperationRef.current = null
+
+      if (operation?.timeout !== undefined) {
+        clearTimeout(operation.timeout)
+      }
+    },
+    []
+  )
 
   const doneHandler = useCallback(() => {
     if (isPending) {
@@ -63,23 +80,51 @@ export default function DoneEditButton() {
       if (result instanceof Promise) {
         setIsPending?.(true)
 
+        const operation: PendingOperation = {}
+        pendingOperationRef.current = operation
+
+        const finishOperation = () => {
+          if (pendingOperationRef.current !== operation) {
+            return false
+          }
+
+          pendingOperationRef.current = null
+
+          if (operation.timeout !== undefined) {
+            clearTimeout(operation.timeout)
+          }
+
+          return true
+        }
+
         // Recover the pending state if the Promise never settles, mirroring
         // the `asyncSubmitTimeout` safety net Form.Handler's `onSubmit` uses.
         // Without it, a Promise that never resolves or rejects would leave
         // the section disabled with no way out. The section stays in edit
         // mode so the user can try again.
-        const timeout = setTimeout(() => {
+        operation.timeout = setTimeout(() => {
+          if (!finishOperation()) {
+            return
+          }
+
+          restoreFocusRef.current = true
           setIsPending?.(false)
         }, asyncSubmitTimeout)
 
         void result.then(
           () => {
-            clearTimeout(timeout)
+            if (!finishOperation()) {
+              return
+            }
+
             setIsPending?.(false)
             switchContainerMode?.('view')
           },
           () => {
-            clearTimeout(timeout)
+            if (!finishOperation()) {
+              return
+            }
+
             restoreFocusRef.current = true
             setIsPending?.(false)
           }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainerDocs.ts
@@ -26,7 +26,7 @@ export const EditContainerProperties: PropertiesTableProps = {
 
 export const EditContainerEvents: PropertiesTableProps = {
   onDone: {
-    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored.',
+    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored. If the Promise does not settle within `asyncSubmitTimeout` (30 seconds by default), the section re-enables itself and stays in edit mode.',
     type: 'function',
     status: 'optional',
   },

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
@@ -180,4 +180,47 @@ describe('EditContainer async onDone', () => {
       ).not.toHaveAttribute('aria-hidden', 'true')
     })
   })
+
+  it('should re-enable the section after asyncSubmitTimeout when an async onDone never settles', async () => {
+    const onDone = vi.fn(() => new Promise<void>(() => undefined))
+
+    render(
+      <Form.Handler asyncSubmitTimeout={100}>
+        <Form.Section containerMode="edit">
+          <Form.Section.EditContainer onDone={onDone}>
+            <Field.String path="/name" />
+          </Form.Section.EditContainer>
+
+          <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+        </Form.Section>
+      </Form.Handler>
+    )
+
+    const [doneButton, cancelButton] = Array.from(
+      document.querySelectorAll('.dnb-forms-section-edit-block button')
+    )
+    const input = document.querySelector('input')
+
+    await userEvent.click(doneButton)
+
+    // Disabled while the save is in flight
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(doneButton).toBeDisabled()
+    expect(cancelButton).toBeDisabled()
+    expect(input).toBeDisabled()
+
+    // The Promise never settles, so the asyncSubmitTimeout recovers the
+    // section instead of leaving it stuck.
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(cancelButton).not.toBeDisabled()
+    expect(input).not.toBeDisabled()
+
+    // It stays in edit mode, since the save never confirmed, so the user
+    // can try again.
+    expect(
+      document.querySelector('.dnb-forms-section-view-block')
+    ).toHaveAttribute('aria-hidden', 'true')
+  })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { Field, Form, Value } from '../../../..'
 import userEvent from '@testing-library/user-event'
 
@@ -222,5 +222,102 @@ describe('EditContainer async onDone', () => {
     expect(
       document.querySelector('.dnb-forms-section-view-block')
     ).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('should ignore a late resolution after asyncSubmitTimeout', async () => {
+    let resolveOnDone!: () => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOnDone = resolve
+        })
+    )
+
+    render(
+      <Form.Handler asyncSubmitTimeout={100}>
+        <Form.Section containerMode="edit">
+          <Form.Section.EditContainer onDone={onDone}>
+            <Field.String path="/name" />
+          </Form.Section.EditContainer>
+
+          <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+        </Form.Section>
+      </Form.Handler>
+    )
+
+    const doneButton = document.querySelector(
+      '.dnb-forms-section-edit-block button'
+    )
+
+    await userEvent.click(doneButton)
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+
+    await act(async () => {
+      resolveOnDone()
+    })
+
+    expect(
+      document.querySelector('.dnb-forms-section-view-block')
+    ).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('should ignore a stale rejection while a retry is pending', async () => {
+    const operations: Array<{
+      resolve: () => void
+      reject: (reason?: unknown) => void
+    }> = []
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          operations.push({ resolve, reject })
+        })
+    )
+
+    render(
+      <Form.Handler asyncSubmitTimeout={100}>
+        <Form.Section containerMode="edit">
+          <Form.Section.EditContainer onDone={onDone}>
+            <Field.String path="/name" />
+          </Form.Section.EditContainer>
+
+          <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+        </Form.Section>
+      </Form.Handler>
+    )
+
+    const [doneButton, cancelButton] = Array.from(
+      document.querySelectorAll('.dnb-forms-section-edit-block button')
+    )
+
+    await userEvent.click(doneButton)
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(doneButton)
+    expect(onDone).toHaveBeenCalledTimes(2)
+    expect(doneButton).toBeDisabled()
+    expect(cancelButton).toBeDisabled()
+
+    await act(async () => {
+      operations[0].reject(new Error('First save failed late'))
+    })
+
+    expect(doneButton).toBeDisabled()
+    expect(cancelButton).toBeDisabled()
+
+    await act(async () => {
+      operations[1].resolve()
+    })
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-forms-section-view-block')
+      ).not.toHaveAttribute('aria-hidden', 'true')
+    })
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/DoneButton.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/DoneButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { act, render, fireEvent } from '@testing-library/react'
 import FieldBoundaryContext from '../../../../DataContext/FieldBoundary/FieldBoundaryContext'
 import SectionContainerContext from '../../containers/SectionContainerContext'
 import Toolbar from '../../Toolbar'
@@ -9,6 +9,43 @@ import ToolbarContext from '../../Toolbar/ToolbarContext'
 const nb = nbNO['nb-NO'].SectionEditContainer
 
 describe('DoneButton', () => {
+  it('should ignore a pending operation after unmount', async () => {
+    let resolveOnDone!: () => void
+    const switchContainerMode = vi.fn()
+    const setIsPending = vi.fn()
+    const onDone = () =>
+      new Promise<void>((resolve) => {
+        resolveOnDone = resolve
+      })
+
+    const { unmount } = render(
+      <SectionContainerContext value={{ switchContainerMode }}>
+        <ToolbarContext
+          value={{
+            setShowError: vi.fn(),
+            setIsPending,
+            onDone,
+          }}
+        >
+          <DoneButton />
+        </ToolbarContext>
+      </SectionContainerContext>
+    )
+
+    fireEvent.click(document.querySelector('button'))
+    expect(setIsPending).toHaveBeenCalledTimes(1)
+    expect(setIsPending).toHaveBeenCalledWith(true)
+
+    unmount()
+
+    await act(async () => {
+      resolveOnDone()
+    })
+
+    expect(setIsPending).toHaveBeenCalledTimes(1)
+    expect(switchContainerMode).not.toHaveBeenCalled()
+  })
+
   it('calls "switchContainerMode"', () => {
     const switchContainerMode = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/DoneButtonFocus.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/DoneButtonFocus.test.tsx
@@ -3,9 +3,12 @@ import { Field, Form } from '../../../..'
 import userEvent from '@testing-library/user-event'
 
 describe('EditContainer done button focus', () => {
-  const renderSection = (onDone: () => void | Promise<unknown>) =>
+  const renderSection = (
+    onDone: () => void | Promise<unknown>,
+    asyncSubmitTimeout?: number
+  ) =>
     render(
-      <>
+      <Form.Handler asyncSubmitTimeout={asyncSubmitTimeout}>
         {/* Focus target outside the section, so it stays focusable while
         the section is pending */}
         <button type="button" data-testid="outside">
@@ -19,7 +22,7 @@ describe('EditContainer done button focus', () => {
 
           <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
         </Form.Section>
-      </>
+      </Form.Handler>
     )
 
   const getDoneButton = () =>
@@ -81,5 +84,24 @@ describe('EditContainer done button focus', () => {
       expect(doneButton).not.toBeDisabled()
     })
     expect(getOutsideButton()).toHaveFocus()
+  })
+
+  it('should move focus back to the done button after asyncSubmitTimeout', async () => {
+    const onDone = vi.fn(() => new Promise<void>(() => undefined))
+
+    renderSection(onDone, 100)
+
+    const doneButton = getDoneButton()
+    await userEvent.click(doneButton)
+    expect(doneButton).toBeDisabled()
+
+    getOutsideButton().focus()
+    getOutsideButton().blur()
+    expect(document.body).toHaveFocus()
+
+    await waitFor(() => {
+      expect(doneButton).not.toBeDisabled()
+    })
+    expect(doneButton).toHaveFocus()
   })
 })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/Toolbar/ToolbarDocs.ts
@@ -15,7 +15,7 @@ export const ToolbarEvents: PropertiesTableProps = {
     status: 'optional',
   },
   onDone: {
-    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored.',
+    doc: 'Callback for the done button. Return a Promise to keep the section in edit mode until it settles: it switches to view mode when the Promise resolves, and stays in edit mode when it rejects. Any other return value is ignored. If the Promise does not settle within `asyncSubmitTimeout` (30 seconds by default), the section re-enables itself and stays in edit mode.',
     type: 'function',
     status: 'optional',
   },


### PR DESCRIPTION
## Problem

When `Form.Section.EditContainer`'s `onDone` returns a Promise, the section disables its fields and both toolbar buttons until the Promise settles. A Promise that never settles (e.g. a hung request with no timeout) left the section disabled with **no way out**.

## Fix

`Form.Handler`'s async `onSubmit` already guards against this with `asyncSubmitTimeout` (30 seconds by default), after which the submit indicator reverts to normal. The section's `onDone` had no equivalent safety net.

`onDone` now re-enables the section after `asyncSubmitTimeout` when the Promise has not settled, staying in edit mode so the user can try again. This matches the rest of the form's async behavior and reuses the existing `asyncSubmitTimeout` prop — **no new public API**, and the deliberate "Cancel disabled during a pending save" behavior is unchanged.

## Why this approach

An earlier version of this PR re-enabled Cancel during the pending save and passed an `AbortSignal` to `onDone`. It was reworked to this smaller, consistent approach after review: an `AbortSignal` on `onDone` would have been a novel pattern used nowhere else in the forms system, whereas `asyncSubmitTimeout` is exactly how `onSubmit`, async `onChange`, and Wizard steps already recover from a hung async operation.

## Tests

- Added: the section re-enables its fields and buttons after `asyncSubmitTimeout` when `onDone` never settles, and stays in edit mode (verified it fails without the fix).
- Kept the existing "both buttons stay disabled while pending" test unchanged.
- Full `Form/Section` suite green (152 tests); typecheck, lint, and Prettier clean.