### PR TITLE
fix(Forms): clean up submit validation listeners

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Iterate/EditContainer/__tests__/EditAndViewContainer.test.tsx
@@ -3,7 +3,15 @@ import { render, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Flex } from '../../../../../components'
 import IterateItemContext from '../../IterateItemContext'
-import { Field, Form, Iterate, Value } from '../../..'
+import { useItem } from '../../hooks'
+import {
+  Ajv,
+  Field,
+  Form,
+  Iterate,
+  makeAjvInstance,
+  Value,
+} from '../../..'
 import nbNO from '../../../constants/locales/nb-NO'
 
 const tr = {
@@ -12,6 +20,142 @@ const tr = {
 }
 
 describe('EditContainer and ViewContainer', () => {
+  it.each([
+    ['Done', 'done'],
+    ['Cancel', 'cancel'],
+  ])(
+    'should close with %s after hiding a conditionally required field',
+    async (_, action) => {
+      let containerMode = null
+
+      const ContextConsumer = () => {
+        const context = useContext(IterateItemContext)
+        containerMode = context.containerMode
+
+        return null
+      }
+      const Fields = () => {
+        const { index } = useItem()
+
+        return (
+          <>
+            <Field.ArraySelection itemPath="/criteria">
+              <Field.Option value="A">A</Field.Option>
+              <Field.Option value="B">B</Field.Option>
+            </Field.ArraySelection>
+
+            <Form.Visibility
+              visibleWhen={{
+                itemPath: '/criteria',
+                hasValue: (value: string[]) => value?.includes('B'),
+              }}
+            >
+              <Field.Upload
+                id={`documents-${index}`}
+                itemPath="/documents"
+              />
+            </Form.Visibility>
+          </>
+        )
+      }
+
+      const schema = {
+        type: 'object',
+        properties: {
+          entries: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['criteria'],
+              properties: {
+                criteria: {
+                  type: 'array',
+                  minItems: 1,
+                  items: { type: 'string' },
+                },
+                documents: { type: 'array' },
+              },
+              dependentSchemas: {
+                criteria: {
+                  if: {
+                    properties: {
+                      criteria: {
+                        type: 'array',
+                        contains: { enum: ['B'] },
+                      },
+                    },
+                  },
+                  then: {
+                    required: ['documents'],
+                    properties: {
+                      documents: { type: 'array', minItems: 1 },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      render(
+        <Form.Handler
+          id="form-handler-id"
+          locale="en-GB"
+          schema={schema}
+          ajvInstance={makeAjvInstance(
+            new Ajv({ strict: false, allErrors: true })
+          )}
+          defaultData={{ entries: [{ criteria: ['A'] }] }}
+        >
+          <Iterate.Array path="/entries">
+            <Iterate.ViewContainer>
+              <Value.ArraySelection itemPath="/criteria" />
+            </Iterate.ViewContainer>
+            <Iterate.EditContainer>
+              <Fields />
+            </Iterate.EditContainer>
+            <ContextConsumer />
+          </Iterate.Array>
+        </Form.Handler>
+      )
+
+      expect(containerMode).toBe('view')
+
+      await userEvent.click(
+        document.querySelector('.dnb-forms-iterate__edit-button')
+      )
+      expect(containerMode).toBe('edit')
+
+      const criteria = document.querySelectorAll<HTMLInputElement>(
+        '.dnb-forms-field-array-selection input'
+      )
+      await userEvent.click(criteria[1])
+      expect(
+        document.querySelector('.dnb-forms-field-upload')
+      ).toBeInTheDocument()
+
+      await userEvent.click(criteria[1])
+      expect(
+        document.querySelector('.dnb-forms-field-upload')
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(
+        document.querySelector(`.dnb-forms-iterate__${action}-button`)
+      )
+
+      if (action === 'cancel') {
+        await userEvent.click(
+          document.querySelector('.dnb-dialog .dnb-button--primary')
+        )
+      }
+
+      await waitFor(() => {
+        expect(containerMode).toBe('view')
+      })
+    }
+  )
+
   it('should switch mode on pressing edit button', async () => {
     render(
       <Iterate.Array value={['foo', 'bar']}>

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/Errors.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/Errors.tsx
@@ -7,10 +7,15 @@ import withComponentMarkers from '../../../shared/helpers/withComponentMarkers'
 
 function Errors({ label }: { label?: ReactNode }) {
   const [, forceUpdate] = useReducer(() => ({}), {})
-  const { fieldErrorRef, errorsRef } = useContext(DataContext)
+  const { fieldErrorRef, errorsRef, mountedFieldsRef } =
+    useContext(DataContext)
 
   const fieldErrors = Object.keys(fieldErrorRef?.current || {}).reduce(
     (acc, key) => {
+      if (mountedFieldsRef?.current.get(key)?.isMounted === false) {
+        return acc
+      }
+
       acc[key] = fieldErrorRef?.current[key]?.message
       return acc
     },
@@ -27,7 +32,11 @@ function Errors({ label }: { label?: ReactNode }) {
   const handleSetFieldError = useCallback(() => {
     forceUpdate()
   }, [])
+  const handleSetMountedFieldState = useCallback(() => {
+    Promise.resolve().then(forceUpdate)
+  }, [])
   useEventListener('onSetFieldError', handleSetFieldError)
+  useEventListener('onSetMountedFieldState', handleSetMountedFieldState)
 
   const data = {
     fieldErrors,

--- a/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/Errors.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Tools/__tests__/Errors.test.tsx
@@ -63,6 +63,46 @@ describe('Tools.Errors', () => {
     )
   })
 
+  it('should omit field errors after a conditional field unmounts', async () => {
+    render(
+      <Form.Handler defaultData={{ showField: true }}>
+        <Field.Boolean
+          path="/showField"
+          label="Show field"
+          variant="checkbox"
+        />
+        <Form.Visibility pathTrue="/showField">
+          <Field.String path="/foo" required />
+        </Form.Visibility>
+        <Tools.Errors />
+      </Form.Handler>
+    )
+
+    const element = document.querySelector('output')
+    expect(element.textContent).toContain('"/foo"')
+
+    await userEvent.click(document.querySelector('input'))
+
+    await waitFor(() => {
+      expect(element.textContent).toBe(
+        JSON.stringify(
+          {
+            fieldErrors: {},
+            formErrors: {},
+          },
+          null,
+          2
+        ) + ' '
+      )
+    })
+
+    await userEvent.click(document.querySelector('input'))
+
+    await waitFor(() => {
+      expect(element.textContent).toContain('"/foo"')
+    })
+  })
+
   it('should render form errors', () => {
     const schema1: JSONSchema = {
       type: 'object',

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -878,6 +878,57 @@ describe('Wizard.Container', () => {
     expect(output()).toHaveTextContent('Step 3')
   })
 
+  it('should submit after correcting an onChangeValidator error when returning to a step', async () => {
+    const onSubmit: OnSubmit = vi.fn()
+    const onChangeValidator = vi.fn((value: boolean) =>
+      value === true ? undefined : new Error('Consent required')
+    )
+
+    render(
+      <Form.Handler onSubmit={onSubmit}>
+        <Wizard.Container>
+          <Wizard.Step title="Step 1">
+            <output>Step 1</output>
+            <Wizard.Buttons />
+          </Wizard.Step>
+
+          <Wizard.Step title="Step 2">
+            <output>Step 2</output>
+            <Field.Boolean
+              label="Consent"
+              path="/consent"
+              variant="checkbox"
+              required
+              onChangeValidator={onChangeValidator}
+            />
+            <Wizard.Buttons />
+            <Form.SubmitButton />
+          </Wizard.Step>
+        </Wizard.Container>
+      </Form.Handler>
+    )
+
+    await userEvent.click(nextButton())
+    await userEvent.click(document.querySelector('input'))
+    await userEvent.click(document.querySelector('input'))
+
+    expect(document.querySelector('.dnb-form-status')).toHaveTextContent(
+      'Consent required'
+    )
+
+    await userEvent.click(previousButton())
+    await userEvent.click(nextButton())
+    await userEvent.click(document.querySelector('input'))
+
+    await waitFor(() => {
+      expect(document.querySelector('.dnb-form-status')).toBeNull()
+    })
+
+    await userEvent.click(submitButton())
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
   it('should keep current step on rerender', async () => {
     const onStepChange = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1258,9 +1258,14 @@ export default function useFieldProps<Value, EmptyValue, Props>(
           sharedAttachments?.fieldConnectionsRef?.current?.[identifier]
         )
 
-        if (!isMounted && !hasFieldConnection) {
-          setFieldErrorDataContext?.(identifier, undefined)
+        if (!isMounted) {
+          // A shared field connection can preserve form-level status across
+          // remounts, but the unmounted field no longer belongs to this boundary.
           setFieldErrorBoundary?.(identifier, undefined)
+
+          if (!hasFieldConnection) {
+            setFieldErrorDataContext?.(identifier, undefined)
+          }
         }
       })
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1776,6 +1776,17 @@ export default function useFieldProps<Value, EmptyValue, Props>(
   // Validate/call validator functions during submit of the form
   useEffect(() => {
     setFieldEventListener?.(identifier, 'onSubmitCall', onSubmitHandler)
+
+    return () => {
+      setFieldEventListener?.(
+        identifier,
+        'onSubmitCall',
+        onSubmitHandler,
+        {
+          remove: true,
+        }
+      )
+    }
   }, [identifier, onSubmitHandler, setFieldEventListener])
 
   // Set the error in the field block context if this field is inside a field block


### PR DESCRIPTION
Unmounted fields could leave validation listeners or local boundary errors behind, blocking submission or keeping an Iterate.EditContainer open after its conditionally required field was hidden.

Motivation:
- https://dnb.enterprise.slack.com/archives/D07RXF572R0 (PM)
- https://dnb-it.slack.com/archives/CMXABCHEY/p1788866627314909