### PR TITLE
chore(CI): use the shared setup action in the Analytics Lambda workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,6 +25,11 @@ runs:
         registry-url: ${{ inputs.registry-url }}
 
     - name: Use node_modules cache
+      # This cache key is shared by every workflow. Caches are immutable — the
+      # first job to save a key wins — so a workflow that writes it with a
+      # narrower `path:` would give the others an exact hit with directories
+      # missing, and they would skip the install below and fail. Use this action
+      # rather than hand-rolling actions/cache.
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       id: modules-cache
       with:

--- a/.github/workflows/analytics-lambda.yml
+++ b/.github/workflows/analytics-lambda.yml
@@ -43,24 +43,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
         with:
-          node-version-file: 'package.json'
-
-      - name: Use node_modules cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        id: modules-cache
-        with:
-          path: |
-            node_modules
-            tools/analytics/node_modules
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
-
-      - name: Install dependencies
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+          cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Audit dependencies
         # Audit the shipped (production) dep tree to catch known advisories,
@@ -90,24 +76,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Use Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
         with:
-          node-version-file: 'package.json'
-
-      - name: Use node_modules cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        id: modules-cache
-        with:
-          path: |
-            node_modules
-            tools/analytics/node_modules
-          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-modules-
-
-      - name: Install dependencies
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+          cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Skip if GHE credentials are missing
         id: gate


### PR DESCRIPTION
Both jobs in `analytics-lambda.yml` hand-rolled `actions/setup-node`,
`actions/cache` and `yarn install` instead of using `.github/actions/setup`.
This replaces those three steps with the composite in both jobs — the same thing
`mcp-lambda.yml` already does for its sibling `tools/*` workspace.

## The cache-key collision

The hand-rolled cache and the composite wrote **byte-identical keys** with
**different path sets**:

| | key | paths cached |
| --- | --- | --- |
| `.github/actions/setup` | `<ver>-<os>-modules-<hash(**/yarn.lock)>` | `node_modules`, `packages/*/node_modules`, `tools/*/node_modules` |
| `analytics-lambda.yml` (before) | *the same key* | `node_modules`, `tools/analytics/node_modules` |

GitHub Actions caches are immutable: the first job to save a key wins, and any
later save under that key is silently a no-op. So if the Analytics job had won
that key, every other workflow would have restored it as an **exact** hit, seen
`cache-hit == 'true'`, skipped `yarn install`, and then failed on a missing
`packages/dnb-eufemia/node_modules`.

**Being precise about severity, because it matters:** this is latent, not
active. The precondition is a commit reaching `main` that touches both
`tools/analytics/**` and `yarn.lock`, with no full cache already saved under that
key. I checked the history: exactly one commit has ever touched both (#8916), and
it predates this workflow's push-on-`main` trigger (added in #9015), so no
Analytics run existed for it. In the normal flow the PR branch's `Verify` run
saves the full cache first and the Analytics save no-ops harmlessly.

So **the collision has never fired.** It is a race that has not had the
opportunity yet — and the next analytics dependency bump is exactly the commit
that creates it. The failure mode is also nasty to debug: a repo-wide red with
`yarn install` skipped and no obvious cause.

## The unconditional win

Independent of the race, the composite carries a step this workflow was missing:
the `.yarn/cache` download-cache fallback, used when `node_modules` misses and an
install is about to run. The repo has `enableGlobalCache: false`, so the project
cache is `.yarn/cache`. Without that fallback, every cache miss in this workflow
re-downloaded the entire dependency tree from the network rather than installing
from disk. That is true on every miss, today.

It also trades 34 lines of hand-rolled setup for 6, and makes the composite the
single definition of node setup and caching across all workflows.

## Second commit: a guard, not just a fix

Removing the one hand-rolled copy does not stop the next one, and the failure
mode is invisible until it bites. So the second commit records the invariant
where it lives — a comment on the composite's cache step stating that the key is
shared repo-wide, that caches are immutable, and that a narrower `path:` written
under it breaks every other workflow.

It is comment-only: I asserted the composite's parsed steps are byte-identical to
`origin/main`. Happy to drop it if you would rather the PR stayed to one file.

If you want this enforced rather than documented, the natural follow-up is a test
that parses `.github/workflows/*.yml` and fails if anything but the composite
writes a `-modules-` key. I have that check working locally but did not commit it
— it needs a YAML parser as a direct workspace dependency and a home in a test
suite, which felt like a separate decision.

## Verified

- Parsed both versions of the file and compared job-by-job against
  `origin/main`: triggers, job list, timeouts (20 min / 30 min) and **every
  functional step after the setup block** are unchanged. Only the three setup
  steps were replaced.
- The composite covers what this workflow needs: `tools/*/node_modules` includes
  `tools/analytics/node_modules`, and it uses the same
  `node-version-file: 'package.json'`.
- Asserted the removed key was in fact identical to the composite's key, rather
  than assuming it.
- Repo-wide sweep: no workflow hand-rolls a `-modules-` cache key any more; the
  composite is the only writer. The one remaining non-composite `yarn install` is
  `release.yml`'s `action` job, a documented OIDC least-privilege exception that
  writes no cache entry at all — my first version of this check asserted "no
  installs outside the composite" and flagged it, which was the assertion being
  wrong rather than the code.
- `prettier --check` passes.
- Pattern already proven in production: `mcp-lambda.yml` uses this exact
  composite for the sibling `tools/mcp-lambda` workspace and its last six runs
  all succeeded.

## Why CI on this branch cannot exercise it

`analytics-lambda.yml` only triggers on push to `main`, so it will not run here.
It does accept `workflow_dispatch` — but a dispatch runs `build-and-push`, which
force-pushes to the GHE deploy repo and triggers a real analytics deploy. I have
deliberately not done that. Say the word if you want it dispatched before merge.

Note the composite is used by every workflow, so the second commit's blast radius
is wider than the first's even though it changes no behaviour. Worth a moment's
attention on review for that reason alone.

