### PR TITLE
chore(CI): bound the three jobs that could still hang for six hours

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,8 @@ jobs:
     name: Run analysis
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 5
+
     steps:
       - name: Check PR title format
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -319,6 +319,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 20
+
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Three jobs had no `timeout-minutes` and therefore fell back to GitHub's
**six-hour** default. They were the only three in the repository without one —
this makes it 27 of 27.

All three are **required status checks** on `main`, which is what makes it worth
fixing: a wedged runner does not just waste a job slot, it holds the merge queue
for the rest of the working day.

| Workflow | Job | Check name (required) | New timeout | Slowest successful run measured |
| --- | --- | --- | --- | --- |
| `verify.yml` | `build-check` | `Run build tests` | 20 min | 5.5 min (p50 2.8, p90 3.4) |
| `codeql-analysis.yml` | `analyze` | `Run analysis (javascript)` | 30 min | 3.6 min (p50 3.3, p90 3.5) |
| `pr-checks.yml` | `check-pr-title` | `Validate PR title` | 5 min | 0.7 min (p50 3 s) |

Measured from the Actions API over the last ~90 successful runs of each job,
using `started_at → completed_at` rather than run duration, since that is what
`timeout-minutes` actually bounds (it excludes queue time).

## On the values

They are deliberately loose. The goal is to bound a hang, not to fit the observed
runtime — a tight limit just converts an occasional slow run into a red required
check. 20 min for `build-check` matches what `verify.yml`'s `test` job already
uses, and every value here is an integer already in use elsewhere in the repo
(10/15/20/30/40/45/60), so nothing new is introduced. 30 min for CodeQL is the
most generous multiple of the three because it is the job whose runtime is most
likely to grow: it scales with the codebase and with any change to the
`security-and-quality` query suite.

**Correction to my own earlier numbers:** I previously quoted CodeQL at 4.1 min
p50 / 7.2 min p90. That was run duration including queue time. The job-execution
figures above are the correct basis, and CodeQL is both faster and far more
consistent than I said.

## Scope

Nothing else changes and nothing is deleted: one `timeout-minutes` line per file,
each with the blank separator the surrounding style uses, so six added lines in
total. I deliberately did **not**
also add `needs: setup` to `build-check`: its absence plausibly lets the longest
job start without waiting on the install job, and that is a separate question
from bounding a hang.

I also did not add explanatory comments next to the three values. The other 24
jobs carry a bare `timeout-minutes`, and commenting only these three would read
as though they were special.

## Verified

- Parsed each workflow and compared against `origin/main`: the target job is
  byte-identical apart from the added `timeout-minutes`, and every other job,
  trigger block and `permissions` block is unchanged.
- Swept all 14 workflows: 27 jobs, 27 timeouts, none missing.
- `prettier --check` passes on all three files.

## Note on overlap

This touches `verify.yml`, as does #9273 (which moves the audit job out). I
tested the merge rather than assuming: merging the two branches produces a
`verify.yml` with the audit job gone **and** `build-check` bounded at 20, with no
conflict. The hunks are far apart — a job removal near the top of the file versus
one added line in the last job — so either merge order works.

