### PR TITLE
chore(CI): retry transient dependency audit timeouts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,9 +80,35 @@ jobs:
         # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
         # are tracked via Dependabot instead.
         run: |
-          yarn workspace @dnb/eufemia audit:ci
-          yarn workspace @dnb/eufemia-mcp audit:ci
-          yarn workspace eufemia-analytics audit:ci
+          run_audit() {
+            local output
+            local status
+
+            for attempt in 1 2 3; do
+              set +e
+              output="$("$@" 2>&1)"
+              status=$?
+              set -e
+
+              printf '%s\n' "$output"
+
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+
+              if [[ "$output" != *"RequestError: Timeout awaiting 'socket'"* ]] ||
+                [ "$attempt" -eq 3 ]; then
+                return "$status"
+              fi
+
+              echo "::warning::Audit registry timed out; retrying in 10 seconds"
+              sleep 10
+            done
+          }
+
+          run_audit yarn workspace @dnb/eufemia audit:ci
+          run_audit yarn workspace @dnb/eufemia-mcp audit:ci
+          run_audit yarn workspace eufemia-analytics audit:ci
 
       - name: Verify SBOM + audit generation (release smoke test)
         # release.yml generates a CycloneDX SBOM and a vulnerability report after


### PR DESCRIPTION
The npm audit endpoint can accept a connection without returning a response, causing Yarn to fail after its 60-second socket timeout. This affected unrelated branches and main while other dependency checks passed.

Retry only this timeout up to three attempts. Vulnerability findings and other audit failures still fail immediately, and repeated timeouts remain a hard failure.

I don't think it solves this issue: https://github.com/dnbexperience/eufemia/actions/runs/33839289898/job/100918164344

But it may solve it later in different cases?