### PR TITLE
chore(Portal): record page-view status (ok, not_found, error)

### DIFF
--- a/packages/dnb-design-system-portal/src/core/ErrorBoundary.tsx
+++ b/packages/dnb-design-system-portal/src/core/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { Code, CopyOnClick, P } from '@dnb/eufemia/src'
 
 type ErrorBoundaryProps = {
   children: ReactNode
+  onError?: (error: Error) => void
 }
 
 type ErrorBoundaryState = {
@@ -19,6 +20,10 @@ export default class ErrorBoundary extends Component<
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { error }
+  }
+
+  componentDidCatch(error: Error): void {
+    this.props.onError?.(error)
   }
 
   render() {

--- a/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
@@ -61,6 +61,7 @@ describe('trackPageView', () => {
     expect(payload[0].path).toBe('/uilib/components/button')
     expect(payload[0]).toHaveProperty('timestamp')
     expect(payload[0].env).toBe('unknown')
+    expect(payload[0].status).toBe('ok')
     expect(payload[0]).not.toHaveProperty('id')
   })
 
@@ -121,6 +122,35 @@ describe('trackPageView', () => {
       '/y',
       '/x',
     ])
+  })
+
+  it('records the status of a view', async () => {
+    trackPageView('/missing', 'not_found')
+    trackPageView('/boom', 'error')
+    flush()
+
+    const payload = JSON.parse(
+      await (beacon.mock.calls[0][1] as Blob).text()
+    )
+    expect(
+      payload.map(
+        (event: { path: string; status: string }) =>
+          `${event.status} ${event.path}`
+      )
+    ).toEqual(['not_found /missing', 'error /boom'])
+  })
+
+  it('records the same path again when only the status changes', async () => {
+    trackPageView('/page', 'ok')
+    trackPageView('/page', 'error')
+    flush()
+
+    const payload = JSON.parse(
+      await (beacon.mock.calls[0][1] as Blob).text()
+    )
+    expect(
+      payload.map((event: { status: string }) => event.status)
+    ).toEqual(['ok', 'error'])
   })
 
   it('does not throw when sendBeacon is unavailable', () => {

--- a/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
+++ b/packages/dnb-design-system-portal/vite/__tests__/track-page-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { trackPageView, buildTrackedPath } from '../client/track-page-view'
+import { buildTrackedPath } from '../client/track-page-view'
 
 function setBeacon(fn: unknown) {
   Object.defineProperty(navigator, 'sendBeacon', {
@@ -15,8 +15,12 @@ function flush() {
 
 describe('trackPageView', () => {
   let beacon: ReturnType<typeof vi.fn>
+  let trackPageView: typeof import('../client/track-page-view').trackPageView
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Re-import so the module-level dedup and buffer start fresh each test.
+    vi.resetModules()
+    ;({ trackPageView } = await import('../client/track-page-view'))
     beacon = vi.fn().mockReturnValue(true)
     setBeacon(beacon)
     vi.stubEnv('VITE_ANALYTICS_ENDPOINT', '/collect')

--- a/packages/dnb-design-system-portal/vite/client/portal-app.tsx
+++ b/packages/dnb-design-system-portal/vite/client/portal-app.tsx
@@ -11,6 +11,7 @@ import {
   RouterProvider,
   Outlet,
   useLocation,
+  useMatches,
   type RouteObject,
 } from 'react-router'
 import { CacheProvider } from '@emotion/react'
@@ -73,7 +74,7 @@ function RootLayout() {
           >
             <SkeletonEnabled>
               <Theme colorScheme={colorScheme || 'auto'} {...theme}>
-                <ErrorBoundary>
+                <ErrorBoundary onError={trackRenderError}>
                   <MDXProvider components={tags}>
                     <PageWrapper />
                   </MDXProvider>
@@ -169,12 +170,29 @@ function RouteFocusEffect() {
 /** Records an anonymous page view on initial load and each navigation. */
 function TrackPageView() {
   const location = useLocation()
+  const matches = useMatches()
+
+  // The catch-all 404 route is the only splat route, so a `*` param on the
+  // matched leaf marks a path that fell through to the not-found page.
+  const leaf = matches[matches.length - 1]
+  const notFound = Boolean(leaf) && '*' in (leaf.params ?? {})
 
   useEffect(() => {
-    trackPageView(buildTrackedPath(location))
-  }, [location.pathname, location.search, location.hash])
+    trackPageView(
+      buildTrackedPath(location),
+      notFound ? 'not_found' : 'ok'
+    )
+  }, [location.pathname, location.search, location.hash, notFound])
 
   return null
+}
+
+// Record a render error caught by the boundary against the path the user was on
+// when it happened.
+function trackRenderError() {
+  if (typeof window !== 'undefined') {
+    trackPageView(buildTrackedPath(window.location), 'error')
+  }
 }
 
 type PortalAppProps = {

--- a/packages/dnb-design-system-portal/vite/client/track-page-view.ts
+++ b/packages/dnb-design-system-portal/vite/client/track-page-view.ts
@@ -29,7 +29,16 @@ function analyticsEnv(): string {
   )
 }
 
-type PageViewEvent = { path: string; timestamp: string; env: string }
+// How the portal classified the view: a normal page, an unknown path that fell
+// through to the 404 page, or a render error caught by the error boundary.
+export type PageViewStatus = 'ok' | 'not_found' | 'error'
+
+type PageViewEvent = {
+  path: string
+  timestamp: string
+  env: string
+  status: PageViewStatus
+}
 
 /**
  * The in-app path to record for a location: its pathname, query and hash.
@@ -53,7 +62,7 @@ const MAX_BUFFER = 50
 
 const buffer: PageViewEvent[] = []
 let flushRegistered = false
-let lastTrackedPath: string | null = null
+let lastTrackedKey: string | null = null
 
 function canTrack(): boolean {
   return (
@@ -101,24 +110,31 @@ function registerFlush(): void {
 }
 
 /** Record a single anonymous page view for the given in-app path. */
-export function trackPageView(path: string): void {
+export function trackPageView(
+  path: string,
+  status: PageViewStatus = 'ok'
+): void {
   if (!canTrack()) {
     return
   }
 
-  // Skip an immediate repeat of the same path (a re-mount or dev StrictMode
-  // double-invoke); a genuine navigation back to it later still counts.
-  if (path === lastTrackedPath) {
+  // Skip an immediate repeat of the same path and status (a re-mount or dev
+  // StrictMode double-invoke); a genuine navigation back to it later still
+  // counts, and a status change on the current path (e.g. a render error) is
+  // always recorded.
+  const key = `${status} ${path}`
+  if (key === lastTrackedKey) {
     return
   }
 
   try {
     registerFlush()
-    lastTrackedPath = path
+    lastTrackedKey = key
     buffer.push({
       path,
       timestamp: new Date().toISOString(),
       env: analyticsEnv(),
+      status,
     })
 
     if (buffer.length >= MAX_BUFFER) {

--- a/tools/analytics/__tests__/portal-view.test.ts
+++ b/tools/analytics/__tests__/portal-view.test.ts
@@ -90,6 +90,25 @@ describe('validatePortalViews', () => {
     }
   })
 
+  it('accepts a valid status', () => {
+    for (const status of ['ok', 'not_found', 'error']) {
+      const result = validatePortalViews({ path: '/a', status })
+
+      expect(result).toEqual({
+        ok: true,
+        value: [{ path: '/a', status }],
+      })
+    }
+  })
+
+  it('rejects an invalid status', () => {
+    for (const status of ['OK', '404', 'notfound', 'redirect', 42]) {
+      const result = validatePortalViews({ path: '/a', status })
+
+      expect(result.ok).toBe(false)
+    }
+  })
+
   it('drops any field that is not an allow-listed key', () => {
     const result = validatePortalViews({
       path: '/a',
@@ -123,6 +142,7 @@ describe('buildPortalViewRecord', () => {
       path: '/a',
       env: 'unknown',
       timestamp: createdAt,
+      status: 'ok',
       createdat: createdAt,
     })
   })
@@ -137,8 +157,22 @@ describe('buildPortalViewRecord', () => {
       path: '/a',
       env: 'prod',
       timestamp: '2026-08-20T10:00:00.000Z',
+      status: 'ok',
       createdat: createdAt,
     })
+  })
+
+  it('defaults status to "ok" and keeps a supplied status', () => {
+    expect(buildPortalViewRecord({ path: '/a' }, createdAt).status).toBe(
+      'ok'
+    )
+
+    expect(
+      buildPortalViewRecord(
+        { path: '/missing', status: 'not_found' },
+        createdAt
+      ).status
+    ).toBe('not_found')
   })
 
   it('never carries identifiers or personal data', () => {
@@ -148,6 +182,7 @@ describe('buildPortalViewRecord', () => {
       'createdat',
       'env',
       'path',
+      'status',
       'timestamp',
     ])
   })

--- a/tools/analytics/__tests__/store.test.ts
+++ b/tools/analytics/__tests__/store.test.ts
@@ -99,6 +99,7 @@ describe('storePortalViews', () => {
       'createdat',
       'env',
       'path',
+      'status',
       'timestamp',
     ])
   })

--- a/tools/analytics/infra/main.tf
+++ b/tools/analytics/infra/main.tf
@@ -130,6 +130,11 @@ resource "aws_glue_catalog_table" "portal_views" {
     }
 
     columns {
+      name = "status"
+      type = "string"
+    }
+
+    columns {
       name = "createdat"
       type = "string"
     }

--- a/tools/analytics/src/records/portal-view.ts
+++ b/tools/analytics/src/records/portal-view.ts
@@ -8,11 +8,24 @@
  * module under `src/records/`, so its shape and validation live in one place.
  */
 
+/**
+ * How the portal classified the view: a normal page, an unknown path that fell
+ * through to the 404 page, or a render error caught by the error boundary.
+ */
+export type PortalViewStatus = 'ok' | 'not_found' | 'error'
+
+const PORTAL_VIEW_STATUSES: readonly PortalViewStatus[] = [
+  'ok',
+  'not_found',
+  'error',
+]
+
 /** A single anonymous portal page view sent by the docs portal. */
 export type PortalViewInput = {
   path: string
   timestamp?: string
   env?: string
+  status?: PortalViewStatus
 }
 
 /** The stored portal-view record (one row in the portal_views Glue table). */
@@ -20,6 +33,7 @@ export type PortalViewRecord = {
   path: string
   env: string
   timestamp: string
+  status: PortalViewStatus
   createdat: string
 }
 
@@ -94,9 +108,9 @@ function isIsoTimestamp(value: string): boolean {
  * Validate an untrusted ingest payload into a batch of portal views.
  *
  * Accepts either a single event object or an array of them. Portal views carry
- * no identifiers or personal data — only a `path` and an optional timestamp and
- * environment label. Only the allow-listed keys are returned here, and the path
- * is minimised to a safe shape when the record is built (see
+ * no identifiers or personal data — only a `path` and an optional timestamp,
+ * environment label and status. Only the allow-listed keys are returned here,
+ * and the path is minimised to a safe shape when the record is built (see
  * {@link buildPortalViewRecord} and {@link normalizeTrackedPath}), so nothing
  * incidental in the request can reach storage.
  */
@@ -129,7 +143,10 @@ export function validatePortalViews(
       return
     }
 
-    const { path, timestamp, env } = event as Record<string, unknown>
+    const { path, timestamp, env, status } = event as Record<
+      string,
+      unknown
+    >
     let valid = true
 
     if (typeof path !== 'string' || !path.startsWith('/')) {
@@ -162,11 +179,28 @@ export function validatePortalViews(
       }
     }
 
+    if (status !== undefined) {
+      if (
+        typeof status !== 'string' ||
+        !PORTAL_VIEW_STATUSES.includes(status as PortalViewStatus)
+      ) {
+        errors.push(
+          `Event ${index}: "status" must be one of ${PORTAL_VIEW_STATUSES.join(
+            ', '
+          )}`
+        )
+        valid = false
+      }
+    }
+
     if (valid) {
       value.push({
         path: path as string,
         ...(typeof timestamp === 'string' ? { timestamp } : {}),
         ...(typeof env === 'string' ? { env } : {}),
+        ...(typeof status === 'string'
+          ? { status: status as PortalViewStatus }
+          : {}),
       })
     }
   })
@@ -191,6 +225,7 @@ export function buildPortalViewRecord(
     path: normalizeTrackedPath(input.path),
     env: input.env ?? 'unknown',
     timestamp: input.timestamp ?? createdAt,
+    status: input.status ?? 'ok',
     createdat: createdAt,
   }
 }


### PR DESCRIPTION
Page-view analytics could not tell a normal view apart from a 404 or a render error — every event looked the same, so a bad link or a crashing page was invisible in the data.

Each page view now carries a `status`:

- `not_found` — the visited path fell through to the catch-all 404 route (detected from the matched splat route). The attempted pathname is already captured, so you can see *which* URLs 404.
- `error` — a render error caught by the error boundary, recorded against the path the user was on.
- `ok` — everything else (the default).

Dedup now keys on path *and* status, so a status change on the current path (e.g. a page that renders then errors) is still recorded.

The stored record and the `portal_views` Glue table gain a `status` column. It is schema-on-read, so older rows read NULL and no migration is needed.

Stacked on #9298 (base `feat/portal-analytics-tracked-path`) — merge that first. Tracking still ships dark until `VITE_ANALYTICS_ENDPOINT` is set.
