### PR TITLE
chore(Motion): simplify the house illustration animation

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion/FamilyHomeIllustration.tsx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion/FamilyHomeIllustration.tsx
@@ -17,13 +17,13 @@ export default function FamilyHomeIllustration() {
       fill="none"
     >
       <Greenery side="left" />
-      <g className="dnb-motion-scene__illustration-body" data-motion="">
+      <g className="dnb-motion-scene__illustration-body">
         <path
           d="M66.0293 104.303L164.854 16.7002L271.413 104.303V248.76H66.0293V104.303Z"
           fill="#A5E1D2"
         />
       </g>
-      <g className="dnb-motion-scene__illustration-details" data-motion="">
+      <g className="dnb-motion-scene__illustration-details">
         <path
           d="M270.805 248.76L408.351 246.968V130.922L270.805 104.303V248.76Z"
           fill="#A0D8CB"
@@ -37,10 +37,7 @@ export default function FamilyHomeIllustration() {
           d="M269.621 248.76L443.098 248.216L444.394 103.967H269.621V248.76Z"
           fill="#008484"
         />
-        <g
-          className="dnb-motion-scene__illustration-windows dnb-motion-scene__illustration-windows--side"
-          data-motion=""
-        >
+        <g className="dnb-motion-scene__illustration-windows dnb-motion-scene__illustration-windows--side">
           <g>
             <mask
               id={`${id}-window-1`}
@@ -165,10 +162,7 @@ export default function FamilyHomeIllustration() {
             </g>
           </g>
         </g>
-        <g
-          className="dnb-motion-scene__illustration-windows dnb-motion-scene__illustration-windows--front"
-          data-motion=""
-        >
+        <g className="dnb-motion-scene__illustration-windows dnb-motion-scene__illustration-windows--front">
           <g>
             <mask
               id={`${id}-window-4`}
@@ -302,7 +296,7 @@ export default function FamilyHomeIllustration() {
           />
         </g>
       </g>
-      <g className="dnb-motion-scene__illustration-roof" data-motion="">
+      <g className="dnb-motion-scene__illustration-roof">
         <path
           d="M164.805 16.7002L341.69 17.4841L444.394 103.967L268.997 104.303L164.805 16.7002Z"
           fill="#C1F8EA"
@@ -354,7 +348,6 @@ export default function FamilyHomeIllustration() {
       <g
         className="dnb-motion-scene__garage"
         clipPath={`url(#${id}-garage)`}
-        data-motion=""
       >
         <rect
           x="105.921"
@@ -400,7 +393,6 @@ function Greenery({ side }: { side: 'left' | 'right' }) {
     <g transform={`translate(${side === 'right' ? 399 : 0} 0)`}>
       <path
         className={`dnb-motion-scene__illustration-greenery dnb-motion-scene__illustration-greenery--${side}`}
-        data-motion=""
         fillRule="evenodd"
         clipRule="evenodd"
         d="M121.81 248H0.592879C0.250578 246.593 0.0482497 245.15 0.00756007 243.693C-0.172685 237.255 2.8806 230.736 8.03796 227.229C13.1944 223.723 20.3154 223.517 25.4846 227.005C26.6032 227.76 27.6475 228.704 28.325 229.892C29.7479 227.22 31.9127 225.182 34.4778 224.239C34.9632 216.964 40.5626 211.223 47.4037 211.223C48.4979 211.223 49.5594 211.371 50.5739 211.648C52.9678 209.386 56.1787 208 59.7093 208C64.4455 208 68.6047 210.491 70.9886 214.248C72.5773 213.49 74.3372 213.065 76.1904 213.065C80.038 213.065 83.4853 214.885 85.8221 217.758C88.553 215.686 91.9984 214.446 95.7474 214.446C103.982 214.446 110.763 220.413 111.68 228.095C112.351 227.903 113.048 227.799 113.765 227.799C118.984 227.799 123.214 233.158 123.214 239.769C123.214 242.047 122.69 245.65 121.81 248Z"

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion/MotionDemos.scss
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion/MotionDemos.scss
@@ -304,43 +304,9 @@
     animation-timing-function: linear;
   }
 
-  &__illustration-artwork [data-motion] {
-    animation-timing-function: ease-out;
-  }
-
-  &__illustration-greenery {
-    --motion-greenery-offset: -16px;
-
-    animation-name: dnb-motion-illustration-greenery;
-
-    &--right {
-      --motion-greenery-offset: 16px;
-    }
-  }
-
-  &__illustration-body {
-    animation-name: dnb-motion-illustration-body;
-  }
-
-  &__illustration-roof {
-    animation-name: dnb-motion-illustration-roof;
-  }
-
-  &__illustration-details,
-  &__garage {
-    animation-name: dnb-motion-illustration-details;
-  }
-
-  &__illustration-windows {
-    animation-name: dnb-motion-illustration-windows;
-
-    &--side {
-      animation-delay: 150ms;
-    }
-  }
-
   &__garage-door {
     animation-name: dnb-motion-garage-door;
+    animation-timing-function: ease-in-out;
   }
 
   &__icon[data-motion] {
@@ -688,85 +654,16 @@
   }
 }
 
-@keyframes dnb-motion-illustration-body {
-  0%,
-  2.5%,
-  95%,
-  100% {
-    opacity: 0;
-  }
-  7.5%,
-  87.5% {
-    opacity: 1;
-  }
-}
-
-@keyframes dnb-motion-illustration-roof {
-  0%,
-  7.5%,
-  87.5%,
-  100% {
-    opacity: 0;
-    transform: translateY(-16px);
-  }
-  17.5%,
-  80% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes dnb-motion-illustration-details {
-  0%,
-  10%,
-  82.5%,
-  100% {
-    opacity: 0;
-  }
-  25%,
-  75% {
-    opacity: 1;
-  }
-}
-
-// The details group controls exit; reset the windows after it is hidden.
-@keyframes dnb-motion-illustration-windows {
-  0%,
-  17.5%,
-  100% {
-    opacity: 0;
-  }
-  27.5%,
-  82.5% {
-    opacity: 1;
-  }
-}
-
 @keyframes dnb-motion-garage-door {
   0%,
-  27.5%,
-  72.5%,
+  25%,
+  75%,
   100% {
     transform: translateY(0);
   }
   40%,
   60% {
     transform: translateY(-52px);
-  }
-}
-
-@keyframes dnb-motion-illustration-greenery {
-  0%,
-  7.5%,
-  75%,
-  100% {
-    opacity: 0;
-    transform: translateX(var(--motion-greenery-offset));
-  }
-  25%,
-  65% {
-    opacity: 1;
-    transform: translateX(0);
   }
 }
 

--- a/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion/MotionDemos.tsx
+++ b/packages/dnb-design-system-portal/src/docs/quickguide-designer/motion/MotionDemos.tsx
@@ -95,7 +95,7 @@ export default function MotionDemos({
         <MotionStudy
           id="animate-an-illustration"
           title="Animate an illustration"
-          description="Make the subject recognisable quickly, then let it settle. Coordinate related movements so the illustration supports the message without competing with the task."
+          description="Keep the subject recognisable and animate only the part that supports the message. Here, the house stays still while the garage opens and closes."
         >
           <FamilyHomeIllustration />
         </MotionStudy>

--- a/packages/dnb-design-system-portal/src/e2e/motion-webkit.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/motion-webkit.spec.ts
@@ -59,7 +59,7 @@ for (const width of [320, 1280]) {
   }
 }
 
-test('WebKit animates the inline house groups in the same sequence', async ({
+test('WebKit keeps the house still while the garage opens and closes', async ({
   page,
 }) => {
   await page.emulateMedia({ reducedMotion: 'no-preference' })
@@ -67,43 +67,29 @@ test('WebKit animates the inline house groups in the same sequence', async ({
   await waitForApp(page)
   const artwork = page.locator('.dnb-motion-scene__illustration-artwork')
   await expect(artwork.locator('image')).toHaveCount(0)
-  const [start, entering, assembled, closed] = await artwork.evaluate(
-    sampleMotionStyles,
-    {
-      times: [300, 500, 1600, 3600],
-      selectors: {
-        roof: 'g.dnb-motion-scene__illustration-roof',
-        details: 'g.dnb-motion-scene__illustration-details',
-        windows: 'g.dnb-motion-scene__illustration-windows',
-        door: 'g.dnb-motion-scene__garage-door',
-      },
-    }
-  )
-  expect(start.roof.opacity).toBe(0)
-  expect(start.roof.y).toBe(-16)
-  expect(entering.roof.opacity).toBeGreaterThan(0)
-  expect(entering.roof.opacity).toBeLessThan(1)
-  expect(entering.roof.y).toBeGreaterThan(-16)
-  expect(entering.roof.y).toBeLessThan(0)
-  expect(entering.windows.opacity).toBe(0)
-  expect(assembled.roof.opacity).toBe(1)
-  expect(assembled.roof.y).toBeCloseTo(0)
-  expect(assembled.details.opacity).toBe(1)
-  expect(assembled.windows.opacity).toBe(1)
-  expect(assembled.door.y).toBeCloseTo(-52)
-  expect(closed.roof.opacity).toBe(0)
-  expect(closed.details.opacity).toBe(0)
-  expect(closed.door.y).toBeCloseTo(0)
-
-  const [windows] = await artwork.evaluate(sampleMotionStyles, {
-    times: [1000],
+  const frames = await artwork.evaluate(sampleMotionStyles, {
+    times: [0, 1200, 1600, 2400, 2800, 4000],
     selectors: {
-      front: '.dnb-motion-scene__illustration-windows--front',
-      side: '.dnb-motion-scene__illustration-windows--side',
+      roof: 'g.dnb-motion-scene__illustration-roof',
+      details: 'g.dnb-motion-scene__illustration-details',
+      windows: 'g.dnb-motion-scene__illustration-windows',
+      door: 'g.dnb-motion-scene__garage-door',
     },
   })
-  expect(windows.side.opacity).toBeGreaterThan(0)
-  expect(windows.side.opacity).toBeLessThan(windows.front.opacity)
+  frames.forEach(({ roof, details, windows }) => {
+    expect(roof.opacity).toBe(1)
+    expect(roof.y).toBeCloseTo(0)
+    expect(details.opacity).toBe(1)
+    expect(windows.opacity).toBe(1)
+  })
+  expect(frames[0].door.y).toBeCloseTo(0)
+  expect(frames[1].door.y).toBeGreaterThan(-52)
+  expect(frames[1].door.y).toBeLessThan(0)
+  expect(frames[2].door.y).toBeCloseTo(-52)
+  expect(frames[3].door.y).toBeCloseTo(-52)
+  expect(frames[4].door.y).toBeGreaterThan(-52)
+  expect(frames[4].door.y).toBeLessThan(0)
+  expect(frames[5].door.y).toBeCloseTo(0)
 })
 
 test('WebKit morphs disclosure chevrons and line graph paths', async ({

--- a/packages/dnb-design-system-portal/src/e2e/motion.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/motion.spec.ts
@@ -578,7 +578,7 @@ test('TextCounter changes its message immediately and makes room for the warning
   })
 })
 
-test('the DNB house stays still while greenery slides a short distance from both sides', async ({
+test('the complete DNB house remains visible and stationary', async ({
   page,
 }) => {
   const artwork = page.locator(
@@ -601,242 +601,26 @@ test('the DNB house stays still while greenery slides a short distance from both
     natural: [523, 250],
     rendered: [261.5, 125],
   })
+
+  for (const selector of [
+    '.dnb-motion-scene__illustration-body',
+    '.dnb-motion-scene__illustration-details',
+    '.dnb-motion-scene__illustration-roof',
+    '.dnb-motion-scene__garage',
+  ]) {
+    await expect(artwork.locator(selector)).toHaveCount(1)
+  }
+  await expect(
+    artwork.locator('.dnb-motion-scene__illustration-windows')
+  ).toHaveCount(2)
   await expect(
     artwork.locator('.dnb-motion-scene__illustration-greenery')
   ).toHaveCount(2)
-  await expect(artwork.locator('[data-motion]')).toHaveCount(9)
-  expect(
-    await artwork.evaluate((element) => element.getAnimations().length)
-  ).toBe(0)
-  const stage = await artwork.evaluate((element) => {
-    const { x, y, width, height } = element
-      .closest('.dnb-motion-demo__stage')
-      .getBoundingClientRect()
-    return { x, y, width, height }
-  })
-  const frames = (
-    await artwork.evaluate(sampleMotionStyles, {
-      times: [300, 650, 1000, 2400, 2800, 3200],
-      selectors: {
-        artwork: ':scope',
-        house: '.dnb-motion-scene__illustration-body',
-        left: '.dnb-motion-scene__illustration-greenery--left',
-        right: '.dnb-motion-scene__illustration-greenery--right',
-      },
-    })
-  ).map(({ artwork, house, left, right }) => ({
-    greenery: [left, right],
-    opacity: artwork.opacity,
-    house: house.bounds,
-  }))
-  expect(frames[0].greenery.map(({ x }) => x)).toEqual([-16, 16])
-  for (const index of [1, 4]) {
-    expect(frames[index].greenery[0].x).toBeGreaterThan(-16)
-    expect(frames[index].greenery[0].x).toBeLessThan(0)
-    expect(frames[index].greenery[1].x).toBeLessThan(16)
-    expect(frames[index].greenery[1].x).toBeGreaterThan(0)
-    frames[index].greenery.forEach(({ opacity }) => {
-      expect(opacity).toBeGreaterThan(0)
-      expect(opacity).toBeLessThan(1)
-    })
-  }
-  for (const index of [2, 3]) {
-    frames[index].greenery.forEach(({ x, opacity }) => {
-      expect(x).toBeCloseTo(0)
-      expect(opacity).toBeCloseTo(1)
-    })
-  }
-  expect(frames[5]).toEqual(frames[0])
-  frames.forEach(({ opacity, house, greenery }) => {
-    expect(opacity).toBe(1)
-    expect(house).toEqual(frames[0].house)
-    greenery.forEach(({ y, scaleX, bounds }) => {
-      expect(y).toBe(0)
-      expect(scaleX).toBe(1)
-      expect(bounds.x).toBeGreaterThanOrEqual(stage.x)
-      expect(bounds.y).toBeGreaterThanOrEqual(stage.y)
-      expect(bounds.x + bounds.width).toBeLessThanOrEqual(
-        stage.x + stage.width
-      )
-      expect(bounds.y + bounds.height).toBeLessThanOrEqual(
-        stage.y + stage.height
-      )
-    })
-  })
-})
-
-test('windows wait for the roof to settle and leave with the details', async ({
-  page,
-}) => {
-  const artwork = page.locator('.dnb-motion-scene__illustration-artwork')
-  const windows = artwork.locator(
-    '.dnb-motion-scene__illustration-details > .dnb-motion-scene__illustration-windows'
+  await expect(artwork.locator('[data-motion]')).toHaveCount(1)
+  await expect(artwork.locator('[data-motion]')).toHaveClass(
+    /dnb-motion-scene__garage-door/
   )
-  await expect(windows).toHaveCount(2)
-  await expect(windows.locator('mask')).toHaveCount(6)
-  const frames = await artwork.evaluate(sampleMotionStyles, {
-    times: [400, 600, 700, 900, 1100, 3000, 3150, 3300, 4000],
-    selectors: {
-      windows: '.dnb-motion-scene__illustration-windows--front',
-      details: '.dnb-motion-scene__illustration-details',
-      roof: '.dnb-motion-scene__illustration-roof',
-      door: '.dnb-motion-scene__garage-door',
-    },
-  })
-  for (const index of [0, 1, 2, 8]) {
-    expect(frames[index].windows.opacity).toBeCloseTo(0, 10)
-  }
-  expect(frames[2].roof.opacity).toBe(1)
-  expect(frames[2].details.opacity).toBeGreaterThan(0)
-  expect(frames[3].windows.opacity).toBeGreaterThan(0)
-  expect(frames[3].windows.opacity).toBeLessThan(1)
-  expect(frames[4].windows.opacity).toBe(1)
-  expect(frames[4].door.y).toBeCloseTo(0)
-  for (const index of [5, 6, 7]) {
-    expect(frames[index].windows.opacity).toBe(1)
-  }
-  expect(frames[5].details.opacity).toBe(1)
-  expect(frames[6].details.opacity).toBeGreaterThan(0)
-  expect(frames[6].details.opacity).toBeLessThan(1)
-  expect(frames[7].details.opacity).toBeCloseTo(0, 10)
-})
 
-test('side windows follow the front windows by 150ms on every loop', async ({
-  page,
-}) => {
-  const artwork = page.locator('.dnb-motion-scene__illustration-artwork')
-  const side = artwork.locator(
-    '.dnb-motion-scene__illustration-windows--side'
-  )
-  await expect(side.locator('mask')).toHaveCount(3)
-  await expect(side).toHaveCSS('animation-delay', '0.15s')
-  for (const loop of [0, 4000]) {
-    const [
-      frontEntering,
-      sideEntering,
-      frontSettled,
-      bothSettled,
-      leaving,
-    ] = await artwork.evaluate(sampleMotionStyles, {
-      times: [800, 950, 1100, 1250, 3300].map((time) => time + loop),
-      selectors: {
-        front: '.dnb-motion-scene__illustration-windows--front',
-        side: '.dnb-motion-scene__illustration-windows--side',
-        details: '.dnb-motion-scene__illustration-details',
-      },
-    })
-    expect(frontEntering.front.opacity).toBeGreaterThan(0)
-    expect(frontEntering.side.opacity).toBeCloseTo(0, 10)
-    expect(sideEntering.side.opacity).toBeGreaterThan(0)
-    expect(sideEntering.side.opacity).toBeLessThan(
-      sideEntering.front.opacity
-    )
-    expect(frontSettled.front.opacity).toBe(1)
-    expect(frontSettled.side.opacity).toBeGreaterThan(0)
-    expect(frontSettled.side.opacity).toBeLessThan(1)
-    expect(bothSettled.front.opacity).toBe(1)
-    expect(bothSettled.side.opacity).toBe(1)
-    expect(leaving.front.opacity).toBe(1)
-    expect(leaving.side.opacity).toBe(1)
-    expect(leaving.details.opacity).toBeCloseTo(0, 10)
-  }
-})
-
-test('the front wall fades in first and disappears last', async ({
-  page,
-}) => {
-  const artwork = page.locator('.dnb-motion-scene__illustration-artwork')
-  await expect(
-    artwork.locator('.dnb-motion-scene__illustration-body')
-  ).toHaveCount(1)
-  const frames = (
-    await artwork.evaluate(sampleMotionStyles, {
-      times: [0, 200, 300, 1800, 3500, 3650, 3800, 4000],
-      selectors: {
-        body: '.dnb-motion-scene__illustration-body',
-        roof: '.dnb-motion-scene__illustration-roof',
-        details: '.dnb-motion-scene__illustration-details',
-        garage: '.dnb-motion-scene__garage',
-        left: '.dnb-motion-scene__illustration-greenery--left',
-        right: '.dnb-motion-scene__illustration-greenery--right',
-      },
-    })
-  ).map(({ body, ...otherParts }) => ({
-    body: body.opacity,
-    otherParts: Object.values(otherParts).map(({ opacity }) => opacity),
-  }))
-  for (const index of [0, 6, 7]) {
-    expect(frames[index].body).toBeCloseTo(0)
-  }
-  for (const index of [1, 5]) {
-    expect(frames[index].body).toBeGreaterThan(0)
-    expect(frames[index].body).toBeLessThan(1)
-  }
-  for (const index of [2, 3, 4]) {
-    expect(frames[index].body).toBeCloseTo(1)
-  }
-  frames.forEach(({ otherParts }, index) => {
-    otherParts.forEach((opacity) =>
-      expect(opacity).toBeCloseTo(index === 3 ? 1 : 0)
-    )
-  })
-})
-
-test('house assembly starts quickly and decelerates into its final pose', async ({
-  page,
-}) => {
-  for (const [part, start, duration] of [
-    ['illustration-roof', 300, 400],
-    ['illustration-greenery--left', 300, 700],
-    ['illustration-greenery--right', 300, 700],
-  ] as const) {
-    const frames = (
-      await page
-        .locator(`.dnb-motion-scene__${part}`)
-        .evaluate(sampleMotionStyles, {
-          times: [0, 0.25, 0.5, 0.75, 1].map(
-            (progress) => start + duration * progress
-          ),
-        })
-    ).map(({ target }) => 16 - Math.hypot(target.x, target.y))
-    expect(frames[0]).toBeCloseTo(0)
-    expect(frames[4]).toBeCloseTo(16)
-    const distances = frames
-      .slice(1)
-      .map((position, index) => position - frames[index])
-    distances.forEach((distance, index) => {
-      expect(distance).toBeGreaterThan(0)
-      if (index > 0) {
-        expect(distance).toBeLessThan(distances[index - 1])
-      }
-    })
-    expect(distances[0]).toBeGreaterThan(distances[3] * 2)
-  }
-})
-
-test('the illustration reveals its details before opening the garage and reverses the sequence', async ({
-  page,
-}) => {
-  const artwork = page.locator('.dnb-motion-scene__illustration-artwork')
-  for (const name of ['body', 'roof', 'details']) {
-    const layer = artwork.locator(
-      `g.dnb-motion-scene__illustration-${name}`
-    )
-    await expect(layer).toHaveCount(1)
-    await expect(layer.locator('path').first()).toBeAttached()
-    if (name !== 'roof') {
-      await expect(layer).toHaveCSS('transform', 'none')
-    }
-  }
-  const details = artwork.locator(
-    '.dnb-motion-scene__illustration-details'
-  )
-  await expect(details.locator('path[d^="M269.621 248.76"]')).toHaveCount(
-    2
-  )
-  await expect(
-    details.locator('mask rect[x="308"][y="184"][width="33"][height="64"]')
-  ).toHaveCount(1)
   const masks = await artwork.evaluate((element) =>
     Array.from(element.querySelectorAll('g[mask]')).map((group) => {
       const id = group.getAttribute('mask').slice(5, -1)
@@ -854,6 +638,7 @@ test('the illustration reveals its details before opening the garage and reverse
   masks.forEach((mask) =>
     expect(mask).toEqual({ unique: true, local: true, type: 'alpha' })
   )
+
   const clipId = await artwork.locator('clipPath').getAttribute('id')
   await expect(
     artwork.locator('.dnb-motion-scene__garage')
@@ -867,70 +652,77 @@ test('the illustration reveals its details before opening the garage and reverse
         )
       )
   ).toEqual(['105.921', '183.7', '112', '65'])
+
   const frames = (
     await artwork.evaluate(sampleMotionStyles, {
-      times: [
-        300, 400, 800, 1000, 1100, 1350, 1600, 2400, 2650, 2900, 3100,
-        3350, 3600,
-      ],
+      times: [0, 1300, 2000, 2700, 4000],
       selectors: {
+        artwork: ':scope',
+        body: '.dnb-motion-scene__illustration-body',
         roof: '.dnb-motion-scene__illustration-roof',
         details: '.dnb-motion-scene__illustration-details',
-        garage: '.dnb-motion-scene__garage',
-        door: '.dnb-motion-scene__garage-door',
+        left: '.dnb-motion-scene__illustration-greenery--left',
+        right: '.dnb-motion-scene__illustration-greenery--right',
       },
     })
-  ).map(({ roof, details, garage, door }) => ({
-    roof: roof.opacity,
-    roofY: roof.y,
-    roofScale: roof.scaleY,
-    details: details.opacity,
-    garage: garage.opacity,
-    doorY: door.y,
-    doorScale: door.scaleY,
+  ).map((frame) =>
+    Object.values(frame).map(
+      ({ opacity, x, y, scaleX, scaleY, bounds }) => ({
+        opacity,
+        x,
+        y,
+        scaleX,
+        scaleY,
+        bounds,
+      })
+    )
+  )
+  frames.forEach((frame) => {
+    expect(frame).toEqual(frames[0])
+    frame.forEach(({ opacity }) => {
+      expect(opacity).toBe(1)
+    })
+  })
+})
+
+test('the garage door opens, closes, and repeats over four seconds', async ({
+  page,
+}) => {
+  const door = page.locator('.dnb-motion-scene__garage-door')
+  await expect(door).toHaveCount(1)
+  await expect(door).toHaveCSS('animation-duration', '4s')
+  await expect(door).toHaveCSS('animation-iteration-count', 'infinite')
+
+  const frames = (
+    await door.evaluate(sampleMotionStyles, {
+      times: [0, 1000, 1300, 1600, 2400, 2700, 3000, 4000, 5600],
+    })
+  ).map(({ target }) => ({
+    opacity: target.opacity,
+    x: target.x,
+    y: target.y,
+    scaleX: target.scaleX,
+    scaleY: target.scaleY,
   }))
-  expect(frames[0]).toEqual({
-    roof: 0,
-    roofY: -16,
-    roofScale: 1,
-    details: 0,
-    garage: 0,
-    doorY: 0,
-    doorScale: 1,
+
+  for (const index of [0, 1, 6, 7]) {
+    expect(frames[index].y).toBeCloseTo(0)
+  }
+  for (const index of [3, 4, 8]) {
+    expect(frames[index].y).toBeCloseTo(-52)
+  }
+  for (const index of [2, 5]) {
+    expect(frames[index].y).toBeGreaterThan(-52)
+    expect(frames[index].y).toBeLessThan(0)
+  }
+  frames.forEach(({ opacity, x, scaleX, scaleY }) => {
+    expect(opacity).toBe(1)
+    expect(x).toBe(0)
+    expect(scaleX).toBe(1)
+    expect(scaleY).toBe(1)
   })
-  expect(frames[1].roof).toBeGreaterThan(0)
-  expect(frames[1].roof).toBeLessThan(1)
-  for (const index of [1, 11]) {
-    expect(frames[index].roofY).toBeGreaterThan(-16)
-    expect(frames[index].roofY).toBeLessThan(0)
-  }
-  expect(frames[1].details).toBeCloseTo(0)
-  expect(frames[2].roof).toBe(1)
-  expect(frames[2].roofY).toBeCloseTo(0)
-  expect(frames[2].details).toBeGreaterThan(0)
-  expect(frames[2].details).toBeLessThan(1)
-  expect(frames[3].details).toBeCloseTo(1)
-  expect(frames[4].doorY).toBeCloseTo(0)
-  for (const index of [5, 8]) {
-    expect(frames[index].doorY).toBeGreaterThan(-52)
-    expect(frames[index].doorY).toBeLessThan(0)
-  }
-  for (const index of [6, 7]) {
-    expect(frames[index].doorY).toBeCloseTo(-52)
-  }
-  expect(frames[9].doorY).toBeCloseTo(0)
-  expect(frames[10].details).toBeGreaterThan(0)
-  expect(frames[10].details).toBeLessThan(1)
-  expect(frames[10].roof).toBe(1)
-  expect(frames[11].details).toBe(0)
-  expect(frames[11].roof).toBeGreaterThan(0)
-  expect(frames[11].roof).toBeLessThan(1)
-  expect(frames[12]).toEqual(frames[0])
-  frames.forEach(({ doorScale, garage, details, roofScale }) => {
-    expect(doorScale).toBe(1)
-    expect(roofScale).toBe(1)
-    expect(garage).toBeCloseTo(details)
-  })
+  expect(frames[7]).toEqual(frames[0])
+  expect(frames[8]).toEqual(frames[3])
 })
 
 test('the Eufemia bell rings with diminishing swings inside a stationary circle', async ({


### PR DESCRIPTION
The house illustration assembled several layers before opening its garage, which made a supporting example compete for attention. Keep the house recognisable and stationary, animate only the garage door, and remove the unused animation hooks and timing-specific tests.

The reduced motion behavior remains unchanged.