### PR TITLE
fix(Field.MultiSelection): hide popover wrapper outline on keyboard navigation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
+++ b/packages/dnb-eufemia/src/extensions/forms/Field/MultiSelection/style/dnb-multi-selection.scss
@@ -209,10 +209,6 @@
     &:focus {
       outline: none;
     }
-    &:focus-visible {
-      outline: var(--focus-ring-width) solid
-        var(--token-color-stroke-action-focus);
-    }
   }
 
   &__nested-items {


### PR DESCRIPTION
The popover content wrapper needs programmatic focus so arrow-key handling works immediately, but it is not itself an interactive control. Keep that focus behavior while hiding its blue focus outline.