### PR TITLE
chore(release): fail the build when a prepublish task fails

### DIFF
--- a/packages/dnb-eufemia/scripts/prebuild/__tests__/index.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/__tests__/index.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Scripts test
+ *
+ */
+
+import { runPrepublishTasks } from '../index'
+import { makeReleaseVersion } from '../tasks/makeReleaseVersion'
+import { prepareTemplates } from '../tasks/prepareTemplates'
+import { runStyleFactory } from '../tasks/styleFactory'
+import { runThemeFactory } from '../tasks/themeFactory'
+import convertSvgToJsx from '../tasks/convertSvgToJsx'
+import makeLibStyles from '../tasks/makeLibStyles'
+import makeMainStyle from '../tasks/makeMainStyle'
+import makePropertiesFile from '../tasks/makePropertiesFile'
+import { log } from '../../lib'
+
+vi.mock('../tasks/makeReleaseVersion', () => ({
+  makeReleaseVersion: vi.fn(),
+}))
+vi.mock('../tasks/prepareTemplates', () => ({
+  prepareTemplates: vi.fn(),
+}))
+vi.mock('../tasks/styleFactory', () => ({ runStyleFactory: vi.fn() }))
+vi.mock('../tasks/themeFactory', () => ({ runThemeFactory: vi.fn() }))
+vi.mock('../tasks/convertSvgToJsx', () => ({ default: vi.fn() }))
+vi.mock('../tasks/makeLibStyles', () => ({ default: vi.fn() }))
+vi.mock('../tasks/makeMainStyle', () => ({ default: vi.fn() }))
+vi.mock('../tasks/makePropertiesFile', () => ({ default: vi.fn() }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(log, 'start').mockImplementation(vi.fn())
+  vi.spyOn(log, 'succeed').mockImplementation(vi.fn())
+  vi.spyOn(log, 'fail').mockImplementation(vi.fn())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('runPrepublishTasks', () => {
+  it('runs every task and reports success', async () => {
+    await expect(runPrepublishTasks()).resolves.toBe(true)
+
+    expect(convertSvgToJsx).toHaveBeenCalledTimes(1)
+    expect(makeReleaseVersion).toHaveBeenCalledTimes(1)
+    expect(runStyleFactory).toHaveBeenCalledTimes(1)
+    expect(runThemeFactory).toHaveBeenCalledTimes(1)
+    expect(makeLibStyles).toHaveBeenCalledTimes(1)
+    expect(makeMainStyle).toHaveBeenCalledTimes(1)
+    expect(makePropertiesFile).toHaveBeenCalledTimes(1)
+    expect(prepareTemplates).toHaveBeenCalledTimes(1)
+    expect(log.succeed).toHaveBeenCalledWith(
+      'Prepublishing has Succeeded!'
+    )
+  })
+
+  it('rejects when a task fails, so the build cannot continue', async () => {
+    vi.mocked(makeReleaseVersion).mockRejectedValueOnce(
+      new Error('Could not determine the next release version')
+    )
+
+    await expect(runPrepublishTasks()).rejects.toThrow(
+      'Could not determine the next release version'
+    )
+
+    expect(log.fail).toHaveBeenCalledWith('Failed to run prepublish!')
+    expect(log.succeed).not.toHaveBeenCalled()
+
+    // The tasks after the failing one write what the build reads
+    expect(runStyleFactory).not.toHaveBeenCalled()
+    expect(prepareTemplates).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dnb-eufemia/scripts/prebuild/index.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/index.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { ErrorHandler, log } from '../lib'
+import { log } from '../lib'
 
 /**
  * The Templates (prepareTemplates) generation is special in the sense
@@ -53,8 +53,8 @@ export const runPrepublishTasks = async ({
     log.succeed('Prepublishing has Succeeded!')
   } catch (e) {
     log.fail('Failed to run prepublish!')
-    // @ts-expect-error - strictFunctionTypes
-    ErrorHandler(e)
+
+    throw e
   }
   return true
 }

--- a/packages/dnb-eufemia/scripts/prebuild/runPrepub.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/runPrepub.ts
@@ -5,4 +5,10 @@
  */
 
 import { runPrepublishTasks } from './index'
-runPrepublishTasks({ preventDelete: false })
+
+runPrepublishTasks({ preventDelete: false }).catch((error) => {
+  console.error(error)
+
+  // Every later build step reads what these tasks write, so stop here
+  process.exitCode = 1
+})


### PR DESCRIPTION
`runPrepublishTasks` caught every task error, handed it to `ErrorHandler` — which only logs at its default `ERROR_HARMLESS` level — and then returned `true`. A failing task therefore skipped the tasks after it, exited `0`, and let the build carry on with whatever those tasks had not written.

That is how a broken prebuild reaches the release job as a "successful" build. It came up while fixing #9247, where a thrown version-resolution error would have left `__VERSION__` unstamped and still published.

The error is now rethrown, and `runPrepub` reports it and exits non-zero. Verified that a full `build:prebuild` still succeeds, so nothing latent turns red.