### PR TITLE
chore(Portal): enable anonymous page-view analytics on the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,10 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+          # Anonymous page-view tracking. Only set here, so preview/dev builds
+          # stay dark; the endpoint is public and edge-locked at the origin.
+          VITE_ANALYTICS_ENDPOINT: https://server.eufemia.dnb.no/analytics/collect-portal-views
+          VITE_ANALYTICS_ENV: prod
 
       - name: Push Algolia search index
         if: github.ref == 'refs/heads/release'


### PR DESCRIPTION
Turns on the anonymous page-view tracking that has been shipping dark since it was added. The `release` portal build now sets `VITE_ANALYTICS_ENDPOINT` (the edge-locked `/collect-portal-views` route) and `VITE_ANALYTICS_ENV=prod`; preview and dev builds set neither, so they stay dark.

All page-view shape work has merged (#9298, #9299, #9326, #9343, #9351) and the enriched record round-trips end to end (edge → Lambda → `portal_views`, all dimensions). Merging this, then the next release, ships tracking live with the first real rows already on the final shape.

The collected data is anonymous (no identifiers, cookies or device storage) and out of DPIA scope — see EDS-960.
