### PR TITLE
fix(Field.Selection): keep Autocomplete data stable between renders

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -179,6 +179,19 @@ function Selection(props: FieldSelectionProps) {
   const renderedChildren = useMemo(() => {
     return resolveChildren(children, value, dataList)
   }, [children, dataList, value])
+  const normalizedData = useMemo(() => {
+    return renderDropdownItems(
+      hasRenderPropChildren ? undefined : dataList,
+      transformSelection
+    )
+      .concat(makeOptions(renderedChildren, transformSelection))
+      .filter(Boolean)
+  }, [
+    dataList,
+    hasRenderPropChildren,
+    renderedChildren,
+    transformSelection,
+  ])
 
   const handleDrawerListChange = useCallback(
     ({ data, value }: DrawerListChangeParams) => {
@@ -315,12 +328,7 @@ function Selection(props: FieldSelectionProps) {
 
     case 'autocomplete':
     case 'dropdown': {
-      const data = renderDropdownItems(
-        hasRenderPropChildren ? undefined : dataList,
-        transformSelection
-      )
-        .concat(makeOptions(renderedChildren, transformSelection))
-        .filter(Boolean)
+      const data = normalizedData
       const displayValue = data.find(
         (item) => item.selectedKey === value
       )?.content

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.data.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.data.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react'
+import type { AutocompleteAllProps } from '../../../../../components/Autocomplete'
+import Selection from '../Selection'
+
+const autocompleteProps = vi.hoisted(() => [] as AutocompleteAllProps[])
+
+vi.mock('../../../../../components', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../../../../../components')>()
+
+  return {
+    ...original,
+    Autocomplete: (props: AutocompleteAllProps) => {
+      autocompleteProps.push(props)
+      return <input aria-label="Autocomplete" />
+    },
+  }
+})
+
+describe('Field.Selection data', () => {
+  it('keeps normalized Autocomplete data stable between renders', () => {
+    const data = [
+      { value: 'one', title: 'One' },
+      { value: 'two', title: 'Two' },
+    ]
+    const { rerender } = render(
+      <Selection variant="autocomplete" data={data} />
+    )
+    const firstData = autocompleteProps.at(-1).data
+
+    rerender(<Selection variant="autocomplete" data={data} />)
+
+    expect(autocompleteProps.at(-1).data).toBe(firstData)
+  })
+})


### PR DESCRIPTION
Field.Selection recreated normalized Autocomplete data on every render. Keeping that data stable prevents unnecessary DrawerList state updates during surrounding form rerenders.