### PR TITLE
chore(Release): hide test commits from release notes

### DIFF
--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -344,11 +344,6 @@
                 "hidden": false
               },
               {
-                "type": "test",
-                "section": ":white_check_mark: Tests",
-                "hidden": false
-              },
-              {
                 "type": "deps",
                 "section": ":package: Dependencies",
                 "hidden": false

--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/prepareForRelease.test.ts
@@ -426,6 +426,25 @@ describe('package.json', () => {
 })
 
 describe('release config', () => {
+  it('excludes test commits from release notes', async () => {
+    const packageJson = await fs.readJson(
+      path.resolve(PKG_ROOT, 'package.json')
+    )
+    const releaseNotesPlugin = packageJson.release.plugins.find(
+      (plugin) =>
+        Array.isArray(plugin) &&
+        plugin[0] === '@semantic-release/release-notes-generator'
+    )
+    const releaseNotesConfig = Array.isArray(releaseNotesPlugin)
+      ? releaseNotesPlugin[1]
+      : undefined
+    const testType = releaseNotesConfig?.presetConfig?.types?.find(
+      ({ type }) => type === 'test'
+    )
+
+    expect(testType).toBeUndefined()
+  })
+
   it('creates .releaserc.json in build directory', async () => {
     const buildDir = path.resolve(PKG_ROOT, 'build')
 


### PR DESCRIPTION
Test-only commits are internal maintenance and add noise to user-facing release notes. Hide the test commit type from generated notes while keeping it recognized by the release configuration.