### PR TITLE
fix(Tooltip): stay open when pointer returns to trigger

### DIFF
--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import type { ComponentType, HTMLAttributes } from 'react'
+import type { ComponentType, HTMLAttributes, MouseEvent } from 'react'
 import { clsx } from 'clsx'
 import { combineDescribedBy, warn } from '../../shared/component-helper'
 import { isTouch } from './TooltipHelpers'
@@ -294,21 +294,36 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     }
   }, [isControlled])
 
-  const handleOverlayMouseLeave = useCallback(() => {
-    if (isControlled) {
-      return undefined
-    }
-    const run = () => setOverlayHovered(false)
-    clearOverlayTimers()
-    if (skipPortal) {
-      overlayDelayTimeout.current = setTimeout(
-        run,
-        parseFloat(String(hideDelay)) || 1
-      )
-    } else {
-      run()
-    }
-  }, [hideDelay, isControlled, skipPortal])
+  const handleOverlayMouseLeave = useCallback(
+    (event: MouseEvent) => {
+      if (isControlled) {
+        return undefined
+      }
+
+      const targetElement = getRefElement(cloneRef)
+      if (
+        targetElement instanceof HTMLElement &&
+        event.relatedTarget instanceof Node &&
+        targetElement.contains(event.relatedTarget)
+      ) {
+        setIsOpen(true)
+        setOverlayHovered(false)
+        return undefined
+      }
+
+      const run = () => setOverlayHovered(false)
+      clearOverlayTimers()
+      if (skipPortal) {
+        overlayDelayTimeout.current = setTimeout(
+          run,
+          parseFloat(String(hideDelay)) || 1
+        )
+      } else {
+        run()
+      }
+    },
+    [hideDelay, isControlled, skipPortal]
+  )
 
   const { className: attributeClassName, ...restAttributes } =
     attributes || {}

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -576,6 +576,42 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should stay visible when mouse returns to the target', async () => {
+      render(
+        <OriginalTooltip
+          {...defaultProps}
+          showDelay={100}
+          hideDelay={50}
+          targetElement={
+            <button>
+              <span>Button</span>
+            </button>
+          }
+        />
+      )
+
+      const buttonElem = document.querySelector('button')
+      const buttonContent = buttonElem.querySelector('span')
+
+      fireEvent.mouseEnter(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+      })
+
+      fireEvent.mouseLeave(buttonElem)
+      fireEvent.mouseEnter(getMainElem())
+
+      const tooltipElem = getMainElem()
+
+      fireEvent.mouseLeave(tooltipElem, { relatedTarget: buttonContent })
+      fireEvent.mouseEnter(buttonContent, { relatedTarget: tooltipElem })
+
+      await wait(75)
+
+      expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+    })
+
     it('should set fixed class', () => {
       render(<Tooltip fixedPosition open />)
 


### PR DESCRIPTION
Moving the pointer from an open tooltip back to its trigger starts the show delay again. The tooltip can therefore close and reopen even though the pointer remains within the same tooltip interaction.

Transfer the open state directly back to the trigger when the pointer returns, keeping the tooltip continuously visible in both directions.


Preview: https://fix-tooltip-trigger-return-f.eufemia-e25.pages.dev/design-system/contact