### PR TITLE
test(Portal): stabilize focus mode scroll restoration

### DIFF
--- a/packages/dnb-design-system-portal/src/e2e/focusmode.spec.ts
+++ b/packages/dnb-design-system-portal/src/e2e/focusmode.spec.ts
@@ -119,16 +119,20 @@ test.describe('Focus mode', () => {
   test('should restore scroll position after exiting focusmode', async ({
     page,
   }) => {
-    // Scroll down
-    await page.evaluate(() => window.scrollTo({ top: 500 }))
-    await page.waitForTimeout(200)
+    const focusModeButton = page
+      .locator('button[aria-label="Focus mode"]')
+      .last()
+
+    // Scroll down while keeping the button in view. Otherwise Playwright
+    // scrolls back to the button while clicking and changes the position
+    // this test is meant to restore.
+    await focusModeButton.scrollIntoViewIfNeeded()
 
     const scrollBefore = await page.evaluate(() => window.scrollY)
     expect(scrollBefore).toBeGreaterThan(0)
 
     // Enter focusmode
-    const buttons = page.locator('button[aria-label="Focus mode"]')
-    await buttons.first().click()
+    await focusModeButton.click()
     await expect(page).toHaveURL(/focusmode=/)
 
     // Should scroll to top in focusmode


### PR DESCRIPTION
## Motivation

The focus-mode scroll restoration E2E test scrolls the page to a fixed offset, then clicks the first focus-mode button. Playwright has to scroll that off-screen button into view, changing the position the test intends to save and racing with the portal scroll behavior. This failed the v11.14.0 release PR E2E run.

## Solution

Use a focus-mode button further down the page and explicitly scroll it into view before capturing the scroll position. The click no longer introduces an implicit scroll, while the test still verifies that leaving focus mode restores a non-zero page position.

## Test

- Focused failing test repeated 5 times: passed 5/5
- Complete focus-mode Playwright spec: passed 7/7
- Portal E2E production build
- Prettier and git diff checks