### PR TITLE
feat(Icon): add opt-in animated icons API and docs

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/icons.mdx
+++ b/packages/dnb-design-system-portal/src/docs/icons.mdx
@@ -18,4 +18,8 @@ This is a comprehensive list of all available icons, sorted by categories. Prima
 
 Some icons support a filled variant where the SVG paths are filled with `currentColor`. Use the toggle below to preview filled icons. Use the `fill` prop on `Icon`. See the [Icon component docs](/uilib/components/icon#filled-icons) for usage details.
 
+## Animated Icons
+
+Some icons have an optional animated import. Use the toggle below to see which icons support motion, then hover an icon to preview the animation. Animated icons use direct default imports rather than named imports. See the [Icon component docs](/uilib/components/icon#animated-icons) for where, why, and when to use them.
+
 <ListAllIcons groupBy="category" />

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/animation-principles.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/animation-principles.mdx
@@ -78,7 +78,7 @@ Animations should not:
 - Draw attention to themselves.
 - Exist to make the application look cool or feel impressive.
 - Happen off-content.
-- Start on their own.
+- Start without a user action or meaningful state change.
 - Use a spring or bounce effect for large or repeated movements.
 - Make the user wait for them to finish.
 
@@ -91,3 +91,5 @@ To give the user the experience of something sliding in, the element does not ne
 ## Motion examples
 
 See [Motion](/quickguide-designer/motion/) for visual examples, component references, and implementation guidance.
+
+For motion in icons, see the [animated Icon guidance](/uilib/components/icon/#animated-icons).

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion.mdx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion.mdx
@@ -22,6 +22,7 @@ Reuse an Eufemia component's built-in motion before adding a custom animation.
 
 ### Components
 
+- [Icon](/uilib/components/icon/#animated-icons) provides opt-in, individually imported animated icons for event feedback and ongoing activity.
 - [Accordion](/uilib/components/accordion/) opens and closes content in place.
 - [Table](/uilib/components/table/#table-with-accordion) lets details settle into an expanding row.
 - [Breadcrumb](/uilib/components/breadcrumb/#always-be-collapsed-variantcollapse) reveals a collapsed path.

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/Examples.tsx
@@ -3,6 +3,7 @@
  *
  */
 
+import { useState } from 'react'
 import ComponentBox from '../../../../shared/tags/ComponentBox'
 import {
   bell_medium as BellMedium,
@@ -18,6 +19,8 @@ import {
 } from '@dnb/eufemia/src/icons'
 import * as PrimaryIconsMedium from '@dnb/eufemia/src/icons/dnb/primary_icons_medium'
 import * as SecondaryIconsMedium from '@dnb/eufemia/src/icons/dnb/secondary_icons_medium'
+import AnimatedBell from '@dnb/eufemia/src/icons/animated/bell_medium'
+import AnimatedArrowRight from '@dnb/eufemia/src/icons/animated/arrow_right'
 import { getListOfIcons } from '../../../../shared/parts/icons/ListAllIcons'
 import {
   Icon,
@@ -69,6 +72,45 @@ export const IconFilled = () => (
         <Button icon={<Icon icon={Heart} fill />} title="Favorite" />
       </Flex.Horizontal>
     </Flex.Stack>
+  </ComponentBox>
+)
+
+export const IconAnimated = () => (
+  <ComponentBox data-visual-test="icon-animated" scope={{ AnimatedBell }}>
+    {() => {
+      const App = () => {
+        const [animationKey, setAnimationKey] = useState(0)
+
+        return (
+          <Flex.Horizontal align="center" gap="small">
+            <Icon
+              icon={AnimatedBell}
+              size="medium"
+              animate
+              animationKey={animationKey}
+              aria-hidden
+            />
+            <Button
+              variant="secondary"
+              text="Replay"
+              onClick={() => setAnimationKey((key) => key + 1)}
+            />
+          </Flex.Horizontal>
+        )
+      }
+
+      return <App />
+    }}
+  </ComponentBox>
+)
+
+export const IconAnimatedButtonInvite = () => (
+  <ComponentBox scope={{ AnimatedArrowRight }}>
+    <Button
+      variant="tertiary"
+      text="Continue"
+      icon={<Icon icon={AnimatedArrowRight} animateWhen="hover" />}
+    />
   </ComponentBox>
 )
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/demos.mdx
@@ -6,6 +6,8 @@ import {
   IconDefault,
   IconBorder,
   IconFilled,
+  IconAnimated,
+  IconAnimatedButtonInvite,
   IconInheritSized,
   IconColors,
   IconsSizes,
@@ -30,6 +32,20 @@ import {
 Use the `fill` prop on a single icon to fill it.
 
 <IconFilled />
+
+### Animated icon demos
+
+Animated icons are static by default and only move when you opt in. Import each animated icon directly using its default export. Named imports are intentionally unavailable so each icon's animation code is only included when it is used.
+
+Use a single animation to reinforce an event. Change `animationKey` to replay it while `animate` remains enabled.
+
+<IconAnimated />
+
+#### Animated icons in buttons
+
+Use hover to invite or preview an action. Play the animation once and keep the button understandable without motion.
+
+<IconAnimatedButtonInvite />
 
 ### Responsive to its inherited `font-size`
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/components/icon/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/components/icon/info.mdx
@@ -71,6 +71,52 @@ Set `fill` on an `Icon` to fill its SVG paths with `currentColor`:
 
 See the [Icon Library](/icons#filled-icons) for icons that are known to look good when filled.
 
+### Animated Icons
+
+Animated icons are an opt-in enhancement. Use them to reinforce nearby feedback, such as a bell moving once when a new notification arrives. Motion must not be the only indication that something changed.
+
+Read the [Animation Principles](/quickguide-designer/animation-principles/) for where, why, and when to use motion, and [Motion](/quickguide-designer/motion/) for visual examples and implementation guidance.
+
+See the [animated icon demos](#animated-icon-demos) for one-time, replayed, and looping examples.
+
+Animated icons can be used in buttons when the trigger matches the purpose:
+
+- Animate once on hover to invite or preview an action.
+- Animate after a click only to acknowledge the interaction itself.
+- Animate after a state change to confirm the actual outcome, such as showing an animated check after saving succeeds.
+- Loop only while the icon represents genuine ongoing activity.
+
+Animated icons intentionally support direct default imports only. They are not available as named imports from `@dnb/eufemia/icons`. The direct import is the bundle boundary that keeps each icon's animation styles out of applications that do not use it. The icon remains static unless `animate` is enabled.
+
+```jsx
+import bell from '@dnb/eufemia/icons/animated/bell'
+import arrowRight from '@dnb/eufemia/icons/animated/arrow_right'
+
+<Icon icon={bell} />
+<Icon icon={bell} animate />
+```
+
+Do not import animated icons from a shared barrel:
+
+```jsx
+// Not supported
+import { bell } from '@dnb/eufemia/icons/animated'
+```
+
+Import `bell_medium` when the icon is displayed at medium size or larger.
+
+Use `animate="loop"` only for genuine ongoing activity, and stop the loop when the activity ends. Change `animationKey` to replay a one-time animation after a new event.
+
+```jsx
+<Icon icon={bell} animate animationKey={notificationId} />
+<Icon icon={bell} animate={isActive ? 'loop' : false} />
+<Icon icon={arrowRight} animateWhen="hover" />
+```
+
+The animation is disabled automatically when the user prefers reduced motion.
+
+Use `animateWhen="hover"` to animate an icon when the icon itself, or an interactive parent such as a button or link, is hovered.
+
 ### Custom project Icons
 
 For decorative or functional icons (not illustrations), use `SVG` as it gives the user responsiveness and better accessibility. It also gives you more control, so you can change the color and size inherited by the parent HTML element.

--- a/packages/dnb-design-system-portal/src/shared/parts/icons/ListAllIcons.tsx
+++ b/packages/dnb-design-system-portal/src/shared/parts/icons/ListAllIcons.tsx
@@ -9,11 +9,19 @@ import {
   ToggleButton,
 } from '@dnb/eufemia/src/components'
 import { isSupportedFilled } from '@dnb/eufemia/src/components/icon/filledIconSet'
+import { isSupportedAnimated } from '@dnb/eufemia/src/icons/animated/animatedIconSet'
 import { P } from '@dnb/eufemia/src'
+import { Hr } from '@dnb/eufemia/src/elements'
 import * as PrimaryIcons from '@dnb/eufemia/src/icons/dnb/primary_icons'
 import * as SecondaryIcons from '@dnb/eufemia/src/icons/dnb/secondary_icons'
 import * as PrimaryIconsMedium from '@dnb/eufemia/src/icons/dnb/primary_icons_medium'
 import * as SecondaryIconsMedium from '@dnb/eufemia/src/icons/dnb/secondary_icons_medium'
+import AnimatedBell from '@dnb/eufemia/src/icons/animated/bell'
+import AnimatedBellMedium from '@dnb/eufemia/src/icons/animated/bell_medium'
+import AnimatedArrowRight from '@dnb/eufemia/src/icons/animated/arrow_right'
+import AnimatedArrowRightMedium from '@dnb/eufemia/src/icons/animated/arrow_right_medium'
+import AnimatedCheck from '@dnb/eufemia/src/icons/animated/check'
+import AnimatedCheckMedium from '@dnb/eufemia/src/icons/animated/check_medium'
 import iconsMetaData from '@dnb/eufemia/src/icons/dnb/icons-meta.json'
 import AutoLinkHeader from '../../tags/AutoLinkHeader'
 import {
@@ -21,6 +29,17 @@ import {
   listItemStyle,
   listItemInnerStyle,
 } from './ListAllIcons.module.scss'
+
+const animatedIcons = {
+  arrow_right: AnimatedArrowRight,
+  bell: AnimatedBell,
+  check: AnimatedCheck,
+}
+const animatedIconsMedium = {
+  arrow_right_medium: AnimatedArrowRightMedium,
+  bell_medium: AnimatedBellMedium,
+  check_medium: AnimatedCheckMedium,
+}
 
 export const getListOfIcons = (icons) => {
   return Object.entries(icons)
@@ -60,9 +79,51 @@ type Props = {
   variant: string
 }
 
+function IconPreviewItem({
+  iconName,
+  Svg,
+  SvgMedium,
+  tags,
+  showAnimated,
+  showFilled,
+}) {
+  return (
+    <li className={listItemStyle}>
+      <div className={listItemInnerStyle} data-icon-animation-trigger>
+        <figure aria-labelledby={`icon-${iconName}`} aria-hidden>
+          <Icon
+            icon={Svg}
+            fill={showFilled}
+            animateWhen={showAnimated ? 'hover' : undefined}
+            right
+          />
+          <Icon
+            icon={SvgMedium}
+            size="medium"
+            fill={showFilled}
+            animateWhen={showAnimated ? 'hover' : undefined}
+          />
+        </figure>
+
+        <AutoLinkHeader
+          level={3}
+          size="medium"
+          element="figcaption"
+          useSlug={iconName}
+        >
+          <CopyOnClick>{iconName}</CopyOnClick>
+        </AutoLinkHeader>
+
+        <P>{tags.length > 0 ? tags.join(', ') : '(no tags)'}</P>
+      </div>
+    </li>
+  )
+}
+
 export default function ListAllIcons(props: Props) {
   const { groupBy, variant } = props
   const [showFilled, setShowFilled] = useState(false)
+  const [showAnimated, setShowAnimated] = useState(false)
 
   const iconsToRender = useMemo(() => {
     let icons = {}
@@ -82,18 +143,27 @@ export default function ListAllIcons(props: Props) {
 
     const all = getListOfIcons(icons)
 
+    if (showAnimated) {
+      return all.filter(({ iconName }) => isSupportedAnimated(iconName))
+    }
+
     if (showFilled) {
       return all.filter(({ iconName }) => isSupportedFilled(iconName))
     }
 
     return all
-  }, [variant, showFilled])
+  }, [variant, showAnimated, showFilled])
 
   const renderListItem = (icons) => {
     return icons.map(({ iconName, Svg, variant, tags }) => {
-      const SvgMedium = (
+      let SvgMedium = (
         variant === 'primary' ? PrimaryIconsMedium : SecondaryIconsMedium
       )[`${iconName}_medium`]
+
+      if (showAnimated) {
+        Svg = animatedIcons[iconName]
+        SvgMedium = animatedIconsMedium[`${iconName}_medium`]
+      }
 
       // remove duplications
       tags = tags.filter((item, index) => {
@@ -104,25 +174,15 @@ export default function ListAllIcons(props: Props) {
       })
 
       return (
-        <li key={iconName} className={listItemStyle}>
-          <div className={listItemInnerStyle}>
-            <figure aria-labelledby={`icon-${iconName}`} aria-hidden>
-              <Icon icon={Svg} fill={showFilled} right />
-              <Icon icon={SvgMedium} size="medium" fill={showFilled} />
-            </figure>
-
-            <AutoLinkHeader
-              level={3}
-              size="medium"
-              element="figcaption"
-              useSlug={iconName}
-            >
-              <CopyOnClick>{iconName}</CopyOnClick>
-            </AutoLinkHeader>
-
-            <P>{tags.length > 0 ? tags.join(', ') : '(no tags)'}</P>
-          </div>
-        </li>
+        <IconPreviewItem
+          key={iconName}
+          iconName={iconName}
+          Svg={Svg}
+          SvgMedium={SvgMedium}
+          tags={tags}
+          showAnimated={showAnimated}
+          showFilled={showFilled}
+        />
       )
     })
   }
@@ -132,13 +192,30 @@ export default function ListAllIcons(props: Props) {
   }
 
   const toggle = (
-    <ToggleButton
-      checked={showFilled}
-      onChange={({ checked }) => setShowFilled(checked)}
-      bottom="medium"
-    >
-      Show filled
-    </ToggleButton>
+    <>
+      <Hr bottom="medium" />
+      <ToggleButton
+        checked={showFilled}
+        onChange={({ checked }) => {
+          setShowFilled(checked)
+          setShowAnimated(false)
+        }}
+        right="small"
+        bottom="medium"
+      >
+        Show filled
+      </ToggleButton>
+      <ToggleButton
+        checked={showAnimated}
+        onChange={({ checked }) => {
+          setShowAnimated(checked)
+          setShowFilled(false)
+        }}
+        bottom="medium"
+      >
+        Show animated
+      </ToggleButton>
+    </>
   )
 
   if (groupBy === 'category') {

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeLibStyles.test.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/__tests__/makeLibStyles.test.ts
@@ -76,6 +76,26 @@ describe('makeLibStyles transform main SCSS to CSS', () => {
   })
 })
 
+describe('makeLibStyles animated icon styles', () => {
+  it('compiles animated icon styles as individual files', async () => {
+    const files = await runFactory(
+      './src/icons/animated/**/style/**/dnb-*.scss',
+      { returnFiles: true }
+    )
+
+    expect(
+      files.some((file) =>
+        file.includes('/icons/animated/style/dnb-bell.css')
+      )
+    ).toBe(true)
+    expect(
+      files.some((file) =>
+        file.includes('/icons/animated/style/dnb-bell.min.css')
+      )
+    ).toBe(true)
+  })
+})
+
 describe('makeLibStyles with enableBuildStyleScope', () => {
   // Ensure enableBuildStyleScope returns true
   let originalEnv

--- a/packages/dnb-eufemia/scripts/prebuild/tasks/makeLibStyles.ts
+++ b/packages/dnb-eufemia/scripts/prebuild/tasks/makeLibStyles.ts
@@ -30,6 +30,7 @@ export default async function makeLibStyles() {
   try {
     await runFactory('./src/components/**/style/**/dnb-*.scss')
     await runFactory('./src/extensions/**/style/**/dnb-*.scss')
+    await runFactory('./src/icons/animated/**/style/**/dnb-*.scss')
     log.succeed(
       `> PrePublish: "makeLibStyles" converting sass to css done`
     )

--- a/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
+++ b/packages/dnb-eufemia/src/components/icon-primary/IconPrimary.tsx
@@ -32,8 +32,16 @@ export default function IconPrimary(localProps: IconAllProps) {
     context.IconPrimary
   )
 
-  const { icon, size, wrapperParams, iconParams, alt, transitionState } =
-    prepareIcon(props, context)
+  const {
+    icon,
+    size,
+    wrapperParams,
+    iconParams,
+    alt,
+    transitionState,
+    animationMode,
+  } = prepareIcon(props, context)
+  const { animationKey } = props
 
   const spacingProps = useSpacing(props, {
     className: wrapperParams.className,
@@ -85,7 +93,10 @@ export default function IconPrimary(localProps: IconAllProps) {
 
   return (
     <span {...restWrapperParams} ref={combinedRef} {...spacingProps}>
-      <IconContainer {...iconParams} />
+      <IconContainer
+        key={animationMode ? animationKey : undefined}
+        {...iconParams}
+      />
     </span>
   )
 }

--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -57,6 +57,7 @@ export type IconSVGProps = SVGProps<SVGSVGElement> & {
 export type IconFunction = ((props?: IconSVGProps) => JSX.Element) & {
   __iconTransitionStyle?: Record<string, string>
   __iconTransitionFallback?: boolean
+  __iconAnimation?: string
 }
 
 /** For internal usage */
@@ -123,6 +124,21 @@ export type IconProps = {
    */
   fill?: boolean
 
+  /**
+   * Plays motion provided by an explicitly imported animated icon. Set to `true` or `once` to play once, or `loop` to repeat it.
+   */
+  animate?: boolean | 'once' | 'loop'
+
+  /**
+   * Plays the icon animation when the icon or its interactive parent is hovered.
+   */
+  animateWhen?: 'hover'
+
+  /**
+   * Change this value to replay an animated icon while `animate` remains enabled.
+   */
+  animationKey?: string | number
+
   border?: boolean
   width?: `${IconSize}` | `${number}%` | number
   height?: `${IconSize}` | `${number}%` | number
@@ -157,6 +173,8 @@ export default function Icon(localProps: IconAllProps) {
     alt,
     children,
     transitionState,
+    animationMode,
+    animationKey,
   } = usePrepareIcon(props, context)
   const icon = iconProp ?? children
 
@@ -196,7 +214,10 @@ export default function Icon(localProps: IconAllProps) {
 
   return (
     <span {...restWrapperParams} ref={combinedRef}>
-      <IconContainer {...iconParams} />
+      <IconContainer
+        key={animationMode ? animationKey : undefined}
+        {...iconParams}
+      />
     </span>
   )
 }
@@ -399,6 +420,9 @@ export function prepareIcon(
     skeleton,
     className,
     transitionState: _transitionState,
+    animate,
+    animateWhen,
+    animationKey: _animationKey,
     ...attributes
   } = props
 
@@ -458,8 +482,23 @@ export function prepareIcon(
   )
 
   const iconToRender = getIcon(props)
+  const hasAnimation =
+    typeof iconToRender === 'function' &&
+    Boolean(iconToRender.__iconAnimation)
+  const animationMode =
+    hasAnimation && animate ? (animate === true ? 'once' : animate) : null
+  const animationTrigger = hasAnimation ? animateWhen : null
 
   if (typeof iconToRender === 'function') {
+    if (animationMode || animationTrigger) {
+      wrapperParams.className = clsx(
+        wrapperParams.className,
+        animationMode && 'dnb-icon--animate',
+        animationMode && `dnb-icon--animate-${animationMode}`,
+        animationTrigger && `dnb-icon--animate-when-${animationTrigger}`,
+        `dnb-icon--animated-${iconToRender.__iconAnimation}`
+      )
+    }
     if (iconToRender.__iconTransitionFallback) {
       wrapperParams.className += ' dnb-icon--transition-fallback'
 
@@ -486,6 +525,7 @@ export function prepareIcon(
     alt,
     iconParams,
     wrapperParams,
+    animationMode,
   }
 }
 

--- a/packages/dnb-eufemia/src/components/icon/IconDocs.ts
+++ b/packages/dnb-eufemia/src/components/icon/IconDocs.ts
@@ -56,6 +56,21 @@ export const IconProperties: PropertiesTableProps = {
     type: 'string',
     status: 'optional',
   },
+  animate: {
+    doc: 'Plays motion provided by an explicitly imported animated icon. Use `true` or `once` to play once, or `loop` to repeat the animation.',
+    type: ['boolean', '"once"', '"loop"'],
+    status: 'optional',
+  },
+  animateWhen: {
+    doc: 'Plays an animated icon when the icon itself, or an interactive parent such as a button or link, is hovered.',
+    type: '"hover"',
+    status: 'optional',
+  },
+  animationKey: {
+    doc: 'Change this value to replay an animated icon while `animate` remains enabled.',
+    type: ['string', 'number'],
+    status: 'optional',
+  },
   skeleton: {
     doc: 'If set to `true`, an overlaying skeleton with animation will be shown.',
     type: 'boolean',

--- a/packages/dnb-eufemia/src/components/icon/__tests__/IconAnimated.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/IconAnimated.test.tsx
@@ -1,0 +1,113 @@
+import { render } from '@testing-library/react'
+import Icon from '../Icon'
+import IconPrimary from '../../icon-primary/IconPrimary'
+import bell from '../../../icons/dnb/bell'
+import animatedBell from '../../../icons/animated/bell'
+import animatedBellMedium from '../../../icons/animated/bell_medium'
+import animatedArrowRight from '../../../icons/animated/arrow_right'
+import animatedCheck from '../../../icons/animated/check'
+
+describe('animated Icon', () => {
+  it('keeps the animated icon static by default', () => {
+    render(<Icon icon={animatedBell} />)
+
+    const element = document.querySelector('.dnb-icon')
+
+    expect(element).not.toHaveClass('dnb-icon--animate')
+    expect(element).not.toHaveAttribute('animate')
+  })
+
+  it('preserves the medium icon size', () => {
+    render(<Icon icon={animatedBellMedium} animate />)
+
+    expect(document.querySelector('.dnb-icon')).toHaveClass(
+      'dnb-icon--medium',
+      'dnb-icon--animated-bell'
+    )
+  })
+
+  it('plays the animation once', () => {
+    render(<Icon icon={animatedBell} animate="once" />)
+
+    const element = document.querySelector('.dnb-icon')
+
+    expect(element).toHaveClass(
+      'dnb-icon--animate',
+      'dnb-icon--animate-once',
+      'dnb-icon--animated-bell'
+    )
+    expect(element).not.toHaveAttribute('animate')
+  })
+
+  it('treats animate={true} as once', () => {
+    render(<Icon icon={animatedBell} animate />)
+
+    expect(document.querySelector('.dnb-icon')).toHaveClass(
+      'dnb-icon--animate-once'
+    )
+  })
+
+  it('loops the animation', () => {
+    render(<Icon icon={animatedBell} animate="loop" />)
+
+    expect(document.querySelector('.dnb-icon')).toHaveClass(
+      'dnb-icon--animate-loop'
+    )
+  })
+
+  it('supports animation triggered by hover', () => {
+    render(<Icon icon={animatedArrowRight} animateWhen="hover" />)
+
+    const element = document.querySelector('.dnb-icon')
+
+    expect(element).toHaveClass(
+      'dnb-icon--animate-when-hover',
+      'dnb-icon--animated-arrow-right'
+    )
+    expect(element).not.toHaveClass('dnb-icon--animate')
+    expect(element).not.toHaveAttribute('animateWhen')
+  })
+
+  it('does not animate a regular icon', () => {
+    render(<Icon icon={bell} animate />)
+
+    expect(document.querySelector('.dnb-icon')).not.toHaveClass(
+      'dnb-icon--animate'
+    )
+  })
+
+  it('replays when animationKey changes', () => {
+    const { rerender } = render(
+      <Icon icon={animatedBell} animate animationKey={0} />
+    )
+    const initialSvg = document.querySelector('.dnb-icon svg')
+
+    rerender(<Icon icon={animatedBell} animate animationKey={1} />)
+
+    expect(document.querySelector('.dnb-icon svg')).not.toBe(initialSvg)
+    expect(document.querySelector('.dnb-icon')).toHaveClass(
+      'dnb-icon--animate-once'
+    )
+  })
+
+  it('supports animation through IconPrimary', () => {
+    render(<IconPrimary icon={animatedBell} animate="loop" />)
+
+    expect(document.querySelector('.dnb-icon')).toHaveClass(
+      'dnb-icon--animate-loop',
+      'dnb-icon--animated-bell'
+    )
+  })
+
+  it.each([
+    ['arrow-right', animatedArrowRight],
+    ['check', animatedCheck],
+  ])('supports the %s animated icon', (name, icon) => {
+    render(<Icon icon={icon} animate />)
+
+    expect(document.querySelector('.dnb-icon')).toHaveClass(
+      `dnb-icon--animated-${name}`,
+      'dnb-icon--animate-once'
+    )
+  })
+})

--- a/packages/dnb-eufemia/src/icons/animated/animatedIconSet.ts
+++ b/packages/dnb-eufemia/src/icons/animated/animatedIconSet.ts
@@ -1,0 +1,13 @@
+const animatedIconNames = ['arrow_right', 'bell', 'check'] as const
+
+export type AnimatedIconName = (typeof animatedIconNames)[number]
+
+const animatedIconSet: ReadonlySet<string> = new Set(
+  animatedIconNames.flatMap((name) => [name, `${name}_medium`])
+)
+
+export function isSupportedAnimated(name: string): boolean {
+  return animatedIconSet.has(name)
+}
+
+export default animatedIconSet

--- a/packages/dnb-eufemia/src/icons/animated/arrow_right.tsx
+++ b/packages/dnb-eufemia/src/icons/animated/arrow_right.tsx
@@ -1,0 +1,16 @@
+import type {
+  IconFunction,
+  IconSVGProps,
+} from '../../components/icon/Icon'
+import arrowRightIcon from '../dnb/arrow_right'
+import './style/dnb-arrow-right.scss'
+
+const arrow_right = ((props?: IconSVGProps) =>
+  arrowRightIcon(props)) as IconFunction
+
+arrow_right.__iconAnimation = 'arrow-right'
+Object.defineProperty(arrow_right, 'name', {
+  value: arrowRightIcon.name,
+})
+
+export default arrow_right

--- a/packages/dnb-eufemia/src/icons/animated/arrow_right_medium.tsx
+++ b/packages/dnb-eufemia/src/icons/animated/arrow_right_medium.tsx
@@ -1,0 +1,16 @@
+import type {
+  IconFunction,
+  IconSVGProps,
+} from '../../components/icon/Icon'
+import arrowRightIcon from '../dnb/arrow_right_medium'
+import './style/dnb-arrow-right.scss'
+
+const arrow_right_medium = ((props?: IconSVGProps) =>
+  arrowRightIcon(props)) as IconFunction
+
+arrow_right_medium.__iconAnimation = 'arrow-right'
+Object.defineProperty(arrow_right_medium, 'name', {
+  value: arrowRightIcon.name,
+})
+
+export default arrow_right_medium

--- a/packages/dnb-eufemia/src/icons/animated/bell.tsx
+++ b/packages/dnb-eufemia/src/icons/animated/bell.tsx
@@ -1,0 +1,13 @@
+import type {
+  IconFunction,
+  IconSVGProps,
+} from '../../components/icon/Icon'
+import bellIcon from '../dnb/bell'
+import './style/dnb-bell.scss'
+
+const bell = ((props?: IconSVGProps) => bellIcon(props)) as IconFunction
+
+bell.__iconAnimation = 'bell'
+Object.defineProperty(bell, 'name', { value: bellIcon.name })
+
+export default bell

--- a/packages/dnb-eufemia/src/icons/animated/bell_medium.tsx
+++ b/packages/dnb-eufemia/src/icons/animated/bell_medium.tsx
@@ -1,0 +1,14 @@
+import type {
+  IconFunction,
+  IconSVGProps,
+} from '../../components/icon/Icon'
+import bellIcon from '../dnb/bell_medium'
+import './style/dnb-bell.scss'
+
+const bell_medium = ((props?: IconSVGProps) =>
+  bellIcon(props)) as IconFunction
+
+bell_medium.__iconAnimation = 'bell'
+Object.defineProperty(bell_medium, 'name', { value: bellIcon.name })
+
+export default bell_medium

--- a/packages/dnb-eufemia/src/icons/animated/check.tsx
+++ b/packages/dnb-eufemia/src/icons/animated/check.tsx
@@ -1,0 +1,14 @@
+import type {
+  IconFunction,
+  IconSVGProps,
+} from '../../components/icon/Icon'
+import checkIcon from '../dnb/check'
+import './style/dnb-check.scss'
+
+const check = ((props?: IconSVGProps) =>
+  checkIcon(props)) as IconFunction
+
+check.__iconAnimation = 'check'
+Object.defineProperty(check, 'name', { value: checkIcon.name })
+
+export default check

--- a/packages/dnb-eufemia/src/icons/animated/check_medium.tsx
+++ b/packages/dnb-eufemia/src/icons/animated/check_medium.tsx
@@ -1,0 +1,14 @@
+import type {
+  IconFunction,
+  IconSVGProps,
+} from '../../components/icon/Icon'
+import checkIcon from '../dnb/check_medium'
+import './style/dnb-check.scss'
+
+const check_medium = ((props?: IconSVGProps) =>
+  checkIcon(props)) as IconFunction
+
+check_medium.__iconAnimation = 'check'
+Object.defineProperty(check_medium, 'name', { value: checkIcon.name })
+
+export default check_medium

--- a/packages/dnb-eufemia/src/icons/animated/style/dnb-arrow-right.scss
+++ b/packages/dnb-eufemia/src/icons/animated/style/dnb-arrow-right.scss
@@ -1,0 +1,30 @@
+@use '../../../style/core/utilities.scss' as utilities;
+
+.dnb-icon--animated-arrow-right.dnb-icon--animate svg,
+:where(button, a, [role='button'], [data-icon-animation-trigger]):hover
+  .dnb-icon--animated-arrow-right.dnb-icon--animate-when-hover
+  svg,
+.dnb-icon--animated-arrow-right.dnb-icon--animate-when-hover:hover svg {
+  transform-origin: right center;
+  animation: dnb-icon-animated-arrow-right 650ms var(--easing-default)
+    both;
+
+  @include utilities.reducedMotion() {
+    animation: none;
+  }
+}
+
+@keyframes dnb-icon-animated-arrow-right {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  18% {
+    transform: translateX(-0.06em) scaleX(0.82);
+  }
+
+  52% {
+    transform: translateX(0.35em) scaleX(1.12);
+  }
+}

--- a/packages/dnb-eufemia/src/icons/animated/style/dnb-bell.scss
+++ b/packages/dnb-eufemia/src/icons/animated/style/dnb-bell.scss
@@ -1,0 +1,75 @@
+@use '../../../style/core/utilities.scss' as utilities;
+
+.dnb-icon--animated-bell.dnb-icon--animate svg,
+:where(button, a, [role='button'], [data-icon-animation-trigger]):hover
+  .dnb-icon--animated-bell.dnb-icon--animate-when-hover
+  svg,
+.dnb-icon--animated-bell.dnb-icon--animate-when-hover:hover svg {
+  transform-origin: 50% 12.5%;
+  transform-box: view-box;
+  animation-name: dnb-icon-animated-bell;
+  animation-duration: 700ms;
+  animation-timing-function: var(--easing-default);
+  animation-fill-mode: both;
+
+  @include utilities.reducedMotion() {
+    animation: none;
+  }
+}
+
+.dnb-icon--animated-bell.dnb-icon--animate-loop svg {
+  animation-name: dnb-icon-animated-bell-loop;
+  animation-duration: 3s;
+  animation-iteration-count: infinite;
+
+  @include utilities.reducedMotion() {
+    animation: none;
+  }
+}
+
+@keyframes dnb-icon-animated-bell {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  20% {
+    transform: rotate(-16deg);
+  }
+
+  40% {
+    transform: rotate(14deg);
+  }
+
+  60% {
+    transform: rotate(-8deg);
+  }
+
+  80% {
+    transform: rotate(4deg);
+  }
+}
+
+@keyframes dnb-icon-animated-bell-loop {
+  0%,
+  24%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  5% {
+    transform: rotate(-16deg);
+  }
+
+  10% {
+    transform: rotate(14deg);
+  }
+
+  15% {
+    transform: rotate(-8deg);
+  }
+
+  20% {
+    transform: rotate(4deg);
+  }
+}

--- a/packages/dnb-eufemia/src/icons/animated/style/dnb-check.scss
+++ b/packages/dnb-eufemia/src/icons/animated/style/dnb-check.scss
@@ -1,0 +1,62 @@
+@use '../../../style/core/utilities.scss' as utilities;
+
+.dnb-icon--animated-check.dnb-icon--animate svg,
+:where(button, a, [role='button'], [data-icon-animation-trigger]):hover
+  .dnb-icon--animated-check.dnb-icon--animate-when-hover
+  svg,
+.dnb-icon--animated-check.dnb-icon--animate-when-hover:hover svg {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation: dnb-icon-animated-check-settle 650ms
+    var(--easing-default) both;
+
+  @include utilities.reducedMotion() {
+    animation: none;
+  }
+}
+
+.dnb-icon--animated-check.dnb-icon--animate path,
+:where(button, a, [role='button'], [data-icon-animation-trigger]):hover
+  .dnb-icon--animated-check.dnb-icon--animate-when-hover
+  path,
+.dnb-icon--animated-check.dnb-icon--animate-when-hover:hover path {
+  animation: dnb-icon-animated-check-draw 650ms var(--easing-default)
+    both;
+
+  @include utilities.reducedMotion() {
+    animation: none;
+  }
+}
+
+@keyframes dnb-icon-animated-check-draw {
+  from {
+    stroke-dasharray: 40;
+    stroke-dashoffset: 40;
+  }
+
+  to {
+    stroke-dasharray: 40;
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes dnb-icon-animated-check-settle {
+  0% {
+    opacity: 0;
+    transform: scale(0.7) rotate(-8deg);
+  }
+
+  55% {
+    opacity: 1;
+    transform: scale(1.15) rotate(2deg);
+  }
+
+  75% {
+    transform: scale(0.96) rotate(-1deg);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+}


### PR DESCRIPTION
Add per-icon animated imports so icon motion stays opt-in and is excluded from bundles that do not use it. Start with the bell icon and document when one-time, replayed, and looping motion is appropriate.

Preview:
- [Animated Icon docs and demos](https://feat-animated-icons.eufemia-e25.pages.dev/uilib/components/icon/#animated-icons)
- [Icons Library](https://feat-animated-icons.eufemia-e25.pages.dev/icons/#animated-icons)
- [Animation Principles](https://feat-animated-icons.eufemia-e25.pages.dev/quickguide-designer/animation-principles/)
- [Motion](https://feat-animated-icons.eufemia-e25.pages.dev/quickguide-designer/motion/)