### PR TITLE
chore(Portal): store URL hash and portal render flags in page-view path

### DIFF
--- a/packages/dnb-design-system-portal/src/core/FocusModeCodeContext.tsx
+++ b/packages/dnb-design-system-portal/src/core/FocusModeCodeContext.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react'
 import type { ReactNode } from 'react'
+import { useLocation, useNavigate } from 'react-router'
 
 const FOCUS_MODE_CODE_PARAM = 'focusmode'
 
@@ -27,6 +28,8 @@ export function FocusModeCodeProvider({
 }: {
   children: ReactNode
 }) {
+  const location = useLocation()
+  const navigate = useNavigate()
   const [focusModeCodeId, setFocusModeCodeIdState] = useState<
     string | null
   >(null)
@@ -38,7 +41,7 @@ export function FocusModeCodeProvider({
       return // stop here
     }
 
-    const params = new URLSearchParams(window.location.search)
+    const params = new URLSearchParams(location.search)
     const value = params.get(FOCUS_MODE_CODE_PARAM)
 
     if (value) {
@@ -64,34 +67,47 @@ export function FocusModeCodeProvider({
         const elementExists = document.getElementById(value)
 
         if (!elementExists) {
-          const url = new URL(window.location.href)
-          url.searchParams.delete(FOCUS_MODE_CODE_PARAM)
-          window.history.replaceState(null, '', url.toString())
+          const params = new URLSearchParams(location.search)
+          params.delete(FOCUS_MODE_CODE_PARAM)
+          navigate(
+            {
+              pathname: location.pathname,
+              search: params.toString(),
+              hash: location.hash,
+            },
+            { replace: true }
+          )
           setFocusModeCodeIdState(null)
         }
       }, 500)
 
       return () => clearTimeout(timeoutId)
     }
-  }, [])
+  }, [location, navigate])
 
-  const setFocusModeCodeId = useCallback((id: string | null) => {
-    setFocusModeCodeIdState(id)
+  const setFocusModeCodeId = useCallback(
+    (id: string | null) => {
+      setFocusModeCodeIdState(id)
 
-    if (typeof window === 'undefined') {
-      return // stop here
-    }
+      const params = new URLSearchParams(location.search)
 
-    const url = new URL(window.location.href)
+      if (id) {
+        params.set(FOCUS_MODE_CODE_PARAM, id)
+      } else {
+        params.delete(FOCUS_MODE_CODE_PARAM)
+      }
 
-    if (id) {
-      url.searchParams.set(FOCUS_MODE_CODE_PARAM, id)
-    } else {
-      url.searchParams.delete(FOCUS_MODE_CODE_PARAM)
-    }
-
-    window.history.replaceState(null, '', url.toString())
-  }, [])
+      navigate(
+        {
+          pathname: location.pathname,
+          search: params.toString(),
+          hash: location.hash,
+        },
+        { replace: true }
+      )
+    },
+    [location, navigate]
+  )
 
   return (
     <FocusModeCodeContext.Provider

--- a/packages/dnb-design-system-portal/src/core/FocusModeCodeContext.tsx
+++ b/packages/dnb-design-system-portal/src/core/FocusModeCodeContext.tsx
@@ -35,7 +35,7 @@ export function FocusModeCodeProvider({
   >(null)
   const savedScrollY = useRef(0)
 
-  // Read URL param on mount
+  // Read the URL param on mount and on every navigation
   useEffect(() => {
     if (typeof window === 'undefined') {
       return // stop here

--- a/packages/dnb-design-system-portal/src/core/__tests__/FocusModeCodeContext.test.tsx
+++ b/packages/dnb-design-system-portal/src/core/__tests__/FocusModeCodeContext.test.tsx
@@ -1,13 +1,42 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router'
 import {
   FocusModeCodeProvider,
   useFocusModeCode,
 } from '../FocusModeCodeContext'
 
 function Consumer() {
-  const { focusModeCodeId } = useFocusModeCode()
-  return <div data-testid="consumer">{focusModeCodeId ?? 'null'}</div>
+  const { focusModeCodeId, setFocusModeCodeId } = useFocusModeCode()
+  const location = useLocation()
+
+  return (
+    <>
+      <div data-testid="consumer">{focusModeCodeId ?? 'null'}</div>
+      <div data-testid="location">
+        {location.pathname + location.search + location.hash}
+      </div>
+      <button onClick={() => setFocusModeCodeId('my-block')}>
+        Enter focus mode
+      </button>
+      <button onClick={() => setFocusModeCodeId(null)}>
+        Exit focus mode
+      </button>
+    </>
+  )
+}
+
+function TestProvider({ children }: { children: React.ReactNode }) {
+  const initialEntry =
+    window.location.pathname +
+    window.location.search +
+    window.location.hash
+
+  return (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <FocusModeCodeProvider>{children}</FocusModeCodeProvider>
+    </MemoryRouter>
+  )
 }
 
 describe('FocusModeCodeContext', () => {
@@ -19,7 +48,6 @@ describe('FocusModeCodeContext', () => {
       value: new URL('http://localhost/'),
       writable: true,
     })
-    window.history.replaceState = vi.fn()
     sessionStorage.clear()
   })
 
@@ -39,9 +67,9 @@ describe('FocusModeCodeContext', () => {
     document.body.appendChild(element)
 
     const { getByTestId } = render(
-      <FocusModeCodeProvider>
+      <TestProvider>
         <Consumer />
-      </FocusModeCodeProvider>
+      </TestProvider>
     )
 
     expect(getByTestId('consumer').textContent).toBe('my-block')
@@ -55,9 +83,9 @@ describe('FocusModeCodeContext', () => {
     ) as unknown as Location & string
 
     const { getByTestId } = render(
-      <FocusModeCodeProvider>
+      <TestProvider>
         <Consumer />
-      </FocusModeCodeProvider>
+      </TestProvider>
     )
 
     expect(getByTestId('consumer').textContent).toBe('non-existent-id')
@@ -67,11 +95,7 @@ describe('FocusModeCodeContext', () => {
     })
 
     expect(getByTestId('consumer').textContent).toBe('null')
-    expect(window.history.replaceState).toHaveBeenCalledWith(
-      null,
-      '',
-      expect.not.stringContaining('focusmode')
-    )
+    expect(getByTestId('location').textContent).toBe('/')
   })
 
   it('keeps focusmode state when element exists after timeout', async () => {
@@ -84,9 +108,9 @@ describe('FocusModeCodeContext', () => {
     document.body.appendChild(element)
 
     const { getByTestId } = render(
-      <FocusModeCodeProvider>
+      <TestProvider>
         <Consumer />
-      </FocusModeCodeProvider>
+      </TestProvider>
     )
 
     expect(getByTestId('consumer').textContent).toBe('existing-block')
@@ -96,10 +120,8 @@ describe('FocusModeCodeContext', () => {
     })
 
     expect(getByTestId('consumer').textContent).toBe('existing-block')
-    expect(window.history.replaceState).not.toHaveBeenCalledWith(
-      null,
-      '',
-      expect.not.stringContaining('focusmode')
+    expect(getByTestId('location').textContent).toBe(
+      '/?focusmode=existing-block'
     )
 
     document.body.removeChild(element)
@@ -110,11 +132,35 @@ describe('FocusModeCodeContext', () => {
       string
 
     const { getByTestId } = render(
-      <FocusModeCodeProvider>
+      <TestProvider>
         <Consumer />
-      </FocusModeCodeProvider>
+      </TestProvider>
     )
 
     expect(getByTestId('consumer').textContent).toBe('null')
+  })
+
+  it('updates the router location when focus mode changes', () => {
+    window.location = new URL(
+      'http://localhost/uilib?q=term#examples'
+    ) as unknown as Location & string
+
+    const { getByRole, getByTestId } = render(
+      <TestProvider>
+        <Consumer />
+      </TestProvider>
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Enter focus mode' }))
+
+    expect(getByTestId('location').textContent).toBe(
+      '/uilib?q=term&focusmode=my-block#examples'
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Exit focus mode' }))
+
+    expect(getByTestId('location').textContent).toBe(
+      '/uilib?q=term#examples'
+    )
   })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { trackPageView } from '../client/track-page-view'
+import { trackPageView, buildTrackedPath } from '../client/track-page-view'
 
 function setBeacon(fn: unknown) {
   Object.defineProperty(navigator, 'sendBeacon', {
@@ -140,5 +140,61 @@ describe('trackPageView', () => {
     flush()
 
     expect(beacon).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('buildTrackedPath', () => {
+  const location = (pathname: string, search = '', hash = '') => ({
+    pathname,
+    search,
+    hash,
+  })
+
+  it('keeps the pathname and hash', () => {
+    expect(
+      buildTrackedPath(location('/uilib/components/button', '', '#events'))
+    ).toBe('/uilib/components/button#events')
+  })
+
+  it('keeps allow-listed portal query params', () => {
+    expect(
+      buildTrackedPath(location('/uilib/components/button', '?fullscreen'))
+    ).toBe('/uilib/components/button?fullscreen')
+
+    expect(buildTrackedPath(location('/', '?eufemia-theme=sbanken'))).toBe(
+      '/?eufemia-theme=sbanken'
+    )
+  })
+
+  it('drops query params that are not allow-listed', () => {
+    expect(
+      buildTrackedPath(location('/uilib', '?q=some+search+term'))
+    ).toBe('/uilib')
+  })
+
+  it('keeps only the allow-listed params from a mixed query', () => {
+    expect(
+      buildTrackedPath(
+        location('/uilib', '?q=secret&fullscreen&page=2', '#top')
+      )
+    ).toBe('/uilib?fullscreen#top')
+  })
+
+  it('reduces a flag to its key, dropping any crafted value', () => {
+    expect(
+      buildTrackedPath(location('/uilib', '?fullscreen=personal+data'))
+    ).toBe('/uilib?fullscreen')
+  })
+
+  it('drops a value param whose value is not a safe token', () => {
+    expect(
+      buildTrackedPath(location('/', '?eufemia-theme=personal+data'))
+    ).toBe('/')
+  })
+
+  it('does not match a param that merely ends with an allow-listed key', () => {
+    expect(
+      buildTrackedPath(location('/', '?x-eufemia-theme=sbanken'))
+    ).toBe('/')
   })
 })

--- a/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
@@ -150,51 +150,17 @@ describe('buildTrackedPath', () => {
     hash,
   })
 
-  it('keeps the pathname and hash', () => {
-    expect(
-      buildTrackedPath(location('/uilib/components/button', '', '#events'))
-    ).toBe('/uilib/components/button#events')
-  })
-
-  it('keeps allow-listed portal query params', () => {
-    expect(
-      buildTrackedPath(location('/uilib/components/button', '?fullscreen'))
-    ).toBe('/uilib/components/button?fullscreen')
-
-    expect(buildTrackedPath(location('/', '?eufemia-theme=sbanken'))).toBe(
-      '/?eufemia-theme=sbanken'
-    )
-  })
-
-  it('drops query params that are not allow-listed', () => {
-    expect(
-      buildTrackedPath(location('/uilib', '?q=some+search+term'))
-    ).toBe('/uilib')
-  })
-
-  it('keeps only the allow-listed params from a mixed query', () => {
+  it('returns the full in-app path (pathname, query and hash)', () => {
     expect(
       buildTrackedPath(
-        location('/uilib', '?q=secret&fullscreen&page=2', '#top')
+        location('/uilib/components/button', '?fullscreen', '#events')
       )
-    ).toBe('/uilib?fullscreen#top')
+    ).toBe('/uilib/components/button?fullscreen#events')
   })
 
-  it('reduces a flag to its key, dropping any crafted value', () => {
+  it('sends the raw query as-is; the collector minimises it on ingest', () => {
     expect(
-      buildTrackedPath(location('/uilib', '?fullscreen=personal+data'))
-    ).toBe('/uilib?fullscreen')
-  })
-
-  it('drops a value param whose value is not a safe token', () => {
-    expect(
-      buildTrackedPath(location('/', '?eufemia-theme=personal+data'))
-    ).toBe('/')
-  })
-
-  it('does not match a param that merely ends with an allow-listed key', () => {
-    expect(
-      buildTrackedPath(location('/', '?x-eufemia-theme=sbanken'))
-    ).toBe('/')
+      buildTrackedPath(location('/uilib', '?q=some+search+term'))
+    ).toBe('/uilib?q=some+search+term')
   })
 })

--- a/packages/dnb-design-system-portal/vite/client/portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/portal-app.tsx
@@ -18,7 +18,7 @@ import createEmotionCache from '@emotion/cache'
 import { Provider, Context, Theme } from '@dnb/eufemia/src/shared'
 import IsolatedStyleScope from '@dnb/eufemia/src/shared/IsolatedStyleScope'
 import { applyRouteFocus } from './route-focus'
-import { trackPageView } from './track-page-view'
+import { trackPageView, buildTrackedPath } from './track-page-view'
 import { MDXProvider } from '@mdx-js/react'
 import { usePrefetchOnHover } from 'virtual:prefetch-on-hover'
 import { useCatchLinks } from 'virtual:catch-links'
@@ -171,8 +171,8 @@ function TrackPageView() {
   const location = useLocation()
 
   useEffect(() => {
-    trackPageView(location.pathname)
-  }, [location.pathname])
+    trackPageView(buildTrackedPath(location))
+  }, [location.pathname, location.search, location.hash])
 
   return null
 }

--- a/packages/dnb-design-system-portal/vite/client/track-page-view.ts
+++ b/packages/dnb-design-system-portal/vite/client/track-page-view.ts
@@ -32,9 +32,12 @@ function analyticsEnv(): string {
 type PageViewEvent = { path: string; timestamp: string; env: string }
 
 /**
- * The in-app path to record for a location: its pathname, query and hash. The
- * collector minimises this to a safe shape on ingest, so the full path is sent
- * as-is.
+ * The in-app path to record for a location: its pathname, query and hash.
+ *
+ * Sent raw on purpose: minimisation is centralised in the collector's
+ * `normalizeTrackedPath`, which drops search terms and other incidental query
+ * values at ingest. Do not strip here — that would only duplicate, and risk
+ * drifting from, the authoritative server-side allow-list.
  */
 export function buildTrackedPath(location: {
   pathname: string

--- a/packages/dnb-design-system-portal/vite/client/track-page-view.ts
+++ b/packages/dnb-design-system-portal/vite/client/track-page-view.ts
@@ -1,14 +1,14 @@
 /**
  * Anonymous page-view tracking for the docs portal.
  *
- * The pathname and hash are sent, plus a short allow-list of query params that
- * drive portal rendering (see {@link buildTrackedPath}); any other query value,
- * such as a docs search term, is dropped. No identifiers, cookies or device
- * storage are used. Events are buffered in memory and flushed with `sendBeacon`
- * when the page is hidden or unloaded, or eagerly once the buffer reaches the
- * collector's batch limit, so navigation is never blocked and nothing is
- * retried across reloads. Consecutive views of the same path (e.g. a re-mount)
- * are recorded once.
+ * The in-app path (pathname, query and hash) is sent; the collector minimises
+ * it to a safe shape — dropping docs search terms and other incidental query
+ * values — before storing, so nothing incidental is persisted. No identifiers,
+ * cookies or device storage are used. Events are buffered in memory and flushed
+ * with `sendBeacon` when the page is hidden or unloaded, or eagerly once the
+ * buffer reaches the collector's batch limit, so navigation is never blocked
+ * and nothing is retried across reloads. Consecutive views of the same path
+ * (e.g. a re-mount) are recorded once.
  */
 
 // The collector URL and the single on/off switch: tracking is OFF unless a
@@ -31,43 +31,17 @@ function analyticsEnv(): string {
 
 type PageViewEvent = { path: string; timestamp: string; env: string }
 
-// Valueless portal flags that change how a page renders (fullscreen view, code
-// focus mode). Only the key is kept, so a crafted value cannot smuggle free
-// text into analytics.
-const TRACKED_FLAG_PARAMS = new Set(['fullscreen', 'focusmode'])
-
-// Portal params with a meaningful value (the active theme). Kept only when the
-// value is a short lowercase token, so anything else is dropped.
-const TRACKED_VALUE_PARAMS = new Set(['eufemia-theme'])
-const SAFE_PARAM_VALUE = /^[a-z][a-z0-9-]{0,31}$/
-
 /**
- * Build the path to record: the pathname, a short allow-list of portal query
- * params, and the hash. Flags are reduced to their key and value params are
- * kept only for a safe token; every other query param (e.g. a docs search
- * term) is dropped so no incidental data is stored.
+ * The in-app path to record for a location: its pathname, query and hash. The
+ * collector minimises this to a safe shape on ingest, so the full path is sent
+ * as-is.
  */
 export function buildTrackedPath(location: {
   pathname: string
   search: string
   hash: string
 }): string {
-  const kept: string[] = []
-
-  new URLSearchParams(location.search).forEach((value, key) => {
-    if (TRACKED_FLAG_PARAMS.has(key)) {
-      kept.push(key)
-    } else if (
-      TRACKED_VALUE_PARAMS.has(key) &&
-      SAFE_PARAM_VALUE.test(value)
-    ) {
-      kept.push(`${key}=${value}`)
-    }
-  })
-
-  const query = kept.length > 0 ? '?' + kept.join('&') : ''
-
-  return location.pathname + query + location.hash
+  return location.pathname + location.search + location.hash
 }
 
 // Flush once the buffer reaches the collector's batch limit, so a long session

--- a/packages/dnb-design-system-portal/vite/client/track-page-view.ts
+++ b/packages/dnb-design-system-portal/vite/client/track-page-view.ts
@@ -1,9 +1,11 @@
 /**
  * Anonymous page-view tracking for the docs portal.
  *
- * Only the pathname is sent (no query, hash, identifiers, cookies or device
- * storage). Events are buffered in memory and flushed with `sendBeacon` when
- * the page is hidden or unloaded, or eagerly once the buffer reaches the
+ * The pathname and hash are sent, plus a short allow-list of query params that
+ * drive portal rendering (see {@link buildTrackedPath}); any other query value,
+ * such as a docs search term, is dropped. No identifiers, cookies or device
+ * storage are used. Events are buffered in memory and flushed with `sendBeacon`
+ * when the page is hidden or unloaded, or eagerly once the buffer reaches the
  * collector's batch limit, so navigation is never blocked and nothing is
  * retried across reloads. Consecutive views of the same path (e.g. a re-mount)
  * are recorded once.
@@ -28,6 +30,45 @@ function analyticsEnv(): string {
 }
 
 type PageViewEvent = { path: string; timestamp: string; env: string }
+
+// Valueless portal flags that change how a page renders (fullscreen view, code
+// focus mode). Only the key is kept, so a crafted value cannot smuggle free
+// text into analytics.
+const TRACKED_FLAG_PARAMS = new Set(['fullscreen', 'focusmode'])
+
+// Portal params with a meaningful value (the active theme). Kept only when the
+// value is a short lowercase token, so anything else is dropped.
+const TRACKED_VALUE_PARAMS = new Set(['eufemia-theme'])
+const SAFE_PARAM_VALUE = /^[a-z][a-z0-9-]{0,31}$/
+
+/**
+ * Build the path to record: the pathname, a short allow-list of portal query
+ * params, and the hash. Flags are reduced to their key and value params are
+ * kept only for a safe token; every other query param (e.g. a docs search
+ * term) is dropped so no incidental data is stored.
+ */
+export function buildTrackedPath(location: {
+  pathname: string
+  search: string
+  hash: string
+}): string {
+  const kept: string[] = []
+
+  new URLSearchParams(location.search).forEach((value, key) => {
+    if (TRACKED_FLAG_PARAMS.has(key)) {
+      kept.push(key)
+    } else if (
+      TRACKED_VALUE_PARAMS.has(key) &&
+      SAFE_PARAM_VALUE.test(value)
+    ) {
+      kept.push(`${key}=${value}`)
+    }
+  })
+
+  const query = kept.length > 0 ? '?' + kept.join('&') : ''
+
+  return location.pathname + query + location.hash
+}
 
 // Flush once the buffer reaches the collector's batch limit, so a long session
 // cannot grow the buffer unbounded or exceed the sendBeacon payload cap.
@@ -82,7 +123,7 @@ function registerFlush(): void {
   })
 }
 
-/** Record a single anonymous page view for the given pathname. */
+/** Record a single anonymous page view for the given in-app path. */
 export function trackPageView(path: string): void {
   if (!canTrack()) {
     return

--- a/tools/analytics/__tests__/portal-view.test.ts
+++ b/tools/analytics/__tests__/portal-view.test.ts
@@ -106,13 +106,13 @@ describe('validatePortalViews', () => {
 describe('buildPortalViewRecord', () => {
   const createdAt = '2026-09-07T12:00:00.000Z'
 
-  it('strips the query string and fragment from the path', () => {
+  it('keeps the query string and fragment in the path', () => {
     const record = buildPortalViewRecord(
-      { path: '/a?q=secret#frag' },
+      { path: '/a?tab=demos#example' },
       createdAt
     )
 
-    expect(record.path).toBe('/a')
+    expect(record.path).toBe('/a?tab=demos#example')
   })
 
   it('defaults env to "unknown" and timestamp to the receive time', () => {

--- a/tools/analytics/__tests__/portal-view.test.ts
+++ b/tools/analytics/__tests__/portal-view.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   validatePortalViews,
   buildPortalViewRecord,
+  normalizeTrackedPath,
 } from '../src/records/portal-view.js'
 
 describe('validatePortalViews', () => {
@@ -106,13 +107,13 @@ describe('validatePortalViews', () => {
 describe('buildPortalViewRecord', () => {
   const createdAt = '2026-09-07T12:00:00.000Z'
 
-  it('keeps the query string and fragment in the path', () => {
+  it('minimises the path when building the record', () => {
     const record = buildPortalViewRecord(
-      { path: '/a?tab=demos#example' },
+      { path: '/a?q=secret&fullscreen#example' },
       createdAt
     )
 
-    expect(record.path).toBe('/a?tab=demos#example')
+    expect(record.path).toBe('/a?fullscreen#example')
   })
 
   it('defaults env to "unknown" and timestamp to the receive time', () => {
@@ -149,5 +150,56 @@ describe('buildPortalViewRecord', () => {
       'path',
       'timestamp',
     ])
+  })
+})
+
+describe('normalizeTrackedPath', () => {
+  it('keeps the pathname and an anchor fragment', () => {
+    expect(normalizeTrackedPath('/uilib/components/button#events')).toBe(
+      '/uilib/components/button#events'
+    )
+  })
+
+  it('keeps allow-listed render params', () => {
+    expect(normalizeTrackedPath('/a?fullscreen')).toBe('/a?fullscreen')
+    expect(normalizeTrackedPath('/?eufemia-theme=sbanken')).toBe(
+      '/?eufemia-theme=sbanken'
+    )
+  })
+
+  it('drops query params that are not allow-listed', () => {
+    expect(normalizeTrackedPath('/uilib?q=some+search+term')).toBe(
+      '/uilib'
+    )
+  })
+
+  it('reduces a flag to its key, dropping any crafted value', () => {
+    expect(normalizeTrackedPath('/a?fullscreen=personal+data')).toBe(
+      '/a?fullscreen'
+    )
+    expect(normalizeTrackedPath('/a?focusmode=my-block')).toBe(
+      '/a?focusmode'
+    )
+  })
+
+  it('drops a value param whose value is not a safe token', () => {
+    expect(normalizeTrackedPath('/?eufemia-theme=personal+data')).toBe('/')
+  })
+
+  it('does not match a param that merely ends with an allow-listed key', () => {
+    expect(normalizeTrackedPath('/?x-eufemia-theme=sbanken')).toBe('/')
+  })
+
+  it('emits allow-listed params in canonical order', () => {
+    expect(normalizeTrackedPath('/a?fullscreen&eufemia-theme=ui')).toBe(
+      '/a?eufemia-theme=ui&fullscreen'
+    )
+    expect(normalizeTrackedPath('/a?eufemia-theme=ui&fullscreen')).toBe(
+      '/a?eufemia-theme=ui&fullscreen'
+    )
+  })
+
+  it('drops a fragment that is not anchor-shaped', () => {
+    expect(normalizeTrackedPath('/a#not a slug')).toBe('/a')
   })
 })

--- a/tools/analytics/__tests__/store.test.ts
+++ b/tools/analytics/__tests__/store.test.ts
@@ -69,13 +69,13 @@ describe('storePortalViews', () => {
     expect(line.timestamp).toBe(line.createdat)
   })
 
-  it('keeps the query string and fragment in the path', async () => {
-    await storePortalViews([{ path: '/a?tab=demos#example' }])
+  it('minimises the stored path', async () => {
+    await storePortalViews([{ path: '/a?q=secret&fullscreen#example' }])
 
     const input = send.mock.calls[0][0].input as PutInput
     const line = JSON.parse(input.Body)
 
-    expect(line.path).toBe('/a?tab=demos#example')
+    expect(line.path).toBe('/a?fullscreen#example')
   })
 
   it('stores the env label, defaulting to "unknown" when absent', async () => {

--- a/tools/analytics/__tests__/store.test.ts
+++ b/tools/analytics/__tests__/store.test.ts
@@ -69,13 +69,13 @@ describe('storePortalViews', () => {
     expect(line.timestamp).toBe(line.createdat)
   })
 
-  it('strips the query string and fragment from the path', async () => {
-    await storePortalViews([{ path: '/a?q=secret#frag' }])
+  it('keeps the query string and fragment in the path', async () => {
+    await storePortalViews([{ path: '/a?tab=demos#example' }])
 
     const input = send.mock.calls[0][0].input as PutInput
     const line = JSON.parse(input.Body)
 
-    expect(line.path).toBe('/a')
+    expect(line.path).toBe('/a?tab=demos#example')
   })
 
   it('stores the env label, defaulting to "unknown" when absent', async () => {

--- a/tools/analytics/src/records/portal-view.ts
+++ b/tools/analytics/src/records/portal-view.ts
@@ -45,11 +45,6 @@ function isIsoTimestamp(value: string): boolean {
   return !Number.isNaN(date.getTime()) && date.toISOString() === value
 }
 
-/** Drop the query string and fragment so no incidental data is stored. */
-export function normalizePath(path: string): string {
-  return path.split(/[?#]/)[0]
-}
-
 /**
  * Validate an untrusted ingest payload into a batch of portal views.
  *
@@ -146,7 +141,7 @@ export function buildPortalViewRecord(
   createdAt: string
 ): PortalViewRecord {
   return {
-    path: normalizePath(input.path),
+    path: input.path,
     env: input.env ?? 'unknown',
     timestamp: input.timestamp ?? createdAt,
     createdat: createdAt,

--- a/tools/analytics/src/records/portal-view.ts
+++ b/tools/analytics/src/records/portal-view.ts
@@ -35,6 +35,50 @@ const MAX_PATH_LENGTH = 2048
 /** A short lowercase environment token, e.g. `prod`, `dev`. */
 const ENV_PATTERN = /^[a-z][a-z0-9-]{0,31}$/
 
+// Query params worth keeping because they change how the portal renders. Flags
+// are stored key-only; value params only for a safe token. Everything else is
+// dropped, so a docs search term can never be persisted.
+const TRACKED_FLAG_PARAMS = new Set(['fullscreen', 'focusmode'])
+const TRACKED_VALUE_PARAMS = new Set(['eufemia-theme'])
+const SAFE_PARAM_VALUE = /^[a-z][a-z0-9-]{0,31}$/
+// An anchor fragment is a slug, e.g. `#events`; anything else is dropped.
+const SAFE_FRAGMENT = /^#[\w-]+$/
+
+/**
+ * Reduce a raw in-app path to a safe shape for storage: the pathname, an
+ * allow-list of render params (flags key-only, theme only for a safe token, in
+ * canonical order) and an anchor-shaped fragment. Everything else — notably a
+ * docs search term — is dropped, so no free text can be persisted even if a
+ * caller sends it straight to the edge-locked route.
+ */
+export function normalizeTrackedPath(path: string): string {
+  const hashAt = path.indexOf('#')
+  const fragment = hashAt >= 0 ? path.slice(hashAt) : ''
+  const beforeHash = hashAt >= 0 ? path.slice(0, hashAt) : path
+
+  const queryAt = beforeHash.indexOf('?')
+  const pathname = queryAt >= 0 ? beforeHash.slice(0, queryAt) : beforeHash
+  const search = queryAt >= 0 ? beforeHash.slice(queryAt + 1) : ''
+
+  const kept: string[] = []
+  new URLSearchParams(search).forEach((value, key) => {
+    if (TRACKED_FLAG_PARAMS.has(key)) {
+      kept.push(key)
+    } else if (
+      TRACKED_VALUE_PARAMS.has(key) &&
+      SAFE_PARAM_VALUE.test(value)
+    ) {
+      kept.push(`${key}=${value}`)
+    }
+  })
+  kept.sort()
+
+  const query = kept.length > 0 ? '?' + kept.join('&') : ''
+  const safeFragment = SAFE_FRAGMENT.test(fragment) ? fragment : ''
+
+  return pathname + query + safeFragment
+}
+
 /**
  * True only for a canonical ISO 8601 UTC timestamp (the form produced by
  * `Date.prototype.toISOString`), rejecting the looser inputs `Date.parse`
@@ -50,7 +94,9 @@ function isIsoTimestamp(value: string): boolean {
  *
  * Accepts either a single event object or an array of them. Portal views carry
  * no identifiers or personal data — only a `path` and an optional timestamp and
- * environment label. Only the allow-listed keys are returned, so nothing
+ * environment label. Only the allow-listed keys are returned here, and the path
+ * is minimised to a safe shape when the record is built (see
+ * {@link buildPortalViewRecord} and {@link normalizeTrackedPath}), so nothing
  * incidental in the request can reach storage.
  */
 export function validatePortalViews(
@@ -141,7 +187,7 @@ export function buildPortalViewRecord(
   createdAt: string
 ): PortalViewRecord {
   return {
-    path: input.path,
+    path: normalizeTrackedPath(input.path),
     env: input.env ?? 'unknown',
     timestamp: input.timestamp ?? createdAt,
     createdat: createdAt,

--- a/tools/analytics/src/records/portal-view.ts
+++ b/tools/analytics/src/records/portal-view.ts
@@ -40,6 +40,7 @@ const ENV_PATTERN = /^[a-z][a-z0-9-]{0,31}$/
 // dropped, so a docs search term can never be persisted.
 const TRACKED_FLAG_PARAMS = new Set(['fullscreen', 'focusmode'])
 const TRACKED_VALUE_PARAMS = new Set(['eufemia-theme'])
+// Same shape as ENV_PATTERN by coincidence, not shared intent — keep separate.
 const SAFE_PARAM_VALUE = /^[a-z][a-z0-9-]{0,31}$/
 // An anchor fragment is a slug, e.g. `#events`; anything else is dropped.
 const SAFE_FRAGMENT = /^#[\w-]+$/


### PR DESCRIPTION
Page-view tracking recorded only the pathname, so navigations that differ only by the URL hash (e.g. component doc anchors) or by a portal render mode looked identical in analytics.

The tracked path now also carries the hash and a small set of portal render params (`fullscreen`, `focusmode`, `eufemia-theme`). Minimisation happens at the collector: `normalizeTrackedPath` keeps the pathname, the allow-listed render params (flags key-only, theme only for a safe token, canonical order) and an anchor-shaped fragment, and drops everything else — notably free-text docs search terms — so nothing incidental is stored, regardless of what reaches the edge-locked ingest route.

Tracking still ships dark until `VITE_ANALYTICS_ENDPOINT` is set.