### PR TITLE
fix(Forms): treat a validator that returns a Promise as async

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1485,12 +1485,14 @@ export default function Provider<Data extends JsonObject>(
         customStatus: undefined,
       })
 
-      const asyncBehaviorIsEnabled =
+      const shouldEnableAsyncBehavior = () =>
         (skipErrorCheck
           ? enableAsyncBehavior
           : // Don't enable async behavior if we have errors, but when we have a pending state
             !hasErrors() || hasFieldState('pending')) &&
         (enableAsyncBehavior || hasFieldWithAsyncValidator())
+
+      let asyncBehaviorIsEnabled = shouldEnableAsyncBehavior()
 
       if (asyncBehaviorIsEnabled) {
         setFormState('pending')
@@ -1512,6 +1514,12 @@ export default function Provider<Data extends JsonObject>(
             }
           }
         }
+      }
+
+      // A validator can reveal its async behavior only after it has been called.
+      if (!asyncBehaviorIsEnabled && shouldEnableAsyncBehavior()) {
+        asyncBehaviorIsEnabled = true
+        setFormState('pending')
       }
 
       let result: EventStateObject | undefined

--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -1485,14 +1485,16 @@ export default function Provider<Data extends JsonObject>(
         customStatus: undefined,
       })
 
-      const shouldEnableAsyncBehavior = () =>
+      const shouldEnableAsyncBehavior = (hasAsyncValidator: boolean) =>
         (skipErrorCheck
           ? enableAsyncBehavior
           : // Don't enable async behavior if we have errors, but when we have a pending state
             !hasErrors() || hasFieldState('pending')) &&
-        (enableAsyncBehavior || hasFieldWithAsyncValidator())
+        (enableAsyncBehavior || hasAsyncValidator)
 
-      let asyncBehaviorIsEnabled = shouldEnableAsyncBehavior()
+      const hadAsyncValidator = hasFieldWithAsyncValidator()
+      let asyncBehaviorIsEnabled =
+        shouldEnableAsyncBehavior(hadAsyncValidator)
 
       if (asyncBehaviorIsEnabled) {
         setFormState('pending')
@@ -1517,7 +1519,11 @@ export default function Provider<Data extends JsonObject>(
       }
 
       // A validator can reveal its async behavior only after it has been called.
-      if (!asyncBehaviorIsEnabled && shouldEnableAsyncBehavior()) {
+      if (
+        !asyncBehaviorIsEnabled &&
+        !hadAsyncValidator &&
+        shouldEnableAsyncBehavior(hasFieldWithAsyncValidator())
+      ) {
         asyncBehaviorIsEnabled = true
         setFormState('pending')
       }

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldProps.test.tsx
@@ -5635,6 +5635,12 @@ describe('useFieldProps', () => {
 
         expect(document.querySelector('.dnb-form-status')).toBeNull()
 
+        // The field is disabled while the async validator runs, so wait for
+        // it before changing the value again
+        await waitFor(() => {
+          expect(input).not.toBeDisabled()
+        })
+
         await userEvent.type(input, '4')
         fireEvent.blur(input)
 
@@ -5644,6 +5650,10 @@ describe('useFieldProps', () => {
           expect(
             document.querySelector('.dnb-form-status')
           ).toHaveTextContent('Error message')
+        })
+
+        await waitFor(() => {
+          expect(input).not.toBeDisabled()
         })
 
         await userEvent.type(input, '{Backspace}4')

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldValidation.test.tsx
@@ -1,0 +1,246 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Field, Form } from '../../Forms'
+
+describe('validator returning a Promise without being declared async', () => {
+  const delayed = <Result,>(result: Result) => {
+    return new Promise<Result>((resolve) => {
+      setTimeout(() => resolve(result), 50)
+    })
+  }
+
+  it('should not submit while an onBlurValidator Promise is still pending', async () => {
+    // Not declared async, but returns a Promise
+    const onBlurValidator = vi.fn(function () {
+      return delayed(new Error('Not valid'))
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.type(document.querySelector('input'), 'x')
+
+    // Submit while the validation is still in flight
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        'Not valid'
+      )
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+  })
+
+  it('should submit when an onBlurValidator Promise reports no error', async () => {
+    const onBlurValidator = vi.fn(function () {
+      return delayed(undefined)
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.type(document.querySelector('input'), 'x')
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(document.querySelector('.dnb-form-status')).toBeNull()
+  })
+
+  it('should submit when an onChangeValidator Promise reports no error', async () => {
+    const onChangeValidator = vi.fn(function () {
+      return delayed(undefined)
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onChangeValidator={onChangeValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.type(document.querySelector('input'), 'x')
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(document.querySelector('.dnb-form-status')).toBeNull()
+  })
+
+  it('should not submit while an onChangeValidator Promise is still pending', async () => {
+    const onChangeValidator = vi.fn(function () {
+      return delayed(new Error('Not valid'))
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onChangeValidator={onChangeValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.type(document.querySelector('input'), 'x')
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        'Not valid'
+      )
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not submit while an onBlurValidator returning an async validator is still pending', async () => {
+    const asyncValidator = vi.fn(async (value: string) => {
+      await delayed(undefined)
+      return value === 'x' ? new Error('Not valid') : undefined
+    })
+    // Not declared async, and returns a list containing an async validator
+    const onBlurValidator = vi.fn(function () {
+      return [asyncValidator]
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.type(document.querySelector('input'), 'x')
+    fireEvent.submit(document.querySelector('form'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        'Not valid'
+      )
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+  })
+
+  it('should show the field as validating while an onBlurValidator Promise is pending', async () => {
+    let resolveValidator!: (value: undefined) => void
+    const validation = new Promise<undefined>((resolve) => {
+      resolveValidator = resolve
+    })
+    const onBlurValidator = vi.fn(function () {
+      return validation
+    })
+
+    render(
+      <Form.Handler>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+      </Form.Handler>
+    )
+
+    const input = document.querySelector('input')
+
+    await userEvent.type(input, 'x')
+    await userEvent.tab()
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '.dnb-forms-submit-indicator--state-pending'
+        )
+      ).toBeInTheDocument()
+      expect(input).toBeDisabled()
+    })
+
+    resolveValidator(undefined)
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '.dnb-forms-submit-indicator--state-pending'
+        )
+      ).toBeNull()
+    })
+    expect(input).not.toBeDisabled()
+  })
+
+  it('should behave the same as an onBlurValidator declared async', async () => {
+    const onBlurValidator = vi.fn(async function () {
+      return delayed(new Error('Not valid'))
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    await userEvent.type(document.querySelector('input'), 'x')
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        'Not valid'
+      )
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+  })
+
+  it('should keep working for a synchronous onBlurValidator', async () => {
+    const onBlurValidator = vi.fn(function (value: string) {
+      return value === 'x' ? new Error('Not valid') : undefined
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    const input = document.querySelector('input')
+
+    await userEvent.type(input, 'x')
+    await userEvent.tab()
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+        'Not valid'
+      )
+    })
+    expect(input).not.toBeDisabled()
+
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+
+    await userEvent.type(input, 'y')
+    await userEvent.tab()
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toBeNull()
+    })
+
+    await userEvent.click(document.querySelector('button[type="submit"]'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldValidation.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/__tests__/useFieldValidation.test.tsx
@@ -9,6 +9,26 @@ describe('validator returning a Promise without being declared async', () => {
     })
   }
 
+  it('should submit when async behavior is first detected during submit', async () => {
+    const onBlurValidator = vi.fn(function () {
+      return delayed(undefined)
+    })
+    const onSubmit = vi.fn()
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Field.String path="/name" onBlurValidator={onBlurValidator} />
+        <Form.SubmitButton />
+      </Form.Handler>
+    )
+
+    fireEvent.submit(document.querySelector('form'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('should not submit while an onBlurValidator Promise is still pending', async () => {
     // Not declared async, but returns a Promise
     const onBlurValidator = vi.fn(function () {

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -660,6 +660,7 @@ export default function useFieldProps<Value, EmptyValue, Props>(
     required,
     hasDataContext,
     getAjvInstanceDataContext,
+    setFieldInternalsDataContext,
     setFieldEventListener,
     getValueByPath,
     getSourceValue,

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldValidation.ts
@@ -16,6 +16,7 @@ import type {
   Validator,
   Identifier,
 } from '../types'
+import type { ContextState } from '../DataContext'
 import pointer from '../utils/json-pointer'
 import { isAsync } from '../../../shared/helpers/isAsync'
 import useProcessManager from './useProcessManager'
@@ -47,6 +48,7 @@ export type UseFieldValidationParams<Value> = {
   required: boolean
   hasDataContext: boolean
   getAjvInstanceDataContext: () => AjvInstance
+  setFieldInternalsDataContext: ContextState['setFieldInternals']
   setFieldEventListener(
     identifier: Identifier,
     event: string,
@@ -116,6 +118,7 @@ export default function useFieldValidation<Value>({
   required,
   hasDataContext,
   getAjvInstanceDataContext,
+  setFieldInternalsDataContext,
   setFieldEventListener,
   getValueByPath,
   getSourceValue,
@@ -149,6 +152,20 @@ export default function useFieldValidation<Value>({
   revealErrorRef,
 }: UseFieldValidationParams<Value>) {
   const { startProcess } = useProcessManager()
+
+  // A validator that is not declared async can still return a Promise, which
+  // is only visible once it has been called. Tell the data context the first
+  // time we see it, so the submit waits for the validation the same way it
+  // does for a validator declared async.
+  const hasDetectedAsyncRef = useRef(false)
+  const detectAsyncValidator = useCallback(() => {
+    if (!hasDetectedAsyncRef.current) {
+      hasDetectedAsyncRef.current = true
+      setFieldInternalsDataContext?.(identifier, {
+        enableAsyncMode: true,
+      })
+    }
+  }, [setFieldInternalsDataContext, identifier])
 
   // -- onChangeValidator resolution --
 
@@ -466,6 +483,7 @@ export default function useFieldValidation<Value>({
     const runAsync = validationResult instanceof Promise
 
     if (runAsync) {
+      detectAsyncValidator()
       defineAsyncProcess('onChangeValidator')
       setFieldState('validating')
       hideError()
@@ -490,6 +508,7 @@ export default function useFieldValidation<Value>({
   }, [
     callValidatorFnAsync,
     callValidatorFnSync,
+    detectAsyncValidator,
     defineAsyncProcess,
     ensureErrorMessageObject,
     hideError,
@@ -518,6 +537,7 @@ export default function useFieldValidation<Value>({
         if (!isAsync(onChangeValidatorRef.current)) {
           clearErrorState()
         }
+        detectAsyncValidator()
         defineAsyncProcess('onChangeValidator')
         setFieldState('validating')
         hideError()
@@ -554,6 +574,7 @@ export default function useFieldValidation<Value>({
     [
       callValidatorFnAsync,
       callValidatorFnSync,
+      detectAsyncValidator,
       clearErrorState,
       defineAsyncProcess,
       ensureErrorMessageObject,
@@ -623,6 +644,7 @@ export default function useFieldValidation<Value>({
       const runAsync = validationResult instanceof Promise
 
       if (runAsync) {
+        detectAsyncValidator()
         defineAsyncProcess('onBlurValidator')
         setFieldState('validating')
       }
@@ -646,6 +668,7 @@ export default function useFieldValidation<Value>({
     [
       callValidatorFnAsync,
       callValidatorFnSync,
+      detectAsyncValidator,
       defineAsyncProcess,
       ensureErrorMessageObject,
       setFieldState,
@@ -721,19 +744,23 @@ export default function useFieldValidation<Value>({
         return { result }
       }
 
-      if (isAsync(onBlurValidatorRef.current)) {
+      const validationResult = isAsync(onBlurValidatorRef.current)
+        ? callValidatorFnAsync(onBlurValidatorRef.current, value)
+        : callValidatorFnSync(onBlurValidatorRef.current, value)
+
+      // Detect the Promise on the returned value instead of on the function,
+      // the same way the onChangeValidator does
+      const runAsync = validationResult instanceof Promise
+
+      if (runAsync) {
+        detectAsyncValidator()
         defineAsyncProcess('onBlurValidator')
         setFieldState('validating')
       }
 
-      let result = isAsync(onBlurValidatorRef.current)
-        ? await callValidatorFnAsync(onBlurValidatorRef.current, value)
-        : callValidatorFnSync(onBlurValidatorRef.current, value)
-      if (result instanceof Promise) {
-        result = await result
-      }
+      const result = runAsync ? await validationResult : validationResult
 
-      revealOnBlurValidatorResult({ result })
+      revealOnBlurValidatorResult({ result, runAsync })
 
       return { result }
     },
@@ -741,6 +768,7 @@ export default function useFieldValidation<Value>({
       asyncBehaviorIsEnabled,
       callValidatorFnAsync,
       callValidatorFnSync,
+      detectAsyncValidator,
       defineAsyncProcess,
       ensureErrorMessageObject,
       revealOnBlurValidatorResult,


### PR DESCRIPTION
## Problem

Whether a validator is asynchronous was decided from the **function** (`isAsync`), not from what it **returned**. A validator that returns a Promise without being declared `async` — for example `(value) => fetch(...).then(...)`, or any wrapper that returns a Promise — fell between the two paths, and the two validators failed in **opposite** directions.

Measured on `main`, with a validator returning a Promise that settles after 50 ms, submitting while it is in flight:

| validator | shape | `onSubmit` on `main` | `onSubmit` with this change |
|---|---|---|---|
| `onBlurValidator` | plain fn → Promise, **returns an error** | **1 — submitted an invalid value** | 0 |
| `onBlurValidator` | plain fn → Promise, no error | 1 | 1 |
| `onChangeValidator` | plain fn → Promise, returns an error | 0 | 0 |
| `onChangeValidator` | plain fn → Promise, **no error** | **0 — the form could never be submitted** | 1 |
| either | declared `async` | unchanged | unchanged |
| either | synchronous | unchanged | unchanged |

- `onBlurValidator` was never marked as validating, so nothing held the submit back and the form **submitted unvalidated**.
- `onChangeValidator` *was* marked as validating (it already detects the Promise at runtime), so the submit was correctly held back — but the data context never learned that the field validates asynchronously, so the queued submit was **dropped instead of continued** once the validation finished. Clicking submit again just repeated it, so the form could not be submitted at all.

There is no public escape hatch for this: the `hasAsyncBehavior` marker used by the Bring connectors is internal and not exported.

## Fix

1. In the onBlur path, detect the Promise on the **returned value** instead of on the function — the same runtime check the onChange path already does — so the field is marked as validating and the submit waits.
2. When a validator is first seen returning a Promise, tell the data context the field validates asynchronously (`enableAsyncMode`, the same field internal `Field.Upload` already sets). That is what arms the "continue the submit once the pending state resolves" path, so the queued submit resumes instead of being dropped.

This makes the documented contract — *"the function can be either asynchronous or synchronous"* — actually hold for both validators.

## Tests

`hooks/__tests__/useFieldValidation.test.tsx` — verified that the four new cases **fail on `main`** and pass with the change:

- `onBlurValidator` Promise with an error → the form does not submit
- `onBlurValidator` Promise with no error → the form does submit
- `onChangeValidator` Promise with no error → the form does submit
- a Promise-returning `onBlurValidator` shows the field as validating while it is pending

Positive controls (pass before and after, so the tests are not vacuous):

- an `onBlurValidator` declared `async` behaves identically
- a synchronous `onBlurValidator` still blocks and then releases the submit
- an `onChangeValidator` Promise with an error still blocks the submit

One existing test, `useFieldProps` → "should support mixed sync and async validators", typed into the field while an async validator was running. That worked only because the field was not marked as validating — the same gap this change closes. It now waits for the field to be enabled before changing the value, and it passes both **with and without** the source change.

Full `extensions/forms` suite: **159 files, 4767 tests passing** (two clean runs). A third run hit an unrelated `ValueBlock` help test that passes in isolation; this environment has a few load-sensitive tests. Typecheck, ESLint and Prettier are clean, with no new `exhaustive-deps` warnings.

## Out of scope

While measuring this I found a separate pre-existing issue: when a validator returns a list containing an async validator and validation re-enters while the first run is still in flight, the call-stack de-duplication can skip the async member, so it resolves as "no error". That is a different root cause and is left alone here.

## Related

- #9252 — recovers a stuck per-field pending state via `asyncSubmitTimeout`.
- #9254 — the same for a never-settling `Field.Upload` `fileHandler`.
