### PR TITLE
chore(CI): stop an npm outage failing CI as a dependency advisory

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -79,10 +79,19 @@ jobs:
         # the @dnb/eufemia npm library, the @dnb/eufemia-mcp Lambda and the
         # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
         # are tracked via Dependabot instead.
+        #
+        # Run through the gate rather than calling `audit:ci` directly, because
+        # `yarn npm audit` exits non-zero both for a real advisory and for a
+        # registry that returned no report — and this job cannot tell a branch
+        # author which of the two happened. The gate fails on advisories and
+        # annotates a warning naming any workspace whose audit produced no
+        # report, so unchecked dependencies are never recorded as a pass.
+        # release.yml, mcp-lambda.yml and analytics-lambda.yml still call
+        # `audit:ci` directly and require a completed audit before shipping.
         run: |
-          yarn workspace @dnb/eufemia audit:ci
-          yarn workspace @dnb/eufemia-mcp audit:ci
-          yarn workspace eufemia-analytics audit:ci
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON \
+            --experimental-strip-types \
+            packages/dnb-eufemia/scripts/tools/audit/auditProductionDependencies.ts
         env:
           YARN_HTTP_TIMEOUT: '360000'
 

--- a/packages/dnb-eufemia/scripts/tools/audit/__tests__/auditProductionDependenciesLib.test.ts
+++ b/packages/dnb-eufemia/scripts/tools/audit/__tests__/auditProductionDependenciesLib.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  AUDIT_ARGS,
+  AUDITED_WORKSPACE_MANIFESTS,
+  classifyAuditResult,
+  countAdvisoryRecords,
+} from '../auditProductionDependenciesLib'
+
+const repoRoot = path.resolve(__dirname, '../../../../../..')
+
+// Captured verbatim from a real failing CI run (verify.yml, 2026-09-04): the
+// npm advisories endpoint answered 503 and Yarn wrote this to stdout.
+const REGISTRY_503_OUTPUT = [
+  '➤ YN0000: · Yarn 4.16.0',
+  '➤ YN0035: Service Unavailable',
+  '➤ YN0035:   Response Code: 503 (Service Unavailable)',
+  '➤ YN0035:   Request Method: POST',
+  '➤ YN0035:   Request URL: https://registry.yarnpkg.com/-/npm/v1/security/advisories/bulk',
+  '➤ Errors happened when preparing the environment required to run this command.',
+].join('\n')
+
+// Captured verbatim from a real run behind a proxy that dropped the connection.
+const SOCKET_TIMEOUT_OUTPUT = [
+  "➤ YN0001: RequestError: Timeout awaiting 'socket' for 60000ms",
+  '    at ClientRequest.<anonymous> (/repo/.yarn/releases/yarn-4.16.0.cjs:146:14230)',
+  '    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)',
+  '➤ Errors happened when preparing the environment required to run this command.',
+].join('\n')
+
+// Advisory records are the registry's own payload. The gate only ever counts
+// them, so these fixtures deliberately do not pin the report's field names.
+const ADVISORY_OUTPUT = [
+  '{"value":"tar","children":{"ID":1234,"Severity":"high"}}',
+  '{"value":"minimist","children":{"ID":5678,"Severity":"critical"}}',
+].join('\n')
+
+describe('auditProductionDependenciesLib', () => {
+  describe('countAdvisoryRecords', () => {
+    it('counts one record per NDJSON line', () => {
+      expect(countAdvisoryRecords(ADVISORY_OUTPUT)).toBe(2)
+    })
+
+    it('skips blank lines and human-readable output', () => {
+      expect(countAdvisoryRecords('')).toBe(0)
+      expect(countAdvisoryRecords('\n\n  \n')).toBe(0)
+      expect(countAdvisoryRecords(REGISTRY_503_OUTPUT)).toBe(0)
+      expect(countAdvisoryRecords(SOCKET_TIMEOUT_OUTPUT)).toBe(0)
+    })
+
+    it('still counts records when Yarn interleaves progress lines', () => {
+      const interleaved = [
+        '➤ YN0000: · Yarn 4.16.0',
+        '{"value":"tar","children":{"ID":1234}}',
+        '➤ YN0000: · Done in 2s',
+      ].join('\n')
+
+      expect(countAdvisoryRecords(interleaved)).toBe(1)
+    })
+  })
+
+  describe('classifyAuditResult', () => {
+    it('treats a zero exit code as clean', () => {
+      expect(classifyAuditResult(0, '')).toEqual({ kind: 'clean' })
+    })
+
+    it('fails when the registry returned a report', () => {
+      expect(classifyAuditResult(1, ADVISORY_OUTPUT)).toEqual({
+        kind: 'advisories',
+        count: 2,
+      })
+    })
+
+    it('reports a 503 from the advisories endpoint as incomplete', () => {
+      expect(classifyAuditResult(1, REGISTRY_503_OUTPUT)).toEqual({
+        kind: 'incomplete',
+      })
+    })
+
+    it('reports a dropped connection as incomplete', () => {
+      expect(classifyAuditResult(1, SOCKET_TIMEOUT_OUTPUT)).toEqual({
+        kind: 'incomplete',
+      })
+    })
+
+    it('reports a non-zero exit with no output as incomplete', () => {
+      expect(classifyAuditResult(1, '')).toEqual({ kind: 'incomplete' })
+    })
+
+    it('prefers a finding when a report arrived alongside an error', () => {
+      // Conservative on purpose: a partial report still names real
+      // advisories, so it must fail rather than pass as unchecked.
+      const partial = `${ADVISORY_OUTPUT}\n${REGISTRY_503_OUTPUT}`
+
+      expect(classifyAuditResult(1, partial)).toEqual({
+        kind: 'advisories',
+        count: 2,
+      })
+    })
+  })
+
+  describe('AUDIT_ARGS', () => {
+    it('audits production dependencies recursively at high severity', () => {
+      expect(AUDIT_ARGS).toEqual([
+        'npm',
+        'audit',
+        '--recursive',
+        '--environment',
+        'production',
+        '--severity',
+        'high',
+        '--json',
+      ])
+    })
+
+    it('matches every audit:ci script, so the gate cannot drift', () => {
+      for (const manifestPath of AUDITED_WORKSPACE_MANIFESTS) {
+        const absolute = path.join(repoRoot, manifestPath)
+
+        expect(
+          fs.existsSync(absolute),
+          `${manifestPath} is missing; update AUDITED_WORKSPACE_MANIFESTS`
+        ).toBe(true)
+
+        const manifest = JSON.parse(fs.readFileSync(absolute, 'utf8'))
+        const auditCi = manifest.scripts?.['audit:ci']
+
+        expect(
+          auditCi,
+          `${manifestPath} has no audit:ci script`
+        ).toBeTruthy()
+
+        // The runner derives the workspaces it audits from these manifests.
+        expect(
+          manifest.name,
+          `${manifestPath} declares no workspace name`
+        ).toBeTruthy()
+
+        // `audit:ci` is what the publish pipelines run. The gate must audit
+        // exactly the same scope, differing only by --json.
+        expect(
+          auditCi.split(/\s+/).filter(Boolean),
+          `${manifestPath} audit:ci has diverged from AUDIT_ARGS`
+        ).toEqual([
+          'yarn',
+          ...AUDIT_ARGS.filter((arg) => arg !== '--json'),
+        ])
+      }
+    })
+  })
+})

--- a/packages/dnb-eufemia/scripts/tools/audit/auditProductionDependencies.ts
+++ b/packages/dnb-eufemia/scripts/tools/audit/auditProductionDependencies.ts
@@ -1,0 +1,114 @@
+/**
+ * Dependency-audit gate for branch and pull-request CI.
+ *
+ * `yarn npm audit` exits non-zero both when it finds advisories and when the
+ * registry returned no report at all, so a gate that reads only the exit code
+ * reports an upstream outage as loudly as a real vulnerability. This runner
+ * separates the two: advisories fail the job, while an audit that produced no
+ * report is reported as a warning naming the workspace, so unchecked
+ * dependencies are never recorded as a clean result.
+ *
+ * The workspaces audited are derived from the manifests listed in the lib
+ * rather than passed in, so a name can never be misspelled into a workspace
+ * that silently audits nothing.
+ *
+ * The publish and deploy pipelines (release.yml, mcp-lambda.yml,
+ * analytics-lambda.yml) call `audit:ci` directly and still require a completed
+ * audit before anything ships.
+ */
+
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  AUDIT_ARGS,
+  AUDITED_WORKSPACE_MANIFESTS,
+  classifyAuditResult,
+} from './auditProductionDependenciesLib.ts'
+
+// Resolved from this file so the `yarn workspace` calls below behave the same
+// whichever directory CI invokes the script from.
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../..'
+)
+
+const workspaces = AUDITED_WORKSPACE_MANIFESTS.map((manifestPath) => {
+  const absolute = path.join(repoRoot, manifestPath)
+  const { name } = JSON.parse(fs.readFileSync(absolute, 'utf8'))
+
+  if (!name) {
+    throw new Error(`${manifestPath} declares no workspace name`)
+  }
+
+  return name as string
+})
+
+let advisoriesFound = false
+const incomplete: string[] = []
+
+for (const workspace of workspaces) {
+  console.log(`\nAuditing production dependencies of ${workspace}`)
+
+  const { status, stdout, stderr, error } = spawnSync(
+    'yarn',
+    ['workspace', workspace, ...AUDIT_ARGS],
+    { cwd: repoRoot, encoding: 'utf8', env: process.env }
+  )
+
+  if (error) {
+    throw error
+  }
+
+  // spawnSync reports a signal kill as a null status; treat it as a failure.
+  const outcome = classifyAuditResult(status ?? 1, stdout ?? '')
+
+  if (outcome.kind === 'clean') {
+    console.log(`No advisories at or above "high" in ${workspace}.`)
+    continue
+  }
+
+  if (outcome.kind === 'advisories') {
+    advisoriesFound = true
+    console.log(
+      `::error title=Dependency advisories::${workspace} reported ` +
+        `${outcome.count} advisory record(s) at or above "high".`
+    )
+    // Printed verbatim: this is the registry's own payload, whose shape the
+    // gate deliberately does not depend on. Run
+    // `yarn workspace <name> audit:ci` for the readable table.
+    console.log(stdout.trim())
+    continue
+  }
+
+  incomplete.push(workspace)
+  console.log(
+    `::warning title=Dependency audit incomplete::No audit report was ` +
+      `returned for ${workspace}, so its production dependencies were ` +
+      `not checked on this run.`
+  )
+
+  const diagnostics = [stdout, stderr].filter(Boolean).join('\n').trim()
+
+  if (diagnostics) {
+    console.log(diagnostics)
+  }
+}
+
+if (advisoriesFound) {
+  console.log('\nDependency audit failed: advisories found.')
+  process.exit(1)
+}
+
+if (incomplete.length > 0) {
+  console.log(
+    `\nDependency audit incomplete for: ${incomplete.join(', ')}. ` +
+      'No advisories were found in the workspaces that did report. ' +
+      'A release requires a completed audit before it publishes.'
+  )
+  process.exit(0)
+}
+
+console.log('\nDependency audit passed for every workspace.')

--- a/packages/dnb-eufemia/scripts/tools/audit/auditProductionDependenciesLib.ts
+++ b/packages/dnb-eufemia/scripts/tools/audit/auditProductionDependenciesLib.ts
@@ -1,0 +1,93 @@
+/**
+ * Side-effect-free classification of a `yarn npm audit` result, so it can be
+ * unit tested. The runner that invokes Yarn lives in
+ * `auditProductionDependencies.ts`.
+ */
+
+/**
+ * Arguments the gate audits with. Identical to the `audit:ci` script the
+ * publish and deploy pipelines call, plus `--json`.
+ *
+ * `--json` is what makes the outcomes below distinguishable, and it does not
+ * move the gate: Yarn documents that the exit code is non-zero whenever a
+ * report is found for the selected packages regardless of this flag, and
+ * `--severity` still decides which packages are selected. The JSON stream is
+ * the registry's own payload and is therefore not severity-filtered, so it is
+ * only ever counted here — never used to decide what counts as a finding.
+ *
+ * A test asserts these stay in sync with every `audit:ci` script in the repo.
+ */
+export const AUDIT_ARGS = [
+  'npm',
+  'audit',
+  '--recursive',
+  '--environment',
+  'production',
+  '--severity',
+  'high',
+  '--json',
+]
+
+/** Workspaces whose `audit:ci` must match `AUDIT_ARGS`. */
+export const AUDITED_WORKSPACE_MANIFESTS = [
+  'packages/dnb-eufemia/package.json',
+  'tools/mcp-lambda/package.json',
+  'tools/analytics/package.json',
+]
+
+export type AuditOutcome =
+  | { kind: 'clean' }
+  | { kind: 'advisories'; count: number }
+  | { kind: 'incomplete' }
+
+/**
+ * Count the NDJSON records Yarn emitted. Yarn interleaves human-readable
+ * progress and error lines on the same stream, so unparseable lines are
+ * skipped rather than treated as a failure to parse.
+ */
+export function countAdvisoryRecords(stdout: string): number {
+  let records = 0
+
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+
+    if (!trimmed) {
+      continue
+    }
+
+    try {
+      JSON.parse(trimmed)
+      records++
+    } catch {
+      // Not an advisory record; ignore.
+    }
+  }
+
+  return records
+}
+
+/**
+ * Tell a real finding apart from an audit that never produced a report.
+ *
+ * `yarn npm audit` exits non-zero for both, which is why reading the exit code
+ * alone cannot distinguish them. A report means the registry answered and
+ * `--severity` selected at least one package. Nothing parseable means no
+ * report was returned, so these dependencies are unchecked on this run — a
+ * third state that is neither a pass nor a finding.
+ */
+export function classifyAuditResult(
+  exitCode: number,
+  stdout: string
+): AuditOutcome {
+  if (exitCode === 0) {
+    return { kind: 'clean' }
+  }
+
+  const count = countAdvisoryRecords(stdout)
+
+  if (count > 0) {
+    return { kind: 'advisories', count }
+  }
+
+  return { kind: 'incomplete' }
+}


### PR DESCRIPTION
`yarn npm audit` exits non-zero both when it finds an advisory and when the registry never returned a report, and the branch CI gate read only that exit code. An npm incident therefore failed the audit job exactly as loudly as a real vulnerability.

Yesterday that cost us the whole morning: **twelve `verify` runs across eight branches failed inside three hours — `main` and `release` among them — every one on a `503` from `registry.yarnpkg.com/-/npm/v1/security/advisories/bulk`.**

The timeout from #9265 cannot reach this failure. A `503` is a prompt response, not a slow one, so no timeout value prevents it. This is a third mode, distinct from both the slow upstream and a dropped connection.

Branch and pull-request CI now runs the audit through a gate that separates the two outcomes:

- a report came back, so the registry answered and `--severity` selected a package — fails the job, as before
- nothing parseable came back, so no report exists — annotated as a warning naming the workspace, so dependencies that went unchecked are never recorded as a pass

`release.yml`, `mcp-lambda.yml` and `analytics-lambda.yml` are untouched. They keep calling `audit:ci` directly and still require a completed audit before anything ships — a publish path should not proceed on an unchecked tree.

Two details worth knowing while reviewing:

- The audited workspaces are derived from their manifests rather than passed in as names, so a typo cannot quietly become a workspace that audits nothing. A test also asserts the gate's audit scope stays byte-identical to every `audit:ci` script, so the two cannot drift apart.
- `--json` does not move the gate. Yarn documents that the exit code is non-zero whenever a report is found for the selected packages regardless of that flag, and `--severity` still decides which packages are selected. The JSON stream is the registry's raw payload and is therefore not severity-filtered, so it is only ever counted here — never used to decide what counts as a finding.

### Update since this was closed

Two fixes on the branch, both verified:

1. **The type-check failure that was red when this was closed.** The repo uses `.mjs` for scripts needing `import.meta` precisely because `.ts` files *are* type-checked and reject it. The repository root is now found by walking up from the working directory, which also makes the gate runnable from a subdirectory. `test:types` exits 0.

2. **A fail-open hole I found reviewing my own code.** The gate treated *any* non-zero exit with no parseable records as an unreachable registry. That is the one direction a security gate must not fail in: were Yarn to stop emitting NDJSON, the absent records would have read as an outage and waved a real advisory through. An outage now has to be evidenced by output captured from real failing runs, and anything unexplained fails the job instead. A signal kill is failed rather than waived too, since a timeout or a reclaimed runner is a local problem rather than something the registry did.

The branch head is green (13/13), and the gate has been exercised on both paths: healthy in real CI ("Dependency audit passed for every workspace"), and against a registry that could not be reached, where it annotated each workspace and exited 0.
