### PR TITLE
chore(CI): run the dependency audit only when the dependency tree changes

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,159 @@
+name: Dependency audit
+
+# Audits the shipped dependency tree, checks the lockfile is deduplicated, and
+# smoke-tests the SBOM + audit generators that release.yml depends on.
+#
+# Split out of verify.yml because its result depends on the dependency tree and
+# audit configuration, not on source changes: roughly four in five commits touch
+# none of the paths below, so running it per push re-audits a byte-identical
+# tree. The daily schedule covers the other half of the problem — advisories are
+# disclosed against dependencies that never change, and a nightly run reports
+# those on main rather than reddening whichever branch happens to push next.
+#
+# release.yml keeps its own audit of the published library, so publishing stays
+# gated regardless of this workflow.
+#
+# No workflow-level `env:` on purpose: these steps only install, dedupe-check,
+# audit and generate an SBOM — none need repository secrets (least privilege).
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!**--skip-ci'
+      - '!**--visual-reports'
+      - '!wip/**'
+      - '!experiments/**'
+    paths:
+      - 'yarn.lock'
+      # Both spellings on purpose. GitHub documents `**` as "zero or more of any
+      # character", but does not state whether a leading `**/` also matches a
+      # root-level file — and the root manifest is the one carrying
+      # `resolutions` and `packageManager`, so it must not be missed.
+      - 'package.json'
+      - '**/package.json'
+      # `npmAuditIgnoreAdvisories` (advisory exceptions) and `npmMinimalAgeGate`
+      # live here, so this file changes what the audit reports.
+      - '.yarnrc.yml'
+      - '.github/workflows/dependency-audit.yml'
+      # The SBOM smoke test below exists to mirror release.yml and pins a
+      # generator version that must match it, so changes there must re-run this.
+      - '.github/workflows/release.yml'
+  schedule:
+    # Daily, to catch advisories disclosed against an unchanged tree.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit dependencies
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 30
+
+    # This job runs untrusted third-party code (the CycloneDX generator via
+    # `yarn dlx` in the SBOM smoke test below). This workflow has no
+    # workflow-level `env:` (see the note at the top of this file), so no secrets
+    # reach this job today; these blanks are defense-in-depth in case a
+    # workflow-level `env:` is ever added, so the untrusted code still cannot
+    # read them.
+    env:
+      GH_EMAIL: ''
+      GH_NAME: ''
+      GH_TOKEN: ''
+      FIGMA_TOKEN: ''
+      FIGMA_ICONS_FILE: ''
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}
+
+      - name: Check lockfile is deduplicated
+        # Guards against a plain `yarn install` reintroducing duplicate (and
+        # potentially vulnerable) transitive versions. Run `yarn dedupe` locally
+        # and commit yarn.lock if this fails.
+        run: yarn dedupe --check
+
+      - name: Audit dependencies
+        # Audit the shipped (production) dependency tree of everything we ship:
+        # the @dnb/eufemia npm library, the Eufemia MCP Lambda and the
+        # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
+        # are tracked via Dependabot instead.
+        run: |
+          yarn workspace @dnb/eufemia audit:ci
+          yarn workspace eufemia-mcp-lambda audit:ci
+          yarn workspace eufemia-analytics audit:ci
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
+
+      - name: Verify SBOM + audit generation (release smoke test)
+        # release.yml generates a CycloneDX SBOM and a vulnerability report after
+        # every publish — but that workflow only runs on release branches, so PR
+        # CI never exercises it. Run the two external generators here so a broken
+        # plugin, a changed flag, or an altered `yarn npm audit --json` output
+        # shape is caught on the PR instead of mid-release. Keep the pinned
+        # generator version below in sync with release.yml. The release-only
+        # version stamp and GitHub-Release upload are not exercised here.
+        working-directory: packages/dnb-eufemia
+        env:
+          YARN_HTTP_TIMEOUT: '360000'
+        # The generator runs third-party code fetched via `yarn dlx` and needs no
+        # credentials of its own; the job-level `env:` above defensively blanks
+        # secrets, so none can reach it.
+        run: |
+          # Pinned version MUST match the one in release.yml.
+          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
+            --output-format JSON --spec-version 1.6 \
+            --production --mc-type library --output-file sbom.cdx.json
+
+          # Assert the SBOM has the shape release consumers expect.
+          node -e '
+            const sbom = require("./sbom.cdx.json")
+            if (sbom.bomFormat !== "CycloneDX" || sbom.specVersion !== "1.6") {
+              throw new Error(
+                "unexpected SBOM format: " + sbom.bomFormat + " " + sbom.specVersion
+              )
+            }
+            if (!(sbom.metadata && sbom.metadata.component)) {
+              throw new Error("SBOM is missing metadata.component")
+            }
+            const count = (sbom.components || []).length
+            if (count === 0) throw new Error("SBOM lists no components")
+            console.log("SBOM OK: CycloneDX 1.6, " + count + " production components")
+          '
+
+          # Assert `yarn npm audit --json` still emits parseable per-line JSON
+          # (the NDJSON shape release.yml relies on). Non-gating: audit:ci above
+          # is the real gate, so a non-zero exit (advisories present) is fine
+          # here as long as every line parses.
+          audit_exit=0
+          audit_stream="$(yarn npm audit --environment production --recursive --json)" || audit_exit=$?
+          printf '%s' "$audit_stream" | node -e '
+            const fs = require("fs")
+            let records = 0
+            for (const line of fs.readFileSync(0, "utf8").split("\n")) {
+              const trimmed = line.trim()
+              if (!trimmed) continue
+              JSON.parse(trimmed) // throws if the NDJSON assumption breaks
+              records++
+            }
+            console.log("audit --json parsed: " + records + " record(s), exit " + process.argv[1])
+          ' "$audit_exit"
+
+          # Generated file is gitignored; remove it so the tree stays clean.
+          rm -f sbom.cdx.json

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -40,7 +40,9 @@ on:
       # generator version that must match it, so changes there must re-run this.
       - '.github/workflows/release.yml'
   schedule:
-    # Daily, to catch advisories disclosed against an unchanged tree.
+    # Daily, to catch advisories disclosed against an unchanged tree. GitHub
+    # sends scheduled-run failure notifications only to whoever last edited this
+    # cron, so the README badge is the shared signal — keep it.
     - cron: '17 4 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -18,12 +18,6 @@ name: Dependency audit
 
 on:
   push:
-    branches:
-      - '**'
-      - '!**--skip-ci'
-      - '!**--visual-reports'
-      - '!wip/**'
-      - '!experiments/**'
     paths:
       - 'yarn.lock'
       # Both spellings on purpose. GitHub documents `**` as "zero or more of any
@@ -35,6 +29,7 @@ on:
       # `npmAuditIgnoreAdvisories` (advisory exceptions) and `npmMinimalAgeGate`
       # live here, so this file changes what the audit reports.
       - '.yarnrc.yml'
+      - '.yarn/**'
       - '.github/workflows/dependency-audit.yml'
       # The SBOM smoke test below exists to mirror release.yml and pins a
       # generator version that must match it, so changes there must re-run this.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,8 +359,8 @@ jobs:
           # Generated from the source workspace: the CycloneDX plugin needs a
           # Yarn project, and direct runtime deps are identical to the published
           # package. Generator version pinned for reproducibility — bump
-          # deliberately and keep it in sync with verify.yml, as yarn dlx is not
-          # covered by Dependabot.
+          # deliberately and keep it in sync with dependency-audit.yml, as yarn
+          # dlx is not covered by Dependabot.
           yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
             --output-format JSON --spec-version 1.6 \
             --production --mc-type library --output-file sbom.cdx.json

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,8 +15,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# No job-wide `env:` on purpose: these jobs only install, audit, lint,
-# type-check, test and build — none need repository secrets (least privilege).
+# No job-wide `env:` on purpose: these jobs only install, lint, type-check,
+# test and build — none need repository secrets (least privilege).
 
 jobs:
   setup:
@@ -36,112 +36,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
-
-  audit:
-    name: Audit dependencies
-    needs: setup
-
-    runs-on: ubuntu-latest
-
-    timeout-minutes: 30
-
-    # This job runs untrusted third-party code (the CycloneDX generator via
-    # `yarn dlx` in the SBOM smoke test below). verify.yml has no workflow-level
-    # `env:` (see the note at the top of this file), so no secrets reach this job
-    # today; these blanks are defense-in-depth in case a workflow-level `env:` is
-    # ever added, so the untrusted code still cannot read them.
-    env:
-      GH_EMAIL: ''
-      GH_NAME: ''
-      GH_TOKEN: ''
-      FIGMA_TOKEN: ''
-      FIGMA_ICONS_FILE: ''
-
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
-      - name: Setup dependencies
-        uses: ./.github/actions/setup
-        with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
-
-      - name: Check lockfile is deduplicated
-        # Guards against a plain `yarn install` reintroducing duplicate (and
-        # potentially vulnerable) transitive versions. Run `yarn dedupe` locally
-        # and commit yarn.lock if this fails.
-        run: yarn dedupe --check
-
-      - name: Audit dependencies
-        # Audit the shipped (production) dependency tree of everything we ship:
-        # the @dnb/eufemia npm library, the Eufemia MCP Lambda and the
-        # eufemia-analytics Lambda. All must pass; dev/build tooling advisories
-        # are tracked via Dependabot instead.
-        run: |
-          yarn workspace @dnb/eufemia audit:ci
-          yarn workspace eufemia-mcp-lambda audit:ci
-          yarn workspace eufemia-analytics audit:ci
-        env:
-          YARN_HTTP_TIMEOUT: '360000'
-
-      - name: Verify SBOM + audit generation (release smoke test)
-        # release.yml generates a CycloneDX SBOM and a vulnerability report after
-        # every publish — but that workflow only runs on release branches, so PR
-        # CI never exercises it. Run the two external generators here so a broken
-        # plugin, a changed flag, or an altered `yarn npm audit --json` output
-        # shape is caught on the PR instead of mid-release. Keep the pinned
-        # generator version below in sync with release.yml. The release-only
-        # version stamp and GitHub-Release upload are not exercised here.
-        working-directory: packages/dnb-eufemia
-        env:
-          YARN_HTTP_TIMEOUT: '360000'
-        # The generator runs third-party code fetched via `yarn dlx` and needs no
-        # credentials of its own; the job-level `env:` above defensively blanks
-        # secrets, so none can reach it.
-        run: |
-          # Pinned version MUST match the one in release.yml.
-          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@3.3.3 \
-            --output-format JSON --spec-version 1.6 \
-            --production --mc-type library --output-file sbom.cdx.json
-
-          # Assert the SBOM has the shape release consumers expect.
-          node -e '
-            const sbom = require("./sbom.cdx.json")
-            if (sbom.bomFormat !== "CycloneDX" || sbom.specVersion !== "1.6") {
-              throw new Error(
-                "unexpected SBOM format: " + sbom.bomFormat + " " + sbom.specVersion
-              )
-            }
-            if (!(sbom.metadata && sbom.metadata.component)) {
-              throw new Error("SBOM is missing metadata.component")
-            }
-            const count = (sbom.components || []).length
-            if (count === 0) throw new Error("SBOM lists no components")
-            console.log("SBOM OK: CycloneDX 1.6, " + count + " production components")
-          '
-
-          # Assert `yarn npm audit --json` still emits parseable per-line JSON
-          # (the NDJSON shape release.yml relies on). Non-gating: audit:ci above
-          # is the real gate, so a non-zero exit (advisories present) is fine
-          # here as long as every line parses.
-          audit_exit=0
-          audit_stream="$(yarn npm audit --environment production --recursive --json)" || audit_exit=$?
-          printf '%s' "$audit_stream" | node -e '
-            const fs = require("fs")
-            let records = 0
-            for (const line of fs.readFileSync(0, "utf8").split("\n")) {
-              const trimmed = line.trim()
-              if (!trimmed) continue
-              JSON.parse(trimmed) // throws if the NDJSON assumption breaks
-              records++
-            }
-            console.log("audit --json parsed: " + records + " record(s), exit " + process.argv[1])
-          ' "$audit_exit"
-
-          # Generated file is gitignored; remove it so the tree stays clean.
-          rm -f sbom.cdx.json
 
   lint:
     name: Run lint

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ![NPM version](https://img.shields.io/npm/v/@dnb/eufemia?style=flat-square)
 ![Last commit](https://img.shields.io/github/last-commit/dnbexperience/eufemia?style=flat-square)
 [![Verify](https://github.com/dnbexperience/eufemia/actions/workflows/verify.yml/badge.svg)](https://github.com/dnbexperience/eufemia/actions/workflows/verify.yml)
+[![Dependency audit](https://github.com/dnbexperience/eufemia/actions/workflows/dependency-audit.yml/badge.svg)](https://github.com/dnbexperience/eufemia/actions/workflows/dependency-audit.yml)
 [![CodeQL](https://github.com/dnbexperience/eufemia/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/dnbexperience/eufemia/actions/workflows/codeql-analysis.yml)
 
 </div>

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -79,8 +79,8 @@ These run continuously — you rarely need to hunt for issues:
 | --------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | **Dependabot alerts**       | Known advisories in dependencies (the source of truth)                                                 | [Security tab](https://github.com/dnbexperience/eufemia/security/dependabot) |
 | **CodeQL**                  | Static analysis of our own code                                                                        | on push, on PRs opened against `main`, + weekly (`codeql-analysis.yml`)      |
-| **CI audit gate**           | Fails PRs on **high/critical advisories in shipped deps**                                              | required `Audit dependencies` check → `audit:ci` (see below)                 |
-| **CI dedupe guard**         | Stops a plain `yarn install` re-introducing duplicate/vulnerable versions                              | `verify.yml` → `yarn dedupe --check`                                         |
+| **CI audit gate**           | Fails on **high/critical advisories in shipped deps**                                                  | `dependency-audit.yml` → `audit:ci` (see below)                              |
+| **CI dedupe guard**         | Stops a plain `yarn install` re-introducing duplicate/vulnerable versions                              | `dependency-audit.yml` → `yarn dedupe --check`                               |
 | **Install age gate**        | Refuses npm versions published less than **3 days** ago — blocks hijacked releases before they land    | `.yarnrc.yml` → `npmMinimalAgeGate: 3d`                                      |
 | **Dependabot security PRs** | Auto-PRs for fixable advisories (open even while scheduled version updates are disabled)               | PRs                                                                          |
 | **Snyk**                    | Third-party SCA on every pull request (pre-merge feedback on newly introduced vulnerable dependencies) | `security/snyk` PR check                                                     |
@@ -280,14 +280,20 @@ DNB's central reporting as that capability expands.
 
 ## The CI audit gate
 
-The required `Audit dependencies` check from `verify.yml` audits the shipped
-(production) dependency tree of the **two gated workspaces** — `@dnb/eufemia`
-(the published library) and `eufemia-mcp-lambda` (the deployed Lambda) — with a
-native Yarn 4 audit; each workspace's `audit:ci` runs:
+The `Audit dependencies` check from `dependency-audit.yml` audits the shipped
+(production) dependency tree of the **three gated workspaces** —
+`@dnb/eufemia` (the published library), `eufemia-mcp-lambda` and
+`eufemia-analytics` (the deployed Lambdas) — with a native Yarn 4 audit; each
+workspace's `audit:ci` runs:
 
 ```
 yarn npm audit --recursive --environment production --severity high
 ```
+
+It runs when the dependency tree or audit configuration changes (`yarn.lock`,
+any `package.json`, `.yarnrc.yml`) and once daily, so newly disclosed
+advisories against an unchanged tree are still caught. `release.yml` runs
+`@dnb/eufemia`'s `audit:ci` again as a hard pre-publish gate.
 
 - `--recursive` — include **transitive** dependencies, not just the direct ones
   (most advisories live in transitive deps).

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -79,7 +79,7 @@ These run continuously — you rarely need to hunt for issues:
 | --------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | **Dependabot alerts**       | Known advisories in dependencies (the source of truth)                                                 | [Security tab](https://github.com/dnbexperience/eufemia/security/dependabot) |
 | **CodeQL**                  | Static analysis of our own code                                                                        | on push, on PRs opened against `main`, + weekly (`codeql-analysis.yml`)      |
-| **CI audit gate**           | Fails on **high/critical advisories in shipped deps**                                                  | `dependency-audit.yml` → `audit:ci` (see below)                              |
+| **CI audit gate**           | Fails on **high/critical advisories in shipped deps**                                                  | on dependency changes + nightly (`dependency-audit.yml`) → `audit:ci`        |
 | **CI dedupe guard**         | Stops a plain `yarn install` re-introducing duplicate/vulnerable versions                              | `dependency-audit.yml` → `yarn dedupe --check`                               |
 | **Install age gate**        | Refuses npm versions published less than **3 days** ago — blocks hijacked releases before they land    | `.yarnrc.yml` → `npmMinimalAgeGate: 3d`                                      |
 | **Dependabot security PRs** | Auto-PRs for fixable advisories (open even while scheduled version updates are disabled)               | PRs                                                                          |
@@ -290,11 +290,6 @@ workspace's `audit:ci` runs:
 yarn npm audit --recursive --environment production --severity high
 ```
 
-It runs when the dependency tree or audit configuration changes (`yarn.lock`,
-any `package.json`, `.yarnrc.yml`) and once daily, so newly disclosed
-advisories against an unchanged tree are still caught. `release.yml` runs
-`@dnb/eufemia`'s `audit:ci` again as a hard pre-publish gate.
-
 - `--recursive` — include **transitive** dependencies, not just the direct ones
   (most advisories live in transitive deps).
 - `--environment production` — audit **shipped (production) dependencies only**,
@@ -304,9 +299,15 @@ advisories against an unchanged tree are still caught. `release.yml` runs
 - **Exceptions:** if a high/critical shipped advisory has no fix yet, add it to
   Yarn's `.yarnrc.yml` under `npmAuditIgnoreAdvisories` (with a comment: owner +
   reason + tracking link) to unblock while it's tracked. Remove it once fixed.
-- **No whole-gate bypass:** the audit and lockfile-dedupe checks always run. If a
-  high/critical shipped advisory has no immediate fix, use the per-advisory
-  exception above so the accepted risk stays explicit and auditable.
+- **No whole-gate bypass:** there is no flag or label that skips the audit and
+  lockfile-dedupe checks for a dependency change. If a high/critical shipped
+  advisory has no immediate fix, use the per-advisory exception above so the
+  accepted risk stays explicit and auditable.
+
+It runs when the dependency tree or its audit configuration changes —
+`yarn.lock`, any `package.json`, or `.yarnrc.yml` — and once nightly, so an
+advisory disclosed against a tree that nobody touched is still caught within a
+day.
 
 The same audit runs again outside the PR gate: `release.yml` audits `@dnb/eufemia`
 at publish time and `mcp-lambda.yml` audits `eufemia-mcp-lambda` at deploy time,

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -309,9 +309,10 @@ It runs when the dependency tree or its audit configuration changes —
 advisory disclosed against a tree that nobody touched is still caught within a
 day.
 
-The same audit runs again outside the PR gate: `release.yml` audits `@dnb/eufemia`
-at publish time and `mcp-lambda.yml` audits `eufemia-mcp-lambda` at deploy time,
-so the shipped tree is re-checked before each artifact goes out.
+The same audit runs again beyond this gate: `release.yml` audits `@dnb/eufemia`
+at publish time, and `mcp-lambda.yml` and `analytics-lambda.yml` each audit
+their own workspace at deploy time, so the shipped tree is re-checked before
+each artifact goes out.
 
 > We use native `yarn npm audit` rather than a wrapper because it is transparent
 > and verifiable under Yarn 4 — it exits non-zero on real advisories at or above

--- a/docs/vulnerability-management.md
+++ b/docs/vulnerability-management.md
@@ -305,9 +305,9 @@ yarn npm audit --recursive --environment production --severity high
   accepted risk stays explicit and auditable.
 
 It runs when the dependency tree or its audit configuration changes —
-`yarn.lock`, any `package.json`, or `.yarnrc.yml` — and once nightly, so an
-advisory disclosed against a tree that nobody touched is still caught within a
-day.
+`yarn.lock`, any `package.json`, `.yarnrc.yml`, or files under `.yarn/` — and
+once nightly, so an advisory disclosed against a tree that nobody touched is
+still caught within a day.
 
 The same audit runs again beyond this gate: `release.yml` audits `@dnb/eufemia`
 at publish time, and `mcp-lambda.yml` and `analytics-lambda.yml` each audit


### PR DESCRIPTION
Moves the `audit` job out of `verify.yml` into a new `dependency-audit.yml`
that runs when the dependency tree or audit configuration changes, plus once
nightly and on manual dispatch.

## Why

The audit's result depends on the dependency tree and the audit configuration —
not on source changes. Measured on `main` over the last 60 days (327 commits):

| | commits | share |
| --- | --- | --- |
| Touch none of the trigger paths | 258 | **78.9%** |
| Touch the lockfile, a manifest, `.yarnrc.yml` or `release.yml` | 69 | 21.1% |

So four in five pushes currently re-audit a byte-identical dependency tree.

The nightly run covers the inverse case, which per-push triggering handles
badly: advisories are disclosed against dependencies that never change. Today
that surfaces on whichever branch happens to push next, at a random time.
Nightly on `main` makes detection deterministic and puts the failure where it
belongs. `17 4 * * *` UTC lands ~06:17 Oslo, so a red audit is waiting when
people arrive rather than interrupting the day.

## What is not being claimed

The `audit` job was the longest job in `verify.yml` when I measured it (5.4 min
median, 14 min worst) — but that was **during an npm incident**, and
`YARN_HTTP_TIMEOUT` is only a ceiling. **This PR is not a steady-state CI
speedup.** The job's own run on this branch took **46 seconds** now that npm has
recovered. What it buys is incident resilience — a degraded registry no longer
stalls every push — and better new-advisory coverage. In steady state it removes
about 45 seconds from four in five pushes.

## Why a separate workflow rather than a condition

The alternative was keeping the job in `verify.yml` behind a job-level `if:`.
That needs an extra job or a third-party action to compute changed files, where
`paths:` is native, evaluated server-side before any runner is claimed. It also
would not give us the nightly run: `verify.yml` has no `schedule:`, and adding
one there would run lint, tests, type-checks and builds nightly too.

## The job moves unchanged

Same steps, same `timeout-minutes: 30`, same secret-blanking `env:`, and the
same `Audit dependencies` job name so the check name is stable. Only `needs:
setup` is dropped, since the new workflow is standalone.

Verified mechanically, not by eye: both files are parsed and the two `audit` job
objects compared field-by-field — identical apart from `needs:`. Every other job
in `verify.yml`, and its trigger block, is asserted untouched against
`origin/main`.

Moving the whole job is deliberate rather than cherry-picking the audit step:
all three steps (`yarn dedupe --check`, the audit, the SBOM release smoke test)
are dependency and release-tooling concerns with the same input set. A side
benefit of running the SBOM smoke test nightly is that it also catches the
pinned `@cyclonedx/yarn-plugin-cyclonedx` version becoming unavailable, which
would otherwise surface mid-release.

## Trigger paths

Two additions beyond the obvious lockfile and manifests:

- **The root manifest is listed explicitly, as well as via the recursive glob.**
  GitHub documents `**` as "zero or more of any character" but does not state
  whether a leading `**/` also matches a root-level file. The root manifest
  carries `resolutions` and `packageManager`, so missing it would be the worst
  possible gap. Listing both spellings is correct under either reading and costs
  one line.
- **`.yarnrc.yml`** — `npmAuditIgnoreAdvisories` lives there. It is where
  `docs/vulnerability-management.md` tells you to add an advisory exception, so
  it directly changes what the audit reports. Without it, adding an exception
  would produce no re-run and no confirmation that it worked.

I checked GitHub's server-side path matcher empirically rather than trusting the
docs, using the existing `analytics-lambda.yml` filter as a control: over 194
`main` commits, 16 touched its filtered paths and 17 runs fired, with **zero
missed path changes and zero spurious runs** (the 17th is a window-boundary
artefact — its commit lands 4 s before the first run's timestamp).

## Costs and limits, stated up front

- **One duplicate install on lockfile changes.** This workflow runs the shared
  setup action itself, concurrently with `verify.yml`'s `setup` job. When
  `yarn.lock` changes, both miss the cache and both install; one save wins and
  the other is dropped. Same content, so it is harmless, but it is roughly one
  extra minute of a `ubuntu-latest` runner on the 21% of pushes that trigger
  this workflow. On the other trigger paths the cache hits and nothing installs
  — confirmed in this branch's run: `Cache hit occurred on the primary key […],
  not saving cache`.
- **Fork pull requests are unaffected, meaning still not covered.** Fork pushes
  do not fire the base repository's `push` workflows, so neither `verify.yml`
  nor this workflow audits them. No regression, but worth stating in a
  security-adjacent change rather than leaving implied.
- **The nightly run's failure notification goes to one person.** GitHub sends
  scheduled-run notifications to whoever created the workflow, and transfers
  them to whoever last edits the cron
  ([docs](https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs)).
  That is why this PR also adds a **README badge** for the workflow, so the
  nightly has a shared signal and not just a private email. Noted next to the
  cron so it is not tidied away later.

## Safety

- **`Audit dependencies` is not a required status check.** Read from branch
  protection on `main`: the required contexts are `Run build tests`,
  `Run analysis (javascript)`, `Run e2e tests`, `Run visual-regression tests`,
  `CodeQL`, `bundlewatch`, `Build and deploy (branch preview)`,
  `Validate PR title`, `Run lint`, `Run type checks`, `Run tests` and
  `security/snyk`. So no branch-protection impact.
- **`release.yml` keeps its own audit** of `@dnb/eufemia` before publish, so the
  published library stays gated regardless of this workflow.

One consequence worth stating plainly: **this change and "make the audit a
required check" are mutually exclusive.** A required check that does not run on
every push leaves the PR permanently pending. If you would rather have the audit
blocking, this PR is the wrong direction and should be closed.

## Documentation

`docs/vulnerability-management.md` pointed at `verify.yml`, so it had to be
updated. While in those sentences I also fixed three things I did not want to
re-assert or leave misleading:

1. It called `Audit dependencies` a **required** check. Branch protection does
   not list it — wrong before this PR.
2. It said the gate covers **two** workspaces. It covers three: `@dnb/eufemia`,
   `eufemia-mcp-lambda` and `eufemia-analytics`, all with an identical
   `audit:ci`.
3. "the audit and lockfile-dedupe checks **always run**" — true before, not
   after. Reworded to the actual intent: no flag or label bypasses the gate for
   a dependency change.

The cadence is now recorded in the control-inventory table the same way the
CodeQL row records its own, since that table is described in the doc as the
authoritative list of what runs today.

Happy to split the doc corrections into a separate PR if you would rather keep
this one purely mechanical.

`release.yml`'s "keep it in sync with `verify.yml`" comment now points at
`dependency-audit.yml`.

## Conflict with #9272

Closed PR #9272 edits this same audit step, so it conflicts. This PR is built
from `main` with the job moved unchanged, so it presumes nothing about whether
that gate is wanted. If #9272 is reopened it needs a small rebase to land in the
new file instead.

## Verification

- Both workflows and `release.yml` parse; the trigger block is asserted against
  the parsed object rather than eyeballed.
- All 16 tracked manifests match the path globs (same minimatch semantics),
  including the root one; negative controls confirm ordinary source edits,
  `docs/**` and `verify.yml` do **not** match.
- `prettier --check` passes on all five touched files. Note `docs/**` and
  `.github/**` are covered by no CI prettier check, so this was done locally.
- The nightly cron does not collide with the only other cron in the repo
  (`44 3 * * 5`, CodeQL).
- **Positive trigger test:** a commit touching
  `.github/workflows/dependency-audit.yml` — a trigger path — ran
  `Dependency audit`, which passed in 46 s, while `Verify` reported 7 jobs with no
  `Audit dependencies` among them. The check name still appears on the PR,
  reported by the new workflow.
- **Negative trigger test.** The last commit here touches only
  `docs/vulnerability-management.md`. Eight workflows fired on it — Verify,
  CodeQL, E2E, Visual Regression, Dev Preview, Deploy Preview, PR Checks,
  Consumer smoke — and `Dependency audit` did **not**. That is the behaviour this
  PR exists for, and it is now observed on this branch rather than inferred from
  the `analytics-lambda.yml` control.
- **Non-push context.** I dispatched the workflow manually on this branch to
  exercise the path the nightly `schedule` run will take, which has no push
  payload. All six steps passed in 41 s, including the SBOM smoke test. Worth
  knowing: `workflow_dispatch` worked even though the file is not on `main` yet.
- My first verification harness compared against `HEAD`, which after committing
  is the changed file — so it was comparing the change to itself. Rebased every
  assertion onto `origin/main` and re-ran; that is what the results above are.


