### PR TITLE
fix(Tabs): show selected tab content after server-side rendering

### DIFF
--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -1508,6 +1508,12 @@ function CachedContent({
 
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
+
+      // React still owns "hidden", so restore its value when the
+      // enhancement no longer applies but the content stays hidden.
+      if (element.getAttribute('hidden') === 'until-found') {
+        element.setAttribute('hidden', '')
+      }
     }
   }, [canOpenOnFind, hidden, onBeforeMatch])
 
@@ -1515,7 +1521,7 @@ function CachedContent({
     <div
       ref={elementRef}
       data-tab-key={tabKey}
-      hidden={hidden && !canOpenOnFind ? true : undefined}
+      hidden={hidden ? true : undefined} // Enhanced to hidden="until-found" after mount when openOnFind is enabled
       aria-hidden={hidden ? true : undefined}
       className={clsx(
         'dnb-tabs__cached',

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -1495,7 +1495,13 @@ function CachedContent({
 
   useEffect(() => {
     const element = elementRef.current
-    if (!element || !hidden || !canOpenOnFind) {
+    if (!element || !hidden) {
+      return undefined
+    }
+
+    if (!canOpenOnFind) {
+      // Undo a previous enhancement, which React does not track.
+      element.setAttribute('hidden', '')
       return undefined
     }
 
@@ -1508,11 +1514,6 @@ function CachedContent({
 
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
-
-      // Restore the value React rendered, since it still owns the attribute.
-      if (element.getAttribute('hidden') === 'until-found') {
-        element.setAttribute('hidden', '')
-      }
     }
   }, [canOpenOnFind, hidden, onBeforeMatch])
 

--- a/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/Tabs.tsx
@@ -1509,8 +1509,7 @@ function CachedContent({
     return () => {
       element.removeEventListener('beforematch', handleBeforeMatch)
 
-      // React still owns "hidden", so restore its value when the
-      // enhancement no longer applies but the content stays hidden.
+      // Restore the value React rendered, since it still owns the attribute.
       if (element.getAttribute('hidden') === 'until-found') {
         element.setAttribute('hidden', '')
       }

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -7,6 +7,7 @@ import { StrictMode } from 'react'
 import type { ReactNode } from 'react'
 import { axeComponent, loadScss } from '../../../core/test-utils/testSetup'
 import { act, fireEvent, render } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
 import { Provider } from '../../../shared'
 import defaultLocales from '../../../shared/locales'
 import type { TabsProps } from '../Tabs'
@@ -832,6 +833,37 @@ describe('A single Tab component', () => {
     expect(
       document.querySelectorAll('.dnb-tabs__cached')[1]
     ).toHaveAttribute('hidden', '')
+  })
+
+  it('renders the same openOnFind markup on the server and the client', () => {
+    const element = (
+      <Tabs
+        {...props}
+        keepInDOM
+        data={[
+          { title: 'One', key: 'one', content: 'Content one' },
+          { title: 'Two', key: 'two', content: 'Content two' },
+        ]}
+      />
+    )
+
+    const cachedContents = (html: string) =>
+      html.match(/<div data-tab-key="[^"]*"[^>]*>/g)
+
+    const client = renderToString(element)
+
+    const originalDocument = globalThis.document
+    let server: string
+
+    try {
+      delete globalThis.document
+      server = renderToString(element)
+    } finally {
+      globalThis.document = originalDocument
+    }
+
+    expect(cachedContents(server)).toEqual(cachedContents(client))
+    expect(cachedContents(server)[1]).toContain('hidden=""')
   })
 
   it('has to work with "Tabs.Content" as children components', () => {

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -819,17 +819,31 @@ describe('A single Tab component', () => {
   })
 
   it('allows openOnFind to be disabled when keepInDOM is true', () => {
-    render(
+    const tabs = (openOnFind: boolean) => (
       <Tabs
         {...props}
         keepInDOM
-        openOnFind={false}
+        openOnFind={openOnFind}
         data={[
           { title: 'One', key: 'one', content: 'Content one' },
           { title: 'Two', key: 'two', content: 'Content two' },
         ]}
       />
     )
+
+    const { rerender } = render(tabs(false))
+
+    expect(
+      document.querySelectorAll('.dnb-tabs__cached')[1]
+    ).toHaveAttribute('hidden', '')
+
+    rerender(tabs(true))
+
+    expect(
+      document.querySelectorAll('.dnb-tabs__cached')[1]
+    ).toHaveAttribute('hidden', 'until-found')
+
+    rerender(tabs(false))
 
     expect(
       document.querySelectorAll('.dnb-tabs__cached')[1]

--- a/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
+++ b/packages/dnb-eufemia/src/components/tabs/__tests__/Tabs.test.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react'
 import { axeComponent, loadScss } from '../../../core/test-utils/testSetup'
 import { act, fireEvent, render } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
+import { hydrateRoot } from 'react-dom/client'
 import { Provider } from '../../../shared'
 import defaultLocales from '../../../shared/locales'
 import type { TabsProps } from '../Tabs'
@@ -835,7 +836,7 @@ describe('A single Tab component', () => {
     ).toHaveAttribute('hidden', '')
   })
 
-  it('renders the same openOnFind markup on the server and the client', () => {
+  it('shows the selected tab content after hydrating server-rendered markup', () => {
     const element = (
       <Tabs
         {...props}
@@ -847,23 +848,38 @@ describe('A single Tab component', () => {
       />
     )
 
-    const cachedContents = (html: string) =>
-      html.match(/<div data-tab-key="[^"]*"[^>]*>/g)
-
-    const client = renderToString(element)
-
     const originalDocument = globalThis.document
-    let server: string
+    let html: string
 
     try {
       delete globalThis.document
-      server = renderToString(element)
+      html = renderToString(element)
     } finally {
       globalThis.document = originalDocument
     }
 
-    expect(cachedContents(server)).toEqual(cachedContents(client))
-    expect(cachedContents(server)[1]).toContain('hidden=""')
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const recoverableErrors = []
+    act(() => {
+      hydrateRoot(container, element, {
+        onRecoverableError: (error) => recoverableErrors.push(error),
+      })
+    })
+
+    expect(recoverableErrors).toEqual([])
+
+    act(() => {
+      fireEvent.click(
+        container.querySelector('button[data-tab-key="two"]')
+      )
+    })
+
+    expect(
+      container.querySelector('div[data-tab-key="two"]')
+    ).not.toHaveAttribute('hidden')
   })
 
   it('has to work with "Tabs.Content" as children components', () => {


### PR DESCRIPTION
`Tabs` with `keepInDOM` renders nothing in the selected tab panel after server-side rendering.

`CachedContent` skipped the `hidden` attribute whenever `hidden="until-found"` was supported, so the server emitted `hidden=""` while the client's hydration render omitted it. React 19 reports this as a hydration mismatch and explicitly does not patch it up, which leaves React's recorded value out of sync with the DOM. Selecting a tab then re-renders to the same recorded value, so the stale attribute is never removed and the panel stays hidden.

`keepInDOM` already existed before `openOnFind`, and `openOnFind` defaults to `keepInDOM`, so this reaches consumers who did not opt into the new feature.

The attribute is now always rendered and upgraded to `until-found` after mount, matching how `Table` already does it.
