### PR TITLE
feat(Field.MultiSelection): add virtualized rendering for large data sets

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/Examples.tsx
@@ -1,6 +1,13 @@
 import ComponentBox from '../../../../../../shared/tags/ComponentBox'
 import { Form, Field } from '@dnb/eufemia/src/extensions/forms'
 import { NumberFormat } from '@dnb/eufemia/src'
+import { createMultiSelectionVirtualization } from '@dnb/eufemia/src/extensions/forms/Field/MultiSelection/Virtualization'
+
+const virtualizedMultiSelection = createMultiSelectionVirtualization()
+const virtualizedItems = Array.from({ length: 10000 }, (_, index) => ({
+  value: `item-${index}`,
+  title: `Item ${index + 1}`,
+}))
 
 export const Basic = () => (
   <ComponentBox data-visual-test="multi-selection-basic">
@@ -34,6 +41,18 @@ export const Basic = () => (
       ]
       return <Field.MultiSelection label="Select cities" data={cities} />
     }}
+  </ComponentBox>
+)
+
+export const Virtualized = () => (
+  <ComponentBox scope={{ virtualizedItems, virtualizedMultiSelection }}>
+    <Field.MultiSelection
+      label="Select from 10,000 items"
+      data={virtualizedItems}
+      listDriver={virtualizedMultiSelection}
+      showSearchField
+      showSelectAll
+    />
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/demos.mdx
@@ -71,3 +71,24 @@ Set `maxHeight` to constrain the inline item list. Only the options scroll, whil
 ### With minimum required items
 
 <Examples.WithError />
+
+### Large data sets
+
+Virtualization is opt-in. Install the optional peer dependency:
+
+```bash
+yarn add @tanstack/react-virtual
+```
+
+Import the driver separately so the default Forms bundle does not include the virtualization dependency:
+
+```tsx
+import { Field } from '@dnb/eufemia/extensions/forms'
+import { createMultiSelectionVirtualization } from '@dnb/eufemia/extensions/forms/Field/MultiSelection/Virtualization'
+
+const listDriver = createMultiSelectionVirtualization()
+
+<Field.MultiSelection data={items} listDriver={listDriver} />
+```
+
+<Examples.Virtualized />

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -6,7 +6,13 @@ import {
   useRef,
   useState,
 } from 'react'
-import type { ReactNode } from 'react'
+import type {
+  ComponentType,
+  CSSProperties,
+  ReactNode,
+  Ref,
+  RefObject,
+} from 'react'
 import * as z from 'zod'
 import { clsx } from 'clsx'
 import { AriaLive, Popover } from '../../../../components'
@@ -42,6 +48,34 @@ export type MultiSelectionItem = {
   description?: ReactNode
   disabled?: boolean
   children?: Array<MultiSelectionItem>
+}
+
+export type MultiSelectionListDriverRowProps = {
+  ref?: Ref<HTMLLIElement>
+  className?: string
+  style?: CSSProperties
+  'data-index'?: number
+  'data-multi-selection-index'?: number
+}
+
+export type MultiSelectionListDriverRow = {
+  key: string
+  disabled?: boolean
+  render: (props?: MultiSelectionListDriverRowProps) => ReactNode
+}
+
+export type MultiSelectionListDriverProps = {
+  rows: MultiSelectionListDriverRow[]
+  open: boolean
+  scrollRef: RefObject<HTMLDivElement>
+  registerListDriver: (driver: {
+    focusIndex: (index: number, direction?: -1 | 1) => void
+    itemCount: number
+  }) => () => void
+}
+
+export type MultiSelectionListDriver = {
+  Renderer: ComponentType<MultiSelectionListDriverProps>
 }
 
 type MultiSelectionData = Array<MultiSelectionItem>
@@ -95,6 +129,11 @@ export type FieldMultiSelectionProps = FieldProps<
   maxHeight?: string | number
 
   /**
+   * Opt in to a custom item-list renderer. Use `createMultiSelectionVirtualization` from `@dnb/eufemia/extensions/forms/Field/MultiSelection/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver. The inline variant defaults to a `32rem` maximum height when virtualized; use `maxHeight` to override it.
+   */
+  listDriver?: MultiSelectionListDriver
+
+  /**
    * When the number of selected items exceeds this threshold, the selected items are hidden by default and can be toggled with a header.
    */
   selectedItemsCollapsibleThreshold?: number
@@ -143,6 +182,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     showSearchField = false,
     showSelectedTags = false,
     maxHeight,
+    listDriver,
     showConfirmButton = false,
     showSelectAll = false,
     selectedItemsCollapsibleThreshold = 10,
@@ -216,6 +256,10 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     }
   }, [value, isOpen, isInline])
   const popoverContentRef = useRef<HTMLDivElement>(null)
+  const listDriverRef = useRef<{
+    focusIndex: (index: number, direction?: -1 | 1) => void
+    itemCount: number
+  } | null>(null)
   const triggerRef = useRef<HTMLElement | null>(null)
 
   // Calculate max height of popover content to prevent it from growing too large and going off-screen
@@ -261,6 +305,20 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   const previousTempValueRef = useRef<Array<number | string>>(value || [])
   const hasFeature =
     showSearchField || showSelectedTags || showConfirmButton
+  const registerListDriver = useCallback(
+    (driver: {
+      focusIndex: (index: number, direction?: -1 | 1) => void
+      itemCount: number
+    }) => {
+      listDriverRef.current = driver
+      return () => {
+        if (listDriverRef.current === driver) {
+          listDriverRef.current = null
+        }
+      }
+    },
+    []
+  )
 
   // Flatten nested items to a single array for searching and counting
   const flattenItems = useCallback(
@@ -280,12 +338,18 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     () => flattenItems(dataList),
     [dataList, flattenItems]
   )
+  const allItemsByValue = useMemo(
+    () => new Map(allFlatItems.map((item) => [item.value, item])),
+    [allFlatItems]
+  )
+  const selectedValueSet = useMemo(() => new Set(tempValue), [tempValue])
+  const valueSet = useMemo(() => new Set(value || []), [value])
 
   // Sync field internals during render so Value.MultiSelection can resolve
   // titles before any user interaction has occurred.
   if (path && allFlatItems.length > 0 && value) {
     const selectedItems = allFlatItems.filter((item) =>
-      value.includes(item.value)
+      valueSet.has(item.value)
     )
     setFieldInternals?.(path + '/multiSelectionData', {
       props: selectedItems,
@@ -403,11 +467,8 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
   // Get items of selected values (based on tempValue)
   const selectedItems = useMemo(() => {
-    if (!tempValue) {
-      return []
-    }
-    return allFlatItems.filter((item) => tempValue.includes(item.value))
-  }, [allFlatItems, tempValue])
+    return allFlatItems.filter((item) => selectedValueSet.has(item.value))
+  }, [allFlatItems, selectedValueSet])
 
   const totalCount = allFlatItems.length
   const selectedCount = selectedItems.length
@@ -420,8 +481,8 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     if (!value) {
       return []
     }
-    return allFlatItems.filter((item) => value.includes(item.value))
-  }, [allFlatItems, value])
+    return allFlatItems.filter((item) => valueSet.has(item.value))
+  }, [allFlatItems, value, valueSet])
   const displayCount = showConfirmButton
     ? confirmedItems.length
     : selectedCount
@@ -454,14 +515,14 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     (item: MultiSelectionItemInternal) => {
       if (!item.children || item.children.length === 0) {
         return {
-          checked: tempValue.includes(item.value),
+          checked: selectedValueSet.has(item.value),
           indeterminate: false,
         }
       }
 
       const children = flattenItems(item.children)
       const checkedChildren = children.filter((child) =>
-        tempValue.includes(child.value)
+        selectedValueSet.has(child.value)
       ).length
 
       return {
@@ -470,7 +531,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
           checkedChildren > 0 && checkedChildren < children.length,
       }
     },
-    [tempValue, flattenItems]
+    [selectedValueSet, flattenItems]
   )
 
   // Normalize value to remove parent items when not all children are selected
@@ -481,7 +542,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
       // Remove parents that don't have all children selected
       normalized.forEach((itemValue) => {
-        const item = allFlatItems.find((i) => i.value === itemValue)
+        const item = allItemsByValue.get(itemValue)
         if (item?.children) {
           const childValues = flattenItems(item.children).map(
             (c) => c.value
@@ -509,7 +570,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
       return Array.from(normalized)
     },
-    [allFlatItems, flattenItems]
+    [allFlatItems, allItemsByValue, flattenItems]
   )
 
   const applyChange = useCallback(
@@ -520,8 +581,9 @@ function MultiSelection(props: FieldMultiSelectionProps) {
           ? (emptyValue as typeof value)
           : normalizedValue
       handleChange?.(finalValue)
+      const normalizedValueSet = new Set(normalizedValue)
       const nextSelectedItems = allFlatItems.filter((item) =>
-        normalizedValue.includes(item.value)
+        normalizedValueSet.has(item.value)
       )
       setDisplayValue(nextSelectedItems.map((item) => item.title))
       if (path) {
@@ -543,7 +605,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
   const handleToggleItem = useCallback(
     (itemValue: number | string) => {
-      const next = tempValue.includes(itemValue)
+      const next = selectedValueSet.has(itemValue)
         ? tempValue.filter((v) => v !== itemValue)
         : [...tempValue, itemValue]
       pendingCheckedCountAnnouncementRef.current = true
@@ -552,7 +614,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
         applyChange(next)
       }
     },
-    [tempValue, showConfirmButton, applyChange]
+    [tempValue, selectedValueSet, showConfirmButton, applyChange]
   )
 
   // Toggle parent item and all its children
@@ -561,7 +623,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       const children = item.children ? flattenItems(item.children) : []
       const allChildValues = children.map((child) => child.value)
       const allChildrenChecked = allChildValues.every((childVal) =>
-        tempValue.includes(childVal)
+        selectedValueSet.has(childVal)
       )
 
       let next = [...tempValue]
@@ -583,7 +645,13 @@ function MultiSelection(props: FieldMultiSelectionProps) {
         applyChange(next)
       }
     },
-    [tempValue, showConfirmButton, applyChange, flattenItems]
+    [
+      tempValue,
+      selectedValueSet,
+      showConfirmButton,
+      applyChange,
+      flattenItems,
+    ]
   )
 
   const handleSelectAll = useCallback(() => {
@@ -591,14 +659,15 @@ function MultiSelection(props: FieldMultiSelectionProps) {
     const selectableItems = allFilteredFlat.filter(
       (item) => !item.disabled
     )
+    const selectableValueSet = new Set(
+      selectableItems.map((item) => item.value)
+    )
     const allSelectableChecked = selectableItems.every((item) =>
-      tempValue.includes(item.value)
+      selectedValueSet.has(item.value)
     )
 
     const next = allSelectableChecked
-      ? tempValue.filter(
-          (v) => !selectableItems.some((item) => item.value === v)
-        )
+      ? tempValue.filter((value) => !selectableValueSet.has(value))
       : Array.from(
           new Set([
             ...tempValue,
@@ -614,6 +683,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   }, [
     filteredItems,
     tempValue,
+    selectedValueSet,
     showConfirmButton,
     applyChange,
     flattenItems,
@@ -621,7 +691,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
   const handleRemoveTag = useCallback(
     (itemValue: number | string) => {
-      const item = allFlatItems.find((i) => i.value === itemValue)
+      const item = allItemsByValue.get(itemValue)
       if (item?.disabled) {
         return
       }
@@ -632,7 +702,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
         applyChange(next)
       }
     },
-    [allFlatItems, tempValue, showConfirmButton, applyChange]
+    [allItemsByValue, tempValue, showConfirmButton, applyChange]
   )
 
   const handleConfirm = useCallback(() => {
@@ -658,10 +728,12 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   )
   const allFilteredSelected =
     selectableFilteredFlat.length > 0 &&
-    selectableFilteredFlat.every((item) => tempValue.includes(item.value))
+    selectableFilteredFlat.every((item) =>
+      selectedValueSet.has(item.value)
+    )
   const someFilteredSelected =
     !allFilteredSelected &&
-    selectableFilteredFlat.some((item) => tempValue.includes(item.value))
+    selectableFilteredFlat.some((item) => selectedValueSet.has(item.value))
 
   const getCheckboxes = useCallback(
     () =>
@@ -695,6 +767,40 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
       const checkboxes = getCheckboxes()
       const searchInput = getSearchInput()
+      const listDriver = listDriverRef.current
+
+      if (listDriver) {
+        const activeItem = (
+          document.activeElement as HTMLElement
+        )?.closest('[data-multi-selection-index]') as HTMLElement | null
+        const currentIndex = Number(
+          activeItem?.getAttribute('data-multi-selection-index')
+        )
+        const hasCurrentIndex = Number.isInteger(currentIndex)
+
+        if (event.key === 'ArrowDown') {
+          if (document.activeElement === searchInput || !hasCurrentIndex) {
+            listDriver.focusIndex(0, 1)
+          } else if (currentIndex < listDriver.itemCount - 1) {
+            listDriver.focusIndex(currentIndex + 1, 1)
+          } else if (searchInput) {
+            searchInput.focus()
+          } else {
+            listDriver.focusIndex(0, 1)
+          }
+        } else if (document.activeElement === searchInput) {
+          listDriver.focusIndex(listDriver.itemCount - 1, -1)
+        } else if (hasCurrentIndex && currentIndex > 0) {
+          listDriver.focusIndex(currentIndex - 1, -1)
+        } else if (searchInput) {
+          searchInput.focus()
+        } else {
+          listDriver.focusIndex(listDriver.itemCount - 1, -1)
+        }
+
+        return
+      }
+
       const navigable: Array<HTMLInputElement> = [
         ...(searchInput ? [searchInput] : []),
         ...checkboxes,
@@ -753,8 +859,14 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   }, [getCheckboxes, getSearchInput])
 
   const handleFocusComplete = useCallback(() => {
+    const dir = pendingTriggerNavigationRef.current
+    const listDriver = listDriverRef.current
+
+    if (listDriver && dir !== null && !getSearchInput()) {
+      listDriver.focusIndex(dir === 1 ? 0 : listDriver.itemCount - 1, dir)
+    }
     pendingTriggerNavigationRef.current = null
-  }, [])
+  }, [getSearchInput])
 
   const fieldBlockProps: FieldBlockProps = {
     forId: id,
@@ -832,7 +944,14 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       selectableFilteredFlat={selectableFilteredFlat}
       allFilteredSelected={allFilteredSelected}
       someFilteredSelected={someFilteredSelected}
-      maxHeight={isInline ? maxHeight : undefined}
+      maxHeight={
+        isInline
+          ? (maxHeight ?? (listDriver ? '32rem' : undefined))
+          : undefined
+      }
+      listDriver={listDriver}
+      open={isInline || isOpen}
+      registerListDriver={registerListDriver}
     />
   )
 
@@ -854,7 +973,7 @@ function MultiSelection(props: FieldMultiSelectionProps) {
       onClearAll={() => {
         const disabledValues = allFlatItems
           .filter(
-            (item) => item.disabled && tempValue.includes(item.value)
+            (item) => item.disabled && selectedValueSet.has(item.value)
           )
           .map((item) => item.value)
         setTempValue(disabledValues)

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionDocs.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionDocs.ts
@@ -44,6 +44,11 @@ export const MultiSelectionProperties: PropertiesTableProps = {
     type: ['string', 'number'],
     status: 'optional',
   },
+  listDriver: {
+    doc: 'Opt in to a custom item-list renderer. Use `createMultiSelectionVirtualization` from `@dnb/eufemia/extensions/forms/Field/MultiSelection/Virtualization` for large data sets. Install the optional `@tanstack/react-virtual` peer dependency when using this driver. The inline variant defaults to a `32rem` maximum height when virtualized; use `maxHeight` to override it.',
+    type: 'MultiSelectionListDriver',
+    status: 'optional',
+  },
   showConfirmButton: {
     doc: 'Show confirm and cancel buttons at the bottom of the popover. Selections are only applied when the user confirms.',
     type: ['boolean'],

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionItemList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback } from 'react'
+import { Fragment, useCallback, useMemo, useRef } from 'react'
 import type { ReactNode, MouseEvent } from 'react'
 import { clsx } from 'clsx'
 import { Checkbox } from '../../../../components'
@@ -7,6 +7,10 @@ import { P } from '../../../../elements'
 import { useHighlightText } from '../../../../shared/helpers/highlightText'
 import type {
   FieldMultiSelectionProps,
+  MultiSelectionListDriver,
+  MultiSelectionListDriverProps,
+  MultiSelectionListDriverRow,
+  MultiSelectionListDriverRowProps,
   MultiSelectionItem,
 } from './MultiSelection'
 
@@ -39,6 +43,9 @@ export type MultiSelectionItemListProps = {
   allFilteredSelected: boolean
   someFilteredSelected: boolean
   maxHeight?: string | number
+  listDriver?: MultiSelectionListDriver
+  open: boolean
+  registerListDriver: MultiSelectionListDriverProps['registerListDriver']
 }
 
 export function MultiSelectionItemList({
@@ -57,7 +64,12 @@ export function MultiSelectionItemList({
   allFilteredSelected,
   someFilteredSelected,
   maxHeight,
+  listDriver,
+  open,
+  registerListDriver,
 }: MultiSelectionItemListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const selectedValueSet = useMemo(() => new Set(tempValue), [tempValue])
   const highlight = useHighlightText({
     search: searchValue,
     className: 'dnb-forms-field-multi-selection__highlighting',
@@ -92,6 +104,60 @@ export function MultiSelectionItemList({
     [disabled, onToggleItem, onToggleParent]
   )
 
+  const renderItem = (
+    item: MultiSelectionItemInternal,
+    depth: number,
+    itemProps: MultiSelectionListDriverRowProps = {}
+  ) => (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
+    <li
+      {...itemProps}
+      className={clsx(
+        'dnb-forms-field-multi-selection__item',
+        item.children && 'dnb-forms-field-multi-selection__item--parent',
+        selectedValueSet.has(item.value) &&
+          'dnb-forms-field-multi-selection__item--selected',
+        item.disabled && 'dnb-forms-field-multi-selection__item--disabled',
+        depth > 0 &&
+          `dnb-forms-field-multi-selection__item--level-${depth}`,
+        itemProps.className
+      )}
+      onClick={(event) => handleItemClick(event, item)}
+    >
+      <Checkbox
+        checked={
+          item.children
+            ? getParentState(item).checked
+            : selectedValueSet.has(item.value)
+        }
+        indeterminate={
+          item.children ? getParentState(item).indeterminate : false
+        }
+        onChange={() =>
+          item.children ? onToggleParent(item) : onToggleItem(item.value)
+        }
+        disabled={disabled || item.disabled}
+        label={highlight(item.title)}
+        className="dnb-forms-field-multi-selection__checkbox"
+        {...htmlAttributes}
+      />
+      {(item.text || item.description) && (
+        <div className="dnb-forms-field-multi-selection__item-details">
+          {item.text && (
+            <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-text">
+              {highlight(item.text)}
+            </span>
+          )}
+          {item.description && (
+            <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-description">
+              {highlight(item.description)}
+            </span>
+          )}
+        </div>
+      )}
+    </li>
+  )
+
   const renderItems = (
     items: MultiSelectionItem[],
     depth = 0,
@@ -102,55 +168,7 @@ export function MultiSelectionItemList({
 
       return (
         <Fragment key={item.value}>
-          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
-          <li
-            className={clsx(
-              'dnb-forms-field-multi-selection__item',
-              item.children &&
-                'dnb-forms-field-multi-selection__item--parent',
-              tempValue.includes(item.value) &&
-                'dnb-forms-field-multi-selection__item--selected',
-              item.disabled &&
-                'dnb-forms-field-multi-selection__item--disabled',
-              depth > 0 &&
-                `dnb-forms-field-multi-selection__item--level-${depth}`
-            )}
-            onClick={(event) => handleItemClick(event, item)}
-          >
-            <Checkbox
-              checked={
-                item.children
-                  ? getParentState(item).checked
-                  : tempValue.includes(item.value)
-              }
-              indeterminate={
-                item.children ? getParentState(item).indeterminate : false
-              }
-              onChange={() =>
-                item.children
-                  ? onToggleParent(item)
-                  : onToggleItem(item.value)
-              }
-              disabled={disabled || item.disabled}
-              label={highlight(item.title)}
-              className="dnb-forms-field-multi-selection__checkbox"
-              {...htmlAttributes}
-            />
-            {(item.text || item.description) && (
-              <div className="dnb-forms-field-multi-selection__item-details">
-                {item.text && (
-                  <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-text">
-                    {highlight(item.text)}
-                  </span>
-                )}
-                {item.description && (
-                  <span className="dnb-t__size--small dnb-forms-field-multi-selection__item-description">
-                    {highlight(item.description)}
-                  </span>
-                )}
-              </div>
-            )}
-          </li>
+          {renderItem(item, depth)}
           {item.children && item.children.length > 0 && (
             <ul className="dnb-forms-field-multi-selection__nested-items">
               {renderItems(item.children, depth + 1, itemPath)}
@@ -161,9 +179,71 @@ export function MultiSelectionItemList({
     })
   }
 
+  const renderSelectAll = (
+    itemProps: MultiSelectionListDriverRowProps = {}
+  ) => (
+    <li
+      {...itemProps}
+      className={clsx(
+        'dnb-forms-field-multi-selection__item',
+        'dnb-forms-field-multi-selection__item--select-all',
+        itemProps.className
+      )}
+    >
+      <Checkbox
+        checked={allFilteredSelected}
+        indeterminate={someFilteredSelected}
+        onChange={onToggleSelectAll}
+        disabled={disabled}
+        label={translation.selectAll}
+        className="dnb-forms-field-multi-selection__checkbox"
+      />
+    </li>
+  )
+
+  const driverRows = (() => {
+    let index = 0
+    const rows: MultiSelectionListDriverRow[] = []
+
+    if (showSelectAll && selectableFilteredFlat.length > 0) {
+      const itemIndex = index++
+      rows.push({
+        key: 'select-all',
+        disabled,
+        render: (props = {}) =>
+          renderSelectAll({
+            ...props,
+            'data-multi-selection-index': itemIndex,
+          }),
+      })
+    }
+
+    const addItems = (items: MultiSelectionItem[], depth = 0) => {
+      items.forEach((item: MultiSelectionItemInternal) => {
+        const itemIndex = index++
+        rows.push({
+          key: String(item.value),
+          disabled: disabled || item.disabled,
+          render: (props = {}) =>
+            renderItem(item, depth, {
+              ...props,
+              'data-multi-selection-index': itemIndex,
+            }),
+        })
+        if (item.children) {
+          addItems(item.children, depth + 1)
+        }
+      })
+    }
+
+    addItems(filteredItems)
+    return rows
+  })()
+
   return (
     <ScrollView
       className={clsx('dnb-forms-field-multi-selection__items')}
+      ref={scrollRef}
       interactive={maxHeight === undefined ? undefined : 'auto'}
       style={
         maxHeight === undefined
@@ -177,18 +257,10 @@ export function MultiSelectionItemList({
       }
     >
       <ul className="dnb-forms-field-multi-selection__list">
-        {showSelectAll && selectableFilteredFlat.length > 0 && (
-          <li className="dnb-forms-field-multi-selection__item dnb-forms-field-multi-selection__item--select-all">
-            <Checkbox
-              checked={allFilteredSelected}
-              indeterminate={someFilteredSelected}
-              onChange={onToggleSelectAll}
-              disabled={disabled}
-              label={translation.selectAll}
-              className="dnb-forms-field-multi-selection__checkbox"
-            />
-          </li>
-        )}
+        {!listDriver &&
+          showSelectAll &&
+          selectableFilteredFlat.length > 0 &&
+          renderSelectAll()}
 
         {filteredItems.length === 0 && searchValue ? (
           <li className="dnb-forms-field-multi-selection__no-options">
@@ -196,6 +268,13 @@ export function MultiSelectionItemList({
               {translation.noOptions}
             </P>
           </li>
+        ) : listDriver ? (
+          <listDriver.Renderer
+            rows={driverRows}
+            open={open}
+            scrollRef={scrollRef}
+            registerListDriver={registerListDriver}
+          />
         ) : (
           renderItems(filteredItems)
         )}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/Virtualization.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/Virtualization.ts
@@ -1,0 +1,6 @@
+export {
+  createMultiSelectionVirtualization as default,
+  createMultiSelectionVirtualization,
+  virtualizedMultiSelection,
+} from './Virtualized'
+export type { MultiSelectionVirtualizationOptions } from './Virtualized'

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/Virtualized.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/Virtualized.tsx
@@ -1,0 +1,210 @@
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
+import { flushSync } from 'react-dom'
+import {
+  defaultRangeExtractor,
+  useVirtualizer,
+} from '@tanstack/react-virtual'
+import type { Range } from '@tanstack/react-virtual'
+import type {
+  MultiSelectionListDriver,
+  MultiSelectionListDriverProps,
+} from './MultiSelection'
+import { useIsomorphicLayoutEffect } from '../../../../shared/helpers/useIsomorphicLayoutEffect'
+
+export type MultiSelectionVirtualizationOptions = {
+  /** Estimated item height in pixels before an item has been measured. */
+  estimateSize?: number
+  /** Number of items rendered before and after the visible range. */
+  overscan?: number
+}
+
+export function createMultiSelectionVirtualization({
+  estimateSize = 56,
+  overscan = 5,
+}: MultiSelectionVirtualizationOptions = {}): MultiSelectionListDriver {
+  const Renderer = memo(function MultiSelectionVirtualizedRenderer(
+    props: MultiSelectionListDriverProps
+  ) {
+    return (
+      <VirtualizedRenderer
+        {...props}
+        estimateSize={estimateSize}
+        overscan={overscan}
+      />
+    )
+  })
+
+  return { Renderer }
+}
+
+function VirtualizedRenderer({
+  rows,
+  open,
+  scrollRef,
+  registerListDriver,
+  estimateSize,
+  overscan,
+}: MultiSelectionListDriverProps &
+  Required<MultiSelectionVirtualizationOptions>) {
+  const isServer = typeof window === 'undefined'
+  const rerender = useReducer((count) => count + 1, 0)[1]
+  const [focusTarget, setFocusTarget] = useState<number | null>(null)
+  const rangeExtractor = useCallback(
+    (range: Range) => {
+      const indexes = new Set(defaultRangeExtractor(range))
+      if (focusTarget !== null && focusTarget < rows.length) {
+        indexes.add(focusTarget)
+      }
+      return Array.from(indexes).sort((a, b) => a - b)
+    },
+    [focusTarget, rows.length]
+  )
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    enabled: !isServer && open,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateSize,
+    measureElement: (element) => {
+      const style = getComputedStyle(element)
+      const measuredSize =
+        element.getBoundingClientRect().height +
+        parseFloat(style.marginTop || '0') +
+        parseFloat(style.marginBottom || '0')
+
+      return measuredSize > 0 ? measuredSize : estimateSize
+    },
+    getItemKey: (index) => rows[index].key,
+    initialRect: { width: 1, height: estimateSize * 8 },
+    overscan,
+    rangeExtractor,
+  })
+  const initialItems = rows.slice(0, overscan * 2 + 1).map((_, index) => ({
+    index,
+    start: index * estimateSize,
+  }))
+  const virtualItems = isServer
+    ? initialItems
+    : virtualizer.getVirtualItems().length > 0
+      ? virtualizer.getVirtualItems()
+      : initialItems
+  if (
+    !isServer &&
+    focusTarget !== null &&
+    focusTarget < rows.length &&
+    !virtualItems.some(({ index }) => index === focusTarget)
+  ) {
+    const focusedMeasurement = virtualizer.measurementsCache[focusTarget]
+    virtualItems.push(
+      focusedMeasurement ?? {
+        index: focusTarget,
+        start: focusTarget * estimateSize,
+      }
+    )
+    virtualItems.sort((a, b) => a.index - b.index)
+  }
+  const totalSize = isServer
+    ? rows.length * estimateSize
+    : virtualizer.getTotalSize()
+  const focusIndex = useCallback(
+    (index: number, direction: -1 | 1 = 1) => {
+      let focusableIndex = index
+      while (
+        focusableIndex >= 0 &&
+        focusableIndex < rows.length &&
+        rows[focusableIndex].disabled
+      ) {
+        focusableIndex += direction
+      }
+
+      if (focusableIndex < 0 || focusableIndex >= rows.length) {
+        return
+      }
+
+      flushSync(() => setFocusTarget(focusableIndex))
+      scrollRef.current
+        ?.querySelector<HTMLInputElement>(
+          `[data-multi-selection-index="${focusableIndex}"] .dnb-checkbox__input:not(:disabled)`
+        )
+        ?.focus({ preventScroll: true })
+      virtualizer.scrollToIndex(focusableIndex, { align: 'auto' })
+    },
+    [rows, scrollRef, virtualizer]
+  )
+  const driver = useMemo(
+    () => ({ focusIndex, itemCount: rows.length }),
+    [focusIndex, rows.length]
+  )
+
+  useIsomorphicLayoutEffect(() => {
+    return registerListDriver(driver)
+  }, [driver, registerListDriver])
+
+  useIsomorphicLayoutEffect(() => {
+    const frame = requestAnimationFrame(rerender)
+    return () => cancelAnimationFrame(frame)
+  }, [rerender])
+
+  const rowKeys = useMemo(() => rows.map(({ key }) => key), [rows])
+  const previousRowKeysRef = useRef(rowKeys)
+  useIsomorphicLayoutEffect(() => {
+    const previousRowKeys = previousRowKeysRef.current
+    previousRowKeysRef.current = rowKeys
+    const changed =
+      rowKeys.length !== previousRowKeys.length ||
+      rowKeys.some((key, index) => key !== previousRowKeys[index])
+
+    if (changed) {
+      setFocusTarget(null)
+      virtualizer.scrollToOffset(0)
+      virtualizer.measure()
+      const frame = requestAnimationFrame(rerender)
+      return () => cancelAnimationFrame(frame)
+    }
+
+    return undefined
+  }, [rerender, rowKeys, virtualizer])
+
+  return (
+    <li
+      role="presentation"
+      className="dnb-forms-field-multi-selection__virtual-content"
+      style={{ height: totalSize }}
+    >
+      <ul role="presentation">
+        {virtualItems.map((virtualItem) => {
+          const row = rows[virtualItem.index]
+
+          return (
+            <Fragment key={row.key}>
+              {row.render({
+                ref: virtualizer.measureElement,
+                'data-index': virtualItem.index,
+                className: 'dnb-forms-field-multi-selection__virtual-row',
+                style: {
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualItem.start}px)`,
+                },
+              })}
+            </Fragment>
+          )
+        })}
+      </ul>
+    </li>
+  )
+}
+
+export default createMultiSelectionVirtualization
+
+export const virtualizedMultiSelection =
+  createMultiSelectionVirtualization()

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -9,6 +9,7 @@ import { afterAll, beforeEach, vi } from 'vitest'
 import { axeComponent } from '../../../../../core/test-utils/testSetup'
 import { Provider } from '../../../../../shared'
 import { Field, Form } from '../../..'
+import { createMultiSelectionVirtualization } from '../Virtualization'
 
 const originalScrollIntoView = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
@@ -39,6 +40,195 @@ describe('MultiSelection', () => {
     }
 
     delete (HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView
+  })
+
+  describe('virtualization', () => {
+    const data = Array.from({ length: 1000 }, (_, index) => ({
+      value: `item-${index}`,
+      title: `Item ${index}`,
+    }))
+    const listDriver = createMultiSelectionVirtualization({ overscan: 2 })
+
+    it('renders a window while retaining the full selection data', async () => {
+      const onChange = vi.fn()
+      render(
+        <Field.MultiSelection
+          data={data}
+          listDriver={listDriver}
+          onChange={onChange}
+        />
+      )
+
+      fireEvent.click(document.querySelector('button'))
+      await waitFor(() => {
+        expect(
+          document.querySelectorAll(
+            '.dnb-forms-field-multi-selection__item'
+          ).length
+        ).toBeGreaterThan(0)
+      })
+      expect(
+        document.querySelectorAll('.dnb-forms-field-multi-selection__item')
+          .length
+      ).toBeLessThan(data.length)
+
+      fireEvent.click(screen.getByText('Item 0'))
+      expect(onChange).toHaveBeenCalledWith(['item-0'], expect.any(Object))
+    })
+
+    it('filters the full data set and renders the matching item', async () => {
+      render(
+        <Field.MultiSelection
+          data={data}
+          listDriver={listDriver}
+          showSearchField
+        />
+      )
+
+      fireEvent.click(document.querySelector('button'))
+      const input = document.querySelector<HTMLInputElement>(
+        '.dnb-forms-field-multi-selection__search input'
+      )
+      fireEvent.change(input, { target: { value: '999' } })
+
+      expect(
+        await screen.findByRole('checkbox', { name: 'Item 999' })
+      ).toBeInTheDocument()
+      expect(screen.queryByText('Item 0')).not.toBeInTheDocument()
+    })
+
+    it('keeps nested parent and child selection behavior', async () => {
+      const onChange = vi.fn()
+      render(
+        <Field.MultiSelection
+          data={[
+            {
+              value: 'parent',
+              title: 'Parent',
+              children: [
+                { value: 'child-1', title: 'Child 1' },
+                { value: 'child-2', title: 'Child 2' },
+              ],
+            },
+          ]}
+          listDriver={listDriver}
+          onChange={onChange}
+        />
+      )
+
+      fireEvent.click(document.querySelector('button'))
+      fireEvent.click(await screen.findByText('Parent'))
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.arrayContaining(['parent', 'child-1', 'child-2']),
+        expect.any(Object)
+      )
+      expect(screen.getByText('Child 1').closest('li')).toHaveClass(
+        'dnb-forms-field-multi-selection__item--level-1'
+      )
+    })
+
+    it('reattaches virtualization after reopening', async () => {
+      render(<Field.MultiSelection data={data} listDriver={listDriver} />)
+
+      const trigger = document.querySelector<HTMLButtonElement>('button')
+      fireEvent.click(trigger)
+      await waitFor(() => {
+        expect(screen.getByText('Item 0')).toBeInTheDocument()
+      })
+
+      fireEvent.click(trigger)
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            '.dnb-forms-field-multi-selection__virtual-content'
+          )
+        ).not.toBeInTheDocument()
+      })
+
+      fireEvent.click(trigger)
+      await waitFor(() => {
+        expect(screen.getByText('Item 0')).toBeInTheDocument()
+      })
+    })
+
+    it('keeps Select all operating on the full data set', async () => {
+      const onChange = vi.fn()
+      render(
+        <Field.MultiSelection
+          data={data}
+          listDriver={listDriver}
+          showSelectAll
+          onChange={onChange}
+        />
+      )
+
+      fireEvent.click(document.querySelector('button'))
+      fireEvent.click(await screen.findByText('Velg alle'))
+
+      expect(onChange.mock.calls.at(-1)[0]).toHaveLength(data.length)
+    })
+
+    it('constrains the inline list when virtualized', () => {
+      render(
+        <Field.MultiSelection
+          variant="inline"
+          data={data}
+          listDriver={listDriver}
+        />
+      )
+
+      expect(
+        document.querySelector('.dnb-forms-field-multi-selection__items')
+      ).toHaveStyle({ maxHeight: '32rem' })
+      expect(
+        document.querySelectorAll('.dnb-forms-field-multi-selection__item')
+          .length
+      ).toBeLessThan(data.length)
+    })
+
+    it('has valid accessibility semantics', async () => {
+      const result = render(
+        <Field.MultiSelection
+          label="Select items"
+          data={data}
+          listDriver={listDriver}
+          showSearchField
+          showSelectAll
+        />
+      )
+
+      fireEvent.click(document.querySelector('button'))
+      await waitFor(() => {
+        expect(screen.getByText('Item 0')).toBeInTheDocument()
+      })
+
+      expect(await axeComponent(result)).toHaveNoViolations()
+    })
+
+    it('navigates to virtualized items with the arrow keys', async () => {
+      render(
+        <Field.MultiSelection
+          data={data}
+          listDriver={listDriver}
+          showSearchField
+        />
+      )
+
+      const trigger = document.querySelector<HTMLButtonElement>('button')
+      fireEvent.click(trigger)
+      const searchInput = document.querySelector<HTMLInputElement>(
+        '.dnb-forms-field-multi-selection__search input'
+      )
+      searchInput.focus()
+      fireEvent.keyDown(searchInput, { key: 'ArrowDown' })
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(
+          screen.getByRole('checkbox', { name: 'Item 0' })
+        )
+      })
+    })
   })
 
   it('renders with label and trigger button', async () => {

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
@@ -46,6 +46,25 @@
     padding: 0;
   }
 
+  &__virtual-content,
+  &__virtual-content > ul {
+    position: relative;
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  &__virtual-content {
+    flex: none;
+  }
+  &__virtual-content > ul {
+    height: 100%;
+  }
+  &__virtual-row {
+    position: absolute;
+  }
+
   &__item-details {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Adds opt-in virtualization for large Field.MultiSelection data sets while preserving search, Select all, nested parent-child selection, keyboard navigation, inline rendering, and popover reopening. The optional virtualization dependency remains outside the default Forms bundle.

Stacked on #9293.

Preview: https://feat-multi-selection-virtual.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection