### PR TITLE
chore(CI): allow slow dependency audits to finish

### DIFF
--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -35,7 +35,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Git checkout
@@ -66,6 +66,8 @@ jobs:
         # Audit the shipped (production) dep tree to catch known advisories,
         # matching the MCP pipeline and the EDS-823 supply-chain work.
         run: yarn workspace eufemia-analytics audit:ci
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
 
       - name: Typecheck
         run: cd tools/analytics && yarn test:types

--- a/.github/workflows/mcp-lambda.yml
+++ b/.github/workflows/mcp-lambda.yml
@@ -35,7 +35,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Git checkout
@@ -52,6 +52,8 @@ jobs:
         # Re-audit the shipped (production) dep tree at deploy time to catch
         # advisories disclosed after the PR gate ran. Mirrors release.yml.
         run: yarn workspace @dnb/eufemia-mcp audit:ci
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
 
       - name: Typecheck
         run: cd tools/mcp-lambda && yarn typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     permissions:
       contents: read
@@ -345,6 +345,7 @@ jobs:
         working-directory: packages/dnb-eufemia
         env:
           RELEASED_VERSION: ${{ needs.action.outputs.released }}
+          YARN_HTTP_TIMEOUT: '360000'
         run: |
           # Generated from the source workspace: the CycloneDX plugin needs a
           # Yarn project, and direct runtime deps are identical to the published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Audit dependencies
         run: yarn workspace @dnb/eufemia audit:ci
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
 
       - name: Prebuild Library
         run: yarn workspace @dnb/eufemia prebuild:ci

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,7 +43,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     # This job runs untrusted third-party code (the CycloneDX generator via
     # `yarn dlx` in the SBOM smoke test below). verify.yml has no workflow-level
@@ -83,6 +83,8 @@ jobs:
           yarn workspace @dnb/eufemia audit:ci
           yarn workspace @dnb/eufemia-mcp audit:ci
           yarn workspace eufemia-analytics audit:ci
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
 
       - name: Verify SBOM + audit generation (release smoke test)
         # release.yml generates a CycloneDX SBOM and a vulnerability report after
@@ -93,6 +95,8 @@ jobs:
         # generator version below in sync with release.yml. The release-only
         # version stamp and GitHub-Release upload are not exercised here.
         working-directory: packages/dnb-eufemia
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
         # The generator runs third-party code fetched via `yarn dlx` and needs no
         # credentials of its own; the job-level `env:` above defensively blanks
         # secrets, so none can reach it.


### PR DESCRIPTION
The npm audit endpoint can keep a healthy connection open for about five minutes before responding, as [documented in npm/cli#9950](https://github.com/npm/cli/issues/9950#issuecomment-5536505917).

Allow every CI audit request to wait six minutes instead of Yarn's default 60 seconds. Extend the affected job limits so sequential audits still have time to finish. Audits remain fail-closed when npm does not respond within six minutes or reports an advisory.