### PR TITLE
fix(plugins): make the ESLint and Stylelint color-variable rules ESM-safe

### DIFF
--- a/packages/dnb-eufemia/src/plugins/__tests__/esm-build-safety.test.ts
+++ b/packages/dnb-eufemia/src/plugins/__tests__/esm-build-safety.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+
+import path from 'path'
+import fs from 'fs-extra'
+import { sync } from 'globby'
+import { transform } from 'lebab'
+
+// The published ESM build runs lebab's "commonjs" transform on the plugin
+// files (see scripts/postbuild transformFilesToESM). lebab only rewrites
+// plain `const x = require('...')` and `module.exports = ...` statements, so a
+// `require(...)` used as part of a larger expression is left untouched and
+// throws "require is not defined in ES module scope" when imported from ESM.
+describe('ESLint and Stylelint plugin ESM build safety', () => {
+  const pluginsRoot = path.resolve(__dirname, '..')
+  const files = sync(
+    ['eslint.js', 'eslint/**/*.js', 'stylelint.js', 'stylelint/**/*.js'],
+    { cwd: pluginsRoot, absolute: true }
+  )
+
+  it('finds plugin source files to check', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it.each(files)(
+    'transforms %s to ESM without leaving a require() call',
+    (file) => {
+      const codeIn = fs
+        .readFileSync(file, 'utf8')
+        .replace(/\.cjs'/g, ".js'")
+
+      const { code } = transform(codeIn, ['commonjs'])
+
+      expect(code).not.toMatch(/\brequire\(/)
+    }
+  )
+})

--- a/packages/dnb-eufemia/src/plugins/__tests__/esm-build-safety.test.ts
+++ b/packages/dnb-eufemia/src/plugins/__tests__/esm-build-safety.test.ts
@@ -13,7 +13,13 @@ import { transform } from 'lebab'
 describe('ESLint and Stylelint plugin ESM build safety', () => {
   const pluginsRoot = path.resolve(__dirname, '..')
   const files = sync(
-    ['eslint.js', 'eslint/**/*.js', 'stylelint.js', 'stylelint/**/*.js'],
+    [
+      'review-rules.js',
+      'eslint.js',
+      'eslint/**/*.js',
+      'stylelint.js',
+      'stylelint/**/*.js',
+    ],
     { cwd: pluginsRoot, absolute: true }
   )
 

--- a/packages/dnb-eufemia/src/plugins/eslint/rules/no-deprecated-color-variables.js
+++ b/packages/dnb-eufemia/src/plugins/eslint/rules/no-deprecated-color-variables.js
@@ -1,7 +1,6 @@
 const COLOR_VARIABLE_REGEX = /--color-[a-z0-9-]+/g
-const reviewRule = require('../../review-rules.js')[
-  'eufemia/no-deprecated-color-variables'
-]
+const reviewRules = require('../../review-rules.js')
+const reviewRule = reviewRules['eufemia/no-deprecated-color-variables']
 
 const reportMatches = (context, node, text) => {
   if (typeof text !== 'string') {

--- a/packages/dnb-eufemia/src/plugins/stylelint/rules/no-deprecated-color-variables.js
+++ b/packages/dnb-eufemia/src/plugins/stylelint/rules/no-deprecated-color-variables.js
@@ -2,7 +2,8 @@ const stylelint = require('stylelint')
 
 const RULE_NAME = 'eufemia/no-deprecated-color-variables'
 const COLOR_VARIABLE_REGEX = /--color-[a-z0-9-]+/g
-const reviewRule = require('../../review-rules.js')[RULE_NAME]
+const reviewRules = require('../../review-rules.js')
+const reviewRule = reviewRules[RULE_NAME]
 
 const messages = stylelint.utils.ruleMessages(RULE_NAME, {
   rejected: (variable) =>


### PR DESCRIPTION
Motivation: https://dnb-it.slack.com/archives/CMXABCHEY/p1788932963743959

Importing `@dnb/eufemia/plugins/eslint.js` from an ESM ESLint flat config (11.11.0+) throws `require is not defined in ES module scope`.

The published ESM build converts the plugin sources with lebab's commonjs transform, which only rewrites plain `const x = require('...')` statements. The color-variable rules used `require('../../review-rules.js')[key]`, so the `require` survived into the ESM output and failed at import time. Splitting it into a plain `const` lets the transform produce an `import`.

Reported on Slack against 11.11.0.