### PR TITLE
chore: rename MCP Lambda workspace

### DIFF
--- a/.github/workflows/mcp-lambda.yml
+++ b/.github/workflows/mcp-lambda.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Audit dependencies
         # Re-audit the shipped (production) dep tree at deploy time to catch
         # advisories disclosed after the PR gate ran. Mirrors release.yml.
-        run: yarn workspace @dnb/eufemia-mcp audit:ci
+        run: yarn workspace eufemia-mcp-lambda audit:ci
         env:
           YARN_HTTP_TIMEOUT: '360000'
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -76,12 +76,12 @@ jobs:
 
       - name: Audit dependencies
         # Audit the shipped (production) dependency tree of everything we ship:
-        # the @dnb/eufemia npm library, the @dnb/eufemia-mcp Lambda and the
+        # the @dnb/eufemia npm library, the Eufemia MCP Lambda and the
         # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
         # are tracked via Dependabot instead.
         run: |
           yarn workspace @dnb/eufemia audit:ci
-          yarn workspace @dnb/eufemia-mcp audit:ci
+          yarn workspace eufemia-mcp-lambda audit:ci
           yarn workspace eufemia-analytics audit:ci
         env:
           YARN_HTTP_TIMEOUT: '360000'

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -21,7 +21,7 @@ The artifacts that reach an end user are:
 - `@dnb/eufemia` — the npm package (published). Its production dependencies
   install directly into every consuming app, so they run in consumers'
   production.
-- `@dnb/eufemia-mcp` — the Eufemia MCP server's **AWS Lambda** deployment
+- `eufemia-mcp-lambda` — the Eufemia MCP server's **AWS Lambda** deployment
   (`tools/mcp-lambda`; **not** npm-published).
 - `dnb-design-system-portal` — the docs site (a deployed static site; **not**
   npm-published, no backend). What reaches users is the **built static
@@ -38,7 +38,7 @@ To check what actually ships, audit the two workspaces whose production tree
 
 ```bash
 yarn workspace @dnb/eufemia npm audit --recursive --environment production --severity low
-yarn workspace @dnb/eufemia-mcp npm audit --recursive --environment production --severity low
+yarn workspace eufemia-mcp-lambda npm audit --recursive --environment production --severity low
 ```
 
 If those are clean, no consumer-facing vulnerability exists regardless of what
@@ -282,7 +282,7 @@ DNB's central reporting as that capability expands.
 
 The required `Audit dependencies` check from `verify.yml` audits the shipped
 (production) dependency tree of the **two gated workspaces** — `@dnb/eufemia`
-(the published library) and `@dnb/eufemia-mcp` (the deployed Lambda) — with a
+(the published library) and `eufemia-mcp-lambda` (the deployed Lambda) — with a
 native Yarn 4 audit; each workspace's `audit:ci` runs:
 
 ```
@@ -303,8 +303,8 @@ yarn npm audit --recursive --environment production --severity high
   exception above so the accepted risk stays explicit and auditable.
 
 The same audit runs again outside the PR gate: `release.yml` audits `@dnb/eufemia`
-at publish time and `mcp-lambda.yml` audits `@dnb/eufemia-mcp` at deploy time, so
-the shipped tree is re-checked before each artifact goes out.
+at publish time and `mcp-lambda.yml` audits `eufemia-mcp-lambda` at deploy time,
+so the shipped tree is re-checked before each artifact goes out.
 
 > We use native `yarn npm audit` rather than a wrapper because it is transparent
 > and verifiable under Yarn 4 — it exits non-zero on real advisories at or above

--- a/tools/mcp-lambda/package.json
+++ b/tools/mcp-lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dnb/eufemia-mcp",
+  "name": "eufemia-mcp-lambda",
   "version": "1.0.0",
   "description": "Eufemia MCP server for AWS Lambda",
   "main": "dist/lambda-handler.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,21 +2754,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dnb/eufemia-mcp@workspace:tools/mcp-lambda":
-  version: 0.0.0-use.local
-  resolution: "@dnb/eufemia-mcp@workspace:tools/mcp-lambda"
-  dependencies:
-    "@dnb/eufemia": "workspace:*"
-    "@modelcontextprotocol/client": "npm:2.0.0"
-    "@modelcontextprotocol/server": "npm:2.0.0"
-    "@types/aws-lambda": "npm:8.10.161"
-    esbuild: "npm:0.25.5"
-    tsx: "npm:4.22.4"
-    typescript: "npm:5.9.3"
-    vitest: "npm:4.1.10"
-  languageName: unknown
-  linkType: soft
-
 "@dnb/eufemia@workspace:*, @dnb/eufemia@workspace:packages/dnb-eufemia":
   version: 0.0.0-use.local
   resolution: "@dnb/eufemia@workspace:packages/dnb-eufemia"
@@ -9867,6 +9852,21 @@ __metadata:
     fs-extra: "npm:10.0.0"
     markdown-tables-utils: "workspace:*"
     prettier: "npm:3.8.1"
+    vitest: "npm:4.1.10"
+  languageName: unknown
+  linkType: soft
+
+"eufemia-mcp-lambda@workspace:tools/mcp-lambda":
+  version: 0.0.0-use.local
+  resolution: "eufemia-mcp-lambda@workspace:tools/mcp-lambda"
+  dependencies:
+    "@dnb/eufemia": "workspace:*"
+    "@modelcontextprotocol/client": "npm:2.0.0"
+    "@modelcontextprotocol/server": "npm:2.0.0"
+    "@types/aws-lambda": "npm:8.10.161"
+    esbuild: "npm:0.25.5"
+    tsx: "npm:4.22.4"
+    typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Rename the internal MCP Lambda workspace from `@dnb/eufemia-mcp` to `eufemia-mcp-lambda`. This avoids presenting the deployment-only workspace as a published `@dnb` package and aligns its name with the Lambda tool.