### PR TITLE
chore(InputMasked): prevent Maskito re-init from an unstable optionsEnhancer

### DIFF
--- a/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/TextMask.tsx
@@ -176,11 +176,14 @@ export default function TextMask(props: TextMaskProps): JSX.Element {
     maskParams?.decimalLimit,
   ])
 
+  // Read optionsEnhancer from a ref so an unstable inline function doesn't re-init Maskito each render
+  const optionsEnhancerRef = useRef(optionsEnhancer)
+  optionsEnhancerRef.current = optionsEnhancer
+
   const enhancedOptions = useMemo<MaskitoOptions | null>(() => {
-    return typeof optionsEnhancer === 'function'
-      ? optionsEnhancer(options)
-      : options
-  }, [options, optionsEnhancer])
+    const enhancer = optionsEnhancerRef.current
+    return typeof enhancer === 'function' ? enhancer(options) : options
+  }, [options])
 
   const maskitoRef = useMaskito({ options: enhancedOptions })
 

--- a/packages/dnb-eufemia/src/components/input-masked/__tests__/TextMask.test.tsx
+++ b/packages/dnb-eufemia/src/components/input-masked/__tests__/TextMask.test.tsx
@@ -127,6 +127,27 @@ describe('TextMask', () => {
     const secondOptions = vi.mocked(useMaskito).mock.lastCall[0].options
     expect(secondOptions).toBe(firstOptions)
   })
+
+  it('keeps Maskito options stable for an unstable optionsEnhancer', () => {
+    const mask = [/\d/, '-', /\d/]
+    const { rerender } = render(
+      <TextMask
+        mask={mask}
+        optionsEnhancer={(options) => (options ? { ...options } : options)}
+      />
+    )
+    const firstOptions = vi.mocked(useMaskito).mock.lastCall[0].options
+
+    rerender(
+      <TextMask
+        mask={mask}
+        optionsEnhancer={(options) => (options ? { ...options } : options)}
+      />
+    )
+
+    const secondOptions = vi.mocked(useMaskito).mock.lastCall[0].options
+    expect(secondOptions).toBe(firstOptions)
+  })
 })
 
 describe('cleanNumericValue', () => {


### PR DESCRIPTION
Follow-up to #9237. That PR stabilized the `mask` reference via `areMasksEqual`, but the `enhancedOptions` memo in `TextMask` still listed `optionsEnhancer` as a dependency. An inline (unstable) `optionsEnhancer` function would therefore rebuild the Maskito options — and re-initialize Maskito — on every render.

This reads `optionsEnhancer` from a ref so the options memo recomputes only when `options` change, keeping Maskito stable regardless of the enhancer's identity.

Not currently reachable in production (no component passes `optionsEnhancer` into `TextMask`), so this is preventive hardening.
