### PR TITLE
chore(release): stamp published packages with the real version again

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -78,7 +78,7 @@
     "test:e2e": "playwright test --config=./playwright.config.e2e.ts",
     "test:e2e:ci": "PLAYWRIGHT_BASE_URL=http://localhost:8001 start-server-and-test 'yarn workspace dnb-design-system-portal serve:8001' http://localhost:8001 test:e2e",
     "test:e2e:watch": "playwright test --config=./playwright.config.e2e.ts --ui",
-    "test:postbuild": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/postbuild.test.ts scripts/postbuild/__tests__/validatePackageContents.test.ts scripts/postbuild/__tests__/writeReleaseConfig.test.ts",
+    "test:postbuild": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/postbuild.test.ts scripts/postbuild/__tests__/validatePackageContents.test.ts scripts/postbuild/__tests__/writeReleaseConfig.test.ts scripts/postbuild/__tests__/getNextReleaseVersion.test.ts",
     "test:postbuild:publish": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/prepareForRelease.test.ts",
     "test:prepare": "yarn build:style-manifest",
     "test:screenshots": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runScreenshotVitest.ts",

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Test the credential-free next release version resolution.
+ *
+ * The release build job runs without Git, npm or GitHub credentials, so these
+ * fixtures deliberately have no reachable remote: a resolution that needs one
+ * would fail here the same way it would fail a release.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { getNextReleaseVersion } from '../getNextReleaseVersion'
+
+const fixtures: Array<string> = []
+
+function createRepository(branch = 'release') {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'eufemia-next-version-'))
+  fixtures.push(cwd)
+
+  const git = (...args: Array<string>) =>
+    execFileSync('git', args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] })
+
+  git('init', '--quiet', `--initial-branch=${branch}`)
+  git('config', 'user.email', 'test@dnb.no')
+  git('config', 'user.name', 'Eufemia test')
+  git('config', 'commit.gpgsign', 'false')
+
+  // semantic-release fetches from `origin` before it reads the branches
+  git('remote', 'add', 'origin', cwd)
+
+  writeFileSync(
+    path.join(cwd, 'package.json'),
+    JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      release: {
+        branches: [branch],
+        plugins: [
+          [
+            '@semantic-release/commit-analyzer',
+            { preset: 'conventionalcommits' },
+          ],
+        ],
+      },
+    })
+  )
+
+  const commit = (message: string) => {
+    git('add', '--all')
+    git('commit', '--quiet', '--allow-empty', '--message', message)
+  }
+
+  commit('chore: initial commit')
+  git('tag', 'v1.0.0')
+
+  return { cwd, commit }
+}
+
+afterAll(() => {
+  for (const fixture of fixtures) {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+describe('getNextReleaseVersion', () => {
+  it('resolves a minor version from a feature commit', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: add a component')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('1.1.0')
+  })
+
+  it('resolves a patch version from a fix commit', async () => {
+    const { cwd, commit } = createRepository()
+    commit('fix: correct a component')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('1.0.1')
+  })
+
+  it('resolves a major version from a breaking change', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: remove a component\n\nBREAKING CHANGE: it is gone')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('2.0.0')
+  })
+
+  it('resolves without writing to the log', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: add a component')
+
+    const warn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const error = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const log = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined)
+
+    await getNextReleaseVersion({ cwd })
+
+    expect(warn).not.toHaveBeenCalled()
+    expect(error).not.toHaveBeenCalled()
+    expect(log).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+    error.mockRestore()
+    log.mockRestore()
+  })
+
+  it('returns null when no commit warrants a release', async () => {
+    const { cwd } = createRepository()
+
+    expect(await getNextReleaseVersion({ cwd })).toBeNull()
+  })
+
+  it('returns null when not on a release branch', async () => {
+    const { cwd, commit } = createRepository('feat/some-branch')
+    commit('feat: add a component')
+
+    expect(await getNextReleaseVersion({ cwd })).toBeNull()
+  })
+})

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -5,19 +5,14 @@
 
 // When on a "release" branch:
 // run: yarn nodemon --exec 'babel-node --extensions .js,.ts,.tsx ./scripts/postbuild/getNextReleaseVersion.js' --ext js --watch './scripts/**/*'
-// run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/postbuild/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
 
-const { execFile } = require('child_process')
+const fs = require('fs')
+const os = require('os')
 const path = require('path')
+const { execFileSync } = require('child_process')
+const { Writable } = require('stream')
 const simpleGit = require('simple-git')
 
-try {
-  process.loadEnvFile()
-} catch {
-  // .env is optional — CI provides env vars directly
-}
-
-const srBin = require.resolve('semantic-release/bin/semantic-release.js')
 const eufemiaRoot = path.resolve(__dirname, '..', '..')
 const releaseBranches = ['release', 'beta', 'alpha']
 
@@ -26,43 +21,146 @@ if (require.main === module) {
   getNextReleaseVersion()
 }
 
-async function getNextReleaseVersion() {
-  const branchName = (await simpleGit().branch()).current
+async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
+  const branchName = (await simpleGit(cwd).branch()).current
 
-  if (releaseBranches.includes(branchName)) {
-    try {
-      const log = await new Promise((resolve) => {
-        execFile(
-          process.execPath,
-          [srBin, '--dry-run'],
-          { timeout: 120000, cwd: eufemiaRoot },
-          (_error, stdout, stderr) => {
-            // Resolve with combined output regardless of exit code —
-            // semantic-release may exit non-zero in dry-run mode
-            // even after printing the next version.
-            resolve((stdout || '') + (stderr || ''))
-          }
-        )
-      })
-      const nextVersion = log.match(
-        /The next release version is ([^\n]*)/
-      )?.[1]
-
-      if (nextVersion) {
-        return nextVersion
-      }
-    } catch (e) {
-      console.error(e)
-    }
-  } else {
-    console.warn(
-      `The current git branch ${branchName} is not one of the release branches ${releaseBranches.join(
-        ','
-      )}`
-    )
+  if (!releaseBranches.includes(branchName)) {
+    return null
   }
 
-  return null
+  try {
+    return await resolveNextReleaseVersion(cwd)
+  } catch (error) {
+    console.warn(
+      `Could not determine the next release version: ${error.message}`
+    )
+
+    return null
+  }
+}
+
+/**
+ * semantic-release derives the version from the commits, but a regular run also
+ * verifies the npm and GitHub credentials it would publish with – and the
+ * release build job deliberately has none. Only the commit analyzer is needed
+ * to get the version, and it needs no credentials, so run that plugin alone.
+ */
+async function resolveNextReleaseVersion(cwd) {
+  const { default: semanticRelease } = await import('semantic-release')
+  const { branches, plugins } = require(
+    path.join(cwd, 'package.json')
+  ).release
+  const commitAnalyzer = plugins.find(
+    (plugin) =>
+      (Array.isArray(plugin) ? plugin[0] : plugin) ===
+      '@semantic-release/commit-analyzer'
+  )
+  const mirror = createRepositoryMirror(cwd)
+
+  try {
+    const result = await semanticRelease(
+      {
+        branches,
+        plugins: [commitAnalyzer],
+        repositoryUrl: mirror.path,
+        dryRun: true,
+        // Report the version for a pull request build too, which
+        // semantic-release skips when it runs as a release
+        ci: false,
+      },
+      {
+        cwd,
+        env: process.env,
+        stdout: createSink(),
+        stderr: createSink(),
+      }
+    )
+
+    return result ? result.nextRelease.version : null
+  } finally {
+    mirror.remove()
+  }
+}
+
+/**
+ * semantic-release verifies that it is allowed to push before it reports a
+ * version, and it discovers the configured branches through the repository URL.
+ * A throwaway bare clone covers both without credentials: `--shared` references
+ * the existing object store instead of copying it, and every known branch head
+ * is added so the branch configuration resolves the same way it would against
+ * the remote.
+ */
+function createRepositoryMirror(cwd) {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'eufemia-release-')
+  )
+  const mirrorPath = path.join(directory, 'repo.git')
+  const repositoryRoot = git(cwd, ['rev-parse', '--show-toplevel'])
+
+  git(cwd, [
+    'clone',
+    '--bare',
+    '--shared',
+    '--quiet',
+    repositoryRoot,
+    mirrorPath,
+  ])
+
+  const updates = Array.from(collectBranchHeads(cwd))
+    .map(([name, hash]) => `update refs/heads/${name} ${hash}\n`)
+    .join('')
+
+  git(mirrorPath, ['update-ref', '--stdin'], { input: updates })
+
+  return {
+    path: mirrorPath,
+    remove: () => fs.rmSync(directory, { recursive: true, force: true }),
+  }
+}
+
+function collectBranchHeads(cwd) {
+  const heads = new Map()
+
+  const collect = (pattern, strip) => {
+    const refs = git(cwd, [
+      'for-each-ref',
+      `--format=%(refname:lstrip=${strip}) %(objectname)`,
+      pattern,
+    ])
+
+    for (const line of refs.split('\n').filter(Boolean)) {
+      const [name, hash] = line.split(' ')
+
+      // The remote HEAD is a symbolic ref, not a branch of its own
+      if (name !== 'HEAD') {
+        heads.set(name, hash)
+      }
+    }
+  }
+
+  collect('refs/remotes/origin', 3)
+
+  // The checked-out branches win, so the mirror agrees with what is built here
+  collect('refs/heads', 2)
+
+  return heads
+}
+
+function git(cwd, args, options = {}) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...options,
+  }).trim()
+}
+
+function createSink() {
+  return new Writable({
+    write(chunk, encoding, callback) {
+      callback()
+    },
+  })
 }
 
 exports.releaseBranches = releaseBranches

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -205,41 +205,26 @@ describe('makeReleaseVersion', () => {
     )
   })
 
-  it('write branch in file', async () => {
+  it('should fail instead of writing the branch name on a release branch', async () => {
     mockBranchName('release')
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
     ).mockImplementationOnce(async () => null)
 
-    await makeReleaseVersion()
-
-    expect(fs.writeFile).toHaveBeenCalledTimes(4)
-
-    // JS
-    expect(fs.writeFile).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
-      expect.stringContaining(`release`)
+    await expect(makeReleaseVersion()).rejects.toThrow(
+      'Could not determine the next release version on the release branch.'
     )
 
-    // CJS
-    expect(fs.writeFile).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('src/shared/build-info/BuildInfoData.cjs'),
-      expect.stringContaining(`release`)
-    )
-
-    // CSS
-    expect(fs.writeFile).toHaveBeenNthCalledWith(
-      3,
-      expect.stringContaining('src/style/core/scopes.scss'),
-      expect.stringContaining(`--eufemia-version: 'release';`)
-    )
+    expect(fs.writeFile).not.toHaveBeenCalled()
   })
 
   it('write sha in file', async () => {
     mockBranchName('release')
+    vi.spyOn(
+      getNextReleaseVersion,
+      'getNextReleaseVersion'
+    ).mockImplementationOnce(async () => '123456789')
     vi.spyOn(child_process, 'execSync').mockReturnValueOnce(
       'test-sha' as any
     )

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -26,6 +26,14 @@ export async function makeReleaseVersion() {
 
   if (releaseBranches.includes(branchName)) {
     version = await getNextReleaseVersion()
+
+    // A release build must never fall back to the branch name below, because
+    // that name would ship as `Eufemia.version` and as the style scope hash.
+    if (!version && isCI) {
+      throw new Error(
+        `Could not determine the next release version on the ${branchName} branch.`
+      )
+    }
   }
 
   if (!version && isCI) {

--- a/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
+++ b/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
@@ -1,20 +1,10 @@
 import { exec } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { promisify } from 'node:util'
 import { findRepoRoot } from './convertHelpers.ts'
 
 const execAsync = promisify(exec)
-const releaseBranches = ['release', 'beta', 'alpha']
-
-async function getBranchName(cwd: string) {
-  try {
-    const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', {
-      cwd,
-    })
-    return stdout.trim()
-  } catch {
-    return ''
-  }
-}
+const require = createRequire(import.meta.url)
 
 export async function getCommitHash() {
   const repoRoot = findRepoRoot()
@@ -30,25 +20,9 @@ export async function getCommitHash() {
 }
 
 export async function getNextReleaseVersion() {
-  const repoRoot = findRepoRoot()
-  const branchName = await getBranchName(repoRoot)
+  const {
+    getNextReleaseVersion: resolveVersion,
+  } = require('@dnb/eufemia/scripts/postbuild/getNextReleaseVersion')
 
-  if (releaseBranches.includes(branchName)) {
-    try {
-      const { stdout } = await execAsync(
-        'yarn workspace @dnb/eufemia semantic-release --dry-run',
-        { cwd: repoRoot }
-      )
-      const nextVersion = stdout.match(
-        /The next release version is ([^\n]*)/
-      )?.[1]
-      if (nextVersion) {
-        return nextVersion
-      }
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  return '0.0.0-development'
+  return (await resolveVersion()) || '0.0.0-development'
 }


### PR DESCRIPTION
The release build job deliberately has no publish authority, but the helper that predicts the next version still ran a full `semantic-release --dry-run`. That run verifies it can push before it reports anything, so it failed and printed a stack trace that looks like a broken release:

```
Error: Command failed: yarn workspace @dnb/eufemia semantic-release --dry-run
  ✘  EGITNOPERMISSION Cannot push to the Git repository.
```

Worse than the noise: every caller swallowed the failure, so the prebuild stamped the branch name instead of the version. `@dnb/eufemia@11.12.0` shipped with `Eufemia.version === 'release'` and the isolated style scope `eufemia-scope--default` instead of `eufemia-scope--11_12_0`.

Since the OIDC cutover a full dry-run needs Git push, GitHub API and npm credentials, so it can only ever succeed in the publish job. Only the commit analyzer is needed to get the version, and it needs nothing — so it now runs on its own against a throwaway bare clone that shares the object store. A release build fails outright when the version cannot be resolved, instead of publishing a placeholder.