### PR TITLE
fix(Drawer): respect the dynamic viewport height

### DIFF
--- a/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/Drawer.test.tsx
@@ -745,6 +745,13 @@ describe('Drawer triggerProps', () => {
 })
 
 describe('Drawer scss', () => {
+  it('uses the dynamic viewport height while keeping a viewport fallback', () => {
+    const css = loadScss(require.resolve('../style/deps.scss'))
+
+    expect(css).toContain('max-height: 100vh')
+    expect(css).toContain('max-height: 100dvh')
+  })
+
   it('should match style dependencies css', () => {
     const css = loadScss(require.resolve('../style/deps.scss'))
     expect(css).toMatchSnapshot()

--- a/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/dnb-eufemia/src/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1399,12 +1399,15 @@ html[data-dnb-modal-active] .eufemia-portal-root {
 .dnb-drawer {
   position: relative;
   max-height: 100vh;
+  max-height: 100dvh;
   width: 100%;
   height: 100vh;
   max-width: 100%;
   max-height: 100vh;
   border-radius: 0;
   box-shadow: none;
+  height: 100dvh;
+  max-height: 100dvh;
   width: var(--drawer-width);
   min-width: var(--drawer-min-width);
   max-width: var(--drawer-max-width);
@@ -1422,6 +1425,8 @@ html[data-dnb-modal-active] .eufemia-portal-root {
     max-height: 100vh;
     border-radius: 0;
     box-shadow: none;
+    height: 100dvh;
+    max-height: 100dvh;
   }
 }
 .dnb-drawer__inner {
@@ -1495,6 +1500,8 @@ html[data-dnb-modal-active] .eufemia-portal-root {
   max-height: 100vh;
   border-radius: 0;
   box-shadow: none;
+  height: 100dvh;
+  max-height: 100dvh;
 }
 .dnb-drawer {
   opacity: 0.1;

--- a/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
+++ b/packages/dnb-eufemia/src/components/drawer/style/dnb-drawer.scss
@@ -22,6 +22,13 @@
   }
 }
 
+@mixin drawerFullscreen {
+  @include modal-mixins.modalFullscreen();
+
+  height: 100dvh;
+  max-height: 100dvh;
+}
+
 .dnb-drawer {
   --drawer-width: 40vw;
   --drawer-min-width: 384px; // (24rem) Use px so a larger font-size will not make the drawer too small
@@ -41,8 +48,9 @@
 
   position: relative;
   max-height: 100vh;
+  max-height: 100dvh;
 
-  @include modal-mixins.modalFullscreen();
+  @include drawerFullscreen();
   width: var(--drawer-width);
   min-width: var(--drawer-min-width);
   max-width: var(--drawer-max-width);
@@ -56,7 +64,7 @@
 
   &--auto-fullscreen {
     @include utilities.allBelow(small) {
-      @include modal-mixins.modalFullscreen();
+      @include drawerFullscreen();
     }
   }
 
@@ -121,7 +129,7 @@
   }
 
   &--fullscreen {
-    @include modal-mixins.modalFullscreen();
+    @include drawerFullscreen();
   }
 
   opacity: 0.1;


### PR DESCRIPTION
Uses the dynamic viewport height so mobile browser controls do not cover the bottom of Drawer content, while retaining the existing viewport-height fallback.