### PR TITLE
docs(Portal): copy heading permalink URLs

### DIFF
--- a/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/AutoLinkHeader.tsx
@@ -5,6 +5,7 @@ import Anchor from './Anchor'
 import Heading, {
   type HeadingAllProps,
 } from '@dnb/eufemia/src/components/Heading'
+import { copyToClipboard } from '@dnb/eufemia/src/shared/helpers'
 import { makeSlug } from '../../uilib/utils/slug'
 import { useLocation } from 'react-router'
 import {
@@ -60,19 +61,22 @@ const AutoLinkHeader = ({
   const clickHandler =
     className && /skip-anchor/g.test(String(className))
       ? null
-      : (event: MouseEvent<HTMLAnchorElement>) => {
+      : async (event: MouseEvent<HTMLAnchorElement>) => {
           event.preventDefault()
 
           if (typeof window !== 'undefined' && id) {
             try {
               window.history.replaceState(undefined, undefined, '#' + id)
 
-              setAnchorUrlSet(true)
-              clearTimeout(tooltipTimeoutRef.current)
-              tooltipTimeoutRef.current = setTimeout(
-                () => setAnchorUrlSet(false),
-                2000
-              )
+              const success = await copyToClipboard(window.location.href)
+              if (success === true) {
+                setAnchorUrlSet(true)
+                clearTimeout(tooltipTimeoutRef.current)
+                tooltipTimeoutRef.current = setTimeout(
+                  () => setAnchorUrlSet(false),
+                  2000
+                )
+              }
             } catch (e) {
               console.error('Could not call replaceState:', e)
             }

--- a/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
+++ b/packages/dnb-design-system-portal/src/shared/tags/__tests__/AutoLinkHeader.test.tsx
@@ -12,6 +12,22 @@ vi.mock('../AutoLinkHeader.module.scss', () => ({
   headingContentStyle: 'headingContentStyle',
 }))
 
+const mockCopyToClipboard = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(true)
+)
+
+vi.mock('@dnb/eufemia/src/shared/helpers', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@dnb/eufemia/src/shared/helpers')
+    >()
+
+  return {
+    ...actual,
+    copyToClipboard: mockCopyToClipboard,
+  }
+})
+
 import AutoLinkHeader from '../AutoLinkHeader'
 
 afterEach(cleanup)
@@ -60,7 +76,7 @@ describe('AutoLinkHeader', () => {
     expect(document.activeElement).toBe(anchor)
   })
 
-  it('updates the hash without native navigation or highlighting the heading', async () => {
+  it('copies the URL and updates the hash without native navigation or highlighting the heading', async () => {
     renderHeader()
 
     const anchor =
@@ -78,7 +94,26 @@ describe('AutoLinkHeader', () => {
     expect(window.location.hash).toBe('#my-heading')
     expect(headingContent?.classList).not.toContain('focus')
     await waitFor(() => {
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        window.location.href
+      )
       expect(document.body.textContent).toContain('Copied')
     })
+  })
+
+  it('does not report success when copying fails', async () => {
+    mockCopyToClipboard.mockResolvedValueOnce(false)
+    renderHeader()
+
+    const anchor =
+      document.querySelector<HTMLAnchorElement>('.anchor-hash')
+
+    fireEvent.mouseEnter(anchor)
+    fireEvent.click(anchor)
+
+    await waitFor(() => {
+      expect(mockCopyToClipboard).toHaveBeenCalled()
+    })
+    expect(document.body.textContent).not.toContain('Copied')
   })
 })


### PR DESCRIPTION
Heading permalinks currently update the URL and show a successful copy message without writing anything to the clipboard. Copy the full updated URL and only show the success feedback when copying succeeds.