### PR TITLE
fix: preserve the default iOS root font size

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/typography/font-size.mdx
@@ -62,10 +62,13 @@ root-relative layout values.
 
 ### Optional JavaScript root scaling
 
-At the default iOS text size, this opt-in script keeps DNB basis text at 18px.
-If the user changes the system text size, all `rem`-based text and layout scale
-proportionally. Place it after the viewport meta tag and before stylesheets to
-avoid a visible layout change.
+At the default iOS text size, this opt-in script uses the normal 16px root, so
+DNB basis text is 18px. It only sets the root font size when the user changes
+the system text size. Text and layout then scale together. If the user returns
+to the default setting, the script restores the original root size.
+
+Place the script after the viewport meta tag and before stylesheets to avoid a
+visible layout change.
 
 ```tsx
 import { TextScaleHeadScript } from '@dnb/eufemia/shared/TextScaleScript'

--- a/packages/dnb-eufemia/src/shared/TextScaleScriptUtils.ts
+++ b/packages/dnb-eufemia/src/shared/TextScaleScriptUtils.ts
@@ -52,13 +52,28 @@ export function applyTextScale(): (() => void) | undefined {
     }
 
     const appleScale = readAppleTextScale()
+    let originalRootFontSize: string | undefined
+
+    const restoreRootFontSize = () => {
+      if (originalRootFontSize === undefined) {
+        return
+      }
+
+      root.style.fontSize = originalRootFontSize
+      originalRootFontSize = undefined
+    }
 
     const apply = (scale: number) => {
       if (!scale) {
         return
       }
 
-      root.style.fontSize = `${16 * scale}px`
+      if (scale === 1) {
+        restoreRootFontSize()
+      } else {
+        originalRootFontSize ??= root.style.fontSize
+        root.style.fontSize = `${16 * scale}px`
+      }
       root.setAttribute(attribute, 'apple')
     }
 
@@ -99,6 +114,7 @@ export function applyTextScale(): (() => void) | undefined {
     }
 
     const cleanup = () => {
+      restoreRootFontSize()
       observer?.disconnect()
       removeProbe(probe)
       document.removeEventListener('DOMContentLoaded', observe)

--- a/packages/dnb-eufemia/src/shared/__tests__/TextScaleScript.test.tsx
+++ b/packages/dnb-eufemia/src/shared/__tests__/TextScaleScript.test.tsx
@@ -26,15 +26,33 @@ describe('TextScaleScript', () => {
     delete globalThis.__eufemiaTextScaleCleanup
   })
 
-  it('sets the root size synchronously from Apple Dynamic Type', () => {
+  it('uses the normal root size at the default Apple text size', () => {
     mockSupport({ appleBodySize: 17 })
 
     Function(getTextScaleScript())()
 
-    expect(document.documentElement.style.fontSize).toBe('16px')
+    expect(document.documentElement.style.fontSize).toBe('')
     expect(
       document.documentElement.getAttribute('data-eufemia-text-scale')
     ).toBe('apple')
+  })
+
+  it('sets the root size synchronously when Apple text size is changed', () => {
+    mockSupport({ appleBodySize: 34 })
+
+    Function(getTextScaleScript())()
+
+    expect(document.documentElement.style.fontSize).toBe('32px')
+  })
+
+  it('preserves an existing root size at the default Apple text size', () => {
+    document.documentElement.style.fontSize = '20px'
+    mockSupport({ appleBodySize: 17 })
+
+    Function(getTextScaleScript())()
+    dispatchEvent(new Event('focus'))
+
+    expect(document.documentElement.style.fontSize).toBe('20px')
   })
 
   it('leaves unsupported browsers unchanged', () => {
@@ -86,6 +104,45 @@ describe('TextScaleScript', () => {
     expect(document.documentElement.style.fontSize).toBe('32px')
   })
 
+  it('removes the root size when Apple text size returns to default', () => {
+    let appleBodySize = 34
+    mockSupport({ getAppleBodySize: () => appleBodySize })
+
+    Function(getTextScaleScript())()
+    expect(document.documentElement.style.fontSize).toBe('32px')
+
+    appleBodySize = 17
+    dispatchEvent(new Event('focus'))
+
+    expect(document.documentElement.style.fontSize).toBe('')
+  })
+
+  it('restores an existing root size when Apple text size returns to default', () => {
+    let appleBodySize = 34
+    document.documentElement.style.fontSize = '20px'
+    mockSupport({ getAppleBodySize: () => appleBodySize })
+
+    Function(getTextScaleScript())()
+    expect(document.documentElement.style.fontSize).toBe('32px')
+
+    appleBodySize = 17
+    dispatchEvent(new Event('focus'))
+
+    expect(document.documentElement.style.fontSize).toBe('20px')
+  })
+
+  it('restores an existing root size during cleanup', () => {
+    document.documentElement.style.fontSize = '20px'
+    mockSupport({ appleBodySize: 34 })
+
+    Function(getTextScaleScript())()
+    expect(document.documentElement.style.fontSize).toBe('32px')
+
+    globalThis.__eufemiaTextScaleCleanup?.()
+
+    expect(document.documentElement.style.fontSize).toBe('20px')
+  })
+
   it('renders a blocking script for the document head', () => {
     render(<TextScaleHeadScript nonce="nonce-value" />)
 
@@ -99,7 +156,7 @@ describe('TextScaleScript', () => {
 
     render(<TextScaleClient />)
 
-    expect(document.documentElement.style.fontSize).toBe('16px')
+    expect(document.documentElement.style.fontSize).toBe('')
   })
 
   function mockSupport({


### PR DESCRIPTION
The opt-in Dynamic Type bridge should not override an application’s normal root size when iOS uses its default text setting. It now applies an inline root size only when the system text size changes, and restores the application’s original value when the user returns to the default.

Fixes the here #9171 introduced feature
Docs preview: https://fix-ios-dynamic-type-default.eufemia-e25.pages.dev/uilib/typography/font-size#why-text-can-be-larger-on-ios