### PR TITLE
fix(Forms): clear stale field errors after Wizard navigation

### DIFF
--- a/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/DataContext/Provider/Provider.tsx
@@ -438,6 +438,7 @@ export default function Provider<Data extends JsonObject>(
 
   // - States (e.g. error) reported by fields, based on their direct validation rules
   const fieldErrorRef = useRef<Record<Path, Error>>({})
+  const fieldStatusRef = useRef<Record<Path, EventStateObject>>({})
   const fieldStateRef = useRef<Record<Path, SubmitState>>({})
   const onSubmitContinueRef = useRef<(() => void) | null>(null)
   const submitContinuationCancelledRef = useRef(false)
@@ -670,7 +671,12 @@ export default function Provider<Data extends JsonObject>(
       if (error) {
         fieldErrorRef.current[path] = error
       } else {
-        delete fieldErrorRef.current[path]
+        const sharedError = fieldStatusRef.current[path]?.error
+        if (sharedError) {
+          fieldErrorRef.current[path] = sharedError
+        } else {
+          delete fieldErrorRef.current[path]
+        }
       }
 
       bumpValidationVersionRef.current()
@@ -909,7 +915,6 @@ export default function Provider<Data extends JsonObject>(
   const fieldConnectionsRef = useRef<
     Record<Path, Record<string, unknown>>
   >({})
-  const fieldStatusRef = useRef<Record<Path, EventStateObject>>({})
   const setFieldConnection = useCallback(
     (path: Path, connections: Record<string, unknown>) => {
       fieldConnectionsRef.current[path] = connections
@@ -1014,10 +1019,14 @@ export default function Provider<Data extends JsonObject>(
 
   if (!hasHydratedFieldErrorRef.current) {
     const sharedFieldErrorRef = sharedAttachments?.data?.fieldErrorRef
+    const sharedFieldStatusRef = sharedAttachments?.data?.fieldStatusRef
     if (sharedFieldErrorRef?.current) {
       fieldErrorRef.current = sharedFieldErrorRef.current
-      hasHydratedFieldErrorRef.current = true
     }
+    if (sharedFieldStatusRef?.current) {
+      fieldStatusRef.current = sharedFieldStatusRef.current
+    }
+    hasHydratedFieldErrorRef.current = true
   }
 
   const cacheRef = useRef({

--- a/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
+++ b/packages/dnb-eufemia/src/extensions/forms/Wizard/Container/__tests__/WizardContainer.test.tsx
@@ -929,6 +929,41 @@ describe('Wizard.Container', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
+  it('should submit after correcting a checkbox error following step navigation', async () => {
+    const onSubmit: OnSubmit = vi.fn()
+
+    render(
+      <Form.Handler id="wizard-checkbox-error" onSubmit={onSubmit}>
+        <Wizard.Container>
+          <Wizard.Step title="Step 1">
+            <Wizard.Buttons />
+          </Wizard.Step>
+          <Wizard.Step title="Step 2">
+            <Field.Boolean
+              path="/test"
+              variant="checkbox"
+              onChangeValidator={(value) =>
+                value === true ? undefined : Error('test error')
+              }
+            />
+            <Wizard.Buttons />
+            <Form.SubmitButton />
+          </Wizard.Step>
+        </Wizard.Container>
+      </Form.Handler>
+    )
+
+    await userEvent.click(nextButton())
+    await userEvent.click(document.querySelector('input'))
+    await userEvent.click(document.querySelector('input'))
+    await userEvent.click(previousButton())
+    await userEvent.click(nextButton())
+    await userEvent.click(document.querySelector('input'))
+    await userEvent.click(submitButton())
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
   it('should keep current step on rerender', async () => {
     const onStepChange = vi.fn()
 

--- a/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
+++ b/packages/dnb-eufemia/src/extensions/forms/hooks/useFieldProps.ts
@@ -1249,23 +1249,10 @@ export default function useFieldProps<Value, EmptyValue, Props>(
       Promise.resolve().then(() => {
         const isMounted =
           mountedFields?.get?.(identifier)?.isMounted === true
-        const sharedAttachments = dataContext?.id
-          ? createSharedState<{
-              fieldConnectionsRef?: ContextState['fieldConnectionsRef']
-            }>(createReferenceKey(dataContext.id, 'attachments')).get?.()
-          : undefined
-        const hasFieldConnection = Boolean(
-          sharedAttachments?.fieldConnectionsRef?.current?.[identifier]
-        )
 
         if (!isMounted) {
-          // A shared field connection can preserve form-level status across
-          // remounts, but the unmounted field no longer belongs to this boundary.
           setFieldErrorBoundary?.(identifier, undefined)
-
-          if (!hasFieldConnection) {
-            setFieldErrorDataContext?.(identifier, undefined)
-          }
+          setFieldErrorDataContext?.(identifier, undefined)
         }
       })
 


### PR DESCRIPTION
A field validator error could remain in a shared `Form.Handler` after navigating away from and back to a Wizard step. The visible field became valid, but the stale form-level error still prevented submission.

Reproduction:

1. Press Next.
2. Toggle the checkbox on and off.
3. Press Back.
4. Press Next.
5. Toggle the checkbox on once.
6. Press Submit.

Before this fix, `onSubmit` was not called.

StackBlitz: https://stackblitz.com/edit/eufemia-starter-bolatdko?file=src%2FApp.tsx
Motivation: https://dnb.enterprise.slack.com/archives/D07RXF572R0 (PM)