### PR TITLE
feat(Autocomplete, Dropdown, DrawerList, Field.Selection): add virtualized rendering for large data sets

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/Examples.tsx
@@ -19,6 +19,7 @@ import {
   NumberFormat,
   List,
 } from '@dnb/eufemia/src'
+import { createDrawerListVirtualization } from '@dnb/eufemia/src/fragments/drawer-list/Virtualization'
 
 const Wrapper = styled.div`
   [data-visual-test] {
@@ -37,6 +38,25 @@ export const AutocompleteDefaultExample = () => (
   <Wrapper>
     <ComponentBox scope={{ topMovies }}>
       <Autocomplete data={topMovies} label="Label" />
+    </ComponentBox>
+  </Wrapper>
+)
+
+const virtualizedList = createDrawerListVirtualization()
+const virtualizedItems = Array.from({ length: 10000 }, (_, index) => ({
+  selectedKey: String(index),
+  content: `Item ${index + 1}`,
+}))
+
+export const AutocompleteVirtualizedExample = () => (
+  <Wrapper>
+    <ComponentBox scope={{ virtualizedItems, virtualizedList }}>
+      <Autocomplete
+        label="Search 10,000 items"
+        data={virtualizedItems}
+        listDriver={virtualizedList}
+        showSubmitButton
+      />
     </ComponentBox>
   </Wrapper>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/autocomplete/demos.mdx
@@ -4,6 +4,7 @@ showTabs: true
 
 import {
   AutocompleteDefaultExample,
+  AutocompleteVirtualizedExample,
   AutocompleteNumbersExample,
   AutocompleteSearchOptionsExample,
   AutocompleteWithCustomTitle,
@@ -28,6 +29,27 @@ import {
 ### Default autocomplete
 
 <AutocompleteDefaultExample />
+
+### Large data sets
+
+Virtualization is opt-in. Import the driver from `@dnb/eufemia/fragments/drawer-list/Virtualization` and pass it as `listDriver`. The default Autocomplete bundle does not import the virtualization dependency. Filtering and “Show all” continue to operate on the complete data set while only the visible options are rendered.
+
+Install the optional peer dependency before using the driver:
+
+```bash
+yarn add @tanstack/react-virtual
+```
+
+```tsx
+import { Autocomplete } from '@dnb/eufemia/components'
+import { createDrawerListVirtualization } from '@dnb/eufemia/fragments/drawer-list/Virtualization'
+
+const listDriver = createDrawerListVirtualization()
+
+<Autocomplete data={items} listDriver={listDriver} />
+```
+
+<AutocompleteVirtualizedExample />
 
 ### Autocomplete with numbers
 

--- a/packages/dnb-eufemia/package.json
+++ b/packages/dnb-eufemia/package.json
@@ -126,6 +126,7 @@
     "zod": "4.4.3"
   },
   "peerDependencies": {
+    "@tanstack/react-virtual": "^3.14.10",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "purgecss": "^8.0.0",
@@ -133,6 +134,9 @@
     "react-dom": "^19"
   },
   "peerDependenciesMeta": {
+    "@tanstack/react-virtual": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     },
@@ -174,6 +178,7 @@
     "@semantic-release/release-notes-generator": "14.1.1",
     "@svgr/core": "6.5.1",
     "@svgr/plugin-jsx": "6.5.1",
+    "@tanstack/react-virtual": "3.14.10",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.7.0",
     "@testing-library/react": "16.3.2",

--- a/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/Autocomplete.tsx
@@ -621,6 +621,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
     submitElement,
     inputElement: CustomInput,
     optionsRender,
+    listDriver,
     preventSelection,
     maxHeight,
     defaultValue,
@@ -1405,6 +1406,8 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
             drawerListRef.current.setState({
               activeItem: (data[0] as DrawerListInternalItem).__id,
             })
+          } else if (propsRef.current.listDriver) {
+            drawerListRef.current.setState({ activeItem: -1 })
           }
         }
       } else {
@@ -1465,15 +1468,26 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
         setShowAllNextTime(false)
       }
 
-      runFilterToHighlight({
-        fillDataIfEmpty: true,
-        skipFilter,
-        ...options,
-      })
+      const selectedTitle = getCurrentDataTitle(
+        drawerListRef.current.selectedItem,
+        drawerListRef.current.originalData
+      )
+      const shouldShowAll =
+        !skipFilter && inputValueRef.current === selectedTitle
+
+      if (shouldShowAll) {
+        showAllItems()
+      } else {
+        runFilterToHighlight({
+          fillDataIfEmpty: true,
+          skipFilter,
+          ...options,
+        })
+      }
 
       setVisible(null, onStateComplete)
     },
-    [showAllNextTime, runFilterToHighlight, setVisible]
+    [showAllNextTime, showAllItems, runFilterToHighlight, setVisible]
   )
 
   const toggleVisible = useCallback(
@@ -1723,9 +1737,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
       })
 
       const trimmed = String(val).trim()
-      if (trimmed !== inputValueRef.current) {
-        runFilterWithSideEffects(trimmed)
-      }
+      runFilterWithSideEffects(trimmed)
     },
     [runFilterWithSideEffects]
   )
@@ -2551,6 +2563,7 @@ function AutocompleteComponent(ownProps: AutocompleteAllProps) {
               direction={direction}
               size={size}
               optionsRender={optionsRender}
+              listDriver={listDriver}
               onChange={onChangeHandler}
               onSelect={onSelectHandler}
               onClose={onCloseHandler}

--- a/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/dnb-eufemia/src/components/autocomplete/__tests__/Autocomplete.test.tsx
@@ -69,6 +69,32 @@ const mockData: DrawerListDataArray = [
 mockImplementationForDirectionObserver()
 
 describe('Autocomplete component', () => {
+  it('uses an opt-in list rendering driver', () => {
+    const listDriver = {
+      Renderer: ({ rows }) => (
+        <>
+          {rows
+            .filter(({ type }) => type === 'option')
+            .slice(0, 3)
+            .map(({ render }) => render())}
+        </>
+      ),
+    }
+
+    render(
+      <Autocomplete
+        data={Array.from({ length: 100 }, (_, index) => `Item ${index}`)}
+        open
+        {...({ listDriver } as AutocompleteAllProps)}
+        {...mockProps}
+      />
+    )
+
+    expect(
+      document.querySelectorAll('li.dnb-drawer-list__option')
+    ).toHaveLength(3)
+  })
+
   it('has correct word and in-word highlighting', () => {
     render(
       <Autocomplete

--- a/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
+++ b/packages/dnb-eufemia/src/components/dropdown/Dropdown.tsx
@@ -446,6 +446,7 @@ const DropdownComponent = memo(function DropdownComponent({
     stretch,
     skeleton,
     variant,
+    listDriver,
 
     title: _title,
     icon: _icon,
@@ -677,6 +678,7 @@ const DropdownComponent = memo(function DropdownComponent({
               maxHeight={maxHeight}
               direction={direction}
               size={size}
+              listDriver={listDriver}
               onChange={onChangeHandler}
               onSelect={onSelectHandler}
               onClose={onCloseHandler}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumber.tsx
@@ -22,7 +22,10 @@ import type { CountryFilterSet } from '../SelectCountry'
 import { countryFilter, getCountryData } from '../SelectCountry'
 import detectCountryCode from '../../../../shared/detectCountryCode'
 import useTranslation from '../../hooks/useTranslation'
-import type { DrawerListDataArrayItem } from '../../../../fragments/DrawerList'
+import type {
+  DrawerListDataArrayItem,
+  DrawerListDriver,
+} from '../../../../fragments/DrawerList'
 import type { AutocompleteOnChangeParams } from '../../../../components/Autocomplete'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
@@ -70,6 +73,11 @@ export type FieldPhoneNumberProps = Omit<
    * For internal testing purposes
    */
   noAnimation?: boolean
+
+  /**
+   * Opt in to a custom list renderer for the country-code selector. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.
+   */
+  listDriver?: DrawerListDriver
 } & Pick<StringFieldProps, 'size'>
 
 // Important for the default value to be defined here, and not after the useFieldProps call, to avoid the UI jumping
@@ -550,6 +558,7 @@ function PhoneNumber(props: FieldPhoneNumberProps = {}) {
           selectAll
           autoComplete="tel-country-code"
           noAnimation={props.noAnimation}
+          listDriver={props.listDriver}
           size={size}
         />
       )}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumberDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/PhoneNumber/PhoneNumberDocs.ts
@@ -4,6 +4,11 @@ import { StringProperties } from '../String/StringDocs'
 import { FieldProperties } from '../../Field/FieldDocs'
 
 export const PhoneNumberProperties: PropertiesTableProps = {
+  listDriver: {
+    doc: 'Opt in to a custom list renderer for the country-code selector. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.',
+    type: 'DrawerListDriver',
+    status: 'optional',
+  },
   countries: {
     doc: 'List only a certain set of countries: `Scandinavia`, `Nordic`, `Europe` or `Prioritized` (all countries [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCountry/#filter-or-prioritize-country-listing)). Defaults to `Prioritized`.',
     type: ['"Scandinavia"', '"Nordic"', '"Europe"', '"Prioritized"'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountry.tsx
@@ -22,6 +22,7 @@ import type {
   AutocompleteAllProps,
   AutocompleteOnChangeParams,
 } from '../../../../components/autocomplete/Autocomplete'
+import type { DrawerListDriver } from '../../../../fragments/DrawerList'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type CountryFilterSet =
@@ -60,6 +61,11 @@ export type FieldSelectCountryProps = FieldPropsWithExtraValue<
    * The size of the component.
    */
   size?: AutocompleteAllProps['size']
+
+  /**
+   * Opt in to a custom list renderer. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.
+   */
+  listDriver?: DrawerListDriver
 }
 
 function SelectCountry(props: FieldSelectCountryProps) {
@@ -129,6 +135,7 @@ function SelectCountry(props: FieldSelectCountryProps) {
     value,
     width,
     noAnimation,
+    listDriver,
     autoComplete,
     htmlAttributes,
     handleFocus,
@@ -279,6 +286,7 @@ function SelectCountry(props: FieldSelectCountryProps) {
         keepSelection
         autoComplete={autoComplete ?? 'country-name'}
         noAnimation={noAnimation}
+        listDriver={listDriver}
         {...htmlAttributes}
       />
     </FieldBlock>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountryDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCountry/SelectCountryDocs.ts
@@ -3,6 +3,11 @@ import { getFieldEventsWithTypes } from '../FieldDocs'
 import { AutocompleteProperties } from '../../../../components/autocomplete/AutocompleteDocs'
 
 export const SelectCountryProperties: PropertiesTableProps = {
+  listDriver: {
+    doc: 'Opt in to a custom list renderer. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.',
+    type: 'DrawerListDriver',
+    status: 'optional',
+  },
   countries: {
     doc: 'List only a certain set of countries: `Scandinavia`, `Nordic`, `Europe` or `Prioritized` (all countries [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCountry/#filter-or-prioritize-country-listing)). Defaults to `Prioritized`.',
     type: ['"Scandinavia"', '"Nordic"', '"Europe"', '"Prioritized"'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrency.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrency.tsx
@@ -20,6 +20,7 @@ import type {
   AutocompleteAllProps,
   AutocompleteOnChangeParams,
 } from '../../../../components/autocomplete/Autocomplete'
+import type { DrawerListDriver } from '../../../../fragments/DrawerList'
 import withComponentMarkers from '../../../../shared/helpers/withComponentMarkers'
 
 export type CurrencyFilterSet =
@@ -58,6 +59,11 @@ export type FieldSelectCurrencyProps = FieldPropsWithExtraValue<
    * The size of the component.
    */
   size?: AutocompleteAllProps['size']
+
+  /**
+   * Opt in to a custom list renderer. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.
+   */
+  listDriver?: DrawerListDriver
 }
 
 function SelectCurrency(props: FieldSelectCurrencyProps) {
@@ -126,6 +132,7 @@ function SelectCurrency(props: FieldSelectCurrencyProps) {
     value,
     width,
     noAnimation,
+    listDriver,
     autoComplete,
     htmlAttributes,
     handleFocus,
@@ -276,6 +283,7 @@ function SelectCurrency(props: FieldSelectCurrencyProps) {
         keepSelection
         autoComplete={autoComplete}
         noAnimation={noAnimation}
+        listDriver={listDriver}
         {...htmlAttributes}
       />
     </FieldBlock>

--- a/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrencyDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/SelectCurrency/SelectCurrencyDocs.ts
@@ -3,6 +3,11 @@ import { getFieldEventsWithTypes } from '../FieldDocs'
 import { AutocompleteProperties } from '../../../../components/autocomplete/AutocompleteDocs'
 
 export const SelectCurrencyProperties: PropertiesTableProps = {
+  listDriver: {
+    doc: 'Opt in to a custom list renderer. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.',
+    type: 'DrawerListDriver',
+    status: 'optional',
+  },
   currencies: {
     doc: 'List only a certain set of currencies: `Scandinavia`, `Nordic`, `Europe` or `Prioritized` (all currencies [sorted by priority](/uilib/extensions/forms/feature-fields/SelectCurrency/#filter-or-prioritize-currency-listing)). Defaults to `Prioritized`.',
     type: ['"Scandinavia"', '"Nordic"', '"Europe"', '"Prioritized"'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/Selection.tsx
@@ -35,6 +35,7 @@ import type { AutocompleteAllProps } from '../../../../components/Autocomplete'
 import type { DropdownAllProps } from '../../../../components/Dropdown'
 import type { HelpProps } from '../../../../components/help-button/HelpButtonInline'
 import type {
+  DrawerListDriver,
   DrawerListDataArrayObjectStrict,
   DrawerListProps,
 } from '../../../../fragments/DrawerList'
@@ -117,6 +118,10 @@ export type FieldSelectionProps = FieldProps<IOption['value']> & {
    */
   groups?: ReactNode[]
   /**
+   * Opt in to a custom list renderer for the Dropdown and Autocomplete variants. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.
+   */
+  listDriver?: DrawerListDriver
+  /**
    * Forward any additional properties to the [Autocomplete](/uilib/components/autocomplete/) component. `onType` will additionally provide the `value` parameter with `emptyValue` support in addition to the internal `dataContext`.
    */
   autocompleteProps?: AutocompleteAllProps
@@ -167,6 +172,7 @@ function Selection(props: FieldSelectionProps) {
     transformSelection,
     data,
     groups,
+    listDriver,
     dataPath,
     children,
     additionalArgs,
@@ -357,6 +363,7 @@ function Selection(props: FieldSelectionProps) {
         ...htmlAttributes,
         data,
         groups,
+        listDriver,
         size,
         onChange: handleDrawerListChange,
         onOpen: handleShow,

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/SelectionDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/SelectionDocs.ts
@@ -1,6 +1,11 @@
 import type { PropertiesTableProps } from '../../../../shared/types'
 
 export const SelectionProperties: PropertiesTableProps = {
+  listDriver: {
+    doc: 'Opt in to a custom list renderer for the Dropdown and Autocomplete variants. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver.',
+    type: 'DrawerListDriver',
+    status: 'optional',
+  },
   variant: {
     doc: 'Choice of UI feature. Defaults to `dropdown`.',
     type: [

--- a/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/Selection/__tests__/Selection.test.tsx
@@ -10,12 +10,47 @@ import {
 import userEvent from '@testing-library/user-event'
 import DataContext from '../../../DataContext/Context'
 import DrawerListProvider from '../../../../../fragments/drawer-list/DrawerListProvider'
+import { createDrawerListVirtualization } from '../../../../../fragments/drawer-list/Virtualization'
 import { makeOptions } from '../Selection'
 import { Field, Form } from '../../..'
 import nbNO from '../../../constants/locales/nb-NO'
 const nb = nbNO['nb-NO']
 
 describe('Selection', () => {
+  it('forwards the virtualized list driver to dropdown and autocomplete variants', async () => {
+    const listDriver = createDrawerListVirtualization({ overscan: 1 })
+    const data = Array.from({ length: 100 }, (_, index) => ({
+      value: String(index),
+      title: `Item ${index}`,
+    }))
+    const { rerender } = render(
+      <Field.Selection
+        variant="dropdown"
+        data={data}
+        listDriver={listDriver}
+        dropdownProps={{ noAnimation: true }}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(screen.getAllByRole('option').length).toBeLessThan(data.length)
+
+    rerender(
+      <Field.Selection
+        variant="autocomplete"
+        data={data}
+        listDriver={listDriver}
+        autocompleteProps={{
+          open: true,
+          noAnimation: true,
+          skipPortal: true,
+        }}
+      />
+    )
+
+    expect(screen.getAllByRole('option').length).toBeLessThan(data.length)
+  })
+
   it('renders selected option', () => {
     render(
       <Field.Selection value="bar">

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerList.tsx
@@ -12,6 +12,7 @@ import type {
   ReactElement,
   ReactNode,
   Ref,
+  RefObject,
   SyntheticEvent,
 } from 'react'
 import useMountEffect from '../../shared/helpers/useMountEffect'
@@ -46,6 +47,7 @@ const propsToFilterOut: Record<string, null> = {
   onSelect: null,
   onKeyDown: null,
   optionsRender: null,
+  listDriver: null,
   wrapperElement: null,
   onItemMouseEnter: null,
 }
@@ -111,6 +113,40 @@ export type DrawerListOptionsRender = ({
   Items: () => ReactNode
   Item: ComponentType<DrawerListItemProps>
 }) => ReactNode
+
+export type DrawerListDriverRow = {
+  key: string
+  type: 'group' | 'option'
+  itemId?: number
+  keepMounted?: boolean
+  render: (props?: DrawerListDriverRowProps) => ReactNode
+}
+
+export type DrawerListDriverRowProps = {
+  ref?: Ref<HTMLLIElement>
+  className?: string
+  style?: CSSProperties
+  'data-index'?: number
+  'aria-describedby'?: string
+  'aria-posinset'?: number
+  'aria-setsize'?: number
+}
+
+export type DrawerListDriverProps = {
+  rows: DrawerListDriverRow[]
+  activeIndex: number
+  selectedIndex: number
+  open: boolean
+  listRef: RefObject<HTMLUListElement>
+  registerListDriver: (driver: {
+    itemIds: number[]
+    scrollToItem: (itemId: number, smooth: boolean) => void
+  }) => () => void
+}
+
+export type DrawerListDriver = {
+  Renderer: ComponentType<DrawerListDriverProps>
+}
 export type DrawerListValue = string | number
 export type DrawerListData =
   | string
@@ -205,6 +241,10 @@ export type DrawerListProps = {
    * Has to be a function, returning the items again. See [example](/uilib/components/fragments/drawer-list#example-usage-of-optionsRender). This can be used to add additional options above the actual rendered list.
    */
   optionsRender?: DrawerListOptionsRender
+  /**
+   * Opt in to a custom list renderer. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` to render large data sets without mounting every option. Install the optional `@tanstack/react-virtual` peer dependency when using this driver. Cannot be combined with `optionsRender`.
+   */
+  listDriver?: DrawerListDriver
   /**
    * Has to be an HTML Element, or a selector for one, ideally a parent element, used to calculate sizes and distances. Also used for the 'click outside' detection. Clicking on the `wrapperElement` will not trigger an outside click.
    */
@@ -355,6 +395,12 @@ const DrawerListComponent = memo(function DrawerListComponent(
 
   // Send along event handlers to the provider state on mount
   useMountEffect(() => {
+    if (propsWithDefaults.listDriver && propsWithDefaults.optionsRender) {
+      warn(
+        'DrawerList: `listDriver` cannot be combined with `optionsRender`. The default list renderer will be used.'
+      )
+    }
+
     const eventHandlerState = Object.keys(propsToFilterOut).reduce<
       Record<string, unknown>
     >((acc, key) => {
@@ -434,6 +480,7 @@ const DrawerListComponent = memo(function DrawerListComponent(
     listClass,
     ignoreEvents,
     optionsRender,
+    listDriver,
     className,
     arrowPosition: _arrowPosition,
     cacheHash: _cacheHash,
@@ -468,6 +515,7 @@ const DrawerListComponent = memo(function DrawerListComponent(
   } = propsWithDefaults as DrawerListAllProps & {
     onKeyDown?: (e: KeyboardEvent) => void
   }
+  const activeListDriver = optionsRender ? undefined : listDriver
 
   function noNullNumbers({
     selectedItem,
@@ -573,61 +621,69 @@ const DrawerListComponent = memo(function DrawerListComponent(
 
   const ignoreEventsBoolean = ignoreEvents
 
+  const renderItem = (
+    dataItem: DrawerListInternalItem,
+    i: number,
+    j: number,
+    data: DrawerListInternalData,
+    itemProps: DrawerListDriverRowProps = {}
+  ) => {
+    const { __id, ignoreEvents, className, disabled, style } = dataItem
+    const hash = `option-${id}-${__id}-${i}`
+    const tagId = `option-${id}-${__id}`
+    const liParams = {
+      ...itemProps,
+      role: role === 'menu' ? 'menuitem' : 'option',
+      'data-item': __id,
+      id: tagId,
+      hash,
+      className: clsx(
+        j === 0 && i === 0 && 'first-item',
+        j === renderData.length - 1 &&
+          i === data.length - 1 &&
+          'last-item',
+        i === 0 && 'first-of-type',
+        i === data.length - 1 && 'last-of-type',
+        (ignoreEventsBoolean || ignoreEvents) && 'ignore-events',
+        className,
+        itemProps.className
+      ),
+      active: __id === activeItem,
+      selected: !ignoreEvents && __id === selectedItem,
+      onClick: selectItemHandler,
+      onKeyDown: preventTab,
+      onMouseEnter: onItemMouseEnterHandler
+        ? (e: MouseEvent<HTMLLIElement>) =>
+            onItemMouseEnterHandler(__id, e)
+        : undefined,
+      disabled,
+      style: { ...style, ...itemProps.style },
+    }
+    if (ignoreEventsBoolean) {
+      liParams.active = null
+      liParams.selected = null
+      liParams.onClick = null
+      liParams.onKeyDown = null
+      liParams.onMouseEnter = null
+      liParams.className = clsx(
+        liParams.className,
+        'dnb-drawer-list__option--ignore'
+      )
+    }
+
+    return (
+      <DrawerList.Item key={hash} {...liParams}>
+        {dataItem}
+      </DrawerList.Item>
+    )
+  }
+
   const GroupItems = () =>
     renderData
       .filter(Boolean) // filter out empty groups
       .map(({ groupTitle, groupData: data, hideTitle }, j) => {
         const Items = () =>
-          data.map((dataItem, i) => {
-            const { __id, ignoreEvents, className, disabled, style } =
-              dataItem
-            const hash = `option-${id}-${__id}-${i}`
-            const tagId = `option-${id}-${__id}`
-            const liParams = {
-              role: role === 'menu' ? 'menuitem' : 'option',
-              'data-item': __id,
-              id: tagId,
-              hash,
-              className: clsx(
-                // helper classes
-                j === 0 && i === 0 && 'first-item',
-                j === renderData.length - 1 &&
-                  i === data.length - 1 &&
-                  'last-item',
-                i === 0 && 'first-of-type', // Different from css pseudo-class in case of injected items
-                i === data.length - 1 && 'last-of-type', // Different from css pseudo-class in case of injected items
-                (ignoreEventsBoolean || ignoreEvents) && 'ignore-events',
-                className
-              ),
-              active: __id === activeItem,
-              selected: !ignoreEvents && __id === selectedItem,
-              onClick: selectItemHandler,
-              onKeyDown: preventTab,
-              onMouseEnter: onItemMouseEnterHandler
-                ? (e: MouseEvent<HTMLLIElement>) =>
-                    onItemMouseEnterHandler(__id, e)
-                : undefined,
-              disabled: disabled,
-              style: style,
-            }
-            if (ignoreEventsBoolean) {
-              liParams.active = null
-              liParams.selected = null
-              liParams.onClick = null
-              liParams.onKeyDown = null
-              liParams.onMouseEnter = null
-              liParams.className = clsx(
-                liParams.className,
-                'dnb-drawer-list__option--ignore'
-              )
-            }
-
-            return (
-              <DrawerList.Item key={hash} {...liParams}>
-                {dataItem}
-              </DrawerList.Item>
-            )
-          })
+          data.map((dataItem, i) => renderItem(dataItem, i, j, data))
         const ItemsRendered = () =>
           typeof optionsRender === 'function' ? (
             optionsRender({ data, Items, Item: DrawerList.Item })
@@ -665,13 +721,67 @@ const DrawerListComponent = memo(function DrawerListComponent(
         }
       })
 
+  let optionPosition = 0
+  const driverRows: DrawerListDriverRow[] = activeListDriver
+    ? renderData.filter(Boolean).flatMap((group, j) => {
+        const groupId = `${id}-group-title-${j}`
+        const groupRows: DrawerListDriverRow[] = []
+
+        if (hasGroups) {
+          groupRows.push({
+            key: groupId,
+            type: 'group',
+            render: (props = {}) => (
+              <li
+                {...props}
+                id={groupId}
+                role="presentation"
+                className={clsx(
+                  'dnb-drawer-list__group-title',
+                  group.hideTitle && 'dnb-sr-only',
+                  props.className
+                )}
+              >
+                {group.groupTitle}
+              </li>
+            ),
+          })
+        }
+
+        group.groupData.forEach((dataItem, i) => {
+          optionPosition += 1
+          const ariaPosition = optionPosition
+          groupRows.push({
+            key: `option-${id}-${dataItem.__id}`,
+            type: 'option',
+            itemId: dataItem.__id,
+            keepMounted: Boolean(dataItem.showAll),
+            render: (props = {}) =>
+              renderItem(dataItem, i, j, group.groupData, {
+                ...props,
+                'aria-describedby': hasGroups ? groupId : undefined,
+                'aria-posinset': ariaPosition,
+                'aria-setsize': data.length,
+              }),
+          })
+        })
+
+        return groupRows
+      })
+    : []
+  const activeIndex = driverRows.findIndex(
+    ({ itemId }) => itemId === activeItem
+  )
+  const selectedIndex = driverRows.findIndex(
+    ({ itemId }) => itemId === selectedItem
+  )
+
   const mainList = (
     <span {...mainParams} ref={_refShell}>
       <span {...listParams}>
         {hidden === false && renderData.length > 0 ? (
           <>
             <DrawerList.Options
-              hasGroups={hasGroups}
               cacheHash={
                 cacheHash +
                 activeItem +
@@ -680,8 +790,23 @@ const DrawerListComponent = memo(function DrawerListComponent(
                 maxHeight
               }
               {...ulParams}
+              renderDriver={activeListDriver}
+              hasGroups={activeListDriver ? false : hasGroups}
             >
-              <GroupItems />
+              {activeListDriver ? (
+                <activeListDriver.Renderer
+                  rows={driverRows}
+                  activeIndex={activeIndex}
+                  selectedIndex={selectedIndex}
+                  open={Boolean(open)}
+                  listRef={_refUl}
+                  registerListDriver={
+                    context.drawerList.registerListDriver
+                  }
+                />
+              ) : (
+                <GroupItems />
+              )}
             </DrawerList.Options>
             <OnMounted
               addObservers={addObservers}
@@ -777,6 +902,7 @@ export type DrawerListOptionsProps = HTMLProps<HTMLUListElement> & {
   children: ReactNode
   cacheHash?: string
   hasGroups?: boolean
+  renderDriver?: DrawerListDriver
 }
 // DrawerList List
 DrawerList.Options = memo(
@@ -785,6 +911,7 @@ DrawerList.Options = memo(
     className,
     cacheHash,
     hasGroups = false,
+    renderDriver: _renderDriver,
     ref,
     ...rest
   }: DrawerListOptionsProps & {
@@ -806,7 +933,10 @@ DrawerList.Options = memo(
     if (!prevProps.cacheHash) {
       return false
     }
-    return prevProps.cacheHash === nextProps.cacheHash
+    return (
+      prevProps.cacheHash === nextProps.cacheHash &&
+      prevProps.renderDriver === nextProps.renderDriver
+    )
   }
 )
 

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListDocs.ts
@@ -151,6 +151,11 @@ export const DrawerListProperties: PropertiesTableProps = {
     type: 'function',
     status: 'optional',
   },
+  listDriver: {
+    doc: 'Opt in to a custom list renderer. Use `createDrawerListVirtualization` from `@dnb/eufemia/fragments/drawer-list/Virtualization` to render large data sets without mounting every option. Install the optional `@tanstack/react-virtual` peer dependency when using this driver. Cannot be combined with `optionsRender`.',
+    type: 'DrawerListDriver',
+    status: 'optional',
+  },
   '[Space](/uilib/layout/space/properties)': {
     doc: 'Spacing properties like `top` or `bottom` are supported.',
     type: ['string', 'object'],

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListHelpers.ts
@@ -62,6 +62,7 @@ export const drawerListDefaultProps: Partial<DrawerListProps> = {
   onResize: null,
   onSelect: null,
   optionsRender: null,
+  listDriver: null,
 }
 
 export const drawerListProviderDefaultProps: Partial<DrawerListProviderProps> =

--- a/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/DrawerListProvider.tsx
@@ -81,6 +81,7 @@ export type DrawerListProviderChainable = {
   selectItem: DrawerListProviderProps['selectItem']
   selectItemAndClose: DrawerListProviderProps['selectItemAndClose']
   scrollToItem: DrawerListProviderProps['scrollToItem']
+  registerListDriver: DrawerListProviderProps['registerListDriver']
   setActiveItemAndScrollToIt: DrawerListProviderProps['setActiveItemAndScrollToIt']
   addObservers: () => void
   removeObservers: () => void
@@ -148,6 +149,10 @@ export type DrawerListProviderProps = Omit<DrawerListProps, 'children'> &
         element?: HTMLElement
       }
     ) => void
+    registerListDriver?: (driver: {
+      itemIds: number[]
+      scrollToItem: (itemId: number, smooth: boolean) => void
+    }) => () => void
     setActiveItemAndScrollToIt?: (
       activeItem: string | number,
       args?: {
@@ -242,6 +247,10 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   const showTimeoutRef = useRef<NodeJS.Timeout>(null)
   const hideTimeoutRef = useRef<NodeJS.Timeout>(null)
   const scrollTimeoutRef = useRef<NodeJS.Timeout>(undefined)
+  const listDriverRef = useRef<{
+    itemIds: number[]
+    scrollToItem: (itemId: number, smooth: boolean) => void
+  } | null>(null)
   const directionTimeoutRef = useRef<NodeJS.Timeout>(null)
 
   const bodyLockEnabledRef = useRef(false)
@@ -581,15 +590,29 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
 
   const getCurrentSelectedItem = useCallback(() => {
     const elem = getSelectedElement()
-    return getItemData(elem)
+    return (
+      getItemData(elem) ??
+      (listDriverRef.current ? stateRef.current.selectedItem : undefined)
+    )
   }, [getSelectedElement, getItemData])
 
   const getCurrentActiveItem = useCallback(() => {
     const elem = getActiveElement()
-    return getItemData(elem)
+    return (
+      getItemData(elem) ??
+      (listDriverRef.current ? stateRef.current.activeItem : undefined)
+    )
   }, [getActiveElement, getItemData])
 
   const getNextActiveItem = useCallback(() => {
+    if (listDriverRef.current) {
+      const { itemIds } = listDriverRef.current
+      const currentIndex = itemIds.indexOf(
+        Number(stateRef.current.activeItem)
+      )
+      return itemIds[currentIndex + 1]
+    }
+
     const activeElement = getActiveElement()
 
     const elem =
@@ -604,6 +627,14 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   }, [getActiveElement, getElementGroup, getItemData])
 
   const getPrevActiveItem = useCallback(() => {
+    if (listDriverRef.current) {
+      const { itemIds } = listDriverRef.current
+      const currentIndex = itemIds.indexOf(
+        Number(stateRef.current.activeItem)
+      )
+      return itemIds[currentIndex - 1]
+    }
+
     const activeElement = getActiveElement()
 
     const elem =
@@ -621,6 +652,10 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   }, [getActiveElement, getElementGroup, getItemData])
 
   const getFirstItem = useCallback(() => {
+    if (listDriverRef.current) {
+      return listDriverRef.current.itemIds[0]
+    }
+
     const elem = _refUl.current?.querySelector<HTMLLIElement>(
       'li.dnb-drawer-list__option.first-item'
     )
@@ -628,11 +663,30 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
   }, [getItemData])
 
   const getLastItem = useCallback(() => {
+    if (listDriverRef.current) {
+      return listDriverRef.current.itemIds.slice(-1)[0]
+    }
+
     const elem = _refUl.current?.querySelector<HTMLLIElement>(
       'li.dnb-drawer-list__option.last-item'
     )
     return getItemData(elem)
   }, [getItemData])
+
+  const registerListDriver = useCallback(
+    (driver: {
+      itemIds: number[]
+      scrollToItem: (itemId: number, smooth: boolean) => void
+    }) => {
+      listDriverRef.current = driver
+      return () => {
+        if (listDriverRef.current === driver) {
+          listDriverRef.current = null
+        }
+      }
+    },
+    []
+  )
 
   /**
    * Returns the first anchor element within the given element, or null if none found.
@@ -678,6 +732,14 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
         scrollTimeoutRef.current = setTimeout(() => {
           if (_refUl.current && parseFloat(activeItem as string) > -1) {
             try {
+              if (listDriverRef.current) {
+                listDriverRef.current.scrollToItem(
+                  Number(activeItem),
+                  scrollTo !== false
+                )
+                return
+              }
+
               const ulElement = _refUl.current
               const liElement =
                 element || getActiveElement() || getSelectedElement()
@@ -1292,7 +1354,9 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
             return // stop here
           }
 
-          activeItem = getCurrentActiveItem() ?? getCurrentSelectedItem()
+          activeItem = Number(
+            getCurrentActiveItem() ?? getCurrentSelectedItem()
+          )
 
           if (
             propsRef.current.skipKeysearch
@@ -1500,6 +1564,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
     selectItem,
     selectItemAndClose,
     scrollToItem,
+    registerListDriver,
     setActiveItemAndScrollToIt,
     addObservers,
     removeObservers,
@@ -1527,6 +1592,7 @@ function DrawerListProviderComponent(ownProps: DrawerListProviderProps) {
           selectItem,
           selectItemAndClose,
           scrollToItem,
+          registerListDriver,
           setActiveItemAndScrollToIt,
           ...stateRef.current,
         },

--- a/packages/dnb-eufemia/src/fragments/drawer-list/Virtualization.ts
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/Virtualization.ts
@@ -1,0 +1,6 @@
+export {
+  createDrawerListVirtualization as default,
+  createDrawerListVirtualization,
+  virtualizedDrawerList,
+} from './Virtualized'
+export type { DrawerListVirtualizationOptions } from './Virtualized'

--- a/packages/dnb-eufemia/src/fragments/drawer-list/Virtualized.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/Virtualized.tsx
@@ -1,0 +1,284 @@
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useMemo,
+  useReducer,
+  useRef,
+} from 'react'
+import {
+  defaultRangeExtractor,
+  observeElementRect,
+  useVirtualizer,
+} from '@tanstack/react-virtual'
+import type { Range } from '@tanstack/react-virtual'
+import type { DrawerListDriver, DrawerListDriverProps } from './DrawerList'
+import { useIsomorphicLayoutEffect } from '../../shared/helpers/useIsomorphicLayoutEffect'
+
+export type DrawerListVirtualizationOptions = {
+  /** Estimated row height in pixels before a row has been measured. */
+  estimateSize?: number
+  /** Number of rows rendered before and after the visible range. */
+  overscan?: number
+}
+
+export function createDrawerListVirtualization({
+  estimateSize = 48,
+  overscan = 5,
+}: DrawerListVirtualizationOptions = {}): DrawerListDriver {
+  const Renderer = memo(function DrawerListVirtualizedRenderer(
+    props: DrawerListDriverProps
+  ) {
+    return (
+      <VirtualizedRenderer
+        {...props}
+        estimateSize={estimateSize}
+        overscan={overscan}
+      />
+    )
+  })
+
+  return {
+    Renderer,
+  }
+}
+
+function VirtualizedRenderer({
+  rows,
+  activeIndex,
+  selectedIndex,
+  open,
+  listRef,
+  registerListDriver,
+  estimateSize,
+  overscan,
+}: DrawerListDriverProps & Required<DrawerListVirtualizationOptions>) {
+  const isServer = typeof window === 'undefined'
+  const rerender = useReducer((count) => count + 1, 0)[1]
+  const rowMetadata = useMemo(() => {
+    let groupIndex = -1
+    const groupIndexes: number[] = []
+    const keepMountedIndexes: number[] = []
+
+    rows.forEach((row, index) => {
+      if (row.type === 'group') {
+        groupIndex = index
+      }
+      groupIndexes[index] = groupIndex
+      if (row.keepMounted) {
+        keepMountedIndexes.push(index)
+      }
+    })
+
+    return { groupIndexes, keepMountedIndexes }
+  }, [rows])
+  const measureElement = useCallback(
+    (element: Element) => {
+      const style = getComputedStyle(element)
+      const measuredSize =
+        element.getBoundingClientRect().height +
+        parseFloat(style.marginTop || '0') +
+        parseFloat(style.marginBottom || '0')
+
+      return measuredSize > 0 ? measuredSize : estimateSize
+    },
+    [estimateSize]
+  )
+
+  const rangeExtractor = useCallback(
+    (range: Range) => {
+      const indexes = new Set(defaultRangeExtractor(range))
+
+      const focusedIndex = activeIndex > -1 ? activeIndex : selectedIndex
+      if (focusedIndex > -1) {
+        const endIndex = Math.min(
+          rows.length - 1,
+          focusedIndex + Math.ceil(range.endIndex - range.startIndex)
+        )
+        for (let index = focusedIndex; index <= endIndex; index++) {
+          indexes.add(index)
+        }
+      }
+      rowMetadata.keepMountedIndexes.forEach((index) => indexes.add(index))
+
+      Array.from(indexes).forEach((index) => {
+        const groupIndex = rowMetadata.groupIndexes[index]
+        if (groupIndex > -1) {
+          indexes.add(groupIndex)
+        }
+      })
+
+      return Array.from(indexes).sort((a, b) => a - b)
+    },
+    [activeIndex, rowMetadata, rows.length, selectedIndex]
+  )
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    enabled: !isServer,
+    getScrollElement: () => listRef.current,
+    observeElementRect: (instance, callback) =>
+      observeElementRect(instance, (rect) => {
+        callback(
+          rect.height > 0
+            ? rect
+            : { width: rect.width, height: estimateSize * 8 }
+        )
+      }),
+    estimateSize: () => estimateSize,
+    measureElement,
+    getItemKey: (index) => rows[index].key,
+    initialRect: { width: 1, height: estimateSize * 8 },
+    initialOffset: 0,
+    useFlushSync: false,
+    overscan,
+    rangeExtractor,
+  })
+  const itemIndexes = useMemo(() => {
+    return new Map(
+      rows.flatMap(({ itemId }, index) =>
+        typeof itemId === 'number' ? [[itemId, index]] : []
+      )
+    )
+  }, [rows])
+  const itemIds = useMemo(() => {
+    return rows.flatMap(({ itemId }) =>
+      typeof itemId === 'number' ? [itemId] : []
+    )
+  }, [rows])
+  const previousItemIdsRef = useRef(itemIds)
+  const scrollToItem = useCallback(
+    (itemId: number, smooth: boolean) => {
+      const index = itemIndexes.get(itemId)
+      if (typeof index === 'number') {
+        virtualizer.scrollToIndex(index, {
+          align: 'auto',
+          behavior: smooth ? 'smooth' : 'auto',
+        })
+      }
+    },
+    [itemIndexes, virtualizer]
+  )
+  const virtualRows = isServer
+    ? rows.slice(0, overscan * 2 + 1).map((_, index) => ({
+        index,
+        start: index * estimateSize,
+      }))
+    : virtualizer.getVirtualItems()
+  const totalSize = isServer
+    ? rows.length * estimateSize
+    : virtualizer.getTotalSize()
+  useIsomorphicLayoutEffect(() => {
+    return registerListDriver({
+      itemIds,
+      scrollToItem,
+    })
+  }, [itemIds, registerListDriver, scrollToItem])
+
+  useIsomorphicLayoutEffect(() => {
+    const frame = requestAnimationFrame(rerender)
+    return () => cancelAnimationFrame(frame)
+  }, [rerender])
+
+  useIsomorphicLayoutEffect(() => {
+    const previousItemIds = previousItemIdsRef.current
+    previousItemIdsRef.current = itemIds
+    const hasItemOrderChanged =
+      itemIds.length !== previousItemIds.length ||
+      itemIds.some((itemId, index) => itemId !== previousItemIds[index])
+
+    if (!hasItemOrderChanged) {
+      return
+    }
+
+    const scrollElement = listRef.current
+    if (!scrollElement) {
+      return
+    }
+
+    if (scrollElement.scrollTop) {
+      scrollElement.scrollTop = 0
+      scrollElement.dispatchEvent(new Event('scroll'))
+    }
+    virtualizer.scrollOffset = 0
+  }, [itemIds, listRef, virtualizer])
+
+  const activeItemId =
+    activeIndex > -1 ? rows[activeIndex]?.itemId : undefined
+  const selectedItemId =
+    selectedIndex > -1 ? rows[selectedIndex]?.itemId : undefined
+  const focusedItemId = activeItemId ?? selectedItemId
+  const focusedItemIdRef = useRef(focusedItemId)
+  focusedItemIdRef.current = focusedItemId
+
+  useIsomorphicLayoutEffect(() => {
+    const itemId = focusedItemIdRef.current
+    if (!open || typeof itemId !== 'number') {
+      return undefined
+    }
+
+    let attempts = 0
+    let frame = 0
+    const revealActiveItem = () => {
+      const scrollElement = listRef.current
+      if (scrollElement) {
+        scrollElement.style.scrollBehavior = 'auto'
+        const activeElement = scrollElement.querySelector<HTMLElement>(
+          `[data-item="${itemId}"]`
+        )
+        const scrollRect = scrollElement.getBoundingClientRect()
+        const activeRect = activeElement?.getBoundingClientRect()
+
+        if (activeRect) {
+          const nextTop =
+            scrollElement.scrollTop + activeRect.top - scrollRect.top - 8
+          scrollElement.scrollTop = Math.max(0, nextTop)
+          scrollElement.dispatchEvent(new Event('scroll'))
+        }
+      }
+
+      attempts += 1
+      if (attempts < 3) {
+        frame = requestAnimationFrame(revealActiveItem)
+      }
+    }
+
+    frame = requestAnimationFrame(revealActiveItem)
+    return () => cancelAnimationFrame(frame)
+  }, [listRef, open])
+
+  return (
+    <li
+      role="presentation"
+      className="dnb-drawer-list__virtual-content"
+      style={{ height: totalSize }}
+    >
+      <ul role="presentation">
+        {virtualRows.map((virtualRow) => {
+          const row = rows[virtualRow.index]
+
+          return (
+            <Fragment key={row.key}>
+              {row.render({
+                ref: virtualizer.measureElement,
+                'data-index': virtualRow.index,
+                className: 'dnb-drawer-list__virtual-row',
+                style: {
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                },
+              })}
+            </Fragment>
+          )
+        })}
+      </ul>
+    </li>
+  )
+}
+
+export default createDrawerListVirtualization
+
+export const virtualizedDrawerList = createDrawerListVirtualization()

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/Virtualized.test.tsx
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/Virtualized.test.tsx
@@ -1,0 +1,594 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderToString } from 'react-dom/server'
+import { axeComponent } from '../../../core/test-utils/testSetup'
+import Autocomplete from '../../../components/autocomplete/Autocomplete'
+import Dropdown from '../../../components/dropdown/Dropdown'
+import { createDrawerListVirtualization } from '../Virtualized'
+import { mockImplementationForDirectionObserver } from './DrawerListTestMocks'
+
+mockImplementationForDirectionObserver()
+
+const data = Array.from({ length: 1000 }, (_, index) => `Item ${index}`)
+const listDriver = createDrawerListVirtualization({ overscan: 2 })
+
+function scrollListenerCount(
+  addEventListener: ReturnType<typeof vi.spyOn>
+) {
+  return addEventListener.mock.instances.filter(
+    (instance, index) =>
+      addEventListener.mock.calls[index][0] === 'scroll' &&
+      instance instanceof HTMLElement &&
+      instance.classList.contains('dnb-drawer-list__options')
+  ).length
+}
+
+describe('DrawerList virtualization', () => {
+  beforeEach(() => {
+    vi.spyOn(
+      HTMLElement.prototype,
+      'getBoundingClientRect'
+    ).mockImplementation(function (this: HTMLElement) {
+      const index = Number(this.getAttribute('data-index') || 0)
+      const top =
+        index * 48 - (this.closest('[role=listbox]')?.scrollTop || 0)
+      return {
+        top,
+        bottom: top + 48,
+        height: 48,
+        width: 320,
+        x: 0,
+        y: top,
+        left: 0,
+        right: 320,
+        toJSON: () => ({}),
+      }
+    })
+  })
+
+  it('renders an initial window during SSR', () => {
+    const html = renderToString(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        inline
+        noAnimation
+        skipPortal
+      />
+    )
+
+    expect((html.match(/role="option"/g) || []).length).toBeGreaterThan(0)
+    expect((html.match(/role="option"/g) || []).length).toBeLessThan(
+      data.length
+    )
+  })
+
+  it('renders a window for Autocomplete while retaining the full dataset', async () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[role="option"]')
+      ).not.toHaveLength(0)
+    })
+    const options = document.querySelectorAll('[role="option"]')
+
+    expect(options.length).toBeGreaterThan(0)
+    expect(options.length).toBeLessThan(data.length)
+    expect(options[0]).toHaveAttribute('aria-posinset', '1')
+    expect(options[0]).toHaveAttribute('aria-setsize', '1000')
+  })
+
+  it('reattaches the scroll observer after reopening', async () => {
+    const addEventListener = vi.spyOn(
+      HTMLElement.prototype,
+      'addEventListener'
+    )
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        showSubmitButton
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const submitButton = document.querySelector<HTMLButtonElement>(
+      '#virtual-autocomplete-submit-button'
+    )
+    fireEvent.click(submitButton)
+    await waitFor(() => {
+      expect(scrollListenerCount(addEventListener)).toBe(1)
+    })
+
+    fireEvent.click(submitButton)
+    await waitFor(() => {
+      expect(
+        document.querySelector('#virtual-autocomplete-ul')
+      ).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(submitButton)
+    await waitFor(() => {
+      expect(scrollListenerCount(addEventListener)).toBe(2)
+    })
+
+    addEventListener.mockRestore()
+  })
+
+  it('reattaches the scroll observer after reopening by focus', async () => {
+    const addEventListener = vi.spyOn(
+      HTMLElement.prototype,
+      'addEventListener'
+    )
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const input = document.querySelector<HTMLInputElement>(
+      '#virtual-autocomplete'
+    )
+    await userEvent.click(input)
+    await waitFor(() => {
+      expect(scrollListenerCount(addEventListener)).toBe(1)
+    })
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => {
+      expect(
+        document.querySelector('#virtual-autocomplete-ul')
+      ).not.toBeInTheDocument()
+    })
+
+    await userEvent.click(document.body)
+    await userEvent.click(input)
+    await waitFor(() => {
+      expect(scrollListenerCount(addEventListener)).toBe(2)
+    })
+
+    addEventListener.mockRestore()
+  })
+
+  it('positions rows using their measured heights', async () => {
+    vi.mocked(
+      HTMLElement.prototype.getBoundingClientRect
+    ).mockImplementation(function (this: HTMLElement) {
+      const index = Number(this.getAttribute('data-index') || 0)
+      const height = index === 0 ? 96 : 48
+      const top =
+        (index === 0 ? 0 : 96 + (index - 1) * 48) -
+        (this.closest('[role=listbox]')?.scrollTop || 0)
+
+      return {
+        top,
+        bottom: top + height,
+        height,
+        width: 320,
+        x: 0,
+        y: top,
+        left: 0,
+        right: 320,
+        toJSON: () => ({}),
+      }
+    })
+
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('[data-index="1"]')
+      ).toHaveStyle({ transform: 'translateY(96px)' })
+    })
+  })
+
+  it('keeps keyboard navigation working beyond the initial window', () => {
+    const onChange = vi.fn()
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        onChange={onChange}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const input = document.querySelector('input')
+    input.focus()
+
+    for (let index = 0; index < 20; index++) {
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+    }
+
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'option-virtual-autocomplete-19'
+    )
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ data: 'Item 19' })
+    )
+  })
+
+  it('keeps keyboard focus moving through visible rows before scrolling', async () => {
+    vi.mocked(
+      HTMLElement.prototype.getBoundingClientRect
+    ).mockImplementation(function (this: HTMLElement) {
+      if (this.getAttribute('role') === 'listbox') {
+        return {
+          top: 0,
+          bottom: 384,
+          height: 384,
+          width: 320,
+          x: 0,
+          y: 0,
+          left: 0,
+          right: 320,
+          toJSON: () => ({}),
+        }
+      }
+
+      const index = Number(this.getAttribute('data-index') || 0)
+      const top =
+        index * 48 - (this.closest('[role=listbox]')?.scrollTop || 0)
+      return {
+        top,
+        bottom: top + 48,
+        height: 48,
+        width: 320,
+        x: 0,
+        y: top,
+        left: 0,
+        right: 320,
+        toJSON: () => ({}),
+      }
+    })
+
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const input = document.querySelector('input')
+    const list = document.querySelector<HTMLElement>(
+      '#virtual-autocomplete-ul'
+    )
+    input.focus()
+
+    for (let index = 0; index < 4; index++) {
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+    }
+
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'option-virtual-autocomplete-3'
+    )
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    )
+    expect(list.scrollTop).toBe(0)
+  })
+
+  it('keeps the selected item mounted when opening', async () => {
+    render(
+      <Dropdown
+        id="virtual-dropdown"
+        data={data}
+        value={999}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        document.getElementById('option-virtual-dropdown-999')
+      ).toBeInTheDocument()
+    })
+    expect(document.querySelector('#virtual-dropdown-ul')).toHaveAttribute(
+      'aria-activedescendant',
+      'option-virtual-dropdown-999'
+    )
+    await waitFor(() => {
+      expect(
+        document.querySelector('#virtual-dropdown-ul').scrollTop
+      ).toBeGreaterThan(0)
+    })
+  })
+
+  it('restores the full list around a selected Autocomplete item', async () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const input = document.querySelector('input')
+    await userEvent.click(input)
+    await userEvent.type(input, 'Item 117')
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'Item 117' })
+    )
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'false')
+    })
+    await userEvent.click(input)
+
+    const selectedOption = await screen.findByRole('option', {
+      name: 'Item 117',
+      selected: true,
+    })
+    expect(selectedOption).toHaveAttribute('aria-setsize', '1000')
+    expect(
+      screen.getByRole('option', { name: 'Item 118' })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps filtering usable after reopening a selected Autocomplete item', async () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const input = document.querySelector('input')
+    await userEvent.click(input)
+    await userEvent.type(input, 'Item 117')
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'Item 117' })
+    )
+    await userEvent.click(input)
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Item 999')
+
+    expect(
+      await screen.findByRole('option', { name: 'Item 999' })
+    ).toBeInTheDocument()
+  })
+
+  it('resets the scroll position when filtering after reopening a selected item', async () => {
+    const searchableData = Array.from({ length: 1000 }, (_, index) => ({
+      selectedKey: String(index),
+      content: `Item ${index + 1}`,
+    }))
+
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={searchableData}
+        listDriver={listDriver}
+        noAnimation
+        skipPortal
+      />
+    )
+
+    const input = document.querySelector('input')
+    await userEvent.click(input)
+    await userEvent.type(input, 'Item 123')
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'Item 123' })
+    )
+    await userEvent.click(input)
+
+    const list = document.querySelector<HTMLUListElement>(
+      '#virtual-autocomplete-ul'
+    )
+    await waitFor(() => {
+      expect(list.scrollTop).toBeGreaterThan(0)
+    })
+
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Item 124')
+    await waitFor(() => {
+      expect(list.scrollTop).toBe(0)
+    })
+    expect(
+      screen.getByRole('option', { name: 'Item 124' })
+    ).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'option-virtual-autocomplete-123'
+    )
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(input).toHaveValue('Item 124')
+    expect(input).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('keeps the complete dataset virtualized after show all', async () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+    fireEvent.change(document.querySelector('input'), {
+      target: { value: '999' },
+    })
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-autocomplete__show-all')
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(document.querySelector('.dnb-autocomplete__show-all'))
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.dnb-autocomplete__show-all')
+      ).not.toBeInTheDocument()
+    })
+
+    const options = document.querySelectorAll('[role="option"]')
+    expect(options.length).toBeGreaterThan(0)
+    expect(options.length).toBeLessThan(data.length)
+    expect(options[0]).toHaveAttribute('aria-setsize', '1000')
+  })
+
+  it('renders group labels required by visible options', async () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        groups={['First group', 'Second group']}
+        data={data.map((content, index) => ({
+          content,
+          groupIndex: index < 500 ? 0 : 1,
+        }))}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="option"]')).toBeInTheDocument()
+    })
+
+    const option = document.querySelector('[role="option"]')
+    const groupId = option.getAttribute('aria-describedby')
+    expect(document.getElementById(groupId)).toHaveTextContent(
+      'First group'
+    )
+  })
+
+  it('reports option positions across groups', async () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        groups={['First group', 'Second group']}
+        data={[
+          { content: 'First', groupIndex: 0 },
+          { content: 'Second', groupIndex: 1 },
+        ]}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="option"]')).toHaveLength(2)
+    })
+
+    const options = document.querySelectorAll('[role="option"]')
+    expect(options[0]).toHaveAttribute('aria-posinset', '1')
+    expect(options[1]).toHaveAttribute('aria-posinset', '2')
+    expect(options[1]).toHaveAttribute('aria-setsize', '2')
+  })
+
+  it('renders a window for Dropdown', async () => {
+    render(
+      <Dropdown
+        id="virtual-dropdown"
+        data={data}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[role="option"]')
+      ).not.toHaveLength(0)
+    })
+    const options = document.querySelectorAll('[role="option"]')
+
+    expect(options.length).toBeGreaterThan(0)
+    expect(options.length).toBeLessThan(data.length)
+  })
+
+  it('has valid accessibility semantics', async () => {
+    const result = render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        label="Items"
+        data={data}
+        listDriver={listDriver}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="option"]')).toBeInTheDocument()
+    })
+    expect(await axeComponent(result)).toHaveNoViolations()
+  })
+
+  it('falls back to optionsRender when both APIs are provided', () => {
+    render(
+      <Autocomplete
+        id="virtual-autocomplete"
+        data={data.slice(0, 3)}
+        listDriver={listDriver}
+        optionsRender={({ Items }) => (
+          <>
+            <Items />
+          </>
+        )}
+        open
+        noAnimation
+        skipPortal
+      />
+    )
+
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(3)
+  })
+})

--- a/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/__tests__/__snapshots__/DrawerList.test.tsx.snap
@@ -206,6 +206,23 @@ exports[`DrawerList scss > has to match style dependencies css 1`] = `
 .dnb-drawer-list__group.first-of-type .dnb-drawer-list__group-title {
   margin-top: calc(var(--drawer-list-padding) * -1);
 }
+.dnb-drawer-list__virtual-content, .dnb-drawer-list__virtual-content > ul {
+  position: relative;
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.dnb-drawer-list__virtual-content {
+  flex: none;
+}
+.dnb-drawer-list__virtual-content > ul {
+  height: 100%;
+}
+.dnb-drawer-list__virtual-row {
+  position: absolute;
+}
 .dnb-drawer-list__option {
   position: relative;
   z-index: 0;
@@ -779,6 +796,23 @@ exports[`DrawerList scss > have to match default theme snapshot 1`] = `
 }
 .dnb-drawer-list__group.first-of-type .dnb-drawer-list__group-title {
   margin-top: calc(var(--drawer-list-padding) * -1);
+}
+.dnb-drawer-list__virtual-content, .dnb-drawer-list__virtual-content > ul {
+  position: relative;
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.dnb-drawer-list__virtual-content {
+  flex: none;
+}
+.dnb-drawer-list__virtual-content > ul {
+  height: 100%;
+}
+.dnb-drawer-list__virtual-row {
+  position: absolute;
 }
 .dnb-drawer-list__option {
   position: relative;

--- a/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
+++ b/packages/dnb-eufemia/src/fragments/drawer-list/style/dnb-drawer-list.scss
@@ -251,6 +251,26 @@
       margin-top: calc(var(--drawer-list-padding) * -1);
     }
   }
+  &__virtual-content,
+  &__virtual-content > ul {
+    position: relative;
+
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+
+    list-style: none;
+  }
+  &__virtual-content {
+    flex: none;
+  }
+  &__virtual-content > ul {
+    height: 100%;
+  }
+  &__virtual-row {
+    position: absolute;
+  }
   // li element
   &__option {
     position: relative;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,6 +2794,7 @@ __metadata:
     "@semantic-release/release-notes-generator": "npm:14.1.1"
     "@svgr/core": "npm:6.5.1"
     "@svgr/plugin-jsx": "npm:6.5.1"
+    "@tanstack/react-virtual": "npm:3.14.10"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.7.0"
     "@testing-library/react": "npm:16.3.2"
@@ -2875,12 +2876,15 @@ __metadata:
     vitest: "npm:4.1.11"
     zod: "npm:4.4.3"
   peerDependencies:
+    "@tanstack/react-virtual": ^3.14.10
     "@types/react": ^19
     "@types/react-dom": ^19
     purgecss: ^8.0.0
     react: ^19
     react-dom: ^19
   peerDependenciesMeta:
+    "@tanstack/react-virtual":
+      optional: true
     "@types/react":
       optional: true
     "@types/react-dom":
@@ -5738,6 +5742,25 @@ __metadata:
   peerDependencies:
     "@svgr/core": ^6.0.0
   checksum: 10/42f22847a6bdf930514d7bedd3c5e1fd8d53eb3594779f9db16cb94c762425907c375cd8ec789114e100a4d38068aca6c7ab5efea4c612fba63f0630c44cc859
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-virtual@npm:3.14.10":
+  version: 3.14.10
+  resolution: "@tanstack/react-virtual@npm:3.14.10"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.17.8"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/2cfb17980499f927c783d0e1dbd2a080433338db358e2cbef5db37fc953207255b88aaa78592081ec9c1c1a6a1e86158e45cb80f3d82700128b8ce292136b534
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.17.8":
+  version: 3.17.8
+  resolution: "@tanstack/virtual-core@npm:3.17.8"
+  checksum: 10/b115caa01ccc748b97b5f1df7ee26e32fe82586da25d900630dc91297d35acaf90709cb5bf7fc0b85a86124aeb640cec7ac1a59ff6de9a6d25b7f53ddfce6a41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds opt-in virtualized list rendering for DrawerList consumers so large Autocomplete and Dropdown data sets remain responsive. The driver preserves filtering, keyboard navigation, groups, selected items, and variable-height rows without adding the virtualization library to default bundles.

Closes #1100

Preview: https://feat-drawer-list-virtualizat.eufemia-e25.pages.dev/uilib/components/autocomplete/demos#large-data-sets