### PR TITLE
chore(Portal): fix scrolling to hash logic to be consistent

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/motion.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/motion.spec.ts
@@ -153,11 +153,17 @@ for (const width of [320, 1280]) {
       await expect
         .poll(() =>
           page.locator(`#${id}`).evaluate((element) => {
-            const offset = Math.max(
-              100,
-              parseFloat(getComputedStyle(element).scrollMarginTop)
+            const scrollPadding = parseFloat(
+              getComputedStyle(document.documentElement).scrollPaddingTop
             )
-            return Math.abs(element.getBoundingClientRect().top - offset)
+            const scrollMargin = parseFloat(
+              getComputedStyle(element).scrollMarginTop
+            )
+
+            return Math.abs(
+              element.getBoundingClientRect().top -
+                (scrollPadding + scrollMargin)
+            )
           })
         )
         .toBeLessThan(1)

--- a/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
+++ b/packages/dnb-design-system-portal/src/shared/menu/StickyMenuBar.module.scss
@@ -2,7 +2,7 @@
 
 :global {
   html {
-    scroll-padding-top: 6rem;
+    scroll-padding-top: 5.5rem;
   }
 }
 

--- a/packages/dnb-design-system-portal/src/shared/parts/layout-utils.ts
+++ b/packages/dnb-design-system-portal/src/shared/parts/layout-utils.ts
@@ -1,16 +1,8 @@
 import { scrollToLocationHashId } from '@dnb/eufemia/src/shared/helpers'
 
 export function scrollToAnimation() {
-  const target =
-    typeof window !== 'undefined'
-      ? document.getElementById(window.location.hash.slice(1))
-      : null
-  const scrollMarginTop = target
-    ? parseFloat(window.getComputedStyle(target).scrollMarginTop)
-    : 0
-
   scrollToLocationHashId({
-    offset: Math.max(100, scrollMarginTop),
+    useScrollIntoView: true,
     delay: 100,
     onCompletion: (elem) => {
       try {

--- a/packages/dnb-eufemia/src/shared/helpers.ts
+++ b/packages/dnb-eufemia/src/shared/helpers.ts
@@ -173,6 +173,7 @@ export function scrollToLocationHashId({
   offset = 0,
   delay = null as number | null,
   onCompletion = null as ((elem: HTMLElement) => void) | null,
+  useScrollIntoView = false,
 } = {}) {
   if (
     typeof document !== 'undefined' &&
@@ -185,14 +186,6 @@ export function scrollToLocationHashId({
       if (id.length > 0) {
         const handleScroll = () => {
           const runScroll = () => {
-            const totalOffset = getOffsetTop(elem)
-
-            if (totalOffset <= 0) {
-              return undefined // stop here
-            }
-
-            const top = totalOffset - offset
-
             try {
               if (typeof IntersectionObserver !== 'undefined') {
                 const intersectionObserver = new IntersectionObserver(
@@ -210,10 +203,22 @@ export function scrollToLocationHashId({
                 intersectionObserver.observe(elem)
               }
 
-              window.scrollTo({
-                top,
-                behavior: 'smooth',
-              })
+              if (useScrollIntoView) {
+                elem.scrollIntoView()
+              } else {
+                const totalOffset = getOffsetTop(elem)
+
+                if (totalOffset <= 0) {
+                  return undefined // stop here
+                }
+
+                const top = totalOffset - offset
+
+                window.scrollTo({
+                  top,
+                  behavior: 'smooth',
+                })
+              }
             } catch (e) {
               warn('Error on scrollToLocationHashId:', e)
             }


### PR DESCRIPTION
- use `scrollIntoView` instead of `scrollTop` to match browser scroll behaviour. 
- Fix a bug where navigating to a heading hash from menu navigation (link or search) would not end up in the same place as if navigating to the same hash from the browser address bar.
- change portal scroll padding to from `6rem` to `5.5rem` to better match the page header (`3rem` header + `2.5rem` smallest heading margin).

---

Browser scrolling is affected, not only by the element's `scrollMargin` but also the `scrollPadding` of the parent scroll element. `scrollTop` can only reasonably get the `scrollMargin`, getting the correct `scrollPadding` would require traversing all parents and a lot of complex/fragile parsing of their styles.

`scrollIntoView` automatically uses the same logic as the browser would.

We could define a `scroll-margin-top` for our `.anchor-hash` elements that changes based on what heading they are in, then we would get more dynamic scrolling.
