### PR TITLE
chore(release): stamp published packages with the real version again

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -78,7 +78,7 @@
     "test:e2e": "playwright test --config=./playwright.config.e2e.ts",
     "test:e2e:ci": "PLAYWRIGHT_BASE_URL=http://localhost:8001 start-server-and-test 'yarn workspace dnb-design-system-portal serve:8001' http://localhost:8001 test:e2e",
     "test:e2e:watch": "playwright test --config=./playwright.config.e2e.ts --ui",
-    "test:postbuild": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/postbuild.test.ts scripts/postbuild/__tests__/validatePackageContents.test.ts scripts/postbuild/__tests__/writeReleaseConfig.test.ts",
+    "test:postbuild": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/postbuild.test.ts scripts/postbuild/__tests__/validatePackageContents.test.ts scripts/postbuild/__tests__/writeReleaseConfig.test.ts scripts/postbuild/__tests__/getNextReleaseVersion.test.ts",
     "test:postbuild:publish": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/prepareForRelease.test.ts",
     "test:prepare": "yarn build:style-manifest",
     "test:screenshots": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runScreenshotVitest.ts",

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
@@ -10,13 +10,18 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { getNextReleaseVersion } from '../getNextReleaseVersion'
+import {
+  getNextReleaseVersion,
+  isReleaseBranch,
+} from '../getNextReleaseVersion'
 
 const fixtures: Array<string> = []
 
+type ConfiguredBranch = string | { name: string; prerelease?: string }
+
 function createRepository({
   branch = 'release',
-  configuredBranches = [branch],
+  configuredBranches = [branch] as Array<ConfiguredBranch>,
 } = {}) {
   const cwd = mkdtempSync(path.join(tmpdir(), 'eufemia-next-version-'))
   fixtures.push(cwd)
@@ -58,7 +63,7 @@ function createRepository({
   git('tag', 'v1.0.0')
 
   for (const name of configuredBranches) {
-    if (name !== branch) {
+    if (typeof name === 'string' && name !== branch) {
       git('branch', name)
     }
   }
@@ -70,6 +75,38 @@ afterAll(() => {
   for (const fixture of fixtures) {
     rmSync(fixture, { recursive: true, force: true })
   }
+})
+
+describe('isReleaseBranch', () => {
+  // Asserted against the package's own `release.branches`, so this fails if the
+  // two ever drift apart again
+  it.each(['release', 'next', 'beta', 'alpha', '10.x', '11.2.x', '1.x'])(
+    'matches %s',
+    (branch) => {
+      expect(isReleaseBranch(branch)).toBe(true)
+    }
+  )
+
+  it.each([
+    'main',
+    'fix/something',
+    'HEAD',
+    '10.x-something',
+    'v10.x',
+    '',
+  ])('does not match %s', (branch) => {
+    expect(isReleaseBranch(branch)).toBe(false)
+  })
+
+  it('matches the branches a repository configures', () => {
+    const { cwd } = createRepository({
+      branch: 'release',
+      configuredBranches: ['some-other-branch'],
+    })
+
+    expect(isReleaseBranch('some-other-branch', { cwd })).toBe(true)
+    expect(isReleaseBranch('release', { cwd })).toBe(false)
+  })
 })
 
 describe('getNextReleaseVersion', () => {
@@ -148,7 +185,7 @@ describe('getNextReleaseVersion', () => {
 
   it('explains why when the version cannot be resolved', async () => {
     const { cwd, commit } = createRepository({
-      configuredBranches: ['some-other-branch'],
+      configuredBranches: [{ name: 'release', prerelease: '@@' }],
     })
     commit('feat: add a component')
 
@@ -163,9 +200,7 @@ describe('getNextReleaseVersion', () => {
       )
     )
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'semantic-release is configured to only publish'
-      )
+      expect.stringContaining('semantic-release')
     )
 
     warn.mockRestore()
@@ -187,6 +222,7 @@ describe('getNextReleaseVersion', () => {
   it('returns null when not on a release branch', async () => {
     const { cwd, commit } = createRepository({
       branch: 'feat/some-branch',
+      configuredBranches: ['release'],
     })
     commit('feat: add a component')
 

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Test the credential-free next release version resolution.
+ *
+ * The release build job runs without Git, npm or GitHub credentials, so these
+ * fixtures deliberately have no reachable remote: a resolution that needs one
+ * would fail here the same way it would fail a release.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { getNextReleaseVersion } from '../getNextReleaseVersion'
+
+const fixtures: Array<string> = []
+
+function createRepository({
+  branch = 'release',
+  configuredBranches = [branch],
+} = {}) {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'eufemia-next-version-'))
+  fixtures.push(cwd)
+
+  const git = (...args: Array<string>) =>
+    execFileSync('git', args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] })
+
+  git('init', '--quiet', `--initial-branch=${branch}`)
+  git('config', 'user.email', 'test@dnb.no')
+  git('config', 'user.name', 'Eufemia test')
+  git('config', 'commit.gpgsign', 'false')
+
+  // semantic-release fetches from `origin` before it reads the branches
+  git('remote', 'add', 'origin', cwd)
+
+  writeFileSync(
+    path.join(cwd, 'package.json'),
+    JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      release: {
+        branches: configuredBranches,
+        plugins: [
+          [
+            '@semantic-release/commit-analyzer',
+            { preset: 'conventionalcommits' },
+          ],
+        ],
+      },
+    })
+  )
+
+  const commit = (message: string) => {
+    git('add', '--all')
+    git('commit', '--quiet', '--allow-empty', '--message', message)
+  }
+
+  commit('chore: initial commit')
+  git('tag', 'v1.0.0')
+
+  for (const name of configuredBranches) {
+    if (name !== branch) {
+      git('branch', name)
+    }
+  }
+
+  return { cwd, commit }
+}
+
+afterAll(() => {
+  for (const fixture of fixtures) {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+describe('getNextReleaseVersion', () => {
+  it('resolves a minor version from a feature commit', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: add a component')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('1.1.0')
+  })
+
+  it('resolves a patch version from a fix commit', async () => {
+    const { cwd, commit } = createRepository()
+    commit('fix: correct a component')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('1.0.1')
+  })
+
+  it('resolves a major version from a breaking change', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: remove a component\n\nBREAKING CHANGE: it is gone')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('2.0.0')
+  })
+
+  it('resolves from the checked-out branch, not from the CI ref', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: add a component')
+
+    vi.stubEnv('GITHUB_ACTIONS', 'true')
+    vi.stubEnv('GITHUB_REF', 'refs/heads/some-other-branch')
+    vi.stubEnv('GITHUB_REF_NAME', 'some-other-branch')
+
+    try {
+      expect(await getNextReleaseVersion({ cwd })).toBe('1.1.0')
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('resolves without writing to the log', async () => {
+    const { cwd, commit } = createRepository()
+    commit('feat: add a component')
+
+    const warn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const error = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const log = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined)
+
+    await getNextReleaseVersion({ cwd })
+
+    expect(warn).not.toHaveBeenCalled()
+    expect(error).not.toHaveBeenCalled()
+    expect(log).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+    error.mockRestore()
+    log.mockRestore()
+  })
+
+  it('returns null when no commit warrants a release', async () => {
+    const { cwd } = createRepository()
+    const warn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+
+    expect(await getNextReleaseVersion({ cwd })).toBeNull()
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
+  it('explains why when the version cannot be resolved', async () => {
+    const { cwd, commit } = createRepository({
+      configuredBranches: ['some-other-branch'],
+    })
+    commit('feat: add a component')
+
+    const warn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+
+    expect(await getNextReleaseVersion({ cwd })).toBeNull()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Could not determine the next release version'
+      )
+    )
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'semantic-release is configured to only publish'
+      )
+    )
+
+    warn.mockRestore()
+  })
+
+  it('returns null when not on a release branch', async () => {
+    const { cwd, commit } = createRepository({
+      branch: 'feat/some-branch',
+    })
+    commit('feat: add a component')
+
+    expect(await getNextReleaseVersion({ cwd })).toBeNull()
+  })
+})

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
@@ -63,7 +63,7 @@ function createRepository({
     }
   }
 
-  return { cwd, commit }
+  return { cwd, commit, git }
 }
 
 afterAll(() => {
@@ -169,6 +169,19 @@ describe('getNextReleaseVersion', () => {
     )
 
     warn.mockRestore()
+  })
+
+  it('resolves when a renamed branch left a colliding remote ref behind', async () => {
+    const { cwd, commit, git } = createRepository()
+    commit('feat: add a component')
+
+    // Renaming a branch into a folder of branches leaves a remote ref that
+    // cannot coexist with the ones that replaced it, and a clone only drops it
+    // once it is pruned
+    git('branch', 'portal/page-toc')
+    git('update-ref', 'refs/remotes/origin/portal', 'HEAD')
+
+    expect(await getNextReleaseVersion({ cwd })).toBe('1.1.0')
   })
 
   it('returns null when not on a release branch', async () => {

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -10,21 +10,46 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { execFileSync } = require('child_process')
+const { createRequire } = require('module')
 const { Writable } = require('stream')
 const simpleGit = require('simple-git')
 
+// The matcher semantic-release itself expands the branch configuration with
+const micromatch = createRequire(
+  require.resolve('semantic-release/package.json')
+)('micromatch')
+
 const eufemiaRoot = path.resolve(__dirname, '..', '..')
-const releaseBranches = ['release', 'beta', 'alpha']
 
 // run this script if it is called from bash / command line
 if (require.main === module) {
   getNextReleaseVersion()
 }
 
+/**
+ * The branches semantic-release publishes from, so `next` and the maintenance
+ * branches are covered too rather than only the ones a hardcoded list knows.
+ */
+function isReleaseBranch(branchName, { cwd = eufemiaRoot } = {}) {
+  if (!branchName) {
+    return false
+  }
+
+  const patterns = getReleaseConfig(cwd).branches.map((branch) =>
+    typeof branch === 'string' ? branch : branch.name
+  )
+
+  return micromatch.isMatch(branchName, patterns)
+}
+
+function getReleaseConfig(cwd) {
+  return require(path.resolve(cwd, 'package.json')).release
+}
+
 async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
   const branchName = (await simpleGit(cwd).branch()).current
 
-  if (!releaseBranches.includes(branchName)) {
+  if (!isReleaseBranch(branchName, { cwd })) {
     return null
   }
 
@@ -47,9 +72,7 @@ async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
  */
 async function resolveNextReleaseVersion(cwd) {
   const { default: semanticRelease } = await import('semantic-release')
-  const { branches, plugins } = require(
-    path.resolve(cwd, 'package.json')
-  ).release
+  const { branches, plugins } = getReleaseConfig(cwd)
   const commitAnalyzer = plugins.find(
     (plugin) =>
       (Array.isArray(plugin) ? plugin[0] : plugin) ===
@@ -58,22 +81,11 @@ async function resolveNextReleaseVersion(cwd) {
   const mirror = createRepositoryMirror(cwd)
   const log = createLogCapture()
 
-  // This hook only runs once the branch and the push check have passed, which
-  // separates "nothing to release" from a run that never got that far
-  let analysable = false
-
   try {
     const result = await semanticRelease(
       {
         branches,
-        plugins: [
-          commitAnalyzer,
-          {
-            verifyConditions: () => {
-              analysable = true
-            },
-          },
-        ],
+        plugins: [commitAnalyzer],
         repositoryUrl: mirror.path,
         dryRun: true,
         // Report the version for a pull request build too, which
@@ -88,15 +100,11 @@ async function resolveNextReleaseVersion(cwd) {
       }
     )
 
-    if (result) {
-      return result.nextRelease.version
-    }
-
-    if (analysable) {
-      return null
-    }
-
-    throw new Error(log.read())
+    // The branch is already known to be one semantic-release publishes from, so
+    // no result means the commits do not warrant a release
+    return result ? result.nextRelease.version : null
+  } catch (error) {
+    throw new Error(`${error.message}\n${log.read()}`, { cause: error })
   } finally {
     mirror.remove()
   }
@@ -242,5 +250,5 @@ function createLogCapture() {
   }
 }
 
-exports.releaseBranches = releaseBranches
+exports.isReleaseBranch = isReleaseBranch
 exports.getNextReleaseVersion = getNextReleaseVersion

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -48,7 +48,7 @@ async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
 async function resolveNextReleaseVersion(cwd) {
   const { default: semanticRelease } = await import('semantic-release')
   const { branches, plugins } = require(
-    path.join(cwd, 'package.json')
+    path.resolve(cwd, 'package.json')
   ).release
   const commitAnalyzer = plugins.find(
     (plugin) =>
@@ -128,27 +128,33 @@ function createRepositoryMirror(cwd) {
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'eufemia-release-')
   )
-  const mirrorPath = path.join(directory, 'repo.git')
-  const repositoryRoot = git(cwd, ['rev-parse', '--show-toplevel'])
+  const remove = () =>
+    fs.rmSync(directory, { recursive: true, force: true })
 
-  git(cwd, [
-    'clone',
-    '--bare',
-    '--shared',
-    '--quiet',
-    repositoryRoot,
-    mirrorPath,
-  ])
+  try {
+    const mirrorPath = path.join(directory, 'repo.git')
+    const repositoryRoot = git(cwd, ['rev-parse', '--show-toplevel'])
 
-  const updates = Array.from(collectBranchHeads(cwd))
-    .map(([name, hash]) => `update refs/heads/${name} ${hash}\n`)
-    .join('')
+    git(cwd, [
+      'clone',
+      '--bare',
+      '--shared',
+      '--quiet',
+      repositoryRoot,
+      mirrorPath,
+    ])
 
-  git(mirrorPath, ['update-ref', '--stdin'], { input: updates })
+    const updates = Array.from(collectBranchHeads(cwd))
+      .map(([name, hash]) => `update refs/heads/${name} ${hash}\n`)
+      .join('')
 
-  return {
-    path: mirrorPath,
-    remove: () => fs.rmSync(directory, { recursive: true, force: true }),
+    git(mirrorPath, ['update-ref', '--stdin'], { input: updates })
+
+    return { path: mirrorPath, remove }
+  } catch (error) {
+    remove()
+
+    throw error
   }
 }
 

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -5,19 +5,14 @@
 
 // When on a "release" branch:
 // run: yarn nodemon --exec 'babel-node --extensions .js,.ts,.tsx ./scripts/postbuild/getNextReleaseVersion.js' --ext js --watch './scripts/**/*'
-// run (mjs): yarn nodemon --exec 'node --experimental-import-meta-resolve ./scripts/postbuild/getNextReleaseVersion.mjs' --ext mjs --watch './scripts/**/*'
 
-const { execFile } = require('child_process')
+const fs = require('fs')
+const os = require('os')
 const path = require('path')
+const { execFileSync } = require('child_process')
+const { Writable } = require('stream')
 const simpleGit = require('simple-git')
 
-try {
-  process.loadEnvFile()
-} catch {
-  // .env is optional — CI provides env vars directly
-}
-
-const srBin = require.resolve('semantic-release/bin/semantic-release.js')
 const eufemiaRoot = path.resolve(__dirname, '..', '..')
 const releaseBranches = ['release', 'beta', 'alpha']
 
@@ -26,43 +21,186 @@ if (require.main === module) {
   getNextReleaseVersion()
 }
 
-async function getNextReleaseVersion() {
-  const branchName = (await simpleGit().branch()).current
+async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
+  const branchName = (await simpleGit(cwd).branch()).current
 
-  if (releaseBranches.includes(branchName)) {
-    try {
-      const log = await new Promise((resolve) => {
-        execFile(
-          process.execPath,
-          [srBin, '--dry-run'],
-          { timeout: 120000, cwd: eufemiaRoot },
-          (_error, stdout, stderr) => {
-            // Resolve with combined output regardless of exit code —
-            // semantic-release may exit non-zero in dry-run mode
-            // even after printing the next version.
-            resolve((stdout || '') + (stderr || ''))
-          }
-        )
-      })
-      const nextVersion = log.match(
-        /The next release version is ([^\n]*)/
-      )?.[1]
-
-      if (nextVersion) {
-        return nextVersion
-      }
-    } catch (e) {
-      console.error(e)
-    }
-  } else {
-    console.warn(
-      `The current git branch ${branchName} is not one of the release branches ${releaseBranches.join(
-        ','
-      )}`
-    )
+  if (!releaseBranches.includes(branchName)) {
+    return null
   }
 
-  return null
+  try {
+    return await resolveNextReleaseVersion(cwd)
+  } catch (error) {
+    console.warn(
+      `Could not determine the next release version:\n${error.message}`
+    )
+
+    return null
+  }
+}
+
+/**
+ * semantic-release derives the version from the commits, but a regular run also
+ * verifies the npm and GitHub credentials it would publish with – and the
+ * release build job deliberately has none. Only the commit analyzer is needed
+ * to get the version, and it needs no credentials, so run that plugin alone.
+ */
+async function resolveNextReleaseVersion(cwd) {
+  const { default: semanticRelease } = await import('semantic-release')
+  const { branches, plugins } = require(
+    path.join(cwd, 'package.json')
+  ).release
+  const commitAnalyzer = plugins.find(
+    (plugin) =>
+      (Array.isArray(plugin) ? plugin[0] : plugin) ===
+      '@semantic-release/commit-analyzer'
+  )
+  const mirror = createRepositoryMirror(cwd)
+  const log = createLogCapture()
+
+  // This hook only runs once the branch and the push check have passed, which
+  // separates "nothing to release" from a run that never got that far
+  let analysable = false
+
+  try {
+    const result = await semanticRelease(
+      {
+        branches,
+        plugins: [
+          commitAnalyzer,
+          {
+            verifyConditions: () => {
+              analysable = true
+            },
+          },
+        ],
+        repositoryUrl: mirror.path,
+        dryRun: true,
+        // Report the version for a pull request build too, which
+        // semantic-release skips when it runs as a release
+        ci: false,
+      },
+      {
+        cwd,
+        env: withoutCiBranchDetection(process.env),
+        stdout: log.stream,
+        stderr: log.stream,
+      }
+    )
+
+    if (result) {
+      return result.nextRelease.version
+    }
+
+    if (analysable) {
+      return null
+    }
+
+    throw new Error(log.read())
+  } finally {
+    mirror.remove()
+  }
+}
+
+/**
+ * semantic-release reads the branch from the CI environment, which is the
+ * workflow's own ref – not necessarily the repository it is pointed at. Hiding
+ * the GitHub Actions marker makes it fall back to reading the branch from that
+ * repository, so the version always describes what is actually checked out.
+ */
+function withoutCiBranchDetection(processEnv) {
+  const env = { ...processEnv }
+
+  delete env.GITHUB_ACTIONS
+
+  return env
+}
+
+/**
+ * semantic-release verifies that it is allowed to push before it reports a
+ * version, and it discovers the configured branches through the repository URL.
+ * A throwaway bare clone covers both without credentials: `--shared` references
+ * the existing object store instead of copying it, and every known branch head
+ * is added so the branch configuration resolves the same way it would against
+ * the remote.
+ */
+function createRepositoryMirror(cwd) {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'eufemia-release-')
+  )
+  const mirrorPath = path.join(directory, 'repo.git')
+  const repositoryRoot = git(cwd, ['rev-parse', '--show-toplevel'])
+
+  git(cwd, [
+    'clone',
+    '--bare',
+    '--shared',
+    '--quiet',
+    repositoryRoot,
+    mirrorPath,
+  ])
+
+  const updates = Array.from(collectBranchHeads(cwd))
+    .map(([name, hash]) => `update refs/heads/${name} ${hash}\n`)
+    .join('')
+
+  git(mirrorPath, ['update-ref', '--stdin'], { input: updates })
+
+  return {
+    path: mirrorPath,
+    remove: () => fs.rmSync(directory, { recursive: true, force: true }),
+  }
+}
+
+function collectBranchHeads(cwd) {
+  const heads = new Map()
+
+  const collect = (pattern, strip) => {
+    const refs = git(cwd, [
+      'for-each-ref',
+      `--format=%(refname:lstrip=${strip}) %(objectname)`,
+      pattern,
+    ])
+
+    for (const line of refs.split('\n').filter(Boolean)) {
+      const [name, hash] = line.split(' ')
+
+      // The remote HEAD is a symbolic ref, not a branch of its own
+      if (name !== 'HEAD') {
+        heads.set(name, hash)
+      }
+    }
+  }
+
+  collect('refs/remotes/origin', 3)
+
+  // The checked-out branches win, so the mirror agrees with what is built here
+  collect('refs/heads', 2)
+
+  return heads
+}
+
+function git(cwd, args, options = {}) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...options,
+  }).trim()
+}
+
+function createLogCapture() {
+  const lines = []
+
+  return {
+    stream: new Writable({
+      write(chunk, encoding, callback) {
+        lines.push(String(chunk))
+        callback()
+      },
+    }),
+    read: () => lines.join('').trim(),
+  }
 }
 
 exports.releaseBranches = releaseBranches

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -120,8 +120,8 @@ function withoutCiBranchDetection(processEnv) {
  * semantic-release verifies that it is allowed to push before it reports a
  * version, and it discovers the configured branches through the repository URL.
  * A throwaway bare clone covers both without credentials: `--shared` references
- * the existing object store instead of copying it, and every known branch head
- * is added so the branch configuration resolves the same way it would against
+ * the existing object store instead of copying it, and the known branch heads
+ * are added so the branch configuration resolves the same way it would against
  * the remote.
  */
 function createRepositoryMirror(cwd) {
@@ -166,18 +166,51 @@ function collectBranchHeads(cwd) {
       const [name, hash] = line.split(' ')
 
       // The remote HEAD is a symbolic ref, not a branch of its own
-      if (name !== 'HEAD') {
+      if (name !== 'HEAD' && !heads.has(name)) {
         heads.set(name, hash)
       }
     }
   }
 
+  // The checked-out branches are collected first and kept, so the mirror
+  // agrees with what is built here wherever the two disagree
+  collect('refs/heads', 2)
   collect('refs/remotes/origin', 3)
 
-  // The checked-out branches win, so the mirror agrees with what is built here
-  collect('refs/heads', 2)
+  return withoutRefPathCollisions(heads)
+}
 
-  return heads
+/**
+ * A branch is stored as a path, so `portal` and `portal/page-toc` cannot both
+ * exist – and `update-ref` applies its input as one transaction, where a single
+ * name it cannot store abandons the whole mirror. Renaming a branch into a
+ * folder of branches leaves exactly that pair behind in every clone that has
+ * not pruned the stale remote ref yet, so drop the names that collide with a
+ * branch already accounted for. The branch being released is never one of them:
+ * it is checked out here, which rules out a local branch inside it.
+ */
+function withoutRefPathCollisions(heads) {
+  const kept = new Map()
+  const folders = new Set()
+
+  for (const [name, hash] of heads) {
+    const segments = name.split('/')
+    const parents = segments
+      .slice(0, -1)
+      .map((_, index) => segments.slice(0, index + 1).join('/'))
+
+    if (folders.has(name) || parents.some((parent) => kept.has(parent))) {
+      continue
+    }
+
+    kept.set(name, hash)
+
+    for (const parent of parents) {
+      folders.add(parent)
+    }
+  }
+
+  return kept
 }
 
 function git(cwd, args, options = {}) {

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -9,7 +9,7 @@ import { isCI } from 'repo-utils'
 import simpleGit from 'simple-git'
 import {
   getNextReleaseVersion,
-  releaseBranches,
+  isReleaseBranch,
 } from '../../postbuild/getNextReleaseVersion'
 import { log } from '../../lib'
 import { getStyleScopeHash } from '../../../src/plugins/postcss-isolated-style-scope/plugin-scope-hash.js'
@@ -24,7 +24,7 @@ export async function makeReleaseVersion() {
   let version = null
   let sha = null
 
-  if (releaseBranches.includes(branchName)) {
+  if (isReleaseBranch(branchName)) {
     version = await getNextReleaseVersion()
   }
 

--- a/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
+++ b/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
@@ -1,20 +1,10 @@
 import { exec } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { promisify } from 'node:util'
 import { findRepoRoot } from './convertHelpers.ts'
 
 const execAsync = promisify(exec)
-const releaseBranches = ['release', 'beta', 'alpha']
-
-async function getBranchName(cwd: string) {
-  try {
-    const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', {
-      cwd,
-    })
-    return stdout.trim()
-  } catch {
-    return ''
-  }
-}
+const require = createRequire(import.meta.url)
 
 export async function getCommitHash() {
   const repoRoot = findRepoRoot()
@@ -30,25 +20,9 @@ export async function getCommitHash() {
 }
 
 export async function getNextReleaseVersion() {
-  const repoRoot = findRepoRoot()
-  const branchName = await getBranchName(repoRoot)
+  const {
+    getNextReleaseVersion: resolveVersion,
+  } = require('@dnb/eufemia/scripts/postbuild/getNextReleaseVersion')
 
-  if (releaseBranches.includes(branchName)) {
-    try {
-      const { stdout } = await execAsync(
-        'yarn workspace @dnb/eufemia semantic-release --dry-run',
-        { cwd: repoRoot }
-      )
-      const nextVersion = stdout.match(
-        /The next release version is ([^\n]*)/
-      )?.[1]
-      if (nextVersion) {
-        return nextVersion
-      }
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  return '0.0.0-development'
+  return (await resolveVersion()) || '0.0.0-development'
 }


### PR DESCRIPTION
The release build job has no publish authority, but the helper that predicts the next version still ran a full `semantic-release --dry-run`. That run verifies it can push before it reports anything, so since the OIDC cutover it can only succeed in the publish job — everywhere else it fails with `EGITNOPERMISSION` and dumps a stack trace that looks like a broken release.

Every caller swallowed that failure, so the prebuild stamped the branch name instead of the version: `@dnb/eufemia@11.12.0` shipped with `Eufemia.version === 'release'` and the style scope `eufemia-scope--default` instead of `eufemia-scope--11_12_0`.

Only the commit analyzer is needed to get the version, and it needs no credentials, so it now runs on its own against a throwaway bare clone that shares the object store. A run that cannot get as far as analysing the commits reports semantic-release's own reason instead of nothing, while a branch with no releasable commits stays quiet.