### PR TITLE
chore(Field.MultiSelection): skip long option lists by using the SkipContent component

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/Examples.tsx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/Examples.tsx
@@ -52,6 +52,7 @@ export const Virtualized = () => (
       listDriver={virtualizedMultiSelection}
       showSearchField
       showSelectAll
+      showConfirmButton
     />
   </ComponentBox>
 )

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/MultiSelection/info.mdx
@@ -132,17 +132,19 @@ Individual items can be disabled by setting their `disabled` property to `true`.
 
 When `showConfirmButton` is enabled, users must click "Confirm selection" to apply changes, or "Cancel" to discard them without modifying the form value.
 
+When more than 20 enabled options are available, keyboard users are offered a `SkipContent` action after the optional search field. Activating it skips the option checkboxes and moves focus directly to the confirm button. Filtering the list hides the skip action once 20 or fewer enabled options remain.
+
 ## Accessibility
 
 ### Keyboard interaction
 
-| Key               | Behavior                                                                                                                                            |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Enter` / `Space` | Opens or closes the popover when the trigger button is focused. Toggles an item when a checkbox is focused.                                         |
-| `ArrowDown`       | When the trigger is focused: opens the popover and moves focus to the first checkbox. When inside the popover: moves focus to the next checkbox.    |
-| `ArrowUp`         | When the trigger is focused: opens the popover and moves focus to the last checkbox. When inside the popover: moves focus to the previous checkbox. |
-| `Escape`          | Closes the popover and discards any pending changes (same as Cancel).                                                                               |
-| `Tab`             | Moves focus through the interactive elements inside the popover (search field, checkboxes, confirm/cancel buttons).                                 |
+| Key               | Behavior                                                                                                                                                               |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Enter` / `Space` | Opens or closes the popover when the trigger button is focused. Toggles an item when a checkbox is focused.                                                            |
+| `ArrowDown`       | When the trigger is focused: opens the popover and moves focus to the first checkbox. When inside the popover: moves focus to the next checkbox.                       |
+| `ArrowUp`         | When the trigger is focused: opens the popover and moves focus to the last checkbox. When inside the popover: moves focus to the previous checkbox.                    |
+| `Escape`          | Closes the popover and discards any pending changes (same as Cancel).                                                                                                  |
+| `Tab`             | Moves focus through the interactive elements inside the popover. With confirmation and more than 20 enabled options, a skip action can move focus directly to Confirm. |
 
 ### Screen reader announcements
 

--- a/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/SkipContent.tsx
@@ -43,6 +43,7 @@ const SkipContent = (localProps: SkipContentAllProps) => {
   useEffect(
     () => () => {
       clearTimeout(timeout.current)
+      clearTimeout(blurTimeout.current)
     },
     []
   )
@@ -51,6 +52,7 @@ const SkipContent = (localProps: SkipContentAllProps) => {
   const [keepReturnActive, setKeepReturnActive] = useState(false)
   const ref = useRef<HTMLElement>(undefined)
   const timeout = useRef<NodeJS.Timeout>(undefined)
+  const blurTimeout = useRef<NodeJS.Timeout>(undefined)
 
   const classes = clsx(
     'dnb-skip-content',
@@ -62,38 +64,42 @@ const SkipContent = (localProps: SkipContentAllProps) => {
   const returnId = `${returnSelector}--alias`
 
   const handleBlur = useCallback(() => {
-    setVisible(false)
+    blurTimeout.current = setTimeout(() => setVisible(false), 0)
+  }, [])
+
+  const handleButtonRef = useCallback((element: HTMLElement | null) => {
+    element?.focus()
   }, [])
 
   const handleClick = useCallback(() => {
-    setVisible(false)
-
     // Scroll to the element at first
-    const element = document.querySelector(selector)
+    const element = document.querySelector<HTMLElement>(selector)
     element?.scrollIntoView?.({ behavior: 'smooth' })
-    element?.classList.add('dnb-skip-content__focus')
 
-    // Delay the focus, so the UX is smoother
-    timeout.current = setTimeout(() => {
+    if (element && !isInteractive(element)) {
+      element.classList.add('dnb-skip-content__focus')
+    }
+
+    const focusTarget = () => {
       applyPageFocus(selector)
 
       // Tell the linked return component, it should stay active (if it gets focused as well)
       document
         .querySelector(`#${returnSelector}--alias--alias`)
         ?.classList.add('dnb-skip-content__return--active')
-    }, focusDelay)
-  }, [selector, focusDelay])
+    }
+
+    if (focusDelay === 0) {
+      focusTarget()
+    } else {
+      setVisible(false)
+      // Delay the focus, so the UX is smoother
+      timeout.current = setTimeout(focusTarget, focusDelay)
+    }
+  }, [focusDelay, returnSelector, selector])
 
   const setFocus = useCallback(() => {
     setVisible(true)
-
-    // Wait one frame, so ref is set
-    window.requestAnimationFrame(() => {
-      const element = ref.current?.querySelector(
-        '.dnb-button'
-      ) as HTMLElement
-      element?.focus()
-    })
 
     // Ensure the __return button stays active
     if (ref.current?.getAttribute('class').includes('__return--active')) {
@@ -114,6 +120,9 @@ const SkipContent = (localProps: SkipContentAllProps) => {
     (e: KeyboardEvent) => {
       if (e.key === 'Tab') {
         setFocus()
+        requestAnimationFrame(() => {
+          ref.current?.querySelector<HTMLElement>('.dnb-button')?.focus()
+        })
       }
     },
     [setFocus]
@@ -127,17 +136,18 @@ const SkipContent = (localProps: SkipContentAllProps) => {
       id={returnId}
     >
       <>
-        {!visible && (
-          <button
-            className="dnb-sr-only"
-            type="button"
-            onKeyUp={handleKeyUp}
-          >
-            {text || children}
-          </button>
-        )}
+        <button
+          className="dnb-sr-only"
+          type="button"
+          tabIndex={visible ? -1 : undefined}
+          aria-hidden={visible || undefined}
+          onKeyUp={handleKeyUp}
+        >
+          {text || children}
+        </button>
         <HeightAnimation open={visible} aria-live="polite">
           <Button
+            ref={handleButtonRef}
             wrap
             variant="secondary"
             onClick={handleClick}
@@ -149,6 +159,21 @@ const SkipContent = (localProps: SkipContentAllProps) => {
         </HeightAnimation>
       </>
     </span>
+  )
+}
+
+function isInteractive(element: HTMLElement) {
+  return (
+    element.matches('a, button, input, textarea, select, label, menu') ||
+    [
+      'a',
+      'button',
+      'input',
+      'textarea',
+      'select',
+      'label',
+      'menu',
+    ].includes(element.getAttribute('role') || '')
   )
 }
 

--- a/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
+++ b/packages/dnb-eufemia/src/components/skip-content/__tests__/SkipContent.test.tsx
@@ -103,9 +103,14 @@ describe('SkipContent', () => {
       key: 'Tab',
     })
 
-    expect(
-      element.querySelector('button.dnb-sr-only')
-    ).not.toBeInTheDocument()
+    expect(element.querySelector('button.dnb-sr-only')).toHaveAttribute(
+      'tabindex',
+      '-1'
+    )
+    expect(element.querySelector('button.dnb-sr-only')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
 
     // 2. make focus action
     fireEvent.click(element.querySelector('.dnb-button'))
@@ -115,6 +120,30 @@ describe('SkipContent', () => {
     })
     expect(element.querySelector('.dnb-button')).not.toBeInTheDocument()
     expect(document.activeElement.classList).toContain(
+      'dnb-skip-content__focus'
+    )
+  })
+
+  it('should not add a supplemental focus ring to interactive targets', async () => {
+    render(
+      <>
+        <SkipContent selector="#unique-id" focusDelay={0}>
+          Aria
+        </SkipContent>
+        <button id="unique-id">content</button>
+      </>
+    )
+
+    const element = document.querySelector('.dnb-skip-content')
+    fireEvent.keyUp(element.querySelector('button.dnb-sr-only'), {
+      key: 'Tab',
+    })
+    fireEvent.click(element.querySelector('.dnb-button'))
+
+    await waitFor(() => {
+      expect(document.activeElement).toHaveAttribute('id', 'unique-id')
+    })
+    expect(document.activeElement).not.toHaveClass(
       'dnb-skip-content__focus'
     )
   })
@@ -228,9 +257,14 @@ describe('SkipContent.Return', { retry: 3 }, () => {
       key: 'Tab',
     })
 
-    expect(
-      element.querySelector('button.dnb-sr-only')
-    ).not.toBeInTheDocument()
+    expect(element.querySelector('button.dnb-sr-only')).toHaveAttribute(
+      'tabindex',
+      '-1'
+    )
+    expect(element.querySelector('button.dnb-sr-only')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
 
     // 2. make focus action
     fireEvent.click(element.querySelector('.dnb-button'))
@@ -250,9 +284,14 @@ describe('SkipContent.Return', { retry: 3 }, () => {
       key: 'Tab',
     })
 
-    expect(
-      section.querySelector('button.dnb-sr-only')
-    ).not.toBeInTheDocument()
+    expect(section.querySelector('button.dnb-sr-only')).toHaveAttribute(
+      'tabindex',
+      '-1'
+    )
+    expect(section.querySelector('button.dnb-sr-only')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
 
     // 4. make focus action
     fireEvent.click(section.querySelector('.dnb-button'))

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelection.tsx
@@ -15,7 +15,7 @@ import type {
 } from 'react'
 import * as z from 'zod'
 import { clsx } from 'clsx'
-import { AriaLive, Popover } from '../../../../components'
+import { AriaLive, Popover, SkipContent } from '../../../../components'
 import type { FieldBlockProps, FieldBlockWidth } from '../../FieldBlock'
 import FieldBlock from '../../FieldBlock'
 import { useFieldProps } from '../../hooks'
@@ -734,6 +734,9 @@ function MultiSelection(props: FieldMultiSelectionProps) {
   const someFilteredSelected =
     !allFilteredSelected &&
     selectableFilteredFlat.some((item) => selectedValueSet.has(item.value))
+  const confirmButtonId = `${id}-confirm-button`
+  const showSkipToActions =
+    showConfirmButton && selectableFilteredFlat.length > 20
 
   const getCheckboxes = useCallback(
     () =>
@@ -1053,9 +1056,18 @@ function MultiSelection(props: FieldMultiSelectionProps) {
 
             {searchContent}
 
+            {showSkipToActions && (
+              <SkipContent
+                selector={`#${confirmButtonId}`}
+                text={translation.skipToActions}
+                focusDelay={0}
+              />
+            )}
+
             {itemListContent}
 
             <MultiSelectionActions
+              id={confirmButtonId}
               show={showConfirmButton}
               disabled={disabled}
               tempValueLength={tempValue.length}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionActions.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/MultiSelectionActions.tsx
@@ -2,6 +2,7 @@ import { Button } from '../../../../components'
 import { close } from '../../../../icons'
 
 export type MultiSelectionActionsProps = {
+  id: string
   show: boolean
   disabled?: boolean
   tempValueLength: number
@@ -18,6 +19,7 @@ export type MultiSelectionActionsProps = {
 }
 
 export function MultiSelectionActions({
+  id,
   show,
   disabled,
   tempValueLength,
@@ -33,6 +35,7 @@ export function MultiSelectionActions({
   return (
     <div className="dnb-forms-field-multi-selection__actions">
       <Button
+        id={id}
         variant="primary"
         onClick={onConfirm}
         disabled={disabled}

--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/__tests__/MultiSelection.test.tsx
@@ -574,6 +574,58 @@ describe('MultiSelection', () => {
   })
 
   describe('showConfirmButton', () => {
+    it('offers to skip more than 20 options and focuses the confirm button', async () => {
+      const data = Array.from({ length: 21 }, (_, index) => ({
+        value: 'option' + (index + 1),
+        title: 'Option ' + (index + 1),
+      }))
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection data={data} showConfirmButton />
+        </Provider>
+      )
+
+      fireEvent.click(document.querySelector('.dnb-dropdown__trigger'))
+
+      const skipContent = await screen.findByText(
+        'Skip options and go to actions'
+      )
+      fireEvent.keyUp(skipContent, { key: 'Tab' })
+      fireEvent.click(
+        await screen.findByRole('button', {
+          name: 'Skip options and go to actions',
+        })
+      )
+
+      await waitFor(() => {
+        expect(document.activeElement?.textContent).toBe(
+          'Confirm (0 selected)'
+        )
+      })
+    })
+
+    it('does not offer to skip 20 or fewer enabled options', async () => {
+      const data = Array.from({ length: 21 }, (_, index) => ({
+        value: 'option' + (index + 1),
+        title: 'Option ' + (index + 1),
+        disabled: index === 0,
+      }))
+
+      render(
+        <Provider locale="en-GB">
+          <Field.MultiSelection data={data} showConfirmButton />
+        </Provider>
+      )
+
+      fireEvent.click(document.querySelector('.dnb-dropdown__trigger'))
+
+      await screen.findByText('Confirm (0 selected)')
+      expect(
+        screen.queryByText('Skip options and go to actions')
+      ).toBeNull()
+    })
+
     it('shows confirm and cancel buttons in popover when showSearchField is true', async () => {
       const data = [{ value: 'option1', title: 'Option 1' }]
 

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/da-DK.ts
@@ -116,6 +116,7 @@ export default {
       selectAll: 'Vælg alle',
       searchPlaceholder: 'Søg...',
       noOptions: 'Ingen muligheder',
+      skipToActions: 'Spring muligheder over, og gå til handlinger',
       confirmButton: 'Bekræft ({count} valgt)',
       cancelButton: 'Annuller',
       selectionCount: '{count} af {total} valgt',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/en-GB.ts
@@ -114,6 +114,7 @@ export default {
       selectAll: 'Select all',
       searchPlaceholder: 'Search...',
       noOptions: 'No options',
+      skipToActions: 'Skip options and go to actions',
       confirmButton: 'Confirm ({count} selected)',
       cancelButton: 'Cancel',
       selectionCount: '{count} of {total} selected',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/nb-NO.ts
@@ -115,6 +115,7 @@ export default {
       selectAll: 'Velg alle',
       searchPlaceholder: 'Søk...',
       noOptions: 'Ingen alternativer',
+      skipToActions: 'Hopp over alternativer og gå til handlinger',
       confirmButton: 'Bekreft ({count} valgt)',
       cancelButton: 'Avbryt',
       selectionCount: '{count} av {total} valgt',

--- a/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/constants/locales/sv-SE.ts
@@ -116,6 +116,7 @@ export default {
       selectAll: 'Välj alla',
       searchPlaceholder: 'Sök...',
       noOptions: 'Inga alternativ',
+      skipToActions: 'Hoppa över alternativ och gå till åtgärder',
       confirmButton: 'Bekräfta ({count} valda)',
       cancelButton: 'Avbryt',
       selectionCount: '{count} av {total} valda',


### PR DESCRIPTION
Long MultiSelection lists can require keyboard users to traverse many options before reaching the confirmation actions. Add a localized SkipContent action when more than 20 enabled options remain, and document the behavior.

Preview: https://feat-multi-selection-skip-ac.eufemia-e25.pages.dev/uilib/extensions/forms/base-fields/MultiSelection#large-data-sets