### PR TITLE
chore(release): resolve versions for every configured release branch

### DIFF
--- a/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
+++ b/packages/dnb-eufemia/scripts/postbuild/__tests__/getNextReleaseVersion.test.ts
@@ -10,13 +10,18 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { getNextReleaseVersion } from '../getNextReleaseVersion'
+import {
+  getNextReleaseVersion,
+  isReleaseBranch,
+} from '../getNextReleaseVersion'
 
 const fixtures: Array<string> = []
 
+type ConfiguredBranch = string | { name: string; prerelease?: string }
+
 function createRepository({
   branch = 'release',
-  configuredBranches = [branch],
+  configuredBranches = [branch] as Array<ConfiguredBranch>,
 } = {}) {
   const cwd = mkdtempSync(path.join(tmpdir(), 'eufemia-next-version-'))
   fixtures.push(cwd)
@@ -58,7 +63,7 @@ function createRepository({
   git('tag', 'v1.0.0')
 
   for (const name of configuredBranches) {
-    if (name !== branch) {
+    if (typeof name === 'string' && name !== branch) {
       git('branch', name)
     }
   }
@@ -70,6 +75,38 @@ afterAll(() => {
   for (const fixture of fixtures) {
     rmSync(fixture, { recursive: true, force: true })
   }
+})
+
+describe('isReleaseBranch', () => {
+  // Asserted against the package's own `release.branches`, so this fails if the
+  // two ever drift apart again
+  it.each(['release', 'next', 'beta', 'alpha', '10.x', '11.2.x', '1.x'])(
+    'matches %s',
+    (branch) => {
+      expect(isReleaseBranch(branch)).toBe(true)
+    }
+  )
+
+  it.each([
+    'main',
+    'fix/something',
+    'HEAD',
+    '10.x-something',
+    'v10.x',
+    '',
+  ])('does not match %s', (branch) => {
+    expect(isReleaseBranch(branch)).toBe(false)
+  })
+
+  it('matches the branches a repository configures', () => {
+    const { cwd } = createRepository({
+      branch: 'release',
+      configuredBranches: ['some-other-branch'],
+    })
+
+    expect(isReleaseBranch('some-other-branch', { cwd })).toBe(true)
+    expect(isReleaseBranch('release', { cwd })).toBe(false)
+  })
 })
 
 describe('getNextReleaseVersion', () => {
@@ -148,7 +185,7 @@ describe('getNextReleaseVersion', () => {
 
   it('explains why when the version cannot be resolved', async () => {
     const { cwd, commit } = createRepository({
-      configuredBranches: ['some-other-branch'],
+      configuredBranches: [{ name: 'release', prerelease: '@@' }],
     })
     commit('feat: add a component')
 
@@ -163,9 +200,7 @@ describe('getNextReleaseVersion', () => {
       )
     )
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'semantic-release is configured to only publish'
-      )
+      expect.stringContaining('semantic-release')
     )
 
     warn.mockRestore()
@@ -187,6 +222,7 @@ describe('getNextReleaseVersion', () => {
   it('returns null when not on a release branch', async () => {
     const { cwd, commit } = createRepository({
       branch: 'feat/some-branch',
+      configuredBranches: ['release'],
     })
     commit('feat: add a component')
 

--- a/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
+++ b/packages/dnb-eufemia/scripts/postbuild/getNextReleaseVersion.js
@@ -10,21 +10,46 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { execFileSync } = require('child_process')
+const { createRequire } = require('module')
 const { Writable } = require('stream')
 const simpleGit = require('simple-git')
 
+// The matcher semantic-release itself expands the branch configuration with
+const micromatch = createRequire(
+  require.resolve('semantic-release/package.json')
+)('micromatch')
+
 const eufemiaRoot = path.resolve(__dirname, '..', '..')
-const releaseBranches = ['release', 'beta', 'alpha']
 
 // run this script if it is called from bash / command line
 if (require.main === module) {
   getNextReleaseVersion()
 }
 
+/**
+ * The branches semantic-release publishes from, so `next` and the maintenance
+ * branches are covered too rather than only the ones a hardcoded list knows.
+ */
+function isReleaseBranch(branchName, { cwd = eufemiaRoot } = {}) {
+  if (!branchName) {
+    return false
+  }
+
+  const patterns = getReleaseConfig(cwd).branches.map((branch) =>
+    typeof branch === 'string' ? branch : branch.name
+  )
+
+  return micromatch.isMatch(branchName, patterns)
+}
+
+function getReleaseConfig(cwd) {
+  return require(path.resolve(cwd, 'package.json')).release
+}
+
 async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
   const branchName = (await simpleGit(cwd).branch()).current
 
-  if (!releaseBranches.includes(branchName)) {
+  if (!isReleaseBranch(branchName, { cwd })) {
     return null
   }
 
@@ -47,9 +72,7 @@ async function getNextReleaseVersion({ cwd = eufemiaRoot } = {}) {
  */
 async function resolveNextReleaseVersion(cwd) {
   const { default: semanticRelease } = await import('semantic-release')
-  const { branches, plugins } = require(
-    path.resolve(cwd, 'package.json')
-  ).release
+  const { branches, plugins } = getReleaseConfig(cwd)
   const commitAnalyzer = plugins.find(
     (plugin) =>
       (Array.isArray(plugin) ? plugin[0] : plugin) ===
@@ -58,22 +81,11 @@ async function resolveNextReleaseVersion(cwd) {
   const mirror = createRepositoryMirror(cwd)
   const log = createLogCapture()
 
-  // This hook only runs once the branch and the push check have passed, which
-  // separates "nothing to release" from a run that never got that far
-  let analysable = false
-
   try {
     const result = await semanticRelease(
       {
         branches,
-        plugins: [
-          commitAnalyzer,
-          {
-            verifyConditions: () => {
-              analysable = true
-            },
-          },
-        ],
+        plugins: [commitAnalyzer],
         repositoryUrl: mirror.path,
         dryRun: true,
         // Report the version for a pull request build too, which
@@ -88,15 +100,11 @@ async function resolveNextReleaseVersion(cwd) {
       }
     )
 
-    if (result) {
-      return result.nextRelease.version
-    }
-
-    if (analysable) {
-      return null
-    }
-
-    throw new Error(log.read())
+    // The branch is already known to be one semantic-release publishes from, so
+    // no result means the commits do not warrant a release
+    return result ? result.nextRelease.version : null
+  } catch (error) {
+    throw new Error(`${error.message}\n${log.read()}`, { cause: error })
   } finally {
     mirror.remove()
   }
@@ -242,5 +250,5 @@ function createLogCapture() {
   }
 }
 
-exports.releaseBranches = releaseBranches
+exports.isReleaseBranch = isReleaseBranch
 exports.getNextReleaseVersion = getNextReleaseVersion

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeReleaseVersion.ts
@@ -9,7 +9,7 @@ import { isCI } from 'repo-utils'
 import simpleGit from 'simple-git'
 import {
   getNextReleaseVersion,
-  releaseBranches,
+  isReleaseBranch,
 } from '../../postbuild/getNextReleaseVersion'
 import { log } from '../../lib'
 import { getStyleScopeHash } from '../../../src/plugins/postcss-isolated-style-scope/plugin-scope-hash.js'
@@ -24,7 +24,7 @@ export async function makeReleaseVersion() {
   let version = null
   let sha = null
 
-  if (releaseBranches.includes(branchName)) {
+  if (isReleaseBranch(branchName)) {
     version = await getNextReleaseVersion()
   }
 


### PR DESCRIPTION
Stacked on #9247.

The resolver matched the branch against a hardcoded `['release', 'beta', 'alpha']`, while `release.yml` and the semantic-release `branches` config also publish from `next` and the maintenance branches. A release from those never reached the resolver at all, so it stamped its own branch name — the same failure 11.12.0 hit, just from a different direction.

The branch is now matched against `release.branches` with the same micromatch semantic-release expands that config with, so the two cannot drift apart again.

That also makes an unmatched branch unreachable once semantic-release runs, so the marker plugin #9247 added to tell "nothing to release" apart from a run that never got that far is gone. The captured log travels with a thrown error instead, which keeps the diagnostics.

#9250 gates the release on the stamp; this is what lets that gate cover every branch the workflow runs on.