### PR TITLE
fix(Form.Section): keep fields disabled during pending saves

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1882,6 +1882,8 @@ export default function Provider<Data extends JsonObject>(
       : formState === 'pending'
         ? true
         : undefined
+  const forceDisabled =
+    typeof rest?.['disabled'] !== 'boolean' && formState === 'pending'
   const contextErrorMessages =
     errorMessages?.[locale ?? sharedLocale] || errorMessages
 
@@ -2008,6 +2010,7 @@ export default function Provider<Data extends JsonObject>(
       <DataContextRefContext value={contextValueRef}>
         <FieldPropsProvider
           FormStatus={formStatusConfig}
+          forceDisabled={forceDisabled || undefined}
           formElement={disabled ? { disabled: true } : undefined}
           locale={locale ? locale : undefined}
           translations={translations ? translations : undefined}

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/__tests__/Provider.test.tsx
@@ -1730,6 +1730,46 @@ describe('DataContext.Provider', { retry: isCI ? 5 : 0 }, () => {
       })
     })
 
+    it('should force fields disabled while async onSubmit is pending', async () => {
+      let resolveSubmit!: () => void
+      const onSubmit = vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            resolveSubmit = resolve
+          })
+      )
+
+      render(
+        <DataContext.Provider onSubmit={onSubmit}>
+          <Form.Section containerMode="edit">
+            <Form.Section.EditContainer>
+              <Field.String path="/name" disabled={false} />
+            </Form.Section.EditContainer>
+
+            <Form.Section.ViewContainer>
+              content
+            </Form.Section.ViewContainer>
+          </Form.Section>
+          <Form.SubmitButton />
+        </DataContext.Provider>
+      )
+
+      const input = document.querySelector('input')
+      fireEvent.click(document.querySelector('.dnb-forms-submit-button'))
+
+      await waitFor(() => {
+        expect(input).toBeDisabled()
+      })
+      await userEvent.type(input, 'Grace')
+      expect(input).toHaveValue('')
+
+      resolveSubmit()
+
+      await waitFor(() => {
+        expect(input).not.toBeDisabled()
+      })
+    })
+
     it('should show submit indicator during submit when "onSubmit" is used', async () => {
       const result: RefObject<ContextState | null> = {
         current: null,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProvider.tsx
@@ -42,6 +42,9 @@ export type FieldProviderProps = FieldProps & {
   }
 
   /** For internal use only */
+  forceDisabled?: boolean
+
+  /** For internal use only */
   formElement?: ContextProps['formElement']
 
   /** For internal use only */

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProviderContext.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/FieldProviderContext.ts
@@ -5,6 +5,7 @@ export type FieldProviderContextProps = {
   extend: <T = UseFieldProps>(props: T) => T
   inheritedProps?: UseFieldProps
   inheritedContext?: UseFieldProps
+  forceDisabled?: boolean
 }
 
 const extend: FieldProviderContextProps['extend'] = (props) => props

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/useFieldProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/useFieldProvider.test.tsx
@@ -15,6 +15,7 @@ describe('useFieldProvider', () => {
     expect(result.current.inheritedContext).toEqual({
       test: 'propField',
     })
+    expect(result.current.forceDisabled).toBeUndefined()
   })
 
   it('extend function should merge overwriteProps correctly', () => {
@@ -84,6 +85,36 @@ describe('useFieldProvider', () => {
 
     expect(result.current.extend(valueProps)).toEqual({
       disabled: false,
+    })
+  })
+
+  it('should preserve forceDisabled through nested providers', () => {
+    const inheritedContext = { disabled: true }
+    const inheritedProps = null
+    const extend = () => null
+
+    const { result } = renderHook(useFieldProvider, {
+      initialProps: { disabled: false },
+      wrapper: ({ children }) => (
+        <FieldProviderContext
+          value={{
+            inheritedContext,
+            inheritedProps,
+            extend,
+            forceDisabled: true,
+          }}
+        >
+          {children}
+        </FieldProviderContext>
+      ),
+    })
+
+    expect(result.current.forceDisabled).toBe(true)
+    expect(result.current.sharedProviderParams.formElement).toEqual({
+      disabled: true,
+    })
+    expect(result.current.extend({ disabled: false })).toEqual({
+      disabled: true,
     })
   })
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/useFieldProvider.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/__tests__/useFieldProvider.test.tsx
@@ -114,8 +114,27 @@ describe('useFieldProvider', () => {
       disabled: true,
     })
     expect(result.current.extend({ disabled: false })).toEqual({
-      disabled: true,
+      disabled: false,
     })
+  })
+
+  it('should allow internal providers to reset forceDisabled', () => {
+    const { result } = renderHook(useFieldProvider, {
+      initialProps: { forceDisabled: false },
+      wrapper: ({ children }) => (
+        <FieldProviderContext
+          value={{
+            extend: () => null,
+            forceDisabled: true,
+          }}
+        >
+          {children}
+        </FieldProviderContext>
+      ),
+    })
+
+    expect(result.current.forceDisabled).toBe(false)
+    expect(result.current.sharedProviderParams.formElement).toBeUndefined()
   })
 
   it('should not include translations in sharedProviderParams when no translations prop is given', () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
@@ -21,7 +21,7 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
   } = props || {}
   const nestedContext = useContext(FieldProviderContext)
   const inheritedProps = nestedContext?.inheritedContext
-  const isForceDisabled = nestedContext?.forceDisabled || forceDisabled
+  const isForceDisabled = forceDisabled ?? nestedContext?.forceDisabled
 
   const sharedContext = useContext(SharedContext)
   const dataContextRef = useRef<ContextState>(undefined)
@@ -131,13 +131,12 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
             )
           : props
 
-      return (isForceDisabled ? { ...value, disabled: true } : value) as T
+      return value as T
     },
     [
       nestedContext?.inheritedContext?.required,
       nestedFieldProps,
       overwriteProps,
-      isForceDisabled,
     ]
   )
 

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Provider/useFieldProvider.ts
@@ -12,10 +12,16 @@ import type { FieldProps } from '../../types'
 import type { FieldProviderProps } from './FieldProvider'
 
 function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
-  const { formElement, FormStatus, overwriteProps, ...restProps } =
-    props || {}
+  const {
+    formElement,
+    FormStatus,
+    overwriteProps,
+    forceDisabled,
+    ...restProps
+  } = props || {}
   const nestedContext = useContext(FieldProviderContext)
   const inheritedProps = nestedContext?.inheritedContext
+  const isForceDisabled = nestedContext?.forceDisabled || forceDisabled
 
   const sharedContext = useContext(SharedContext)
   const dataContextRef = useRef<ContextState>(undefined)
@@ -43,6 +49,12 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
   }
   if (formElement) {
     sharedProviderParams.formElement = formElement
+  }
+  if (isForceDisabled) {
+    sharedProviderParams.formElement = {
+      ...sharedProviderParams.formElement,
+      disabled: true,
+    }
   }
   if (FormStatus) {
     sharedProviderParams.FormStatus = FormStatus
@@ -119,12 +131,13 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
             )
           : props
 
-      return value as T
+      return (isForceDisabled ? { ...value, disabled: true } : value) as T
     },
     [
       nestedContext?.inheritedContext?.required,
       nestedFieldProps,
       overwriteProps,
+      isForceDisabled,
     ]
   )
 
@@ -132,6 +145,7 @@ function useFieldProvider(props?: Omit<FieldProviderProps, 'children'>) {
     extend,
     inheritedProps: restProps,
     inheritedContext: nestedFieldProps,
+    forceDisabled: isForceDisabled,
     sharedProviderParams,
   }
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -140,7 +140,7 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
             className="dnb-forms-section-block__content"
           >
             {title && <Lead size="basis">{title}</Lead>}
-            <FieldPropsProvider forceDisabled={isPending}>
+            <FieldPropsProvider forceDisabled={isPending || undefined}>
               {children}
             </FieldPropsProvider>
             {hasToolbar ? null : (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/EditContainer.tsx
@@ -140,9 +140,7 @@ function EditContainer(props: FormSectionEditContainerAllProps) {
             className="dnb-forms-section-block__content"
           >
             {title && <Lead size="basis">{title}</Lead>}
-            <FieldPropsProvider
-              formElement={isPending ? { disabled: true } : undefined}
-            >
+            <FieldPropsProvider forceDisabled={isPending}>
               {children}
             </FieldPropsProvider>
             {hasToolbar ? null : (

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
@@ -21,7 +21,7 @@ describe('EditContainer async onDone', () => {
       <Form.Handler id={formId} defaultData={{ name: 'Ada' }}>
         <Form.Section containerMode="edit">
           <Form.Section.EditContainer onDone={onDone}>
-            <Field.String path="/name" />
+            <Field.String path="/name" disabled={false} />
           </Form.Section.EditContainer>
 
           <Form.Section.ViewContainer>
@@ -58,6 +58,7 @@ describe('EditContainer async onDone', () => {
     expect(
       document.querySelector('.dnb-forms-section-view-block')
     ).toHaveTextContent('Ada')
+    expect(input).not.toBeDisabled()
   })
 
   it('should enable the fields again when an async onDone rejects', async () => {
@@ -92,6 +93,46 @@ describe('EditContainer async onDone', () => {
     })
 
     // The user can correct the value and try again
+    await userEvent.type(input, 'Grace')
+    expect(input).toHaveValue('Grace')
+  })
+
+  it('should force nested fields disabled until an async onDone rejects', async () => {
+    let rejectOnDone!: (reason?: unknown) => void
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOnDone = reject
+        })
+    )
+
+    render(
+      <Form.Section containerMode="edit">
+        <Form.Section.EditContainer onDone={onDone}>
+          <Field.Provider disabled={false}>
+            <Field.String path="/name" disabled={false} />
+          </Field.Provider>
+        </Form.Section.EditContainer>
+
+        <Form.Section.ViewContainer>content</Form.Section.ViewContainer>
+      </Form.Section>
+    )
+
+    const input = document.querySelector('input')
+    await userEvent.click(
+      document.querySelector('.dnb-forms-section-edit-block button')
+    )
+    expect(input).toBeDisabled()
+
+    await userEvent.type(input, 'Grace')
+    expect(input).toHaveValue('')
+
+    rejectOnDone(new Error('Save failed'))
+
+    await waitFor(() => {
+      expect(input).not.toBeDisabled()
+    })
+
     await userEvent.type(input, 'Grace')
     expect(input).toHaveValue('Grace')
   })

--- a/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/Section/EditContainer/__tests__/AsyncOnDone.test.tsx
@@ -21,7 +21,9 @@ describe('EditContainer async onDone', () => {
       <Form.Handler id={formId} defaultData={{ name: 'Ada' }}>
         <Form.Section containerMode="edit">
           <Form.Section.EditContainer onDone={onDone}>
-            <Field.String path="/name" disabled={false} />
+            <Field.Provider disabled={false}>
+              <Field.String path="/name" disabled={false} />
+            </Field.Provider>
           </Form.Section.EditContainer>
 
           <Form.Section.ViewContainer>

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/SubmitConfirmation.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/SubmitConfirmation.tsx
@@ -8,8 +8,7 @@ import {
 import type { ReactNode } from 'react'
 import DataContext from '../../DataContext/Context'
 import useEventListener from '../../DataContext/Provider/useEventListener'
-import SharedProvider from '../../../../shared/Provider'
-import type { ContextProps } from '../../../../shared/Context'
+import FieldPropsProvider from '../../Field/Provider'
 import { HeightAnimation } from '../../../../components'
 import type {
   DialogContentProps,
@@ -203,21 +202,18 @@ function SubmitConfirmation(props: ConfirmProps) {
     setFocusOnButton,
   ])
 
-  const sharedProviderParams: ContextProps = {
-    formElement: {
-      disabled: false,
-    },
-  }
-
   return (
     <>
       {children}
 
-      <SharedProvider {...sharedProviderParams}>
+      <FieldPropsProvider
+        forceDisabled={false}
+        formElement={{ disabled: false }}
+      >
         <HeightAnimation>
           {renderWithState?.(getParamsRef.current())}
         </HeightAnimation>
-      </SharedProvider>
+      </FieldPropsProvider>
     </>
   )
 }

--- a/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/__tests__/SubmitConfirmation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Form/SubmitConfirmation/__tests__/SubmitConfirmation.test.tsx
@@ -2,7 +2,7 @@ import { act, useEffect, useLayoutEffect, useRef } from 'react'
 import type { RefObject } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { isCI } from 'repo-utils'
-import { Form, Wizard } from '../../..'
+import { Field, Form, Wizard } from '../../..'
 import { Button, Dialog } from '../../../../../components'
 import type { ConfirmParams } from '../SubmitConfirmation'
 import userEvent from '@testing-library/user-event'
@@ -87,6 +87,37 @@ describe('Form.SubmitConfirmation', { retry: isCI ? 5 : 0 }, () => {
           )
         ).toBeFalsy()
       })
+    })
+
+    it('should keep fields enabled inside renderWithState', async () => {
+      render(
+        <Form.Handler onSubmit={vi.fn()}>
+          <Form.SubmitConfirmation
+            preventSubmitWhen={() => true}
+            renderWithState={() => (
+              <Field.String path="/confirmation" disabled={false} />
+            )}
+          >
+            <Form.SubmitButton />
+          </Form.SubmitConfirmation>
+        </Form.Handler>
+      )
+
+      const input = document.querySelector('input')
+      expect(input).not.toBeDisabled()
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-submit-button')
+      )
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-submit-indicator--state-pending'
+          )
+        ).toBeTruthy()
+      })
+      expect(input).not.toBeDisabled()
     })
 
     it('should keep pending state when confirmationState is "readyToBeSubmitted" and onSubmit is async', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -199,7 +199,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     getExternalValueSnapshot = undefined,
   }: UseFieldPropsOptions = {}
 ): typeof localProps & ReturnAdditional<Value> {
-  const { extend } = useContext(FieldProviderContext)
+  const { extend, forceDisabled } = useContext(FieldProviderContext)
   const props = extend(localProps)
 
   const {
@@ -1968,9 +1968,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
 
     /** HTML Attributes */
     disabled:
-      onBlurValidator &&
-      asyncProcessRef.current === 'onBlurValidator' &&
-      fieldStateRef.current === 'validating'
+      forceDisabled ||
+      (onBlurValidator &&
+        asyncProcessRef.current === 'onBlurValidator' &&
+        fieldStateRef.current === 'validating')
         ? true
         : disabled,
 


### PR DESCRIPTION
An explicit `disabled={false}` could re-enable fields while an asynchronous section save was pending, allowing the displayed value to diverge from the value being saved. Make the pending lock authoritative through nested field providers, then restore normal provider precedence when the save settles.