### PR TITLE
fix(Tooltip): prevent flicker during rapid pointer re-entry

### DIFF
--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -13,7 +13,12 @@ import {
   useRef,
   useState,
 } from 'react'
-import type { ComponentType, HTMLAttributes, MouseEvent } from 'react'
+import type {
+  AnimationEvent,
+  ComponentType,
+  HTMLAttributes,
+  MouseEvent,
+} from 'react'
 import { clsx } from 'clsx'
 import { combineDescribedBy, warn } from '../../shared/component-helper'
 import { isTouch } from './TooltipHelpers'
@@ -59,15 +64,32 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   const [isOpen, setIsOpen] = useState(open)
   const [isOverlayHovered, setOverlayHovered] = useState(false)
+  const [skipShowAnimation, setSkipShowAnimation] = useState(false)
 
   const delayTimeout = useRef<NodeJS.Timeout>(undefined)
   const overlayDelayTimeout = useRef<NodeJS.Timeout>(undefined)
+  const isHideAnimationRunning = useRef(false)
   const cloneRef = useRef<HTMLElement>(undefined)
   const previousDescribedByIdRef = useRef<string | null>(null)
 
   const clearTimers = () => {
     clearTimeout(delayTimeout.current)
   }
+
+  const markHideAnimationStarted = useCallback(() => {
+    isHideAnimationRunning.current = !noAnimation && !globalThis.IS_TEST
+  }, [noAnimation])
+
+  const resumeHideAnimation = useCallback(() => {
+    if (!isHideAnimationRunning.current) {
+      return false
+    }
+
+    isHideAnimationRunning.current = false
+    setSkipShowAnimation(true)
+    setIsOpen(true)
+    return true
+  }, [])
 
   const onMouseEnter = useCallback(
     (e: Event) => {
@@ -90,6 +112,10 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       }
 
       clearTimers()
+      if (resumeHideAnimation()) {
+        return
+      }
+
       if (noAnimation || globalThis.IS_TEST) {
         run()
       } else {
@@ -99,7 +125,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         ) // have min 1 to make sure we are after onMouseLeave
       }
     },
-    [noAnimation, showDelay]
+    [noAnimation, resumeHideAnimation, showDelay]
   )
 
   const onFocus = useCallback(
@@ -130,7 +156,9 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       clearTimers()
 
       const run = () => {
+        setSkipShowAnimation(false)
         setIsOpen(false)
+        markHideAnimationStarted()
       }
 
       if (shouldDelayHide && hideDelayMs > 0) {
@@ -139,7 +167,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         run()
       }
     },
-    [open, hideDelayMs, shouldDelayHide]
+    [open, hideDelayMs, markHideAnimationStarted, shouldDelayHide]
   )
 
   const addEvents = useCallback(
@@ -292,9 +320,11 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     clearTimers()
     clearOverlayTimers()
     if (!isControlled) {
-      setOverlayHovered(true)
+      if (!resumeHideAnimation()) {
+        setOverlayHovered(true)
+      }
     }
-  }, [isControlled])
+  }, [isControlled, resumeHideAnimation])
 
   const handleOverlayMouseLeave = useCallback(
     (event: MouseEvent) => {
@@ -315,8 +345,10 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       }
 
       const run = () => {
+        setSkipShowAnimation(false)
         setIsOpen(false)
         setOverlayHovered(false)
+        markHideAnimationStarted()
       }
       clearOverlayTimers()
 
@@ -326,11 +358,25 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         run()
       }
     },
-    [hideDelayMs, isControlled, shouldDelayHide]
+    [hideDelayMs, isControlled, markHideAnimationStarted, shouldDelayHide]
   )
 
-  const { className: attributeClassName, ...restAttributes } =
-    attributes || {}
+  const {
+    className: attributeClassName,
+    onAnimationEnd,
+    ...restAttributes
+  } = attributes || {}
+
+  const handleAnimationEnd = useCallback(
+    (event: AnimationEvent<HTMLElement>) => {
+      if (event.currentTarget === event.target) {
+        isHideAnimationRunning.current = false
+      }
+
+      onAnimationEnd?.(event)
+    },
+    [onAnimationEnd]
+  )
 
   // Keep the Popover active until Tooltip's cancellable hide delay expires.
   return (
@@ -349,7 +395,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         hideDelay={0}
         skipPortal={skipPortal}
         keepInDOM={keepInDOM}
-        noAnimation={noAnimation}
+        noAnimation={noAnimation || skipShowAnimation}
         triggerOffset={triggerOffset}
         targetRefreshKey={targetRefreshKey}
         arrowPosition={arrow}
@@ -371,6 +417,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         onMouseLeave={handleOverlayMouseLeave}
         role="tooltip"
         {...(restAttributes as HTMLAttributes<HTMLElement>)}
+        onAnimationEnd={handleAnimationEnd}
       >
         {children}
       </Popover>

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -117,6 +117,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
       clearTimers()
       clearOverlayTimers()
+      setOverlayHovered(false)
       if (resumeHideAnimation()) {
         return
       }

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -51,6 +51,10 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     omitDescribedBy,
   } = restProps
 
+  const hideDelayMs = Math.max(0, parseFloat(String(hideDelay)) || 0)
+  const shouldDelayHide =
+    skipPortal || (!noAnimation && !globalThis.IS_TEST)
+
   const { internalId, isControlled } = useContext(TooltipContext)
 
   const [isOpen, setIsOpen] = useState(open)
@@ -59,8 +63,6 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
   const delayTimeout = useRef<NodeJS.Timeout>(undefined)
   const overlayDelayTimeout = useRef<NodeJS.Timeout>(undefined)
   const cloneRef = useRef<HTMLElement>(undefined)
-  const isOpenRef = useRef(open)
-  const isHidingRef = useRef(false)
   const previousDescribedByIdRef = useRef<string | null>(null)
 
   const clearTimers = () => {
@@ -84,18 +86,13 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       }
 
       const run = () => {
-        isOpenRef.current = true
         setIsOpen(true)
       }
 
-      const resumeOpenState = isHidingRef.current
-      isHidingRef.current = false
-
-      if (noAnimation || globalThis.IS_TEST || resumeOpenState) {
-        clearTimers()
+      clearTimers()
+      if (noAnimation || globalThis.IS_TEST) {
         run()
       } else {
-        clearTimers()
         delayTimeout.current = setTimeout(
           run,
           parseFloat(String(showDelay)) || 1
@@ -133,31 +130,16 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       clearTimers()
 
       const run = () => {
-        isOpenRef.current = false
-        isHidingRef.current = false
         setIsOpen(false)
       }
 
-      if (skipPortal) {
-        isHidingRef.current = isOpenRef.current
-        delayTimeout.current = setTimeout(
-          run,
-          parseFloat(String(hideDelay))
-        )
+      if (shouldDelayHide && hideDelayMs > 0) {
+        delayTimeout.current = setTimeout(run, hideDelayMs)
       } else {
-        const wasOpen = isOpenRef.current
         run()
-
-        const delay = parseFloat(String(hideDelay)) || 0
-        if (wasOpen && delay > 0) {
-          isHidingRef.current = true
-          delayTimeout.current = setTimeout(() => {
-            isHidingRef.current = false
-          }, delay)
-        }
       }
     },
-    [open, hideDelay, skipPortal]
+    [open, hideDelayMs, shouldDelayHide]
   )
 
   const addEvents = useCallback(
@@ -247,10 +229,8 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   useEffect(() => {
     if (isControlled) {
-      isOpenRef.current = open
       setIsOpen(open)
     } else {
-      isOpenRef.current = false
       setIsOpen(false)
     }
   }, [open, isControlled])
@@ -309,6 +289,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
   useEffect(() => clearOverlayTimers, [])
 
   const handleOverlayMouseEnter = useCallback(() => {
+    clearTimers()
     clearOverlayTimers()
     if (!isControlled) {
       setOverlayHovered(true)
@@ -327,29 +308,31 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         event.relatedTarget instanceof Node &&
         targetElement.contains(event.relatedTarget)
       ) {
-        isOpenRef.current = true
+        clearTimers()
         setIsOpen(true)
         setOverlayHovered(false)
         return undefined
       }
 
-      const run = () => setOverlayHovered(false)
+      const run = () => {
+        setIsOpen(false)
+        setOverlayHovered(false)
+      }
       clearOverlayTimers()
-      if (skipPortal) {
-        overlayDelayTimeout.current = setTimeout(
-          run,
-          parseFloat(String(hideDelay)) || 1
-        )
+
+      if (shouldDelayHide && hideDelayMs > 0) {
+        overlayDelayTimeout.current = setTimeout(run, hideDelayMs)
       } else {
         run()
       }
     },
-    [hideDelay, isControlled, skipPortal]
+    [hideDelayMs, isControlled, shouldDelayHide]
   )
 
   const { className: attributeClassName, ...restAttributes } =
     attributes || {}
 
+  // Keep the Popover active until Tooltip's cancellable hide delay expires.
   return (
     <>
       <Popover
@@ -363,7 +346,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         open={overlayOpen}
         targetElement={cloneRef}
         arrowEdgeOffset={4}
-        hideDelay={hideDelay}
+        hideDelay={0}
         skipPortal={skipPortal}
         keepInDOM={keepInDOM}
         noAnimation={noAnimation}

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -59,6 +59,8 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
   const delayTimeout = useRef<NodeJS.Timeout>(undefined)
   const overlayDelayTimeout = useRef<NodeJS.Timeout>(undefined)
   const cloneRef = useRef<HTMLElement>(undefined)
+  const isOpenRef = useRef(open)
+  const isHidingRef = useRef(false)
   const previousDescribedByIdRef = useRef<string | null>(null)
 
   const clearTimers = () => {
@@ -82,10 +84,15 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       }
 
       const run = () => {
+        isOpenRef.current = true
         setIsOpen(true)
       }
 
-      if (noAnimation || globalThis.IS_TEST) {
+      const resumeOpenState = isHidingRef.current
+      isHidingRef.current = false
+
+      if (noAnimation || globalThis.IS_TEST || resumeOpenState) {
+        clearTimers()
         run()
       } else {
         clearTimers()
@@ -126,16 +133,28 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       clearTimers()
 
       const run = () => {
+        isOpenRef.current = false
+        isHidingRef.current = false
         setIsOpen(false)
       }
 
       if (skipPortal) {
+        isHidingRef.current = isOpenRef.current
         delayTimeout.current = setTimeout(
           run,
           parseFloat(String(hideDelay))
         )
       } else {
+        const wasOpen = isOpenRef.current
         run()
+
+        const delay = parseFloat(String(hideDelay)) || 0
+        if (wasOpen && delay > 0) {
+          isHidingRef.current = true
+          delayTimeout.current = setTimeout(() => {
+            isHidingRef.current = false
+          }, delay)
+        }
       }
     },
     [open, hideDelay, skipPortal]
@@ -228,8 +247,10 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
 
   useEffect(() => {
     if (isControlled) {
+      isOpenRef.current = open
       setIsOpen(open)
     } else {
+      isOpenRef.current = false
       setIsOpen(false)
     }
   }, [open, isControlled])
@@ -306,6 +327,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
         event.relatedTarget instanceof Node &&
         targetElement.contains(event.relatedTarget)
       ) {
+        isOpenRef.current = true
         setIsOpen(true)
         setOverlayHovered(false)
         return undefined

--- a/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/TooltipWithEvents.tsx
@@ -76,6 +76,10 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
     clearTimeout(delayTimeout.current)
   }
 
+  const clearOverlayTimers = () => {
+    clearTimeout(overlayDelayTimeout.current)
+  }
+
   const markHideAnimationStarted = useCallback(() => {
     isHideAnimationRunning.current = !noAnimation && !globalThis.IS_TEST
   }, [noAnimation])
@@ -112,6 +116,7 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       }
 
       clearTimers()
+      clearOverlayTimers()
       if (resumeHideAnimation()) {
         return
       }
@@ -309,10 +314,6 @@ function TooltipWithEvents(props: TooltipProps & TooltipWithEventsProps) {
       updateAriaDescribedBy(null)
     }
   }, [cloneRef, describedById, target])
-
-  const clearOverlayTimers = () => {
-    clearTimeout(overlayDelayTimeout.current)
-  }
 
   useEffect(() => clearOverlayTimers, [])
 

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -640,12 +640,20 @@ describe('Tooltip', () => {
         attributeFilter: ['class'],
       })
 
-      fireEvent.mouseLeave(buttonElem)
-      fireEvent.mouseEnter(buttonElem)
+      for (let i = 0; i < 3; i++) {
+        fireEvent.mouseLeave(buttonElem)
 
-      expect(buttonElem).toHaveAttribute('aria-describedby', describedBy)
+        expect(buttonElem).toHaveAttribute('aria-describedby', describedBy)
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
 
-      await wait(150)
+        await wait(80)
+        fireEvent.mouseEnter(buttonElem)
+
+        expect(buttonElem).toHaveAttribute('aria-describedby', describedBy)
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+
+        await wait(20)
+      }
       observer.disconnect()
 
       expect(classNames).not.toContain(

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -612,6 +612,48 @@ describe('Tooltip', () => {
       expect(getMainElem()).toHaveClass('dnb-tooltip--active')
     })
 
+    it('should not start hiding after rapid target re-entry', async () => {
+      render(
+        <OriginalTooltip
+          {...defaultProps}
+          showDelay={100}
+          hideDelay={100}
+          targetElement={<button>Button</button>}
+        />
+      )
+
+      const buttonElem = document.querySelector('button')
+
+      fireEvent.mouseEnter(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+      })
+
+      const describedBy = buttonElem.getAttribute('aria-describedby')
+      const classNames = []
+      const observer = new MutationObserver(() => {
+        classNames.push(getMainElem().className)
+      })
+      observer.observe(getMainElem(), {
+        attributes: true,
+        attributeFilter: ['class'],
+      })
+
+      fireEvent.mouseLeave(buttonElem)
+      fireEvent.mouseEnter(buttonElem)
+
+      expect(buttonElem).toHaveAttribute('aria-describedby', describedBy)
+
+      await wait(150)
+      observer.disconnect()
+
+      expect(classNames).not.toContain(
+        expect.stringContaining('dnb-tooltip--hide')
+      )
+      expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+    })
+
     it('should set fixed class', () => {
       render(<Tooltip fixedPosition open />)
 

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -639,6 +639,12 @@ describe('Tooltip', () => {
 
       expect(getMainElem()).toHaveClass('dnb-tooltip--active')
       expect(buttonElem).toHaveAttribute('aria-describedby')
+
+      fireEvent.mouseLeave(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--hide')
+      })
     })
 
     it('should not start hiding after rapid target re-entry', async () => {

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -662,6 +662,79 @@ describe('Tooltip', () => {
       expect(getMainElem()).toHaveClass('dnb-tooltip--active')
     })
 
+    it('should not replay the show animation when re-entering while hiding', async () => {
+      render(
+        <OriginalTooltip
+          {...defaultProps}
+          showDelay={100}
+          hideDelay={100}
+          targetElement={<button>Button</button>}
+        />
+      )
+
+      const buttonElem = document.querySelector('button')
+
+      fireEvent.mouseEnter(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+      })
+
+      fireEvent.mouseLeave(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--hide')
+      })
+
+      fireEvent.mouseEnter(buttonElem)
+
+      expect(getMainElem()).toHaveClass(
+        'dnb-tooltip--active',
+        'dnb-tooltip--no-animation'
+      )
+
+      fireEvent.mouseLeave(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--hide')
+        expect(getMainElem()).not.toHaveClass('dnb-tooltip--no-animation')
+      })
+    })
+
+    it('should not replay the show animation when re-entering the Tooltip while hiding', async () => {
+      render(
+        <OriginalTooltip
+          {...defaultProps}
+          showDelay={100}
+          hideDelay={100}
+          targetElement={<button>Button</button>}
+        />
+      )
+
+      const buttonElem = document.querySelector('button')
+
+      fireEvent.mouseEnter(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+      })
+
+      fireEvent.mouseLeave(buttonElem)
+      fireEvent.mouseEnter(getMainElem())
+      fireEvent.mouseLeave(getMainElem())
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--hide')
+      })
+
+      fireEvent.mouseEnter(getMainElem())
+
+      expect(getMainElem()).toHaveClass(
+        'dnb-tooltip--active',
+        'dnb-tooltip--no-animation'
+      )
+    })
+
     it('should set fixed class', () => {
       render(<Tooltip fixedPosition open />)
 

--- a/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/dnb-eufemia/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -612,6 +612,35 @@ describe('Tooltip', () => {
       expect(getMainElem()).toHaveClass('dnb-tooltip--active')
     })
 
+    it('should cancel the overlay hide timer when mouse returns across the gap', async () => {
+      render(
+        <OriginalTooltip
+          {...defaultProps}
+          showDelay={150}
+          hideDelay={100}
+          targetElement={<button>Button</button>}
+        />
+      )
+
+      const buttonElem = document.querySelector('button')
+
+      fireEvent.mouseEnter(buttonElem)
+
+      await waitFor(() => {
+        expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+      })
+
+      fireEvent.mouseLeave(buttonElem)
+      fireEvent.mouseEnter(getMainElem())
+      fireEvent.mouseLeave(getMainElem())
+      fireEvent.mouseEnter(buttonElem)
+
+      await wait(125)
+
+      expect(getMainElem()).toHaveClass('dnb-tooltip--active')
+      expect(buttonElem).toHaveAttribute('aria-describedby')
+    })
+
     it('should not start hiding after rapid target re-entry', async () => {
       render(
         <OriginalTooltip


### PR DESCRIPTION
Follow-up to #9248.\n\nA quick pointer leave and re-entry could still start the hide transition, especially with delays of 100 ms or less. Tooltip now keeps its open state until the hide delay expires and transfers hover ownership between the trigger and overlay. Returning to the trigger cancels both close timers and releases overlay ownership, including when the pointer crosses the physical gap.\n\nIf re-entry happens after hiding has started, the existing tooltip returns to its settled position without replaying the 200 ms entrance motion.