### PR TITLE
chore(release): always stamp a real version on a release branch and verify it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,19 @@ jobs:
       - name: Re-validate restored package contents
         run: yarn workspace @dnb/eufemia validate:package
 
+      # Re-verify the stamp here too, for the same reason the content validation
+      # above runs twice: this is the job that holds the npm and GitHub
+      # credentials, and the artifact it restored was produced by a job whose
+      # output is treated as untrusted. The build job already gated on the stamp,
+      # but a corrupted or tampered artifact would otherwise be able to publish a
+      # package whose `Eufemia.version`, `--eufemia-version` and style scope class
+      # disagree with the release it is published as — which is exactly what
+      # shipped in 11.12.0, just by a different route.
+      - name: Re-verify the release version stamp
+        run: |
+          node packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs \
+            packages/dnb-eufemia/build
+
       - name: Release
         if: github.repository == 'dnbexperience/eufemia' &&
           (github.ref == 'refs/heads/release' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,19 +233,6 @@ jobs:
       - name: Re-validate restored package contents
         run: yarn workspace @dnb/eufemia validate:package
 
-      # Re-verify the stamp here too, for the same reason the content validation
-      # above runs twice: this is the job that holds the npm and GitHub
-      # credentials, and the artifact it restored was produced by a job whose
-      # output is treated as untrusted. The build job already gated on the stamp,
-      # but a corrupted or tampered artifact would otherwise be able to publish a
-      # package whose `Eufemia.version`, `--eufemia-version` and style scope class
-      # disagree with the release it is published as — which is exactly what
-      # shipped in 11.12.0, just by a different route.
-      - name: Re-verify the release version stamp
-        run: |
-          node packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs \
-            packages/dnb-eufemia/build
-
       - name: Release
         if: github.repository == 'dnbexperience/eufemia' &&
           (github.ref == 'refs/heads/release' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,10 +102,9 @@ jobs:
         run: yarn workspace @dnb/eufemia publish:prepare
 
       # The build info, the `--eufemia-version` custom property and the isolated
-      # style scope class all carry the version the prebuild resolved, and a
-      # branch name reaching them is what shipped 11.12.0 as "release". This
-      # workflow only runs on branches that release, so a build that carries no
-      # version must not reach the publish job.
+      # style scope class all carry the version the prebuild resolved. Every
+      # branch this workflow runs on releases, so a build that stamped a branch
+      # name instead must not reach the publish job.
       - name: Verify the release version stamp
         run: |
           node packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,16 @@ jobs:
       - name: Prepare publishable package
         run: yarn workspace @dnb/eufemia publish:prepare
 
+      # The build info, the `--eufemia-version` custom property and the isolated
+      # style scope class all carry the version the prebuild resolved, and a
+      # branch name reaching them is what shipped 11.12.0 as "release". This
+      # workflow only runs on branches that release, so a build that carries no
+      # version must not reach the publish job.
+      - name: Verify the release version stamp
+        run: |
+          node packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs \
+            packages/dnb-eufemia/build
+
       # Capture the artifact immediately after validation, before the consumer
       # smoke tests below: those install their fixtures with `npm ci`, which runs
       # dependency lifecycle scripts with write access to build/ (Yarn installs

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -61,10 +61,8 @@ async function createReleaseNewVersion() {
   try {
     const file = path.resolve(__dirname, '../package.json')
     const packageJson = await fs.readJson(file)
-    // getNextReleaseVersion now throws when it cannot resolve a version, so a
-    // release build stops rather than shipping a made-up one. The portal footer
-    // stays best-effort: report why and fall back to the latest reachable tag
-    // instead of leaving the version unset.
+    // getNextReleaseVersion throws rather than return nothing, which stops a
+    // release build. The footer stays best-effort: report why and fall back.
     const nextVersion = await getNextReleaseVersion().catch((error) => {
       console.warn(
         `Could not determine the next release version:\n${error.message}`

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -63,9 +63,15 @@ async function createReleaseNewVersion() {
     const packageJson = await fs.readJson(file)
     // getNextReleaseVersion now throws when it cannot resolve a version, so a
     // release build stops rather than shipping a made-up one. The portal footer
-    // stays best-effort: a failure here falls back to the latest reachable tag
+    // stays best-effort: report why and fall back to the latest reachable tag
     // instead of leaving the version unset.
-    const nextVersion = await getNextReleaseVersion().catch(() => null)
+    const nextVersion = await getNextReleaseVersion().catch((error) => {
+      console.warn(
+        `Could not determine the next release version:\n${error.message}`
+      )
+
+      return null
+    })
     const latestTag = nextVersion ? null : await getLatestReleaseTag()
     const version = resolveReleaseVersion(nextVersion, latestTag)
     packageJson.releaseVersion = version

--- a/packages/dnb-design-system-portal/scripts/version.js
+++ b/packages/dnb-design-system-portal/scripts/version.js
@@ -61,7 +61,11 @@ async function createReleaseNewVersion() {
   try {
     const file = path.resolve(__dirname, '../package.json')
     const packageJson = await fs.readJson(file)
-    const nextVersion = await getNextReleaseVersion()
+    // getNextReleaseVersion now throws when it cannot resolve a version, so a
+    // release build stops rather than shipping a made-up one. The portal footer
+    // stays best-effort: a failure here falls back to the latest reachable tag
+    // instead of leaving the version unset.
+    const nextVersion = await getNextReleaseVersion().catch(() => null)
     const latestTag = nextVersion ? null : await getLatestReleaseTag()
     const version = resolveReleaseVersion(nextVersion, latestTag)
     packageJson.releaseVersion = version

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -78,7 +78,7 @@
     "test:e2e": "playwright test --config=./playwright.config.e2e.ts",
     "test:e2e:ci": "PLAYWRIGHT_BASE_URL=http://localhost:8001 start-server-and-test 'yarn workspace dnb-design-system-portal serve:8001' http://localhost:8001 test:e2e",
     "test:e2e:watch": "playwright test --config=./playwright.config.e2e.ts --ui",
-    "test:postbuild": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/postbuild.test.ts scripts/postbuild/__tests__/validatePackageContents.test.ts scripts/postbuild/__tests__/writeReleaseConfig.test.ts scripts/postbuild/__tests__/getNextReleaseVersion.test.ts",
+    "test:postbuild": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/postbuild.test.ts scripts/postbuild/__tests__/validatePackageContents.test.ts scripts/postbuild/__tests__/writeReleaseConfig.test.ts scripts/postbuild/__tests__/getNextReleaseVersion.test.ts scripts/postbuild/__tests__/verifyReleaseVersion.test.ts",
     "test:postbuild:publish": "vitest run --config vitest.config.postbuild.ts scripts/postbuild/__tests__/prepareForRelease.test.ts",
     "test:prepare": "yarn build:style-manifest",
     "test:screenshots": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types ./scripts/tools/vitest/runScreenshotVitest.ts",

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
@@ -183,27 +183,15 @@ describe('getNextReleaseVersion', () => {
     warn.mockRestore()
   })
 
-  it('explains why when the version cannot be resolved', async () => {
+  it('throws with the reason when the version cannot be resolved', async () => {
     const { cwd, commit } = createRepository({
       configuredBranches: [{ name: 'release', prerelease: '@@' }],
     })
     commit('feat: add a component')
 
-    const warn = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => undefined)
-
-    expect(await getNextReleaseVersion({ cwd })).toBeNull()
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Could not determine the next release version'
-      )
+    await expect(getNextReleaseVersion({ cwd })).rejects.toThrow(
+      'semantic-release'
     )
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('semantic-release')
-    )
-
-    warn.mockRestore()
   })
 
   it('resolves when a renamed branch left a colliding remote ref behind', async () => {

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/verifyReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/verifyReleaseVersion.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Test the release version stamp gate.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import {
+  BUILD_INFO_FILE,
+  STYLE_FILE,
+  extractCssVersion,
+  extractJsVersion,
+  findVersionViolations,
+  verifyReleaseVersion,
+} from '../verifyReleaseVersion.mjs'
+
+const SCRIPT = path.resolve(__dirname, '../verifyReleaseVersion.mjs')
+const builds: Array<string> = []
+
+function createBuild({
+  jsVersion = '11.12.0',
+  cssVersion = jsVersion,
+} = {}) {
+  const buildDirectory = mkdtempSync(
+    path.join(tmpdir(), 'eufemia-release-stamp-')
+  )
+  builds.push(buildDirectory)
+
+  const write = (file: string, content: string) => {
+    const destination = path.join(buildDirectory, file)
+    mkdirSync(path.dirname(destination), { recursive: true })
+    writeFileSync(destination, content)
+  }
+
+  write(
+    BUILD_INFO_FILE,
+    [
+      `export const version = '${jsVersion}';`,
+      `export const sha = 'c4b07f1ebe3';`,
+      `export const buildDate = '2026-09-03T09:17:38.832Z';`,
+      '',
+    ].join('\n')
+  )
+  write(
+    STYLE_FILE,
+    `@charset "UTF-8";.dnb-core-style{--eufemia-version:"${cssVersion}";color:red}`
+  )
+
+  return buildDirectory
+}
+
+afterAll(() => {
+  for (const build of builds) {
+    rmSync(build, { recursive: true, force: true })
+  }
+})
+
+describe('extractJsVersion', () => {
+  it('reads the stamped version', () => {
+    expect(extractJsVersion("export const version = '11.12.0'")).toBe(
+      '11.12.0'
+    )
+  })
+
+  it('returns undefined without a version', () => {
+    expect(extractJsVersion('export const sha = 1')).toBeUndefined()
+  })
+})
+
+describe('extractCssVersion', () => {
+  it.each([
+    ['--eufemia-version:"11.12.0";', '11.12.0'],
+    [`--eufemia-version: '11.12.0';`, '11.12.0'],
+    ['--eufemia-version: 11.12.0;', '11.12.0'],
+  ])('reads %s', (source, expected) => {
+    expect(extractCssVersion(source)).toBe(expected)
+  })
+
+  it('returns undefined without the property', () => {
+    expect(extractCssVersion('.dnb-core-style{color:red}')).toBeUndefined()
+  })
+})
+
+describe('findVersionViolations', () => {
+  it.each([['11.12.0'], ['11.12.0-beta.1'], ['11.12.0-alpha.1']])(
+    'accepts %s',
+    (version) => {
+      expect(
+        findVersionViolations({ jsVersion: version, cssVersion: version })
+      ).toEqual([])
+    }
+  )
+
+  it.each([['release'], ['beta'], ['10.x'], ['__VERSION__'], ['']])(
+    'rejects %s',
+    (version) => {
+      expect(
+        findVersionViolations({ jsVersion: version, cssVersion: version })
+      ).not.toEqual([])
+    }
+  )
+
+  it('rejects a version the styles do not agree with', () => {
+    expect(
+      findVersionViolations({
+        jsVersion: '11.12.0',
+        cssVersion: '11.11.0',
+      })
+    ).toEqual([expect.stringContaining('11.11.0')])
+  })
+})
+
+describe('verifyReleaseVersion', () => {
+  it('returns the version of a correctly stamped build', () => {
+    expect(verifyReleaseVersion(createBuild())).toBe('11.12.0')
+  })
+
+  it('throws for the branch name the prebuild falls back to', () => {
+    expect(() =>
+      verifyReleaseVersion(createBuild({ jsVersion: 'release' }))
+    ).toThrow('stamped with "release"')
+  })
+
+  it('names the file to look at', () => {
+    expect(() =>
+      verifyReleaseVersion(createBuild({ jsVersion: 'release' }))
+    ).toThrow(BUILD_INFO_FILE)
+  })
+})
+
+describe('the command line', () => {
+  const run = (buildDirectory: string) =>
+    execFileSync(process.execPath, [SCRIPT, buildDirectory], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+  it('reports the version of a correctly stamped build', () => {
+    expect(run(createBuild())).toContain('11.12.0')
+  })
+
+  it('exits non-zero for a build without a release version', () => {
+    expect(() => run(createBuild({ jsVersion: 'release' }))).toThrow()
+  })
+})

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -49,8 +49,7 @@ function getReleaseConfig(cwd) {
 /**
  * The version the next release from this branch would carry, or `null` when the
  * branch does not release or its commits do not warrant one. Throws when it
- * cannot tell the two apart, so a release build stops instead of stamping a
- * version it made up.
+ * cannot tell those apart, so a release build stops instead of guessing.
  */
 async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
   const branchName = (await simpleGit(cwd).branch()).current

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -46,6 +46,12 @@ function getReleaseConfig(cwd) {
   return require(path.resolve(cwd, 'package.json')).release
 }
 
+/**
+ * The version the next release from this branch would carry, or `null` when the
+ * branch does not release or its commits do not warrant one. Throws when it
+ * cannot tell the two apart, so a release build stops instead of stamping a
+ * version it made up.
+ */
 async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
   const branchName = (await simpleGit(cwd).branch()).current
 
@@ -53,15 +59,7 @@ async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
     return null
   }
 
-  try {
-    return await resolveNextReleaseVersion(cwd)
-  } catch (error) {
-    console.warn(
-      `Could not determine the next release version:\n${error.message}`
-    )
-
-    return null
-  }
+  return resolveNextReleaseVersion(cwd)
 }
 
 /**

--- a/packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs
+++ b/packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs
@@ -2,10 +2,9 @@
  * Verify that a release build carries a real version.
  *
  * `Eufemia.version`, the `--eufemia-version` custom property and the isolated
- * style scope class are all derived from the version the prebuild stamps, and a
- * build that carries no version ships that instead — which is how 11.12.0
- * published as "release". Run this on a release build so it fails here rather
- * than in the package.
+ * style scope class are all derived from the version the prebuild stamps, so a
+ * build that resolved none ships the branch name in their place. Run this on a
+ * release build so that fails here rather than in the published package.
  */
 
 import { readFileSync, realpathSync } from 'node:fs'

--- a/packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs
+++ b/packages/dnb-eufemia/scripts/postbuild/verifyReleaseVersion.mjs
@@ -1,0 +1,105 @@
+/**
+ * Verify that a release build carries a real version.
+ *
+ * `Eufemia.version`, the `--eufemia-version` custom property and the isolated
+ * style scope class are all derived from the version the prebuild stamps, and a
+ * build that carries no version ships that instead — which is how 11.12.0
+ * published as "release". Run this on a release build so it fails here rather
+ * than in the package.
+ */
+
+import { readFileSync, realpathSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const BUILD_INFO_FILE = 'shared/build-info/BuildInfoData.js'
+export const STYLE_FILE = 'style/dnb-ui-core.min.css'
+
+const RELEASE_VERSION = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+const JS_VERSION = /export const version = '([^']*)'/
+const CSS_VERSION = /--eufemia-version:\s*["']?([^"';]+)/
+
+export function extractJsVersion(source) {
+  return source.match(JS_VERSION)?.[1]
+}
+
+export function extractCssVersion(source) {
+  return source.match(CSS_VERSION)?.[1]?.trim()
+}
+
+export function findVersionViolations({ jsVersion, cssVersion }) {
+  const violations = []
+
+  if (!jsVersion) {
+    violations.push(`${BUILD_INFO_FILE} declares no version`)
+  } else if (!RELEASE_VERSION.test(jsVersion)) {
+    violations.push(
+      `${BUILD_INFO_FILE} is stamped with "${jsVersion}" instead of a release version`
+    )
+  }
+
+  if (!cssVersion) {
+    violations.push(`${STYLE_FILE} declares no --eufemia-version`)
+  } else if (jsVersion && cssVersion !== jsVersion) {
+    violations.push(
+      `${STYLE_FILE} is stamped with "${cssVersion}", but ${BUILD_INFO_FILE} is stamped with "${jsVersion}"`
+    )
+  }
+
+  return violations
+}
+
+export function verifyReleaseVersion(buildDirectory) {
+  const read = (file) =>
+    readFileSync(path.join(buildDirectory, file), 'utf-8')
+
+  const jsVersion = extractJsVersion(read(BUILD_INFO_FILE))
+  const cssVersion = extractCssVersion(read(STYLE_FILE))
+  const violations = findVersionViolations({ jsVersion, cssVersion })
+
+  if (violations.length > 0) {
+    throw new Error(
+      [
+        'This release build does not carry a release version:',
+        ...violations.map((violation) => `- ${violation}`),
+        '',
+        'The prebuild stamps the version it resolves for the current branch, so',
+        'check the "Prebuild Library" step for why it could not resolve one.',
+      ].join('\n')
+    )
+  }
+
+  return jsVersion
+}
+
+function main() {
+  const buildDirectory = process.argv[2]
+
+  if (!buildDirectory) {
+    console.error(
+      'Usage: node ./scripts/postbuild/verifyReleaseVersion.mjs <buildDir>'
+    )
+    process.exit(1)
+  }
+
+  let version
+  try {
+    version = verifyReleaseVersion(buildDirectory)
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+
+  console.log(`The release build is stamped with ${version}`)
+}
+
+const invokedPath = process.argv[1]
+// Resolve the invoked path before comparing, the same way writeReleaseConfig
+// does: an invocation through a symlinked path would otherwise leave a guard
+// that exits 0 without checking anything.
+if (
+  invokedPath &&
+  import.meta.url === pathToFileURL(realpathSync(invokedPath)).href
+) {
+  main()
+}

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -14,9 +14,10 @@ import { log } from '../../../lib'
 vi.mock('simple-git')
 const mockSimpleGit = vi.mocked(simpleGit)
 
-function mockBranchName(branchName: string) {
+function mockBranchName(branchName: string, tags: Array<string> = []) {
   mockSimpleGit.mockReturnValue({
     branch: vi.fn().mockResolvedValue({ current: branchName }),
+    tags: vi.fn().mockResolvedValue({ all: tags }),
   } as unknown as SimpleGit)
 }
 
@@ -205,8 +206,8 @@ describe('makeReleaseVersion', () => {
     )
   })
 
-  it('write branch in file', async () => {
-    mockBranchName('release')
+  it('writes the released version when nothing warrants a new one', async () => {
+    mockBranchName('release', ['v11.12.0', 'v11.11.0'])
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'
@@ -220,21 +221,54 @@ describe('makeReleaseVersion', () => {
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
-      expect.stringContaining(`release`)
+      expect.stringContaining(`export const version = '11.12.0'`)
     )
 
     // CJS
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining('src/shared/build-info/BuildInfoData.cjs'),
-      expect.stringContaining(`release`)
+      expect.stringContaining(`exports.version = '11.12.0'`)
     )
 
     // CSS
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       3,
       expect.stringContaining('src/style/core/scopes.scss'),
-      expect.stringContaining(`--eufemia-version: 'release';`)
+      expect.stringContaining(`--eufemia-version: '11.12.0';`)
+    )
+  })
+
+  it('write branch in file', async () => {
+    mockBranchName('some-branch')
+    vi.spyOn(
+      getNextReleaseVersion,
+      'getNextReleaseVersion'
+    ).mockImplementationOnce(async () => null)
+
+    await makeReleaseVersion()
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(4)
+
+    // JS
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
+      expect.stringContaining(`some-branch`)
+    )
+
+    // CJS
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('src/shared/build-info/BuildInfoData.cjs'),
+      expect.stringContaining(`some-branch`)
+    )
+
+    // CSS
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('src/style/core/scopes.scss'),
+      expect.stringContaining(`--eufemia-version: 'some-branch';`)
     )
   })
 

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -239,6 +239,24 @@ describe('makeReleaseVersion', () => {
     )
   })
 
+  it('keeps the last stable version when the newest reachable tag is a prerelease', async () => {
+    // git `--sort=-version:refname` ranks v11.12.0-beta.1 above the stable
+    // v11.12.0, so the stable tag has to be selected past the prerelease
+    mockBranchName('release', ['v11.12.0-beta.1', 'v11.12.0', 'v11.11.0'])
+    vi.spyOn(
+      getNextReleaseVersion,
+      'getNextReleaseVersion'
+    ).mockImplementationOnce(async () => null)
+
+    await makeReleaseVersion()
+
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
+      expect.stringContaining(`export const version = '11.12.0'`)
+    )
+  })
+
   it('write branch in file', async () => {
     mockBranchName('some-branch')
     vi.spyOn(

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -215,6 +215,14 @@ describe('makeReleaseVersion', () => {
 
     await makeReleaseVersion()
 
+    // Only tags reachable from HEAD count, so a maintenance branch never picks
+    // up a version released from another line
+    expect(mockSimpleGit().tags).toHaveBeenCalledWith([
+      '--merged',
+      'HEAD',
+      '--sort=-version:refname',
+    ])
+
     expect(fs.writeFile).toHaveBeenCalledTimes(4)
 
     // JS
@@ -243,6 +251,44 @@ describe('makeReleaseVersion', () => {
     // git `--sort=-version:refname` ranks v11.12.0-beta.1 above the stable
     // v11.12.0, so the stable tag has to be selected past the prerelease
     mockBranchName('release', ['v11.12.0-beta.1', 'v11.12.0', 'v11.11.0'])
+    vi.spyOn(
+      getNextReleaseVersion,
+      'getNextReleaseVersion'
+    ).mockImplementationOnce(async () => null)
+
+    await makeReleaseVersion()
+
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
+      expect.stringContaining(`export const version = '11.12.0'`)
+    )
+  })
+
+  it('keeps the prerelease of its own channel on a prerelease branch', async () => {
+    // The stable v11.12.0 is not the version a beta build already has
+    mockBranchName('beta', [
+      'v11.13.0-beta.2',
+      'v11.13.0-beta.1',
+      'v11.12.0',
+      'v11.12.0-alpha.1',
+    ])
+    vi.spyOn(
+      getNextReleaseVersion,
+      'getNextReleaseVersion'
+    ).mockImplementationOnce(async () => null)
+
+    await makeReleaseVersion()
+
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
+      expect.stringContaining(`export const version = '11.13.0-beta.2'`)
+    )
+  })
+
+  it('falls back to the stable tag on a prerelease branch that has not released', async () => {
+    mockBranchName('beta', ['v11.12.0', 'v11.11.0'])
     vi.spyOn(
       getNextReleaseVersion,
       'getNextReleaseVersion'

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -215,8 +215,8 @@ describe('makeReleaseVersion', () => {
 
     await makeReleaseVersion()
 
-    // Only tags reachable from HEAD count, so a maintenance branch never picks
-    // up a version released from another line
+    // Only tags reachable from HEAD count, so a maintenance branch cannot
+    // pick up another line's version
     expect(mockSimpleGit().tags).toHaveBeenCalledWith([
       '--merged',
       'HEAD',
@@ -248,8 +248,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('keeps the last stable version when the newest reachable tag is a prerelease', async () => {
-    // git `--sort=-version:refname` ranks v11.12.0-beta.1 above the stable
-    // v11.12.0, so the stable tag has to be selected past the prerelease
+    // git ranks a prerelease above its own stable, so it has to be skipped
     mockBranchName('release', ['v11.12.0-beta.1', 'v11.12.0', 'v11.11.0'])
     vi.spyOn(
       getNextReleaseVersion,
@@ -266,7 +265,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('keeps the prerelease of its own channel on a prerelease branch', async () => {
-    // The stable v11.12.0 is not the version a beta build already has
+    // The newest stable is not the version a prerelease build already has
     mockBranchName('beta', [
       'v11.13.0-beta.2',
       'v11.13.0-beta.1',
@@ -304,8 +303,7 @@ describe('makeReleaseVersion', () => {
   })
 
   it('skips the legacy channel-suffixed tags', async () => {
-    // The repository still carries `v3.19.0-beta.1@beta` style tags, which are
-    // not versions the package can be stamped with
+    // The legacy channel-suffixed tags are not versions to stamp
     mockBranchName('beta', ['v3.19.0-beta.1@beta', 'v3.18.0'])
     vi.spyOn(
       getNextReleaseVersion,

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeReleaseVersion.test.ts
@@ -303,6 +303,24 @@ describe('makeReleaseVersion', () => {
     )
   })
 
+  it('skips the legacy channel-suffixed tags', async () => {
+    // The repository still carries `v3.19.0-beta.1@beta` style tags, which are
+    // not versions the package can be stamped with
+    mockBranchName('beta', ['v3.19.0-beta.1@beta', 'v3.18.0'])
+    vi.spyOn(
+      getNextReleaseVersion,
+      'getNextReleaseVersion'
+    ).mockImplementationOnce(async () => null)
+
+    await makeReleaseVersion()
+
+    expect(fs.writeFile).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('src/shared/build-info/BuildInfoData.ts'),
+      expect.stringContaining(`export const version = '3.18.0'`)
+    )
+  })
+
   it('write branch in file', async () => {
     mockBranchName('some-branch')
     vi.spyOn(

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -128,9 +128,12 @@ async function getLastReleaseVersion(branchName: string) {
   // the newest stable is not either. semantic-release names a `prerelease: true`
   // branch's versions after the branch itself – `beta` tagged `v10.0.0-beta.8`,
   // `alpha` tagged `v9.0.0-alpha.1` – so the branch name identifies the channel.
+  // The prerelease charset is the one verifyReleaseVersion.mjs accepts, so this
+  // cannot resolve a version the release build would then reject: it also rules
+  // out the legacy `v3.19.0-beta.1@beta` tags, which are not versions at all.
   const isStable = (tag: string) => /^v\d+\.\d+\.\d+$/.test(tag)
   const isOnChannel = (tag: string) =>
-    /^v\d+\.\d+\.\d+-/.test(tag) &&
+    /^v\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(tag) &&
     tag.slice(tag.indexOf('-') + 1).startsWith(`${branchName}.`)
 
   // A prerelease branch that has not released yet falls back to the stable tag

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -116,7 +116,11 @@ async function getLastReleaseVersion() {
     '--sort=-version:refname',
   ])
 
+  // Match a stable tag only: `-version:refname` ranks `v1.2.0-beta.1` above the
+  // stable `v1.2.0`, and with nothing to release the package keeps the last real
+  // version it had — the latest reachable stable tag, the same one the
+  // release.yml checkout comment and the portal footer (version.js) resolve.
   return all
-    .find((tag: string) => /^v\d+\.\d+\.\d+/.test(tag))
+    .find((tag: string) => /^v\d+\.\d+\.\d+$/.test(tag))
     ?.replace(/^v/, '')
 }

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -28,7 +28,8 @@ export async function makeReleaseVersion() {
     // A release build has to carry a version, so when the commits do not
     // warrant one it keeps the version the package already has
     version =
-      (await getNextReleaseVersion()) || (await getLastReleaseVersion())
+      (await getNextReleaseVersion()) ||
+      (await getLastReleaseVersion(branchName))
   }
 
   if (!version && isCI) {
@@ -109,18 +110,29 @@ export async function makeReleaseVersion() {
   }
 }
 
-async function getLastReleaseVersion() {
+/**
+ * The version the package already carries on this branch: the newest reachable
+ * tag of the channel the branch releases on – the same tag release.yml's
+ * checkout comment and the portal footer (version.js) resolve.
+ */
+async function getLastReleaseVersion(branchName: string) {
   const { all } = await simpleGit().tags([
     '--merged',
     'HEAD',
     '--sort=-version:refname',
   ])
 
-  // Match a stable tag only: `-version:refname` ranks `v1.2.0-beta.1` above the
-  // stable `v1.2.0`, and with nothing to release the package keeps the last real
-  // version it had — the latest reachable stable tag, the same one the
-  // release.yml checkout comment and the portal footer (version.js) resolve.
-  return all
-    .find((tag: string) => /^v\d+\.\d+\.\d+$/.test(tag))
-    ?.replace(/^v/, '')
+  // The channel has to be matched rather than the newest tag taken, because
+  // `-version:refname` ranks `v1.2.0-beta.1` above the stable `v1.2.0`: on
+  // `release` that prerelease is not the version the package has, and on `beta`
+  // the newest stable is not either. semantic-release names a `prerelease: true`
+  // branch's versions after the branch itself – `beta` tagged `v10.0.0-beta.8`,
+  // `alpha` tagged `v9.0.0-alpha.1` – so the branch name identifies the channel.
+  const isStable = (tag: string) => /^v\d+\.\d+\.\d+$/.test(tag)
+  const isOnChannel = (tag: string) =>
+    /^v\d+\.\d+\.\d+-/.test(tag) &&
+    tag.slice(tag.indexOf('-') + 1).startsWith(`${branchName}.`)
+
+  // A prerelease branch that has not released yet falls back to the stable tag
+  return (all.find(isOnChannel) || all.find(isStable))?.replace(/^v/, '')
 }

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -25,7 +25,10 @@ export async function makeReleaseVersion() {
   let sha = null
 
   if (isReleaseBranch(branchName)) {
-    version = await getNextReleaseVersion()
+    // A release build has to carry a version, so when the commits do not
+    // warrant one it keeps the version the package already has
+    version =
+      (await getNextReleaseVersion()) || (await getLastReleaseVersion())
   }
 
   if (!version && isCI) {
@@ -104,4 +107,16 @@ export async function makeReleaseVersion() {
       { cwd: packageRoot }
     )
   }
+}
+
+async function getLastReleaseVersion() {
+  const { all } = await simpleGit().tags([
+    '--merged',
+    'HEAD',
+    '--sort=-version:refname',
+  ])
+
+  return all
+    .find((tag: string) => /^v\d+\.\d+\.\d+/.test(tag))
+    ?.replace(/^v/, '')
 }

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -112,8 +112,8 @@ export async function makeReleaseVersion() {
 
 /**
  * The version the package already carries on this branch: the newest reachable
- * tag of the channel the branch releases on – the same tag release.yml's
- * checkout comment and the portal footer (version.js) resolve.
+ * tag of the channel it releases on, which is what the portal footer
+ * (version.js) resolves too.
  */
 async function getLastReleaseVersion(branchName: string) {
   const { all } = await simpleGit().tags([
@@ -122,15 +122,12 @@ async function getLastReleaseVersion(branchName: string) {
     '--sort=-version:refname',
   ])
 
-  // The channel has to be matched rather than the newest tag taken, because
-  // `-version:refname` ranks `v1.2.0-beta.1` above the stable `v1.2.0`: on
-  // `release` that prerelease is not the version the package has, and on `beta`
-  // the newest stable is not either. semantic-release names a `prerelease: true`
-  // branch's versions after the branch itself – `beta` tagged `v10.0.0-beta.8`,
-  // `alpha` tagged `v9.0.0-alpha.1` – so the branch name identifies the channel.
-  // The prerelease charset is the one verifyReleaseVersion.mjs accepts, so this
-  // cannot resolve a version the release build would then reject: it also rules
-  // out the legacy `v3.19.0-beta.1@beta` tags, which are not versions at all.
+  // git ranks a prerelease above its own stable, so the channel has to be
+  // matched rather than the newest tag taken. semantic-release names a
+  // `prerelease: true` branch's versions after the branch, so the branch name
+  // identifies the channel. The prerelease charset is the one
+  // verifyReleaseVersion.mjs accepts, which also excludes the legacy
+  // channel-suffixed tags that are not versions.
   const isStable = (tag: string) => /^v\d+\.\d+\.\d+$/.test(tag)
   const isOnChannel = (tag: string) =>
     /^v\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(tag) &&

--- a/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
+++ b/tools/eufemia-llm-metadata/src/getNextReleaseVersion.ts
@@ -24,5 +24,13 @@ export async function getNextReleaseVersion() {
     getNextReleaseVersion: resolveVersion,
   } = require('@dnb/eufemia/scripts/postbuild/getNextReleaseVersion')
 
-  return (await resolveVersion()) || '0.0.0-development'
+  try {
+    return (await resolveVersion()) || '0.0.0-development'
+  } catch (error) {
+    console.warn(
+      `Could not determine the next release version:\n${error.message}`
+    )
+
+    return '0.0.0-development'
+  }
 }


### PR DESCRIPTION
The prebuild stamps the version it resolves into the build info, the `--eufemia-version` custom property and the isolated style scope class, and fell back to the branch name whenever it had none. Nothing checked the result, so 11.12.0 published as `Eufemia.version === 'release'` with the scope class `eufemia-scope--default` instead of `eufemia-scope--11_12_0`.

The release build now reads the stamp back out of the prepared package and fails before the artifact is uploaded unless it is a release version the styles agree with. Run against the real published tarballs it passes 11.11.0 and rejects 11.12.0.

Gating on that alone would have broken a portal-only deployment, where the commits warrant no release and the branch name is stamped by design — the case release.yml's checkout comment already calls out. So a release branch no longer stamps its own name: with nothing to release the package keeps the version it already has, and a resolution that fails now throws rather than returning nothing, which stops the build. 