### PR TITLE
fix(MCP): make the local docs server start and rename its entry to mcp-server

### DIFF
--- a/packages/dnb-eufemia/src/mcp/README.md
+++ b/packages/dnb-eufemia/src/mcp/README.md
@@ -50,7 +50,7 @@ The MCP server can be exposed in two ways:
 
 Used by editor integrations like Cursor and the VSCode/Claude Code MCP config. The server reads JSON-RPC from `stdin` and writes responses to `stdout`:
 
-- Entry: `src/mcp/mcp-docs-server.ts`
+- Entry: `src/mcp/mcp-stdio.ts`
 - Wrapper: `src/mcp/run-mcp-server.sh`
 
 ### 2. HTTP (SSE + Streamable HTTP)

--- a/packages/dnb-eufemia/src/mcp/README.md
+++ b/packages/dnb-eufemia/src/mcp/README.md
@@ -50,7 +50,7 @@ The MCP server can be exposed in two ways:
 
 Used by editor integrations like Cursor and the VSCode/Claude Code MCP config. The server reads JSON-RPC from `stdin` and writes responses to `stdout`:
 
-- Entry: `src/mcp/mcp-stdio.ts`
+- Entry: `src/mcp/mcp-server.ts`
 - Wrapper: `src/mcp/run-mcp-server.sh`
 
 ### 2. HTTP (SSE + Streamable HTTP)

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -912,3 +912,25 @@ describe('MCP dependency configuration', () => {
     expect(fs.existsSync(scriptPath)).toBe(true)
   })
 })
+
+describe('MCP shipped source constraints', () => {
+  // babel-plugin-fully-specified only rewrites static import/export, not
+  // dynamic import(). A relative dynamic import therefore ships without a
+  // file extension and cannot be resolved by Node ESM, which crashes the
+  // server on startup. Bare `node:*` specifiers are fine.
+  it('does not use relative dynamic imports in shipped source', () => {
+    const mcpDir = path.join(__dirname, '..')
+    const files = fs
+      .readdirSync(mcpDir)
+      .filter((name) => name.endsWith('.ts') && !name.endsWith('.d.ts'))
+
+    const relativeDynamicImport = /import\(\s*['"]\.\.?\//
+    const offenders = files.filter((name) =>
+      relativeDynamicImport.test(
+        fs.readFileSync(path.join(mcpDir, name), 'utf8')
+      )
+    )
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
+++ b/packages/dnb-eufemia/src/mcp/__tests__/mcp-docs-server.test.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import {
+  createDocsServer,
   createDocsTools,
   DocsSearchInput,
   MAX_SEARCH_QUERY_LENGTH,
@@ -183,6 +184,31 @@ describe('docs_entry', () => {
     const tools = createDocsTools({ docsRoot })
     const result = await tools.docsEntry({})
     expect(getText(result)).toContain('Eufemia Docs')
+  })
+})
+
+describe('createDocsServer (Node fallback)', () => {
+  it('resolves docsRoot lazily instead of leaving it as <pending>', async () => {
+    const fixture = createDocsFixture()
+    const previous = process.env.EUFEMIA_DOCS_ROOT
+    process.env.EUFEMIA_DOCS_ROOT = fixture.docsRoot
+
+    try {
+      const { tools } = await createDocsServer()
+
+      expect(tools.docsRoot).not.toBe('<pending>')
+      expect(tools.docsRoot).toBe(path.resolve(fixture.docsRoot))
+
+      const result = await tools.docsEntry({})
+      expect(getText(result)).toContain('Eufemia Docs')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.EUFEMIA_DOCS_ROOT
+      } else {
+        process.env.EUFEMIA_DOCS_ROOT = previous
+      }
+      fixture.cleanup()
+    }
   })
 })
 

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -14,7 +14,11 @@ import {
   type CallToolResult,
 } from '@modelcontextprotocol/server'
 
-import { type DocsSource, normalizeDocsPath } from './docs-source'
+import {
+  createNodeDocsSource,
+  type DocsSource,
+  normalizeDocsPath,
+} from './docs-source'
 import reviewRules from '../plugins/review-rules.js'
 
 type ToolResult = CallToolResult
@@ -135,7 +139,6 @@ export async function validateDocsRoot(
     throw new Error(`Eufemia docs root is not a directory: ${docsRootAbs}`)
   }
 
-  const { createNodeDocsSource } = await import('./docs-source')
   const source = await createNodeDocsSource(docsRootAbs)
   await validateDocsSource(source)
 }
@@ -727,7 +730,6 @@ export function createDocsTools(
           const root = await docsRootPromise
           resolvedDocsRoot = root
           docsRoot = root
-          const { createNodeDocsSource } = await import('./docs-source')
           return createNodeDocsSource(root)
         })()
       }
@@ -998,7 +1000,9 @@ export function createDocsTools(
     componentApi,
     componentProps,
     source,
-    docsRoot,
+    get docsRoot() {
+      return docsRoot
+    },
   }
 }
 

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -3,7 +3,7 @@
  *
  * This module deliberately avoids importing any Node built-ins so that the
  * shared core stays runtime-agnostic and importable in non-Node runtimes.
- * The Node-only stdio entry point lives in `./mcp-stdio.ts` and the local
+ * The Node-only stdio entry point lives in `./mcp-server.ts` and the local
  * Express HTTP server lives in `./mcp-http-server.ts`.
  */
 
@@ -1194,5 +1194,5 @@ export async function createDocsServer(
   return { server, tools }
 }
 
-// The Node-only stdio entry lives in `./mcp-stdio.ts`. Keeping it out of
+// The Node-only stdio entry lives in `./mcp-server.ts`. Keeping it out of
 // this module ensures the shared core stays runtime-agnostic.

--- a/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-docs-server.ts
@@ -736,7 +736,9 @@ export function createDocsTools(
       return nodeSourcePromise
     }
     source = {
-      label: `node:${docsRoot}`,
+      get label() {
+        return `node:${docsRoot}`
+      },
       listMarkdown: () => getNodeSource().then((s) => s.listMarkdown()),
       read: (relPath) => getNodeSource().then((s) => s.read(relPath)),
       stat: (relPath) => getNodeSource().then((s) => s.stat(relPath)),

--- a/packages/dnb-eufemia/src/mcp/mcp-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-server.ts
@@ -34,13 +34,18 @@ const shouldRun = (() => {
   const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
   const entryName = entryPath ? path.basename(entryPath) : ''
   const allowed = new Set([
+    'mcp-server.js',
+    'mcp-server.mjs',
+    'mcp-server.cjs',
+    'mcp-server.ts',
+    'mcp-server.mts',
+    // Backwards-compat for historical entry filenames (`mcp-stdio.*` and the
+    // even older `mcp-docs-server.*`) so existing MCP configs keep working.
     'mcp-stdio.js',
     'mcp-stdio.mjs',
     'mcp-stdio.cjs',
     'mcp-stdio.ts',
     'mcp-stdio.mts',
-    // Backwards-compat for the historical filename used by the wrapper script
-    // `run-mcp-server.sh` which still points at `mcp-docs-server.ts`.
     'mcp-docs-server.js',
     'mcp-docs-server.mjs',
     'mcp-docs-server.cjs',

--- a/packages/dnb-eufemia/src/mcp/mcp-server.ts
+++ b/packages/dnb-eufemia/src/mcp/mcp-server.ts
@@ -33,24 +33,14 @@ async function main() {
 const shouldRun = (() => {
   const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
   const entryName = entryPath ? path.basename(entryPath) : ''
+  // Only auto-start when Node ran this file directly (published as
+  // mcp-server.js); stay a no-op when the module is merely imported.
   const allowed = new Set([
     'mcp-server.js',
     'mcp-server.mjs',
     'mcp-server.cjs',
     'mcp-server.ts',
     'mcp-server.mts',
-    // Backwards-compat for historical entry filenames (`mcp-stdio.*` and the
-    // even older `mcp-docs-server.*`) so existing MCP configs keep working.
-    'mcp-stdio.js',
-    'mcp-stdio.mjs',
-    'mcp-stdio.cjs',
-    'mcp-stdio.ts',
-    'mcp-stdio.mts',
-    'mcp-docs-server.js',
-    'mcp-docs-server.mjs',
-    'mcp-docs-server.cjs',
-    'mcp-docs-server.ts',
-    'mcp-docs-server.mts',
   ])
   return entryName ? allowed.has(entryName) : false
 })()

--- a/packages/dnb-eufemia/src/mcp/run-mcp-server.sh
+++ b/packages/dnb-eufemia/src/mcp/run-mcp-server.sh
@@ -17,4 +17,4 @@ cd "$PACKAGE_ROOT"
 export EUFEMIA_DOCS_ROOT="${EUFEMIA_DOCS_ROOT:-$PACKAGE_ROOT/build/docs}"
 
 # Run with yarn to ensure babel-node is found
-exec yarn babel-node --extensions .js,.ts,.tsx src/mcp/mcp-stdio.ts
+exec yarn babel-node --extensions .js,.ts,.tsx src/mcp/mcp-server.ts


### PR DESCRIPTION
The local MCP stdio docs server exits immediately with `-32000: Connection closed`, so anyone following the Tools guide can't run the version-pinned local server and has to fall back to the hosted one. Reported on Slack against 11.13.0.

Two independent bugs in the shipped package, each fatal on its own:

- The two `await import('./docs-source')` calls ship **without** a `.js` extension. `babel-plugin-fully-specified` only rewrites static `import`/`export`, not dynamic `import()`, and Node ESM can't resolve extensionless relative specifiers — so loading the docs source throws. Fixed by importing `createNodeDocsSource` statically (`docs-source` lazy-loads `node:fs` internally, so the core stays runtime-agnostic); the build then emits `./docs-source.js`.
- `tools.docsRoot` is the literal string `'<pending>'`: the Node fallback resolves the root lazily and never updates the captured value, so `validateDocsRoot()` runs against `'<pending>'` and throws. Exposed `docsRoot` (and `source.label`) via getters that reflect the resolved root.

Also renames the stdio entry file `mcp-stdio.ts` → `mcp-server.ts` (published as `mcp/mcp-server.js`) so the setup command reads clearly.

The portal docs (setup command + package name) are updated in #9337 — this PR is the code side. No files overlap between the two.
