### PR TITLE
fix(Icon): smooth transitions between directional icons

### DIFF
--- a/packages/dnb-eufemia/src/components/icon/Icon.tsx
+++ b/packages/dnb-eufemia/src/components/icon/Icon.tsx
@@ -125,12 +125,12 @@ export type IconProps = {
   fill?: boolean
 
   /**
-   * Plays motion provided by an explicitly imported animated icon. Set to `true` or `once` to play once, or `loop` to repeat it.
+   * Plays motion provided by an explicitly imported animated icon. Use `true` or `once` to play once, or `loop` to repeat the animation.
    */
   animate?: boolean | 'once' | 'loop'
 
   /**
-   * Plays the icon animation when the icon or its interactive parent is hovered.
+   * Plays an animated icon when the icon itself, or an interactive parent such as a button or link, is hovered.
    */
   animateWhen?: 'hover'
 

--- a/packages/dnb-eufemia/src/components/icon/IconTransition.tsx
+++ b/packages/dnb-eufemia/src/components/icon/IconTransition.tsx
@@ -225,33 +225,61 @@ function squaredDistance(pointsA: Point[], pointsB: Point[]): number {
   )
 }
 
-/** Reverses subpath point order when it reduces squared distance to the reference. */
+function splitSubpaths(points: Point[]): Point[][] {
+  const subpaths: Point[][] = []
+
+  for (const point of points) {
+    if (point.cmd === 'M') {
+      subpaths.push([])
+    }
+
+    subpaths[subpaths.length - 1].push(point)
+  }
+
+  return subpaths
+}
+
+function reverseSubpath(points: Point[]): Point[] {
+  return [...points].reverse().map((point, index) => ({
+    ...point,
+    cmd: index === 0 ? 'M' : 'L',
+  }))
+}
+
+/** Reorders and reverses subpaths to minimize movement from the reference. */
 function alignPath(reference: Point[], target: Point[]): Point[] {
   if (reference.length !== target.length || reference.length === 0) {
     return target
   }
 
-  // Split into subpaths (each starting with M)
-  const subpaths: Array<[Point[], Point[]]> = []
+  const targetSubpaths = splitSubpaths(target)
 
-  for (let i = 0; i < reference.length; i++) {
-    if (reference[i].cmd === 'M') {
-      subpaths.push([[], []])
+  return splitSubpaths(reference).flatMap((referenceSubpath) => {
+    let matchIndex = -1
+    let match: Point[]
+    let matchDistance = Infinity
+
+    targetSubpaths.forEach((targetSubpath, index) => {
+      if (targetSubpath.length !== referenceSubpath.length) {
+        return
+      }
+
+      const reversed = reverseSubpath(targetSubpath)
+      const distance = squaredDistance(referenceSubpath, targetSubpath)
+      const reversedDistance = squaredDistance(referenceSubpath, reversed)
+
+      if (Math.min(distance, reversedDistance) < matchDistance) {
+        matchIndex = index
+        matchDistance = Math.min(distance, reversedDistance)
+        match = reversedDistance < distance ? reversed : targetSubpath
+      }
+    })
+
+    if (matchIndex === -1) {
+      return referenceSubpath
     }
 
-    subpaths[subpaths.length - 1][0].push(reference[i])
-    subpaths[subpaths.length - 1][1].push(target[i])
-  }
-
-  return subpaths.flatMap(([referenceSubpath, targetSubpath]) => {
-    const reversed = [...targetSubpath].reverse().map((point, index) => ({
-      ...point,
-      cmd: index === 0 ? 'M' : 'L',
-    }))
-
-    return squaredDistance(referenceSubpath, reversed) <
-      squaredDistance(referenceSubpath, targetSubpath)
-      ? reversed
-      : targetSubpath
+    targetSubpaths.splice(matchIndex, 1)
+    return match
   })
 }

--- a/packages/dnb-eufemia/src/components/icon/__tests__/IconTransition.test.tsx
+++ b/packages/dnb-eufemia/src/components/icon/__tests__/IconTransition.test.tsx
@@ -108,6 +108,27 @@ describe('Icon.transition', () => {
     expect(style).toContain('var(--icon-transition-down)')
   })
 
+  it('aligns reordered subpaths for transitions between every state', () => {
+    const icon = Icon.transition({
+      down: arrow_down,
+      up: arrow_up,
+      left: arrow_left,
+      right: arrow_right,
+    })
+
+    render(<Icon icon={icon} transitionState="down" />)
+
+    const wrapper = document.querySelector('.dnb-icon') as HTMLElement
+    const style = wrapper.getAttribute('style')
+
+    expect(style).toContain(
+      "--icon-transition-left: path('M6 13 L1 8 L6 3 M14.5 8 L1 8')"
+    )
+    expect(style).toContain(
+      "--icon-transition-right: path('M10 3 L15 8 L10 13 M1.5 8 L15 8')"
+    )
+  })
+
   it('defaults to the first state', () => {
     const icon = Icon.transition({
       left: arrow_left,


### PR DESCRIPTION
Directional icon paths can contain matching subpaths in a different order. CSS cannot interpolate those command sequences, so several horizontal transitions snap instead of morphing. Match and orient compatible subpaths before generating the transition paths so every direction pair animates smoothly.

Preview: https://fix-icon-transition-path-ali.eufemia-e25.pages.dev/uilib/components/icon#icon-transition