### PR TITLE
docs(Flex): recommend the CSS layout engine in examples

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/Examples.tsx
@@ -22,7 +22,7 @@ export const LayoutComponents = () => {
         Form,
       }}
     >
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Form.MainHeading>Profile</Form.MainHeading>
 
         <Form.Card>
@@ -57,7 +57,7 @@ export const HorizontalFlexItemResponsiveSize = () => {
       scope={{ colors, TestElement }}
       data-visual-test="flex-item-size"
     >
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Flex.Item span={8}>
           <TestElement style={colors[0]}>FlexItem (8)</TestElement>
         </Flex.Item>
@@ -114,6 +114,7 @@ export const HorizontalFlexItemResponsiveSizeCustomColumns = () => {
         return (
           <CustomMediaQuery>
             <Flex.Container
+              layoutEngine="css"
               direction="horizontal"
               sizeCount={4}
               breakpoints={breakpoints}
@@ -153,7 +154,7 @@ export const HorizontalAutoSize = () => {
       hideCode
     >
       <FieldBlock label="Label">
-        <Flex.Container>
+        <Flex.Container layoutEngine="css">
           <Flex.Item span={{ small: 12, large: 'auto' }}>
             <Field.Name.First
               path="/firstName"

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/Examples.tsx
@@ -7,7 +7,7 @@ import { TestElement, Field } from '@dnb/eufemia/src/extensions/forms'
 export const Default = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -31,7 +31,7 @@ export const HorizontalWithFieldString = () => {
       scope={{ TestElement }}
       data-visual-test="flex-container-field"
     >
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Field.String label="Label" value="Foo" width="medium" />
         <Field.String label="Label" value="Foo" width="small" />
       </Flex.Container>
@@ -42,7 +42,7 @@ export const HorizontalWithFieldString = () => {
 export const HorizontalWithFlexItem = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -63,7 +63,7 @@ export const HorizontalWithFlexItem = () => {
 export const HorizontalWithFlexItemJustifyCenter = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container justify="center">
+      <Flex.Container layoutEngine="css" justify="center">
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -84,7 +84,7 @@ export const HorizontalWithFlexItemJustifyCenter = () => {
 export const HorizontalWithFlexItemJustifyFlexEnd = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container justify="flex-end">
+      <Flex.Container layoutEngine="css" justify="flex-end">
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -105,7 +105,7 @@ export const HorizontalWithFlexItemJustifyFlexEnd = () => {
 export const HorizontalWithFlexItemAlignCenter = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container align="center">
+      <Flex.Container layoutEngine="css" align="center">
         <Flex.Item>
           <TestElement style={{ height: '4rem' }}>Tall</TestElement>
         </Flex.Item>
@@ -126,7 +126,11 @@ export const HorizontalWithFlexItemAlignCenter = () => {
 export const VerticalWithFlexItemAlignCenter = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container direction="vertical" align="center">
+      <Flex.Container
+        layoutEngine="css"
+        direction="vertical"
+        align="center"
+      >
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -144,7 +148,7 @@ export const VerticalWithFlexItemAlignCenter = () => {
 export const VerticalWithFlexItem = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container direction="vertical">
+      <Flex.Container layoutEngine="css" direction="vertical">
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -165,7 +169,7 @@ export const VerticalWithFlexItem = () => {
 export const VerticalWithCard = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container direction="vertical">
+      <Flex.Container layoutEngine="css" direction="vertical">
         <Card>Card contents</Card>
         <Card>Card contents</Card>
         <Card>Card contents</Card>
@@ -181,6 +185,7 @@ export const VerticalLineDivider = () => {
       data-visual-test="flex-container-divider"
     >
       <Flex.Container
+        layoutEngine="css"
         direction="vertical"
         divider="line"
         alignSelf="stretch"
@@ -196,7 +201,7 @@ export const VerticalLineDivider = () => {
 export const LayoutHorizontalFlexGrowItems = () => {
   return (
     <ComponentBox>
-      <Flex.Horizontal>
+      <Flex.Horizontal layoutEngine="css">
         <Flex.Item span={3}>
           <Card>Card contents</Card>
         </Flex.Item>
@@ -232,7 +237,7 @@ export const WrappedWithChildren = () => {
         })
 
         return (
-          <Flex.Container direction="vertical">
+          <Flex.Container layoutEngine="legacy" direction="vertical">
             <TestElement>FlexItem 1</TestElement>
             <Wrapper>
               <TestElement>FlexItem 2</TestElement>
@@ -360,7 +365,9 @@ const CssDividerParity = () => {
         gap: '2rem',
       }}
     >
-      <Flex.Vertical divider="line">{legacyItems}</Flex.Vertical>
+      <Flex.Vertical layoutEngine="legacy" divider="line">
+        {legacyItems}
+      </Flex.Vertical>
       <Flex.Vertical layoutEngine="css" divider="line">
         {cssItems}
       </Flex.Vertical>
@@ -557,14 +564,18 @@ export const FramedLineDividers = () => {
     >
       {() => {
         const Item = () => (
-          <Flex.Stack divider="line-framed" gap="x-small">
+          <Flex.Stack
+            layoutEngine="css"
+            divider="line-framed"
+            gap="x-small"
+          >
             <TestElement>FlexItem</TestElement>
             <TestElement>FlexItem</TestElement>
           </Flex.Stack>
         )
 
         return (
-          <Flex.Horizontal rowGap={false}>
+          <Flex.Horizontal layoutEngine="css" rowGap={false}>
             <Item />
             <Item />
             <Item />

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/container/info.mdx
@@ -6,7 +6,7 @@ showTabs: true
 
 ```tsx
 import { Flex } from '@dnb/eufemia'
-render(<Flex.Container />)
+render(<Flex.Container layoutEngine="css" />)
 ```
 
 ## Description
@@ -26,27 +26,25 @@ You can also use [Flex.Item](/uilib/layout/flex/item) or [Card](/uilib/component
 import { Flex, Card } from '@dnb/eufemia'
 
 render(
-  <Flex.Container>
+  <Flex.Container layoutEngine="css">
     <Flex.Item>content</Flex.Item>
     <Card>content</Card>
   </Flex.Container>
 )
 ```
 
-But you can use it with what ever element too. It will wrap it in an `Flex.Item` to ensure the spacing is applied:
+You can also use it with any element. With the CSS engine, each rendered element participates in the layout directly:
 
 ```jsx
 import { Flex } from '@dnb/eufemia'
 
 render(
-  <Flex.Container>
+  <Flex.Container layoutEngine="css">
     <div>content</div>
     <div>content</div>
   </Flex.Container>
 )
 ```
-
-During render, the items within the "Wrapper" container are wrapped with the same properties. This ensures that all the items have the same appearance.
 
 ### Align vs Justify
 
@@ -71,7 +69,7 @@ For shortening the usage of `direction="..."`, you can use:
 - `<Flex.Vertical>` instead of `<Flex.Container direction="vertical">`
 
 ```jsx
-<Flex.Vertical>
+<Flex.Vertical layoutEngine="css">
   <Flex.Item>part of vertical alignment</Flex.Item>
   <Flex.Item>part of vertical alignment</Flex.Item>
 </Flex.Vertical>
@@ -80,7 +78,7 @@ For shortening the usage of `direction="..."`, you can use:
 - `<Flex.Horizontal>` instead of `<Flex.Container direction="horizontal">`
 
 ```jsx
-<Flex.Horizontal>
+<Flex.Horizontal layoutEngine="css">
   <Flex.Item>part of horizontal alignment</Flex.Item>
   <Flex.Item>part of horizontal alignment</Flex.Item>
 </Flex.Horizontal>
@@ -127,7 +125,7 @@ In CSS mode, `divider="line"` and `divider="line-framed"` are painted visual lin
 The existing React child-inspection engine remains the default, so applications do not need to annotate every established layout:
 
 ```tsx
-<Flex.Container>...</Flex.Container>
+<Flex.Container layoutEngine="legacy">...</Flex.Container>
 ```
 
 Use `layoutEngine="css"` when migrating a layout to native gaps. The explicit `layoutEngine="legacy"` value is still supported when an integration needs to document that dependency.

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/info.mdx
@@ -32,7 +32,7 @@ import { Flex } from '@dnb/eufemia'
 function MyForm() {
   return (
     <Form.Handler>
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Form.MainHeading>Main heading</Form.MainHeading>
         <Form.Card>...</Form.Card>
       </Flex.Stack>

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/item/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/item/Examples.tsx
@@ -9,7 +9,7 @@ import {
 export const Default = () => {
   return (
     <ComponentBox scope={{ TestElement }}>
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Flex.Item>
           <TestElement>FlexItem</TestElement>
         </Flex.Item>
@@ -24,7 +24,7 @@ export const Default = () => {
 export const BasicSize = () => {
   return (
     <ComponentBox>
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Flex.Item span={6}>uses 50% in width</Flex.Item>
         <Flex.Item span={6}>uses 50% in width</Flex.Item>
       </Flex.Container>
@@ -35,7 +35,7 @@ export const BasicSize = () => {
 export const ResponsiveSize = () => {
   return (
     <ComponentBox hidePreview>
-      <Flex.Container>
+      <Flex.Container layoutEngine="css">
         <Flex.Item span={{ small: 12, large: 6 }}>
           uses 50% or 100% based on the screen size
         </Flex.Item>

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/item/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/item/info.mdx
@@ -24,7 +24,7 @@ render(<Flex.Item />)
 import { Flex } from '@dnb/eufemia'
 
 render(
-  <Flex.Container>
+  <Flex.Container layoutEngine="css">
     <Flex.Item>content</Flex.Item>
   </Flex.Container>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/stack/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/stack/Examples.tsx
@@ -5,7 +5,7 @@ import { Card, Flex, P } from '@dnb/eufemia/src'
 export const WithFieldString = () => {
   return (
     <ComponentBox data-visual-test="flex-stack-form">
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Field.String label="Label" value="Foo" />
         <Field.String label="Label" value="Foo" />
         <Form.SubmitButton />
@@ -17,7 +17,7 @@ export const WithFieldString = () => {
 export const WithParagraphs = () => {
   return (
     <ComponentBox data-visual-test="flex-stack-paragraphs">
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <P>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi
           cursus pharetra elit in bibendum.
@@ -34,7 +34,7 @@ export const WithParagraphs = () => {
 export const WithMainHeading = () => {
   return (
     <ComponentBox>
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Form.MainHeading>Heading</Form.MainHeading>
         <P>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</P>
         <P>Aliquam at felis rutrum, luctus dui at, bibendum ipsum.</P>
@@ -46,7 +46,7 @@ export const WithMainHeading = () => {
 export const WithCard = () => {
   return (
     <ComponentBox data-visual-test="flex-stack-card-stack">
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Card gap="medium">
           <P>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</P>
           <P>Aliquam at felis rutrum, luctus dui at, bibendum ipsum.</P>
@@ -63,7 +63,7 @@ export const WithCard = () => {
 export const WithCardAndHeading = () => {
   return (
     <ComponentBox data-visual-test="flex-stack-card-heading">
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Form.MainHeading>Main heading</Form.MainHeading>
         <Card gap="medium">
           <P>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</P>
@@ -77,7 +77,7 @@ export const WithCardAndHeading = () => {
 export const WithCardAndHeadings = () => {
   return (
     <ComponentBox data-visual-test="flex-stack-card-two-headings">
-      <Flex.Stack>
+      <Flex.Stack layoutEngine="css">
         <Form.MainHeading>Main heading</Form.MainHeading>
         <Form.SubHeading>Sub heading</Form.SubHeading>
         <Card gap="medium">
@@ -92,7 +92,7 @@ export const WithCardAndHeadings = () => {
 export const WithHeadingsAndAriaLabel = () => {
   return (
     <ComponentBox hidePreview>
-      <Flex.Stack aria-labelledby="unique-id">
+      <Flex.Stack layoutEngine="css" aria-labelledby="unique-id">
         <Form.SubHeading id="unique-id">Heading</Form.SubHeading>
         <Card>
           <P>Content inside a landmark ...</P>

--- a/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/stack/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/layout/flex/stack/info.mdx
@@ -8,7 +8,7 @@ import * as Examples from './Examples'
 
 ```tsx
 import { Flex } from '@dnb/eufemia'
-render(<Flex.Stack />)
+render(<Flex.Stack layoutEngine="css" />)
 ```
 
 ## Description


### PR DESCRIPTION
Updates the Flex documentation examples to use the CSS layout engine, so new implementations follow the path intended for the next major version. Legacy mode remains explicit in the compatibility examples.