### PR TITLE
chore(CI): share the consumer smoke npm cache across pull requests

### DIFF
--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -19,9 +19,10 @@ on:
   # `pull_request` only, no `main`-scoped copy ever existed, so every PR missed,
   # re-downloaded the fixtures' toolchain and saved its own copy — measured at
   # 26 identical 142 MB entries, 3.6 GB, a third of the repo's 10 GB cache
-  # budget. A single copy on `main` fixes both halves: PRs restore it, and
-  # actions/cache skips saving when the primary key hits, so the duplicate
-  # writes stop too.
+  # budget, none of it reusable. A single copy on `main` fixes both halves: PRs
+  # restore it, and actions/cache skips saving when the primary key hits, so the
+  # duplicate writes stop too. The point is the reclaimed budget, which the
+  # caches that do pay for themselves were being evicted for.
   #
   # Unlike the PR gate above, this trigger only keeps that cache warm, so it is
   # filtered down to the files the cache key is derived from — see `hashFiles`
@@ -64,8 +65,13 @@ jobs:
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
-      # Cache the consumers' npm downloads: run-smoke.mjs runs `npm ci` for each
-      # fixture, which would otherwise re-download react/next/vite every run.
+      # Cache the consumers' npm downloads. Measured across eleven runs this
+      # buys no time: the npm-cache-dependent steps came out at 1.32m with a
+      # hit and 1.20m with a miss, because `npm ci` here is bound by unpacking
+      # rather than fetching. It is kept only because one shared copy is nearly
+      # free; dropping the step altogether is the simpler alternative and would
+      # reclaim the same budget.
+      #
       # The copy this restores is normally the one published by the `main`
       # trigger above; a PR only writes its own when it changes a fixture
       # lockfile, because that is the only time the key differs from `main`'s.

--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -9,9 +9,34 @@ on:
   # No `paths:` filter: this gate protects the publishable build, whose inputs
   # span the whole repo (root package.json/yarn.lock, .github/actions/setup and
   # the tools/* packages used by build:ci), so a narrow filter would let a
-  # build-breaking change skip the check. Runs on every pull request, plus
-  # manual dispatch.
+  # build-breaking change skip the check. Runs on every pull request.
   pull_request:
+
+  # Publishes the one shared copy of the consumer npm cache below.
+  #
+  # Actions caches are scoped per ref: a `pull_request` run reads its own scope
+  # and its base branch, never another PR's. While this workflow ran on
+  # `pull_request` only, no `main`-scoped copy ever existed, so every PR missed,
+  # re-downloaded the fixtures' toolchain and saved its own copy — measured at
+  # 26 identical 142 MB entries, 3.6 GB, a third of the repo's 10 GB cache
+  # budget. A single copy on `main` fixes both halves: PRs restore it, and
+  # actions/cache skips saving when the primary key hits, so the duplicate
+  # writes stop too.
+  #
+  # Unlike the PR gate above, this trigger only keeps that cache warm, so it is
+  # filtered down to the files the cache key is derived from — see `hashFiles`
+  # in the cache step. `main` takes ~70 commits/week and a full run is ~5
+  # minutes, so triggering on all of them would spend hours a week re-publishing
+  # a byte-identical cache. This workflow file is listed as well so that merging
+  # a change here seeds the first copy, instead of leaving the cache unshared
+  # until the next fixture bump.
+  push:
+    branches:
+      - main
+    paths:
+      - 'smoke/*/package-lock.json'
+      - '.github/workflows/consumer-smoke.yml'
+
   workflow_dispatch:
 
 concurrency:
@@ -41,6 +66,9 @@ jobs:
 
       # Cache the consumers' npm downloads: run-smoke.mjs runs `npm ci` for each
       # fixture, which would otherwise re-download react/next/vite every run.
+      # The copy this restores is normally the one published by the `main`
+      # trigger above; a PR only writes its own when it changes a fixture
+      # lockfile, because that is the only time the key differs from `main`'s.
       - name: Cache consumer npm downloads
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:


### PR DESCRIPTION
Actions caches are scoped per ref: a pull request reads only its own scope and its base branch, never another pull request's. This workflow ran on pull requests alone, so no `main`-scoped copy of the consumer npm cache ever existed — every pull request missed it, re-downloaded the fixtures' toolchain, and saved its own copy.

Measured on the live cache: **26 identical 142 MB entries holding 3.6 GB, a third of the repository's 10 GB budget**, none of it reusable. Total storage sits at 9.96 GB, so eviction is already deleting entries — including the ones that *do* pay for themselves, like the 359 MB Playwright browsers and the 168 MB dependency tree.

Triggering on pushes to `main` that touch the fixture lockfiles publishes one shared copy for pull requests to restore. `actions/cache` skips saving whenever the primary key hits, so this stops the duplicate writes as well as the downloads.

The trigger is filtered to the files the cache key is derived from rather than firing on every push — `main` takes ~70 commits a week and a full run is ~5 minutes, so an unfiltered trigger would spend hours a week re-publishing a byte-identical cache. This workflow file is in the filter so that merging seeds the first copy.

### What this is not

The cache itself buys no time. Comparing a hit against a miss across eleven runs put the npm-cache-dependent steps at **1.32m with a hit and 1.20m with a miss** — `npm ci` here is bound by unpacking, not fetching. The whole-job gap (3.98m vs 4.40m) sits in `Build library`, which never touches `~/.npm`, so it is a confound rather than a cache effect.

So the value is entirely the reclaimed budget, not a faster smoke job. **Deleting the cache step would reclaim the same 3.6 GB for a smaller diff**, and is a reasonable alternative to this PR — I kept the cache because one shared copy is nearly free, not because it was measured to help. I tried to show a warm cache surviving an unreachable registry to justify keeping it on resilience grounds and could not complete the test, so no such benefit is claimed.

### Two notes

- The pull request gate is unchanged: still unfiltered, still runs on every pull request.
- Reclamation is gradual. 14 of the 26 entries belong to open pull requests, which keep preferring their own copy while active; the 12 closed ones age out within 7 days. Purging would realise all 3.6 GB immediately.
