### PR TITLE
chore(Portal): fix dead documentation section links

### DIFF
--- a/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
+++ b/packages/dnb-design-system-portal/src/docs/EUFEMIA_CHANGELOG.mdx
@@ -123,7 +123,7 @@
 ## July, 22. 2024
 
 - [Forms](/uilib/extensions/forms/): new Upload field.
-- [Table](/uilib/components/table): new [navigation](/uilib/components/table/#table-with-navigation) mode.
+- [Table](/uilib/components/table): new [navigation](/uilib/components/table/#table-with-clickable-rows-navigation-mode) mode.
 
 ## September, 29. 2024
 

--- a/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/first-contribution/before-started.mdx
@@ -18,15 +18,13 @@ Before you get started, there are some technical decisions you should know about
     - [dnb-design-system-portal](#dnb-design-system-portal)
     - [Configuration files](#configuration-files)
     - [About Types](#about-types)
-      - [Shared Properties docs](#shared-properties-docs)
+      - [Shared Properties docs (legacy)](#shared-properties-docs-legacy)
   - [About component structure](#about-component-structure)
     - [Component folder](#component-folder)
       - [Modifications](#modifications)
   - [Development environments](#development-environments)
     - [Eufemia portal](#eufemia-portal)
       - [Local build](#local-build)
-    - [Testing](#testing)
-    - [Run Algolia search queries locally](#run-algolia-search-queries-locally)
   - [What happens in the build steps](#what-happens-in-the-build-steps)
     - [During prebuild](#during-prebuild)
     - [During postbuild](#during-postbuild)
@@ -142,7 +140,7 @@ There are a couple of environments for different purposes.
 
 - For writing documentation and displaying the components, you can run [the portal](/contribute/first-contribution/before-started#eufemia-portal) locally.
 - After development, you can run [your tests](/contribute/getting-started#make-and-run-tests).
-- If you want to see the local changes in the search results, you can run [Algolia search queries locally](/).
+- If you want to see the local changes in the search results, you can run [Algolia search queries locally](/contribute/getting-started#submit-algolia-search-queries-locally).
 
 ### Eufemia portal
 

--- a/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
+++ b/packages/dnb-design-system-portal/src/docs/contribute/getting-started/making-changes.mdx
@@ -264,7 +264,7 @@ function MyComponent(props: ComponentAllProps) {
 
 ### Skeleton support
 
-How you make skeleton support available varies from case to case. There is also more info on how to create a [custom skeleton](/uilib/components/skeleton#create-custom-skeleton). But in case your component supports the `skeleton` boolean property, then you may ensure it both can be set locally on the component, and it reacts on the global Context.
+How you make skeleton support available varies from case to case. There is also more info on how to create a [custom skeleton](/uilib/components/skeleton#create-a-custom-skeleton). But in case your component supports the `skeleton` boolean property, then you may ensure it both can be set locally on the component, and it reacts on the global Context.
 
 ```tsx
 import { Context } from '../../shared'

--- a/packages/dnb-design-system-portal/src/docs/icons/form-status.mdx
+++ b/packages/dnb-design-system-portal/src/docs/icons/form-status.mdx
@@ -22,4 +22,4 @@ import { InfoIcon } from '@dnb/eufemia/components/FormStatus
 render(<InfoIcon />)
 ```
 
-... or in combination with the [Icon](/uilib/components/form-status?fullscreen#form-status-icons) component. Have a look [at this example](/uilib/components/form-status#in-combination-with-the-icon-component).
+... or in combination with the [Icon](/uilib/components/icon) component. Have a look [at this example](/uilib/components/form-status#in-combination-with-the-icon-component).

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v5-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v5-info.mdx
@@ -34,8 +34,6 @@ To prepare for these changes, you can already today (since `v4.24`) use the now 
 
 Previously, we had [font-weight](/uilib/typography/font-weight).
 
-Read more on how to make CSS vars (Custom Properties) [work on IE](/uilib/usage/customisation/styling).
-
 ### The benefits?
 
 If you are using only properties to change actively your application typography, then a future update with changes will "automatically" happen, so you don't need to make manual code changes later.

--- a/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v7.2-info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/about-the-lib/releases/dnb-ui-lib/v7.2-info.mdx
@@ -25,7 +25,7 @@ color: var(--color-black-3);
 ## New components
 
 - [Skeleton](/uilib/components/skeleton) to show the DNB skeleton preset. Skeletons are also built into every component and element.
-- [ActionMenu](/uilib/components/dropdown/demos#actionmenu) – this menu is extended from the Dropdown.
+- [ActionMenu](/uilib/components/dropdown) – this menu is extended from the Dropdown.
 - [Dropdown.HorizontalItem](/uilib/components/dropdown/demos#dropdown-with-different-item-content-directions) – to more easily place items content in a horizontal direction (same applies to `Autocomplete.HorizontalItem`).
 - [PaymentCard](/uilib/extensions/payment-card) – a component to imitate a physical payment card.
 - [HelpButton](/uilib/components/help-button) – a help button with a custom semantic, helping screen readers determine the meaning of that button.

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/Form/schema-validation/info.mdx
@@ -10,7 +10,7 @@ showTabs: true
 ## Table of Contents
 
 - [About schemas](#about-schemas)
-- [Using schema with DataContext](#using-schema-with-datacontext)
+- [Using schema with Form.Handler (DataContext)](#using-schema-with-formhandler-datacontext)
 - [Fields which are disabled or read-only](#fields-which-are-disabled-or-read-only)
 - [Non-finite numbers (Infinity and NaN)](#non-finite-numbers-infinity-and-nan)
 - [JSONSchema and TypeScript](#jsonschema-and-typescript)

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/base-fields/String/info.mdx
@@ -55,7 +55,7 @@ The `path` property will be used to set the `name` attribute.
 
 Avoid using the `maxlength` attribute when possible, as it is not accessible. Instead, use [TextCounter](/uilib/components/fragments/text-counter/) together with `Field.String`.
 
-A demo of how to use the `TextCounter` with `Field.String` can be found [here](/uilib/extensions/forms/base-fields/String/#validation-maximum-length-with-textcounter).
+A demo of how to use the `TextCounter` with `Field.String` can be found [here](/uilib/extensions/forms/base-fields/String/#validation---maximum-length-with-textcounter).
 
 This way, the user receives visual feedback on the number of characters entered and the maximum allowed, without being limited in their workflow.
 

--- a/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
+++ b/packages/dnb-design-system-portal/src/docs/uilib/extensions/forms/getting-started.mdx
@@ -64,7 +64,7 @@ import { languageDisplayNames } from 'dnb-design-system-portal/src/core/ChangeLo
     - [How to customize translations in a form](#how-to-customize-translations-in-a-form)
       - [Consume the translations](#consume-the-translations)
   - [Layout](#layout)
-  - [Best practices](#best-practices)
+  - [Best practices](#best-practices-on-forms-accessibility-usability-and-performance)
   - [Debugging](#debugging)
     - [Logging](#logging)
     - [Finding errors](#finding-errors)
@@ -1032,7 +1032,7 @@ You can customize the translations in a form by using the `translations` propert
 
 Alternatively, you can use the global Eufemia [Provider](/uilib/usage/customisation/provider/).
 
-You can find all available strings and keys in the properties tab of each field or value component. For example, check out the [PhoneNumber field properties](#!/uilib/extensions/forms/feature-fields/PhoneNumber/properties/#translations).
+You can find all available strings and keys in the properties tab of each field or value component. For example, check out the [PhoneNumber field properties](/uilib/extensions/forms/feature-fields/PhoneNumber/properties/#translations).
 
 ```tsx
 import { Form, Field } from '@dnb/eufemia/extensions/forms'


### PR DESCRIPTION
## Why

Eleven internal documentation links pointed at page sections that no longer exist. They are the quiet kind of broken: the URL resolves, the right page loads, and nothing scrolls — so they never show up as 404s and nobody notices.

The dominant cause is hand-written tables of contents. Several pages list their own sections at the top, and those lists drift whenever a heading is later reworded. Five of the eleven are that.

## What changed

Anchor corrections after heading renames:

| Where | Was | Now |
| --- | --- | --- |
| Design System changelog | `#table-with-navigation` | `#table-with-clickable-rows-navigation-mode` |
| Contribute → making changes | `#create-custom-skeleton` | `#create-a-custom-skeleton` |
| Field.String → accessibility | `#validation-maximum-length-with-textcounter` | `#validation---maximum-length-with-textcounter` |
| Schema validation → contents | `#using-schema-with-datacontext` | `#using-schema-with-formhandler-datacontext` |
| Forms getting started → contents | `#best-practices` | `#best-practices-on-forms-accessibility-usability-and-performance` |
| Before getting started → contents | `#shared-properties-docs` | `#shared-properties-docs-legacy` |

Links whose destination no longer exists at all:

- **ActionMenu** (v7.2 release note) now points at Dropdown. The component was removed from the library and its demo section with it; the sentence already explains it was extended from Dropdown.
- **The FormStatus icons page's "Icon" reference** now points at the Icon component. It pointed at a removed `#form-status-icons` anchor on the FormStatus page, while both the link text and the sentence are about the Icon component. The example link beside it already pointed at the right demo.
- **Two contents entries** in "What you should know before getting started" — *Testing* and *Run Algolia search queries locally* — are removed. Neither section exists any more; that content is now two bullets under *Development environments*, already linked appropriately.

Other link fixes:

- A stray `#!` prefix turned the PhoneNumber properties link into a same-page jump to nowhere. This is the same typo class as #8966, but written as a Markdown link rather than an `href`, which is why it survived that pass.
- A placeholder `](/)` link for "Algolia search queries locally" pointed at the homepage; it now points at the section that documents it.

Finally, the obsolete IE sentence in the v5 release note is removed. Its original target — the *Properties Polyfill* page — was deliberately deleted in #8428, and #8966 repointed the link at the general CSS Styles page. That page says nothing about IE, and no IE or CSS-variable polyfill guidance remains anywhere in the portal, so the sentence promised guidance that does not exist.

## Verification

Every internal link in `src/docs` was audited, comparing this branch against `origin/main` extracted separately via `git archive` — so the baseline cannot drift into the change being measured:

|  | origin/main | this branch |
| --- | --- | --- |
| page links | 2095 checked, 0 broken | 2096 checked, 0 broken |
| cross-page section links | 365 checked, **5 broken** | 365 checked, 0 broken |
| same-page section links | 424 checked, **6 broken** | 421 checked, 0 broken |

The checker mirrors what the portal actually does rather than approximating it: it uses the portal's own slug library (`github-slugger`, via `makeSlug`), follows page composition through imports so that sections defined in an imported partial count toward the parent page, honours `redirect_from`, strips query strings, and ignores links inside code examples.

**No heading was modified in this PR**, so no existing anchor id moves — nothing bookmarked or linked from outside can break.

Prettier reports all nine files clean.

## Note for the reviewer

The `#validation---maximum-length-with-textcounter` triple dash is not a typo. The heading is *"Validation - Maximum length with TextCounter"*, and the surrounding `" - "` slugifies to three dashes. Its sibling sections (`#validation---required`, `#validation---minimum-length`) already have that shape, so the link was corrected to match reality rather than changing the heading's id and risking other references.

## Follow-up

Nothing in the build validates internal links. That is why removing a page in #8428 left links dangling until #8966 months later, and why these eleven were still live today. A build-time check would catch this in the PR that causes it. Happy to add one separately — the two traps to design around are the ones above: pages assembled from imported partials, and headings that contain links.
